### PR TITLE
docs: establish lotus-ai foundation roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ docker compose up --build
 - decisions and rationale: `docs/architecture/decision-log.md`
 - domain integration guide: `docs/guides/integration-guide.md`
 - task execution contract: `docs/guides/task-execution-contract.md`
+- prompt registry and audit: `docs/guides/prompt-registry-and-audit.md`
 - evaluation strategy: `docs/evals/evaluation-strategy.md`
 - security and governance: `docs/security/security-and-governance.md`
 - service-local RFCs: `docs/rfcs/`

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ docker compose up --build
 - phased roadmap: `docs/architecture/phased-roadmap.md`
 - decisions and rationale: `docs/architecture/decision-log.md`
 - domain integration guide: `docs/guides/integration-guide.md`
+- task execution contract: `docs/guides/task-execution-contract.md`
 - evaluation strategy: `docs/evals/evaluation-strategy.md`
 - security and governance: `docs/security/security-and-governance.md`
 - service-local RFCs: `docs/rfcs/`

--- a/README.md
+++ b/README.md
@@ -91,6 +91,45 @@ That means:
 - no speculative overbuilding,
 - no hidden AI behavior in critical workflows.
 
+## Framework Stance
+
+`lotus-ai` is not being built around a large AI orchestration framework as its core architecture.
+
+The foundation remains:
+
+- `FastAPI`
+- `Pydantic`
+- `pydantic-settings`
+- normal Python service modules
+- explicit Lotus-owned contracts, routing, safety, and audit behavior
+
+We may use targeted AI libraries where they reduce plumbing, but those libraries should remain implementation helpers rather than the definition of the platform.
+
+Current default position:
+
+1. own contracts, prompts, routing, safety, and audit logic ourselves,
+2. use provider SDKs or thin wrappers first,
+3. introduce specialized AI libraries only where they clearly improve delivery without obscuring control flow.
+
+## LangGraph Position
+
+LangGraph is not part of the initial foundation of `lotus-ai`.
+
+Why:
+
+1. the first priority is contract-first, auditable platform behavior,
+2. our early use cases are explanation, retrieval, and bounded task execution rather than complex autonomous agents,
+3. we want to avoid hidden orchestration behavior before the governance model is mature.
+
+LangGraph may be considered later for tightly bounded async or tool-using workflows, but only after:
+
+1. task contracts are stable,
+2. audit logging is complete,
+3. safety and approval controls are in place,
+4. we have real evidence that graph-style orchestration is needed.
+
+Even if adopted later, LangGraph should be used as an internal orchestration helper, not as the public architecture of `lotus-ai`.
+
 ## Quick Start
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Shared AI platform service for Lotus applications.
 
 `lotus-ai` provides the reusable AI infrastructure layer for the Lotus estate. It exists to help the other Lotus apps build governed AI features without moving domain ownership out of the services that already own portfolio data, analytics, workflow state, and deterministic decision logic.
 
+## Current Phase
+
+The repository is in foundation phase.
+
+Current goals:
+
+- define the service architecture clearly,
+- document the delivery roadmap,
+- establish enterprise-grade governance expectations,
+- introduce stable task and capability contracts before integrating any model provider.
+
+This is deliberate. The early focus is to make `lotus-ai` understandable, testable, and governable before it becomes feature-rich.
+
 ## What lotus-ai Does
 
 - LLM gateway and model routing
@@ -50,6 +63,34 @@ Examples:
 - `src/app/routers/`: API surfaces
 - `docs/rfcs/`: service-local architecture decisions
 
+## Build Strategy
+
+We are building `lotus-ai` incrementally.
+
+1. Foundation:
+   contracts, settings, architecture docs, governance, and evaluation standards.
+2. Safe task APIs:
+   explanation, summarization, classification, extraction, and knowledge retrieval.
+3. Platform controls:
+   prompt registry, audit logging, redaction, model routing, and eval harnesses.
+4. Cross-app adoption:
+   start with one Lotus app integration, then expand based on evidence.
+5. Advanced orchestration:
+   async runs and tool-using flows only after the core safety and observability layers are solid.
+
+## Enterprise Posture
+
+`lotus-ai` is being built for an enterprise private-banking target environment, while acknowledging startup execution constraints.
+
+That means:
+
+- strong contracts,
+- explicit ownership boundaries,
+- traceability and auditability,
+- pragmatic slice-by-slice delivery,
+- no speculative overbuilding,
+- no hidden AI behavior in critical workflows.
+
 ## Quick Start
 
 ```powershell
@@ -74,6 +115,12 @@ docker compose up --build
 
 ## Documentation
 
+- architecture overview: `docs/architecture/system-overview.md`
+- phased roadmap: `docs/architecture/phased-roadmap.md`
+- decisions and rationale: `docs/architecture/decision-log.md`
+- domain integration guide: `docs/guides/integration-guide.md`
+- evaluation strategy: `docs/evals/evaluation-strategy.md`
+- security and governance: `docs/security/security-and-governance.md`
 - service-local RFCs: `docs/rfcs/`
 - service standards: `docs/standards/`
 - platform governance source: `../lotus-platform/rfcs/RFC-0069-lotus-ai-shared-ai-platform-service.md`

--- a/docs/architecture/decision-log.md
+++ b/docs/architecture/decision-log.md
@@ -1,0 +1,68 @@
+# Decision Log
+
+This file records the core architectural decisions for `lotus-ai` in a concise format.
+
+## Decision 1: Separate AI Platform Service
+
+Decision:
+
+`lotus-ai` is a separate Lotus application rather than embedding all AI capability directly into every Lotus repo.
+
+Why:
+
+1. central prompt and safety governance,
+2. shared auditability,
+3. reusable retrieval and evaluation tooling,
+4. lower duplication across apps.
+
+Trade-off:
+
+Requires careful ownership discipline so the service does not absorb business logic.
+
+## Decision 2: Domain Apps Keep Business Ownership
+
+Decision:
+
+Each Lotus app keeps ownership of the business meaning of AI features that touch its workflows.
+
+Why:
+
+1. domain services understand their own semantics,
+2. deterministic systems remain authoritative,
+3. AI remains assistive rather than authoritative.
+
+## Decision 3: Build Contract-First
+
+Decision:
+
+Introduce capability and task contracts before real provider integrations.
+
+Why:
+
+1. easier integration with downstream apps,
+2. clearer versioning and testing,
+3. avoids provider-driven architecture drift.
+
+## Decision 4: Start With Explanation and Retrieval
+
+Decision:
+
+Initial business-facing AI value should come from explanation, summarization, retrieval, and drafting.
+
+Why:
+
+1. lower risk,
+2. high user value,
+3. fits well with Lotus deterministic services,
+4. easier to govern in a banking context.
+
+## Decision 5: Enterprise-Grade Controls, Startup-Grade Scope
+
+Decision:
+
+Use bank-grade engineering controls, but keep the actual feature scope narrow and incremental.
+
+Why:
+
+1. target customers require strong governance,
+2. startup constraints require disciplined sequencing rather than big-bang builds.

--- a/docs/architecture/decision-log.md
+++ b/docs/architecture/decision-log.md
@@ -66,3 +66,36 @@ Why:
 
 1. target customers require strong governance,
 2. startup constraints require disciplined sequencing rather than big-bang builds.
+
+## Decision 6: No Large AI Framework as the Core Architecture
+
+Decision:
+
+Do not make a large AI framework the primary architectural foundation of `lotus-ai`.
+
+Why:
+
+1. we need explicit control over contracts, safety, auditability, and request flow,
+2. framework abstractions can hide important behavior,
+3. bank-grade platform services need clarity over convenience,
+4. our current use cases do not justify an agent-first architecture.
+
+Allowed use:
+
+Frameworks or helper libraries may be used in narrow internal roles where they reduce plumbing without taking over the service design.
+
+## Decision 7: LangGraph Is Deferred, Not Rejected
+
+Decision:
+
+LangGraph is deferred from the initial implementation of `lotus-ai`.
+
+Why:
+
+1. early `lotus-ai` slices are contract-first and explanation-first,
+2. graph orchestration is not yet the main bottleneck,
+3. we should first prove the need for multi-step agent workflows with real usage evidence.
+
+Future position:
+
+LangGraph can be reconsidered for bounded internal orchestration later, especially for async multi-step flows, but it should remain an implementation detail rather than the public platform architecture.

--- a/docs/architecture/phased-roadmap.md
+++ b/docs/architecture/phased-roadmap.md
@@ -1,0 +1,118 @@
+# Phased Roadmap
+
+This roadmap is the canonical execution plan for `lotus-ai`.
+
+The guiding principle is:
+
+build the minimum platform slice that is useful, well-governed, and easy to understand before expanding into more powerful AI behaviors.
+
+## Phase 0: Service Foundation
+
+Goals:
+
+1. Establish repository standards and branch governance.
+2. Define service purpose, boundaries, and non-goals.
+3. Create architecture, security, integration, and evaluation documents.
+4. Introduce typed capability and task contracts.
+
+Delivery outcomes:
+
+1. `lotus-ai` exists as a standard Lotus backend repo.
+2. New engineers can understand what the service is for and how it should evolve.
+3. Calling apps can discover supported AI task categories through stable contracts.
+
+## Phase 1: Contract-First AI Task Layer
+
+Goals:
+
+1. Define canonical request and response contracts for bounded AI tasks.
+2. Introduce task identifiers, task classes, and output modes.
+3. Add capability discovery endpoints.
+4. Establish the first eval fixtures for contract and policy behavior.
+
+Delivery outcomes:
+
+1. Upstream Lotus apps can integrate against stable contracts.
+2. The platform can version AI features before real model execution is introduced.
+
+## Phase 2: Prompt Registry and Settings
+
+Goals:
+
+1. Add prompt registry abstractions.
+2. Version prompts explicitly.
+3. Add runtime settings for provider, safety, and audit policy behavior.
+4. Ensure every AI task is traceable to a task id and prompt version.
+
+Delivery outcomes:
+
+1. Prompt changes become reviewable and reversible.
+2. The service has a clear bridge from contract to execution policy.
+
+## Phase 3: Audit, Safety, and Redaction
+
+Goals:
+
+1. Add AI request audit records.
+2. Add response labeling and redaction policy.
+3. Add role-aware access hooks and usage policy gates.
+4. Define minimum evidence retained for enterprise review.
+
+Delivery outcomes:
+
+1. The service can be used in supportable pre-production workflows.
+2. AI output can be inspected, attributed, and governed.
+
+## Phase 4: Knowledge Retrieval
+
+Goals:
+
+1. Index approved Lotus documents:
+   - RFCs
+   - standards
+   - architecture docs
+   - OpenAPI-derived documentation
+2. Support search and citation-backed knowledge answers.
+3. Keep source freshness and provenance explicit.
+
+Delivery outcomes:
+
+1. `lotus-ai` becomes a trustworthy platform knowledge layer.
+2. New engineers and downstream apps can consume cited platform explanations.
+
+## Phase 5: First Real Domain Integration
+
+Preferred first integration:
+
+1. `lotus-manage` explanation of rebalance run outcomes.
+
+Why:
+
+1. high value,
+2. low execution risk,
+3. clear structured inputs,
+4. deterministic domain system remains in control.
+
+Delivery outcomes:
+
+1. One real Lotus app gets business value from `lotus-ai`.
+2. The integration pattern becomes the template for other apps.
+
+## Phase 6: Expansion Across Lotus Apps
+
+Likely next adopters:
+
+1. `lotus-advise` for workflow summaries,
+2. `lotus-risk` for risk explanations,
+3. `lotus-performance` for analytics commentary,
+4. `lotus-core` for supportability triage.
+
+## Phase 7: Async Runs and Controlled Tool Use
+
+Goals:
+
+1. Add async task execution.
+2. Add governed tool invocation patterns.
+3. Keep human-in-the-loop controls where consequences are non-trivial.
+
+This phase should only start after prior phases have real usage evidence.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -17,3 +17,60 @@ The other Lotus applications remain responsible for:
 2. domain semantics,
 3. deterministic workflows,
 4. applying or rejecting AI output.
+
+## Architectural Shape
+
+The service is intentionally being built in layers.
+
+### Contracts
+
+- `src/app/contracts/`
+
+Owns:
+
+1. task categories,
+2. output labels,
+3. capability catalog response models,
+4. future task request and response envelopes.
+
+### Configuration
+
+- `src/app/config.py`
+
+Owns:
+
+1. service phase settings,
+2. provider mode settings,
+3. retrieval mode settings,
+4. safety mode settings.
+
+### Services
+
+- `src/app/services/`
+
+Owns:
+
+1. orchestration logic behind routers,
+2. capability catalog assembly,
+3. future prompt and provider orchestration.
+
+### Routers
+
+- `src/app/routers/`
+
+Owns:
+
+1. public API endpoints,
+2. OpenAPI-facing contracts,
+3. upstream integration surfaces.
+
+## Current Foundation Endpoints
+
+1. `/`
+2. `/health`
+3. `/health/live`
+4. `/health/ready`
+5. `/metadata`
+6. `/platform/capabilities`
+
+The current capability endpoint is intentionally simple. It gives other Lotus apps a stable discovery surface while the rest of the platform is still under construction.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -64,6 +64,36 @@ Owns:
 2. OpenAPI-facing contracts,
 3. upstream integration surfaces.
 
+## Framework Policy
+
+`lotus-ai` is a normal backend service first and an AI platform second.
+
+That means the service is built around:
+
+1. explicit API contracts,
+2. typed Python modules,
+3. observable service orchestration,
+4. Lotus-owned safety and audit controls.
+
+AI frameworks may be used selectively, but they must not become the source of truth for:
+
+1. request flow,
+2. task semantics,
+3. output policy,
+4. audit boundaries.
+
+## LangGraph Guidance
+
+LangGraph is currently out of the foundation scope.
+
+It may be appropriate later for:
+
+1. bounded async orchestration,
+2. multi-step tool workflows,
+3. internal state-machine style AI execution.
+
+It is not appropriate right now as the base architecture for all of `lotus-ai`.
+
 ## Current Foundation Endpoints
 
 1. `/`

--- a/docs/evals/evaluation-strategy.md
+++ b/docs/evals/evaluation-strategy.md
@@ -1,0 +1,56 @@
+# Evaluation Strategy
+
+`lotus-ai` must be testable in a way that matches its intended role as enterprise-facing AI infrastructure.
+
+## Evaluation Principles
+
+1. Every supported task should have golden examples.
+2. Output structure matters as much as output quality.
+3. Hallucination risk should be measured explicitly for retrieval-backed flows.
+4. Prompt changes should be regression-tested before promotion.
+5. Evaluation should be cheap enough to run often.
+
+## Evaluation Layers
+
+### Contract evaluations
+
+Check:
+
+1. schema validity,
+2. required metadata presence,
+3. deterministic error handling,
+4. policy gating behavior.
+
+### Retrieval evaluations
+
+Check:
+
+1. source selection quality,
+2. citation presence,
+3. freshness/provenance behavior,
+4. refusal behavior when sources are insufficient.
+
+### Prompt regression evaluations
+
+Check:
+
+1. output stability against approved examples,
+2. expected tone and enterprise posture,
+3. no leakage of disallowed content,
+4. no structural regression.
+
+### Domain-integration evaluations
+
+Check:
+
+1. domain context assembly quality,
+2. correct task choice,
+3. downstream rendering compatibility,
+4. audit trail completeness.
+
+## First Evaluation Assets To Add
+
+1. task capability contract fixtures,
+2. explanation task fixture set,
+3. summarization fixture set,
+4. retrieval citation fixture set.

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -1,0 +1,69 @@
+# Integration Guide
+
+This guide explains how other Lotus apps should integrate with `lotus-ai`.
+
+## Core Rule
+
+The calling Lotus application owns the business context.
+
+`lotus-ai` should receive structured context that has already been curated by the calling service or by `lotus-gateway`.
+
+## Recommended Integration Pattern
+
+1. Build a domain-owned context payload.
+2. Select a bounded AI task id.
+3. Call `lotus-ai` with correlation id and caller metadata.
+4. Receive structured AI output and audit metadata.
+5. Apply that output only within the calling service's own business rules.
+
+## Good Use Cases
+
+### lotus-manage
+
+1. Explain rebalance outcome.
+2. Summarize blocking diagnostics.
+3. Draft reviewer notes for support or operations.
+
+### lotus-advise
+
+1. Summarize proposal workflow status.
+2. Draft approval-pack commentary.
+3. Explain suitability or gate recommendations.
+
+### lotus-risk and lotus-performance
+
+1. Turn structured analytics into narrative explanations.
+2. Summarize material changes between periods or scenarios.
+
+### lotus-core
+
+1. Summarize ingestion or support anomalies.
+2. Explain likely causes from structured lineage/support data.
+
+## Bad Use Cases
+
+1. Replacing domain calculations with LLM guesses.
+2. Letting `lotus-ai` invent missing core business data.
+3. Asking `lotus-ai` to authoritatively decide approvals or trade execution.
+4. Sending uncurated, overly broad data just because it might help.
+
+## Request Design Guidance
+
+Every request should include:
+
+1. `task_id`
+2. `caller_app`
+3. `correlation_id`
+4. `input_mode`
+5. structured context object
+6. expected output mode
+
+Prefer smaller, explicit context bundles over large raw payload dumps.
+
+## Retrieval Guidance
+
+If retrieval is used:
+
+1. retrieval sources should be explicit,
+2. cited output should keep source references,
+3. platform docs and approved standards should be favored over ad hoc notes.

--- a/docs/guides/prompt-registry-and-audit.md
+++ b/docs/guides/prompt-registry-and-audit.md
@@ -1,0 +1,63 @@
+# Prompt Registry and Audit
+
+This guide explains the current prompt-registry and audit design in `lotus-ai`.
+
+## Why This Exists
+
+The task execution contract established the public integration surface.
+
+The next platform requirement is traceability:
+
+1. every task execution should resolve to an explicit prompt version,
+2. every execution should leave a retrievable audit record,
+3. future provider integrations should not change the shape of that traceability model.
+
+## Prompt Registry
+
+Current implementation:
+
+1. in-repo registry keyed by `task_id`,
+2. versioned prompt descriptors,
+3. one prompt descriptor per registered task.
+
+Current prompt fields:
+
+1. `task_id`
+2. `prompt_version`
+3. `prompt_kind`
+4. `system_instructions`
+5. `output_contract_notes`
+
+This is intentionally simple for foundation phase.
+
+## Audit Store
+
+Current implementation:
+
+1. in-memory audit store abstraction,
+2. save-on-execution behavior,
+3. retrieval by `request_id`.
+
+This gives us immediate traceability while keeping persistence pragmatic.
+
+## Why In-Memory First
+
+1. We want the contract and service seams first.
+2. We do not yet need a durable database just to validate the architecture.
+3. Moving to PostgreSQL later should be an implementation change behind the same service interfaces.
+
+## Current Endpoints
+
+1. `GET /platform/prompts`
+2. `GET /platform/prompts/{task_id}`
+3. `GET /ai/audit/{request_id}`
+
+## Future Direction
+
+Likely next evolution:
+
+1. prompt files or database-backed prompt registry,
+2. durable audit persistence in PostgreSQL,
+3. tenant-aware prompt selection,
+4. prompt promotion and rollback workflow,
+5. richer audit records including safety-policy outcomes.

--- a/docs/guides/task-execution-contract.md
+++ b/docs/guides/task-execution-contract.md
@@ -1,0 +1,87 @@
+# Task Execution Contract
+
+This document describes the first executable integration surface for `lotus-ai`.
+
+## Endpoint
+
+- `POST /ai/tasks/execute`
+
+## Purpose
+
+Provide a governed, contract-first task execution API that Lotus apps can integrate with before live provider execution is enabled.
+
+During foundation phase, supported tasks return deterministic stub results.
+
+This is intentional:
+
+1. downstream apps can integrate early,
+2. audit metadata shape becomes stable,
+3. task contracts can evolve under test before model providers are introduced.
+
+## Request Shape
+
+Required fields:
+
+1. `task_id`
+2. `input_mode`
+3. `caller`
+4. `context`
+
+### caller
+
+Includes:
+
+1. `caller_app`
+2. `correlation_id`
+3. optional `requested_by`
+4. optional `tenant_id`
+
+### context
+
+Includes:
+
+1. `summary`
+2. `payload`
+3. `source_refs`
+
+## Response Shape
+
+Returns:
+
+1. `status`
+2. `task_id`
+3. `category`
+4. `output_label`
+5. `result`
+6. `audit`
+
+The `audit` block is part of the core platform contract and should be preserved by calling systems.
+
+## Current Execution Behavior
+
+Supported enabled tasks in foundation phase:
+
+1. `explain.v1`
+2. `summarize.v1`
+3. `classify.v1`
+4. `extract.v1`
+5. `generate_structured.v1`
+
+Retrieval tasks remain registered but disabled until retrieval infrastructure is ready.
+
+## Error Behavior
+
+1. unknown `task_id` returns `404`
+2. disabled task in current phase returns `409`
+3. output-label mismatch returns `409`
+
+## Integration Guidance
+
+Calling Lotus apps should treat current results as contract-valid placeholders, not final business value.
+
+The correct use right now is:
+
+1. integrate request/response handling,
+2. preserve audit metadata,
+3. validate downstream UI or service compatibility,
+4. avoid assuming live model execution.

--- a/docs/security/security-and-governance.md
+++ b/docs/security/security-and-governance.md
@@ -1,0 +1,47 @@
+# Security and Governance
+
+`lotus-ai` is intended for a banking-oriented platform, so security and governance are first-class design concerns.
+
+## Core Security Posture
+
+1. Least privilege for all integrations.
+2. No uncontrolled tool execution in production-facing paths.
+3. No silent use of sensitive data.
+4. Explicit redaction and output labeling policies.
+5. Full correlation and audit metadata for every AI run.
+
+## Governance Rules
+
+1. `lotus-ai` must not become the source of truth for business decisions.
+2. Domain apps remain accountable for the user-facing consequences of AI output.
+3. New task categories require documentation and test coverage.
+4. Prompt changes must be reviewable.
+5. Retrieval sources must be curated and attributable.
+
+## Data Handling
+
+Initial rule set:
+
+1. only send the minimum context required,
+2. keep caller identity and correlation metadata,
+3. separate raw domain data from AI-generated output,
+4. preserve audit references for source documents and prompt versions.
+
+## Output Policy
+
+AI output should be labeled by intended use:
+
+1. `EXPLANATION_ONLY`
+2. `DRAFT`
+3. `CLASSIFICATION`
+4. `RETRIEVAL_ANSWER`
+
+No output label should imply authoritative domain execution.
+
+## Deferred Security Work
+
+1. secret scanning for prompt assets,
+2. sensitive-data classifiers,
+3. role-aware redaction policy engine,
+4. production-grade provider credential rotation,
+5. formal threat model.

--- a/docs/security/security-and-governance.md
+++ b/docs/security/security-and-governance.md
@@ -17,6 +17,7 @@
 3. New task categories require documentation and test coverage.
 4. Prompt changes must be reviewable.
 5. Retrieval sources must be curated and attributable.
+6. Frameworks must not obscure audit, safety, or approval boundaries.
 
 ## Data Handling
 
@@ -45,3 +46,15 @@ No output label should imply authoritative domain execution.
 3. role-aware redaction policy engine,
 4. production-grade provider credential rotation,
 5. formal threat model.
+
+## Framework Governance
+
+Any future framework adoption, including LangGraph or similar orchestration libraries, should be judged against these questions:
+
+1. Does it preserve explicit task contracts?
+2. Does it preserve traceable request and response boundaries?
+3. Does it make audit logging easier rather than harder?
+4. Does it keep human-approval and policy gates explicit?
+5. Can the team explain the runtime behavior without relying on framework magic?
+
+If the answer to any of these is no, the framework should not be introduced into a production-facing path.

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     provider_mode: str = "disabled"
     retrieval_mode: str = "disabled"
     safety_mode: str = "documented_only"
+    audit_store_mode: str = "memory"
 
     model_config = SettingsConfigDict(env_prefix="LOTUS_AI_", extra="ignore")
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    service_name: str = "lotus-ai"
+    service_version: str = "0.1.0"
+    delivery_phase: str = "foundation"
+    provider_mode: str = "disabled"
+    retrieval_mode: str = "disabled"
+    safety_mode: str = "documented_only"
+
+    model_config = SettingsConfigDict(env_prefix="LOTUS_AI_", extra="ignore")
+
+
+settings = Settings()

--- a/src/app/contracts/__init__.py
+++ b/src/app/contracts/__init__.py
@@ -1,1 +1,1 @@
-
+"""Request and response models for lotus-ai."""

--- a/src/app/contracts/audit.py
+++ b/src/app/contracts/audit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AuditRecordResponse(BaseModel):
+    request_id: str = Field(description="Generated task execution request identifier.")
+    task_id: str = Field(description="Task identifier evaluated for this execution.")
+    caller_app: str = Field(description="Calling Lotus application associated with the request.")
+    correlation_id: str = Field(description="Correlation identifier propagated by the caller.")
+    prompt_version: str = Field(description="Prompt version associated with the execution.")
+    provider_mode: str = Field(description="Provider mode active for the execution.")
+    generated_at: str = Field(description="UTC timestamp when the record was created.")
+    stubbed: bool = Field(description="Whether the execution result was stubbed.")
+    context_summary: str = Field(description="Short summary of the caller-provided context.")
+    context_keys: list[str] = Field(description="Sorted list of structured context keys.")
+    source_refs: list[str] = Field(description="Source references carried by the caller.")
+    result_preview: str = Field(description="Short preview of the generated result.")
+    structured_output: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured task result stored in the audit record.",
+    )

--- a/src/app/contracts/prompts.py
+++ b/src/app/contracts/prompts.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PromptDescriptor(BaseModel):
+    task_id: str = Field(description="Stable task identifier associated with the prompt.")
+    prompt_version: str = Field(description="Version of the prompt definition.")
+    prompt_kind: str = Field(description="High-level type of prompt definition.")
+    system_instructions: str = Field(description="Primary system instructions for the task.")
+    output_contract_notes: str = Field(
+        description="Contract notes constraining how task output should behave."
+    )

--- a/src/app/contracts/tasks.py
+++ b/src/app/contracts/tasks.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class TaskCategory(str, Enum):
+    EXPLAIN = "explain"
+    SUMMARIZE = "summarize"
+    CLASSIFY = "classify"
+    EXTRACT = "extract"
+    GENERATE_STRUCTURED = "generate_structured"
+    KNOWLEDGE_SEARCH = "knowledge_search"
+    KNOWLEDGE_ANSWER = "knowledge_answer"
+
+
+class OutputLabel(str, Enum):
+    EXPLANATION_ONLY = "EXPLANATION_ONLY"
+    DRAFT = "DRAFT"
+    CLASSIFICATION = "CLASSIFICATION"
+    RETRIEVAL_ANSWER = "RETRIEVAL_ANSWER"
+
+
+class CapabilityDescriptor(BaseModel):
+    task_id: str = Field(description="Stable task identifier.")
+    category: TaskCategory = Field(description="Task category owned by lotus-ai.")
+    enabled: bool = Field(description="Whether the task is currently enabled.")
+    output_label: OutputLabel = Field(description="Intended use label for the task output.")
+    description: str = Field(description="Human-readable task description.")
+
+
+class CapabilityCatalogResponse(BaseModel):
+    service: str = Field(description="Service name emitting the catalog.")
+    version: str = Field(description="Service version.")
+    phase: str = Field(description="Current delivery phase for lotus-ai.")
+    tasks: list[CapabilityDescriptor] = Field(
+        description="Bounded AI task capabilities currently exposed by the service."
+    )

--- a/src/app/contracts/tasks.py
+++ b/src/app/contracts/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -22,6 +23,15 @@ class OutputLabel(str, Enum):
     RETRIEVAL_ANSWER = "RETRIEVAL_ANSWER"
 
 
+class TaskInputMode(str, Enum):
+    STRUCTURED_CONTEXT = "STRUCTURED_CONTEXT"
+
+
+class TaskExecutionStatus(str, Enum):
+    COMPLETED = "COMPLETED"
+    REJECTED = "REJECTED"
+
+
 class CapabilityDescriptor(BaseModel):
     task_id: str = Field(description="Stable task identifier.")
     category: TaskCategory = Field(description="Task category owned by lotus-ai.")
@@ -37,3 +47,66 @@ class CapabilityCatalogResponse(BaseModel):
     tasks: list[CapabilityDescriptor] = Field(
         description="Bounded AI task capabilities currently exposed by the service."
     )
+
+
+class CallerMetadata(BaseModel):
+    caller_app: str = Field(description="Calling Lotus application or platform component.")
+    correlation_id: str = Field(description="Correlation identifier propagated by the caller.")
+    requested_by: str | None = Field(
+        default=None,
+        description="Optional human or system identity associated with the request.",
+    )
+    tenant_id: str | None = Field(
+        default=None,
+        description="Optional tenant or environment ownership marker for the request.",
+    )
+
+
+class TaskContextEnvelope(BaseModel):
+    summary: str = Field(description="Short human-readable description of the provided context.")
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured task context assembled by the calling Lotus application.",
+    )
+    source_refs: list[str] = Field(
+        default_factory=list,
+        description="Optional source references carried by the calling system.",
+    )
+
+
+class TaskExecutionRequest(BaseModel):
+    task_id: str = Field(description="Stable Lotus AI task identifier.")
+    input_mode: TaskInputMode = Field(description="How the task input context is provided.")
+    caller: CallerMetadata = Field(description="Calling system metadata.")
+    context: TaskContextEnvelope = Field(description="Structured context envelope for execution.")
+    expected_output_label: OutputLabel | None = Field(
+        default=None,
+        description="Optional caller assertion about the expected output label for the task.",
+    )
+
+
+class TaskAuditMetadata(BaseModel):
+    request_id: str = Field(description="Generated task execution request identifier.")
+    task_id: str = Field(description="Task identifier evaluated for this execution.")
+    output_label: OutputLabel = Field(description="Output label attached to the execution.")
+    prompt_version: str = Field(description="Prompt version associated with the execution.")
+    provider_mode: str = Field(description="Provider mode active for the execution.")
+    generated_at: str = Field(description="UTC timestamp when the result was generated.")
+    stubbed: bool = Field(description="Whether the result came from deterministic stub execution.")
+
+
+class TaskExecutionResult(BaseModel):
+    message: str = Field(description="Primary human-readable result string.")
+    structured_output: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured result payload returned by the task execution layer.",
+    )
+
+
+class TaskExecutionResponse(BaseModel):
+    status: TaskExecutionStatus = Field(description="Execution outcome for the task request.")
+    task_id: str = Field(description="Executed task identifier.")
+    category: TaskCategory = Field(description="Task category associated with the task id.")
+    output_label: OutputLabel = Field(description="Output label emitted by the task.")
+    result: TaskExecutionResult = Field(description="Task result payload.")
+    audit: TaskAuditMetadata = Field(description="Audit metadata for the execution.")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -3,7 +3,9 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.config import settings
 from app.middleware.correlation import CorrelationIdMiddleware
+from app.routers.audit import router as audit_router
 from app.routers.capabilities import router as capabilities_router
+from app.routers.prompts import router as prompts_router
 from app.routers.tasks import router as tasks_router
 
 SERVICE_NAME = settings.service_name
@@ -22,7 +24,9 @@ app = FastAPI(
 app.add_middleware(CorrelationIdMiddleware, service_name=SERVICE_NAME)
 Instrumentator().instrument(app).expose(app)
 app.include_router(capabilities_router)
+app.include_router(prompts_router)
 app.include_router(tasks_router)
+app.include_router(audit_router)
 
 
 @app.get("/health")
@@ -61,6 +65,7 @@ async def root() -> dict[str, object]:
         "providerMode": settings.provider_mode,
         "retrievalMode": settings.retrieval_mode,
         "safetyMode": settings.safety_mode,
+        "auditStoreMode": settings.audit_store_mode,
         "capabilityAreas": [
             "llm_gateway",
             "prompt_registry",

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -4,6 +4,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from app.config import settings
 from app.middleware.correlation import CorrelationIdMiddleware
 from app.routers.capabilities import router as capabilities_router
+from app.routers.tasks import router as tasks_router
 
 SERVICE_NAME = settings.service_name
 SERVICE_VERSION = settings.service_version
@@ -21,6 +22,7 @@ app = FastAPI(
 app.add_middleware(CorrelationIdMiddleware, service_name=SERVICE_NAME)
 Instrumentator().instrument(app).expose(app)
 app.include_router(capabilities_router)
+app.include_router(tasks_router)
 
 
 @app.get("/health")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,9 +1,12 @@
 from fastapi import FastAPI, Response, status
 from prometheus_fastapi_instrumentator import Instrumentator
-from app.middleware.correlation import CorrelationIdMiddleware
 
-SERVICE_NAME = "lotus-ai"
-SERVICE_VERSION = "0.1.0"
+from app.config import settings
+from app.middleware.correlation import CorrelationIdMiddleware
+from app.routers.capabilities import router as capabilities_router
+
+SERVICE_NAME = settings.service_name
+SERVICE_VERSION = settings.service_version
 ROUNDING_POLICY_VERSION = "v1"
 
 app = FastAPI(
@@ -17,6 +20,7 @@ app = FastAPI(
 )
 app.add_middleware(CorrelationIdMiddleware, service_name=SERVICE_NAME)
 Instrumentator().instrument(app).expose(app)
+app.include_router(capabilities_router)
 
 
 @app.get("/health")
@@ -51,6 +55,10 @@ async def root() -> dict[str, object]:
     return {
         "service": SERVICE_NAME,
         "version": SERVICE_VERSION,
+        "phase": settings.delivery_phase,
+        "providerMode": settings.provider_mode,
+        "retrievalMode": settings.retrieval_mode,
+        "safetyMode": settings.safety_mode,
         "capabilityAreas": [
             "llm_gateway",
             "prompt_registry",

--- a/src/app/prompts/registry.py
+++ b/src/app/prompts/registry.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from app.contracts.prompts import PromptDescriptor
+
+_PROMPTS: dict[str, PromptDescriptor] = {
+    "explain.v1": PromptDescriptor(
+        task_id="explain.v1",
+        prompt_version="foundation.explain.v1",
+        prompt_kind="system",
+        system_instructions=(
+            "Explain structured Lotus domain outputs clearly, conservatively, and without "
+            "inventing missing business facts."
+        ),
+        output_contract_notes=(
+            "Output must remain explanation-oriented, enterprise-safe, and non-authoritative."
+        ),
+    ),
+    "summarize.v1": PromptDescriptor(
+        task_id="summarize.v1",
+        prompt_version="foundation.summarize.v1",
+        prompt_kind="system",
+        system_instructions=(
+            "Summarize caller-provided structured inputs into concise, decision-supporting text."
+        ),
+        output_contract_notes="Output is a draft summary, not business truth.",
+    ),
+    "classify.v1": PromptDescriptor(
+        task_id="classify.v1",
+        prompt_version="foundation.classify.v1",
+        prompt_kind="system",
+        system_instructions=(
+            "Classify caller-provided structured content into bounded categories only."
+        ),
+        output_contract_notes="Classification must remain within caller-approved label sets.",
+    ),
+    "extract.v1": PromptDescriptor(
+        task_id="extract.v1",
+        prompt_version="foundation.extract.v1",
+        prompt_kind="system",
+        system_instructions="Extract structured fields from curated caller content.",
+        output_contract_notes="Extraction output must stay schema-bound and conservative.",
+    ),
+    "generate_structured.v1": PromptDescriptor(
+        task_id="generate_structured.v1",
+        prompt_version="foundation.generate_structured.v1",
+        prompt_kind="system",
+        system_instructions=(
+            "Generate schema-bound structured output from curated caller context."
+        ),
+        output_contract_notes="Generated output must remain draft-only and schema-bound.",
+    ),
+    "knowledge_search.v1": PromptDescriptor(
+        task_id="knowledge_search.v1",
+        prompt_version="foundation.knowledge_search.v1",
+        prompt_kind="system",
+        system_instructions="Search approved Lotus knowledge sources with traceable provenance.",
+        output_contract_notes="Citations and source attribution are mandatory when enabled.",
+    ),
+    "knowledge_answer.v1": PromptDescriptor(
+        task_id="knowledge_answer.v1",
+        prompt_version="foundation.knowledge_answer.v1",
+        prompt_kind="system",
+        system_instructions=(
+            "Answer questions from approved Lotus knowledge sources with explicit citations."
+        ),
+        output_contract_notes="Refuse when sources are insufficient or unsupported.",
+    ),
+}
+
+
+def get_prompt_by_task_id(task_id: str) -> PromptDescriptor | None:
+    return _PROMPTS.get(task_id)
+
+
+def list_prompts() -> list[PromptDescriptor]:
+    return list(_PROMPTS.values())

--- a/src/app/routers/audit.py
+++ b/src/app/routers/audit.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.contracts.audit import AuditRecordResponse
+from app.services.audit_store import get_audit_store
+
+router = APIRouter(prefix="/ai/audit", tags=["audit"])
+
+
+@router.get(
+    "/{request_id}",
+    response_model=AuditRecordResponse,
+    summary="Get lotus-ai audit record",
+    description=(
+        "Returns the stored audit record for a prior lotus-ai task execution request. "
+        "During foundation phase, records are stored in an in-memory audit store."
+    ),
+)
+async def get_audit_record(request_id: str) -> AuditRecordResponse:
+    record = get_audit_store().get(request_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No lotus-ai audit record found for request_id: {request_id}",
+        )
+    return record

--- a/src/app/routers/capabilities.py
+++ b/src/app/routers/capabilities.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.contracts.tasks import CapabilityCatalogResponse
+from app.services.capability_catalog import build_capability_catalog
+
+router = APIRouter(tags=["platform"])
+
+
+@router.get(
+    "/platform/capabilities",
+    response_model=CapabilityCatalogResponse,
+    summary="Get lotus-ai capability catalog",
+    description=(
+        "Returns the current bounded AI task capabilities exposed by lotus-ai. "
+        "This endpoint is intended for upstream Lotus services and platforms to discover "
+        "which task classes are available during the current delivery phase."
+    ),
+)
+async def get_platform_capabilities() -> CapabilityCatalogResponse:
+    return build_capability_catalog()

--- a/src/app/routers/prompts.py
+++ b/src/app/routers/prompts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.contracts.prompts import PromptDescriptor
+from app.services.prompt_registry import get_prompt_or_raise, list_registered_prompts
+
+router = APIRouter(prefix="/platform/prompts", tags=["platform"])
+
+
+@router.get(
+    "",
+    response_model=list[PromptDescriptor],
+    summary="List registered lotus-ai prompts",
+    description=(
+        "Returns the currently registered prompt definitions known to lotus-ai. "
+        "This endpoint is intended for platform transparency and engineering inspection."
+    ),
+)
+async def list_prompts_route() -> list[PromptDescriptor]:
+    return list_registered_prompts()
+
+
+@router.get(
+    "/{task_id}",
+    response_model=PromptDescriptor,
+    summary="Get lotus-ai prompt definition",
+    description="Returns the registered prompt definition associated with a task identifier.",
+)
+async def get_prompt_route(task_id: str) -> PromptDescriptor:
+    return get_prompt_or_raise(task_id)

--- a/src/app/routers/tasks.py
+++ b/src/app/routers/tasks.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.contracts.tasks import TaskExecutionRequest, TaskExecutionResponse
+from app.services.task_executor import execute_task
+
+router = APIRouter(prefix="/ai/tasks", tags=["tasks"])
+
+
+@router.post(
+    "/execute",
+    response_model=TaskExecutionResponse,
+    summary="Execute a bounded lotus-ai task",
+    description=(
+        "Validates and executes a bounded lotus-ai task using the current delivery-phase "
+        "execution policy. During foundation phase, supported tasks return deterministic "
+        "stub responses so downstream Lotus apps can integrate against stable contracts "
+        "before live provider execution is enabled."
+    ),
+)
+async def execute_task_route(request: TaskExecutionRequest) -> TaskExecutionResponse:
+    return execute_task(request)

--- a/src/app/services/audit_store.py
+++ b/src/app/services/audit_store.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from threading import Lock
+
+from app.contracts.audit import AuditRecordResponse
+
+
+class InMemoryAuditStore:
+    def __init__(self) -> None:
+        self._records: dict[str, AuditRecordResponse] = {}
+        self._lock = Lock()
+
+    def save(self, record: AuditRecordResponse) -> None:
+        with self._lock:
+            self._records[record.request_id] = record
+
+    def get(self, request_id: str) -> AuditRecordResponse | None:
+        with self._lock:
+            return self._records.get(request_id)
+
+
+_audit_store = InMemoryAuditStore()
+
+
+def get_audit_store() -> InMemoryAuditStore:
+    return _audit_store

--- a/src/app/services/capability_catalog.py
+++ b/src/app/services/capability_catalog.py
@@ -66,3 +66,11 @@ def build_capability_catalog() -> CapabilityCatalogResponse:
             ),
         ],
     )
+
+
+def get_capability_by_task_id(task_id: str) -> CapabilityDescriptor | None:
+    catalog = build_capability_catalog()
+    for task in catalog.tasks:
+        if task.task_id == task_id:
+            return task
+    return None

--- a/src/app/services/capability_catalog.py
+++ b/src/app/services/capability_catalog.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.tasks import (
+    CapabilityCatalogResponse,
+    CapabilityDescriptor,
+    OutputLabel,
+    TaskCategory,
+)
+
+
+def build_capability_catalog() -> CapabilityCatalogResponse:
+    return CapabilityCatalogResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        phase=settings.delivery_phase,
+        tasks=[
+            CapabilityDescriptor(
+                task_id="explain.v1",
+                category=TaskCategory.EXPLAIN,
+                enabled=True,
+                output_label=OutputLabel.EXPLANATION_ONLY,
+                description="Explain structured Lotus domain outputs in plain English.",
+            ),
+            CapabilityDescriptor(
+                task_id="summarize.v1",
+                category=TaskCategory.SUMMARIZE,
+                enabled=True,
+                output_label=OutputLabel.DRAFT,
+                description="Summarize structured inputs into concise, governed narrative output.",
+            ),
+            CapabilityDescriptor(
+                task_id="classify.v1",
+                category=TaskCategory.CLASSIFY,
+                enabled=True,
+                output_label=OutputLabel.CLASSIFICATION,
+                description="Classify structured content into bounded output categories.",
+            ),
+            CapabilityDescriptor(
+                task_id="extract.v1",
+                category=TaskCategory.EXTRACT,
+                enabled=True,
+                output_label=OutputLabel.DRAFT,
+                description="Extract structured fields from caller-provided content.",
+            ),
+            CapabilityDescriptor(
+                task_id="generate_structured.v1",
+                category=TaskCategory.GENERATE_STRUCTURED,
+                enabled=True,
+                output_label=OutputLabel.DRAFT,
+                description="Generate schema-bound structured output from curated context.",
+            ),
+            CapabilityDescriptor(
+                task_id="knowledge_search.v1",
+                category=TaskCategory.KNOWLEDGE_SEARCH,
+                enabled=False,
+                output_label=OutputLabel.RETRIEVAL_ANSWER,
+                description="Search approved Lotus knowledge sources with source attribution.",
+            ),
+            CapabilityDescriptor(
+                task_id="knowledge_answer.v1",
+                category=TaskCategory.KNOWLEDGE_ANSWER,
+                enabled=False,
+                output_label=OutputLabel.RETRIEVAL_ANSWER,
+                description="Answer questions from approved Lotus knowledge sources with citations.",
+            ),
+        ],
+    )

--- a/src/app/services/prompt_registry.py
+++ b/src/app/services/prompt_registry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from app.contracts.prompts import PromptDescriptor
+from app.prompts.registry import get_prompt_by_task_id, list_prompts
+
+
+def get_prompt_or_raise(task_id: str) -> PromptDescriptor:
+    prompt = get_prompt_by_task_id(task_id)
+    if prompt is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No registered prompt definition for task_id: {task_id}",
+        )
+    return prompt
+
+
+def list_registered_prompts() -> list[PromptDescriptor]:
+    return list_prompts()

--- a/src/app/services/task_executor.py
+++ b/src/app/services/task_executor.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+
+from app.config import settings
+from app.contracts.tasks import (
+    CapabilityDescriptor,
+    TaskExecutionRequest,
+    TaskExecutionResponse,
+    TaskExecutionResult,
+    TaskExecutionStatus,
+    TaskAuditMetadata,
+)
+from app.services.capability_catalog import get_capability_by_task_id
+
+PROMPT_VERSION = "foundation.stub.v1"
+
+
+def execute_task(request: TaskExecutionRequest) -> TaskExecutionResponse:
+    capability = get_capability_by_task_id(request.task_id)
+    if capability is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown lotus-ai task_id: {request.task_id}",
+        )
+    if not capability.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Task is registered but not enabled in the current phase: {request.task_id}",
+        )
+    if request.expected_output_label and request.expected_output_label != capability.output_label:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Expected output label does not match task configuration: "
+                f"{request.expected_output_label} != {capability.output_label}"
+            ),
+        )
+
+    return TaskExecutionResponse(
+        status=TaskExecutionStatus.COMPLETED,
+        task_id=capability.task_id,
+        category=capability.category,
+        output_label=capability.output_label,
+        result=_build_stub_result(request=request, capability=capability),
+        audit=TaskAuditMetadata(
+            request_id=f"air_{uuid4().hex}",
+            task_id=capability.task_id,
+            output_label=capability.output_label,
+            prompt_version=PROMPT_VERSION,
+            provider_mode=settings.provider_mode,
+            generated_at=datetime.now(UTC).isoformat(),
+            stubbed=True,
+        ),
+    )
+
+
+def _build_stub_result(
+    *,
+    request: TaskExecutionRequest,
+    capability: CapabilityDescriptor,
+) -> TaskExecutionResult:
+    return TaskExecutionResult(
+        message=(
+            "Stub execution completed for foundation-phase task "
+            f"{capability.task_id} requested by {request.caller.caller_app}."
+        ),
+        structured_output={
+            "phase": settings.delivery_phase,
+            "input_mode": request.input_mode,
+            "caller_app": request.caller.caller_app,
+            "context_summary": request.context.summary,
+            "context_keys": sorted(request.context.payload.keys()),
+            "source_refs": request.context.source_refs,
+            "stub_reason": (
+                "lotus-ai foundation phase exposes governed integration contracts "
+                "before live provider execution is enabled."
+            ),
+        },
+    )

--- a/src/app/services/task_executor.py
+++ b/src/app/services/task_executor.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from fastapi import HTTPException, status
 
 from app.config import settings
+from app.contracts.audit import AuditRecordResponse
 from app.contracts.tasks import (
     CapabilityDescriptor,
     TaskExecutionRequest,
@@ -14,9 +15,9 @@ from app.contracts.tasks import (
     TaskExecutionStatus,
     TaskAuditMetadata,
 )
+from app.services.audit_store import get_audit_store
 from app.services.capability_catalog import get_capability_by_task_id
-
-PROMPT_VERSION = "foundation.stub.v1"
+from app.services.prompt_registry import get_prompt_or_raise
 
 
 def execute_task(request: TaskExecutionRequest) -> TaskExecutionResponse:
@@ -39,23 +40,43 @@ def execute_task(request: TaskExecutionRequest) -> TaskExecutionResponse:
                 f"{request.expected_output_label} != {capability.output_label}"
             ),
         )
-
-    return TaskExecutionResponse(
+    prompt = get_prompt_or_raise(request.task_id)
+    request_id = f"air_{uuid4().hex}"
+    result = _build_stub_result(request=request, capability=capability)
+    response = TaskExecutionResponse(
         status=TaskExecutionStatus.COMPLETED,
         task_id=capability.task_id,
         category=capability.category,
         output_label=capability.output_label,
-        result=_build_stub_result(request=request, capability=capability),
+        result=result,
         audit=TaskAuditMetadata(
-            request_id=f"air_{uuid4().hex}",
+            request_id=request_id,
             task_id=capability.task_id,
             output_label=capability.output_label,
-            prompt_version=PROMPT_VERSION,
+            prompt_version=prompt.prompt_version,
             provider_mode=settings.provider_mode,
             generated_at=datetime.now(UTC).isoformat(),
             stubbed=True,
         ),
     )
+    get_audit_store().save(
+        AuditRecordResponse(
+            request_id=response.audit.request_id,
+            task_id=response.task_id,
+            caller_app=request.caller.caller_app,
+            correlation_id=request.caller.correlation_id,
+            prompt_version=response.audit.prompt_version,
+            provider_mode=response.audit.provider_mode,
+            generated_at=response.audit.generated_at,
+            stubbed=response.audit.stubbed,
+            context_summary=request.context.summary,
+            context_keys=sorted(request.context.payload.keys()),
+            source_refs=request.context.source_refs,
+            result_preview=response.result.message,
+            structured_output=response.result.structured_output,
+        )
+    )
+    return response
 
 
 def _build_stub_result(

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -52,4 +52,43 @@ def test_task_execute_contract() -> None:
     assert body["task_id"] == "explain.v1"
     assert body["status"] == "COMPLETED"
     assert body["audit"]["stubbed"] is True
+    assert body["audit"]["prompt_version"] == "foundation.explain.v1"
     assert body["result"]["structured_output"]["caller_app"] == "lotus-manage"
+
+
+def test_prompt_registry_routes() -> None:
+    client = TestClient(app)
+
+    list_response = client.get("/platform/prompts")
+    assert list_response.status_code == 200
+    assert any(prompt["task_id"] == "explain.v1" for prompt in list_response.json())
+
+    detail_response = client.get("/platform/prompts/explain.v1")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["prompt_version"] == "foundation.explain.v1"
+
+
+def test_audit_record_route_returns_saved_execution() -> None:
+    client = TestClient(app)
+    execute_response = client.post(
+        "/ai/tasks/execute",
+        json={
+            "task_id": "summarize.v1",
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": "lotus-advise",
+                "correlation_id": "corr-789",
+            },
+            "context": {
+                "summary": "Summarize proposal workflow",
+                "payload": {"status": "PENDING_REVIEW", "approvals": 1},
+                "source_refs": ["lotus-advise:proposal:prop_001"],
+            },
+        },
+    )
+    request_id = execute_response.json()["audit"]["request_id"]
+
+    audit_response = client.get(f"/ai/audit/{request_id}")
+    assert audit_response.status_code == 200
+    assert audit_response.json()["caller_app"] == "lotus-advise"
+    assert audit_response.json()["prompt_version"] == "foundation.summarize.v1"

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -25,3 +25,31 @@ def test_platform_capabilities_contract() -> None:
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
     assert any(task["task_id"] == "explain.v1" for task in body["tasks"])
+
+
+def test_task_execute_contract() -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/ai/tasks/execute",
+        json={
+            "task_id": "explain.v1",
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": "lotus-manage",
+                "correlation_id": "corr-456",
+            },
+            "context": {
+                "summary": "Explain rebalance outcome",
+                "payload": {"status": "BLOCKED", "violations": 2},
+                "source_refs": ["lotus-manage:run:reb_002"],
+            },
+            "expected_output_label": "EXPLANATION_ONLY",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["task_id"] == "explain.v1"
+    assert body["status"] == "COMPLETED"
+    assert body["audit"]["stubbed"] is True
+    assert body["result"]["structured_output"]["caller_app"] == "lotus-manage"

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -14,3 +14,14 @@ def test_correlation_header_propagation() -> None:
     response = client.get("/health", headers={"X-Correlation-Id": "corr-123"})
     assert response.status_code == 200
     assert response.headers["X-Correlation-Id"] == "corr-123"
+
+
+def test_platform_capabilities_contract() -> None:
+    client = TestClient(app)
+    response = client.get("/platform/capabilities")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["service"] == "lotus-ai"
+    assert body["phase"] == "foundation"
+    assert any(task["task_id"] == "explain.v1" for task in body["tasks"])

--- a/tests/unit/test_audit_store.py
+++ b/tests/unit/test_audit_store.py
@@ -1,0 +1,26 @@
+from app.contracts.audit import AuditRecordResponse
+from app.services.audit_store import InMemoryAuditStore
+
+
+def test_in_memory_audit_store_save_and_get() -> None:
+    store = InMemoryAuditStore()
+    record = AuditRecordResponse(
+        request_id="air_test",
+        task_id="explain.v1",
+        caller_app="lotus-manage",
+        correlation_id="corr-123",
+        prompt_version="foundation.explain.v1",
+        provider_mode="disabled",
+        generated_at="2026-03-22T00:00:00Z",
+        stubbed=True,
+        context_summary="Explain rebalance outcome",
+        context_keys=["status"],
+        source_refs=["lotus-manage:run:reb_1"],
+        result_preview="Stub execution completed.",
+        structured_output={"phase": "foundation"},
+    )
+
+    store.save(record)
+
+    assert store.get("air_test") == record
+    assert store.get("air_missing") is None

--- a/tests/unit/test_capability_catalog.py
+++ b/tests/unit/test_capability_catalog.py
@@ -1,0 +1,28 @@
+from app.contracts.tasks import OutputLabel, TaskCategory
+from app.services.capability_catalog import build_capability_catalog
+
+
+def test_build_capability_catalog_returns_expected_phase_and_tasks() -> None:
+    catalog = build_capability_catalog()
+
+    assert catalog.service == "lotus-ai"
+    assert catalog.phase == "foundation"
+    assert len(catalog.tasks) == 7
+    assert catalog.tasks[0].task_id == "explain.v1"
+    assert catalog.tasks[0].category == TaskCategory.EXPLAIN
+    assert catalog.tasks[0].output_label == OutputLabel.EXPLANATION_ONLY
+
+
+def test_retrieval_tasks_start_disabled_in_foundation_phase() -> None:
+    catalog = build_capability_catalog()
+
+    retrieval_tasks = {
+        task.task_id: task.enabled
+        for task in catalog.tasks
+        if task.category in {TaskCategory.KNOWLEDGE_SEARCH, TaskCategory.KNOWLEDGE_ANSWER}
+    }
+
+    assert retrieval_tasks == {
+        "knowledge_search.v1": False,
+        "knowledge_answer.v1": False,
+    }

--- a/tests/unit/test_prompt_registry.py
+++ b/tests/unit/test_prompt_registry.py
@@ -1,0 +1,27 @@
+from fastapi import HTTPException
+
+from app.services.prompt_registry import get_prompt_or_raise, list_registered_prompts
+
+
+def test_list_registered_prompts_contains_task_entries() -> None:
+    prompts = list_registered_prompts()
+
+    assert len(prompts) >= 7
+    assert any(prompt.task_id == "explain.v1" for prompt in prompts)
+
+
+def test_get_prompt_or_raise_returns_registered_prompt() -> None:
+    prompt = get_prompt_or_raise("explain.v1")
+
+    assert prompt.prompt_version == "foundation.explain.v1"
+    assert prompt.prompt_kind == "system"
+
+
+def test_get_prompt_or_raise_rejects_unknown_prompt() -> None:
+    try:
+        get_prompt_or_raise("missing.v1")
+    except HTTPException as exc:
+        assert exc.status_code == 404
+        assert "No registered prompt definition" in str(exc.detail)
+    else:
+        raise AssertionError("Expected HTTPException for unknown prompt")

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -1,5 +1,16 @@
-from app.main import SERVICE_NAME
+from fastapi.testclient import TestClient
+
+from app.main import SERVICE_NAME, app
 
 
 def test_service_name_is_lotus_prefixed() -> None:
     assert SERVICE_NAME.startswith("lotus-")
+
+
+def test_root_contract_includes_delivery_phase() -> None:
+    client = TestClient(app)
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json()["phase"] == "foundation"

--- a/tests/unit/test_task_executor.py
+++ b/tests/unit/test_task_executor.py
@@ -36,6 +36,7 @@ def test_execute_task_returns_stubbed_completed_response() -> None:
     assert response.result.structured_output["phase"] == "foundation"
     assert response.result.structured_output["context_keys"] == ["rule_count", "status"]
     assert response.audit.stubbed is True
+    assert response.audit.prompt_version == "foundation.explain.v1"
 
 
 def test_execute_task_rejects_unknown_task() -> None:

--- a/tests/unit/test_task_executor.py
+++ b/tests/unit/test_task_executor.py
@@ -1,0 +1,58 @@
+from fastapi import HTTPException
+
+from app.contracts.tasks import (
+    CallerMetadata,
+    OutputLabel,
+    TaskContextEnvelope,
+    TaskExecutionRequest,
+    TaskInputMode,
+)
+from app.services.task_executor import execute_task
+
+
+def _request(
+    task_id: str, expected_output_label: OutputLabel | None = None
+) -> TaskExecutionRequest:
+    return TaskExecutionRequest(
+        task_id=task_id,
+        input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+        caller=CallerMetadata(caller_app="lotus-manage", correlation_id="corr-123"),
+        context=TaskContextEnvelope(
+            summary="Explain rebalance outcome",
+            payload={"status": "BLOCKED", "rule_count": 3},
+            source_refs=["lotus-manage:run:reb_001"],
+        ),
+        expected_output_label=expected_output_label,
+    )
+
+
+def test_execute_task_returns_stubbed_completed_response() -> None:
+    response = execute_task(
+        _request("explain.v1", expected_output_label=OutputLabel.EXPLANATION_ONLY)
+    )
+
+    assert response.status == "COMPLETED"
+    assert response.task_id == "explain.v1"
+    assert response.result.structured_output["phase"] == "foundation"
+    assert response.result.structured_output["context_keys"] == ["rule_count", "status"]
+    assert response.audit.stubbed is True
+
+
+def test_execute_task_rejects_unknown_task() -> None:
+    try:
+        execute_task(_request("unknown.v1"))
+    except HTTPException as exc:
+        assert exc.status_code == 404
+        assert "Unknown lotus-ai task_id" in str(exc.detail)
+    else:
+        raise AssertionError("Expected HTTPException for unknown task")
+
+
+def test_execute_task_rejects_output_label_mismatch() -> None:
+    try:
+        execute_task(_request("explain.v1", expected_output_label=OutputLabel.DRAFT))
+    except HTTPException as exc:
+        assert exc.status_code == 409
+        assert "Expected output label does not match task configuration" in str(exc.detail)
+    else:
+        raise AssertionError("Expected HTTPException for output label mismatch")


### PR DESCRIPTION
## Summary
- establish the initial lotus-ai architecture pack and phased roadmap
- document integration, evaluation, and security/governance guidance
- add foundation-phase capability contracts and a capability catalog endpoint
- extend tests to cover the new discovery surface

## Validation
- python -m ruff check .
- python -m ruff format --check .
- python -m pytest tests/unit tests/integration tests/e2e -q