### PR TITLE
docs: add RFC for controlled live provider backbone

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,5 +1,6 @@
 # RFC Index
 
-- `RFC-0001-shared-ai-platform-service.md`
-- `RFC-0002-real-retrieval-backbone.md`
+- `RFC-0001-shared-ai-platform-service.md` - Proposed
+- `RFC-0002-real-retrieval-backbone.md` - Implemented
+- `RFC-0003-controlled-live-provider-backbone.md` - Proposed
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,6 +1,6 @@
 # RFC Index
 
-- `RFC-0001-shared-ai-platform-service.md` - Proposed
+- `RFC-0001-shared-ai-platform-service.md` - Implemented
 - `RFC-0002-real-retrieval-backbone.md` - Implemented
 - `RFC-0003-controlled-live-provider-backbone.md` - Proposed
 

--- a/docs/rfcs/RFC-0001-shared-ai-platform-service.md
+++ b/docs/rfcs/RFC-0001-shared-ai-platform-service.md
@@ -1,7 +1,8 @@
 # RFC-0001: Shared AI Platform Service
 
-- Status: Proposed
+- Status: Implemented
 - Date: 2026-03-22
+- Implemented Date: 2026-03-22
 - Owners: lotus-ai
 
 ## Summary
@@ -9,6 +10,18 @@
 `lotus-ai` is the shared AI platform service for the Lotus ecosystem.
 
 It provides reusable AI infrastructure and governed task execution for the other Lotus applications while keeping business ownership in the domain services that already own portfolio state, analytics, reporting, and workflow logic.
+
+This RFC originally established the existence and responsibility boundary of `lotus-ai` itself. It is now implemented as the platform-foundation RFC for the service.
+
+## Original Intent
+
+The original intent of RFC-0001 was to define:
+
+1. that `lotus-ai` should exist as a separate Lotus service,
+2. what the service owns versus what domain apps still own,
+3. how Lotus apps should integrate with it,
+4. the initial capability areas and repository shape,
+5. the acceptance criteria for saying the shared platform service exists in a meaningful way.
 
 ## Responsibilities
 
@@ -65,8 +78,109 @@ Initial module layout:
 7. `routers`
 8. `contracts`
 
-## Acceptance Criteria
+## What Was Implemented Under RFC-0001
 
-1. The service is scaffolded as a standard Lotus backend repo.
-2. The repo clearly documents what it does and does not own.
-3. The platform can depend on `lotus-ai` for shared AI infrastructure without moving domain logic into it.
+RFC-0001 is now considered implemented because the repo no longer contains only a concept or scaffold. It contains a real shared platform foundation with the core boundaries, contracts, governance surfaces, and bounded execution paths that make `lotus-ai` a usable Lotus platform service.
+
+Implemented foundation scope includes:
+
+1. standard Lotus backend service structure, startup/readiness controls, and platform metadata endpoints,
+2. contract-first API design across tasks, prompts, providers, retrieval, safety, evaluation, async runtime, audit, and platform runtime status,
+3. a real task execution pipeline with explicit validation, prompt selection, safety resolution, provider routing, evidence assembly, and audit persistence,
+4. prompt registry, prompt runtime selection, and prompt governance/readiness surfaces,
+5. provider gateway, provider policy, and provider governance/readiness surfaces,
+6. safety policy, safety runtime visibility, and persisted safety posture in task audit records,
+7. audit persistence, audit lookup, and bounded audit catalog inspection,
+8. retrieval source/document/chunk metadata, retrieval governance, catalog-only retrieval execution, and retrieval-backed task flows,
+9. evaluation fixture inventory, run artifacts, validation gates, and evaluation runtime visibility,
+10. async runtime contracts, seeded job registry, submission envelope, and governance/readiness surfaces,
+11. platform-wide runtime status aggregation that exposes the posture of the major governed seams in one operator entry point,
+12. strong local/CI validation gates across formatting, typing, OpenAPI quality, manifest validation, migrations, tests, and coverage.
+
+## Requirement Traceability
+
+| Original requirement | Implemented reality | Evidence |
+| --- | --- | --- |
+| Separate shared AI service exists | `lotus-ai` is a standalone FastAPI backend with its own contracts, routers, startup policy, and metadata surfaces | [main.py](C:/Users/Sandeep/projects/lotus-ai/src/app/main.py#L1), [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1) |
+| Clear ownership boundary versus domain apps | Service docs and contracts consistently position `lotus-ai` as assistive/governed infrastructure rather than business truth | [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1), [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md#L1) |
+| Contract-first architecture | API and internal boundaries are modeled explicitly through `contracts`, routers, and service-layer orchestration | [contracts](C:/Users/Sandeep/projects/lotus-ai/src/app/contracts), [routers](C:/Users/Sandeep/projects/lotus-ai/src/app/routers), [services](C:/Users/Sandeep/projects/lotus-ai/src/app/services) |
+| Shared provider layer | Provider gateway, policy, governance, and runtime posture exist even while live execution remains disabled | [provider_gateway.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/provider_gateway.py#L1), [providers.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/providers.py#L1) |
+| Shared prompt layer | Prompt registry, runtime selection, and governance/readiness surfaces exist | [prompts.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/prompts.py#L1), [prompt_runtime.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/prompt_runtime.py#L1) |
+| Shared retrieval layer | Retrieval metadata, governance, execution, and retrieval-backed task behavior exist in bounded form | [retrieval.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/retrieval.py#L1), [retrieval_service.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/retrieval_service.py#L1), [task_execution_contract.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/task-execution-contract.md#L1) |
+| Shared safety layer | Safety posture is modeled explicitly and reflected in runtime and audit behavior | [safety.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/safety.py#L1), [task_execution_mapping.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/task_execution_mapping.py#L1) |
+| Shared audit and telemetry posture | Audit persistence and bounded audit inspection are implemented | [audit.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/audit.py#L1), [sqlalchemy_audit_repository.py](C:/Users/Sandeep/projects/lotus-ai/src/app/repositories/sqlalchemy_audit_repository.py#L1) |
+| Shared evaluation harnesses | Eval catalog, eval runtime, run artifacts, validation gates, and fixture manifest are implemented | [evals.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/evals.py#L1), [fixture-manifest.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixture-manifest.json#L1), [run-artifacts.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/run-artifacts.json#L1) |
+| Shared async platform posture | Async contracts, job artifacts, submission path, and governance/readiness surfaces are implemented | [async_runtime.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/async_runtime.py#L1), [job-artifacts.json](C:/Users/Sandeep/projects/lotus-ai/docs/async/job-artifacts.json#L1) |
+| Reusable AI task APIs | Bounded task APIs exist with real execution pipeline and dedicated inspection surfaces | [tasks.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/tasks.py#L1), [task_runtime.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/task_runtime.py#L1) |
+
+## Current Reality
+
+`lotus-ai` is now a real shared platform service with:
+
+1. reusable governed task APIs,
+2. prompt, provider, retrieval, safety, evaluation, async, and audit seams,
+3. operator-facing runtime and governance visibility,
+4. migration-managed persistence,
+5. a bounded but real execution path for key task categories.
+
+What it is not yet:
+
+1. a broadly activated live-provider platform,
+2. an unconstrained agent runtime,
+3. the owner of domain business truth,
+4. a replacement for deterministic Lotus domain services.
+
+## Design Evolution Since The Original RFC
+
+RFC-0001 started as a high-level platform-establishment RFC. In implementation, that foundation grew into a substantial amount of concrete platform work before later major phases were split into their own RFCs.
+
+The main evolution was:
+
+1. RFC-0001 absorbed the foundation platform build-out: contracts, governance, bounded execution, audit, evaluation, and async posture,
+2. deeper real retrieval work was then split into RFC-0002 because it became a major phase in its own right,
+3. live provider activation is now being proposed separately in RFC-0003 because it is also a major phase with its own rollout risks.
+
+That split is the right architecture/documentation outcome. RFC-0001 remains the platform-foundation RFC, while later RFCs describe major capability deepening on top of that foundation.
+
+## Acceptance Criteria Status
+
+### 1. The service is scaffolded as a standard Lotus backend repo.
+
+Implemented.
+
+Evidence:
+
+1. [main.py](C:/Users/Sandeep/projects/lotus-ai/src/app/main.py#L1)
+2. [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1)
+3. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md#L1)
+
+### 2. The repo clearly documents what it does and does not own.
+
+Implemented.
+
+Evidence:
+
+1. [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1)
+2. [RFC-0001-shared-ai-platform-service.md](C:/Users/Sandeep/projects/lotus-ai/docs/rfcs/RFC-0001-shared-ai-platform-service.md#L1)
+3. [decision-log.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/decision-log.md#L1)
+
+### 3. The platform can depend on `lotus-ai` for shared AI infrastructure without moving domain logic into it.
+
+Implemented.
+
+Evidence:
+
+1. [tasks.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/tasks.py#L1)
+2. [task_execution_pipeline.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/task_execution_pipeline.py#L1)
+3. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md#L1)
+
+## Close-Out Notes
+
+RFC-0001 is closed as implemented in the sense intended for a platform-foundation RFC:
+
+1. the shared service exists,
+2. the ownership boundary is explicit,
+3. the core platform seams are present,
+4. downstream Lotus apps have a governed integration surface to depend on.
+
+Follow-on work should not reopen RFC-0001. Major capability deepening should continue through focused follow-on RFCs such as retrieval and live provider activation.

--- a/docs/rfcs/RFC-0003-controlled-live-provider-backbone.md
+++ b/docs/rfcs/RFC-0003-controlled-live-provider-backbone.md
@@ -83,6 +83,13 @@ The first live provider rollout should:
 3. be enabled only through explicit reviewed configuration and governance evidence,
 4. preserve the current stub path as the fallback and safe default.
 
+The first live provider rollout should also be intentionally narrow:
+
+1. one provider integration,
+2. one allowlisted model family at first,
+3. task-level allowlisting rather than blanket service-wide enablement,
+4. no silent drift from stubbed execution to live execution.
+
 ## Architecture Direction
 
 ### Provider Adapter Layer
@@ -104,6 +111,12 @@ Live provider execution must include:
 4. rate-limit and quota controls,
 5. fallback behavior when the live path is unavailable or blocked.
 
+Fallback must remain explicit:
+
+1. approved tasks may use an explicit reviewed fallback path,
+2. blocked live rollout must not silently masquerade as successful live execution,
+3. operator-facing surfaces must make stubbed, blocked, and live execution distinguishable.
+
 ### Audit and Evidence
 
 The live path must preserve:
@@ -114,6 +127,12 @@ The live path must preserve:
 4. token and cost accounting where available,
 5. enough structured evidence for support review and rollout governance.
 
+Audit behavior must also remain bank-grade:
+
+1. credentials and provider secrets must never be persisted,
+2. prompt/system content must remain governed by existing prompt and audit posture rather than raw provider SDK logging,
+3. provider response evidence must be structured enough for incident review without requiring replay against the live provider.
+
 ### Safety and Grounding
 
 The provider backbone must not weaken existing controls:
@@ -123,6 +142,27 @@ The provider backbone must not weaken existing controls:
 3. safety posture remains explicit and inspectable,
 4. live generation must not bypass task-level output contracts.
 
+### Configuration and Secret Handling
+
+Live provider activation must also define:
+
+1. credential source-of-truth and environment handling,
+2. explicit startup/readiness behavior when credentials are missing or malformed,
+3. redaction rules for provider-related operational telemetry,
+4. configuration surfaces that separate supported provider modes from enabled rollout state.
+
+### Rollout States
+
+Provider rollout should be treated as an explicit progression:
+
+1. `DOCUMENTED_ONLY`
+2. `STUB_DEFAULT`
+3. `ALLOWLISTED_DISABLED`
+4. `CANARY_ENABLED`
+5. `ROLLED_OUT`
+
+The implementation does not need to expose those exact labels immediately, but the rollout model should remain this explicit in behavior and governance.
+
 ## Data and Operational Requirements
 
 1. Live provider activation remains disabled by default until governance gates are satisfied.
@@ -131,6 +171,8 @@ The provider backbone must not weaken existing controls:
 4. Operational runbooks must exist for rate limits, outages, degraded fallback, and cost anomalies.
 5. Provider execution telemetry must be inspectable without reading raw SDK logs.
 6. CI and evaluation assets must cover provider failure and fallback behavior, not only happy-path execution.
+7. Task-level routing into live provider execution must be reviewable and bounded.
+8. Activation must preserve a deterministic fallback or refusal posture for blocked-live cases.
 
 ## Delivery Slices
 
@@ -148,7 +190,21 @@ Acceptance gate:
 2. contracts are stable and tested,
 3. the gateway is cleaner and more modular than the current stub-only branch.
 
-### Slice 2: Controlled Live Text Generation Path
+### Slice 2: Credential, Configuration, and Rollout-State Contracts
+
+Outcome:
+
+1. live-provider credentials and configuration posture are modeled explicitly,
+2. rollout state is separated from supported provider mode,
+3. startup/readiness behavior for malformed or missing provider configuration is defined.
+
+Acceptance gate:
+
+1. missing or invalid credentials fail clearly,
+2. no secret material appears in logs, runtime status, or audit records,
+3. rollout state remains inspectable before any live task execution is possible.
+
+### Slice 3: Controlled Live Text Generation Path
 
 Outcome:
 
@@ -162,7 +218,7 @@ Acceptance gate:
 2. stub fallback remains intact,
 3. no hidden runtime enablement exists.
 
-### Slice 3: Execution Hardening
+### Slice 4: Execution Hardening
 
 Outcome:
 
@@ -176,7 +232,7 @@ Acceptance gate:
 2. audit evidence preserves execution posture,
 3. operator-facing runtime surfaces reflect the live path honestly.
 
-### Slice 4: Task Runtime Integration
+### Slice 5: Task Runtime Integration
 
 Outcome:
 
@@ -190,7 +246,7 @@ Acceptance gate:
 2. non-retrieval tasks remain contract-bound,
 3. task audit and evidence surfaces remain clear.
 
-### Slice 5: Evaluation and Failure-Mode Evidence
+### Slice 6: Evaluation and Failure-Mode Evidence
 
 Outcome:
 
@@ -204,7 +260,7 @@ Acceptance gate:
 2. failure-mode evidence is visible in provider governance posture,
 3. CI gates protect core provider contracts.
 
-### Slice 6: Operational Activation Readiness
+### Slice 7: Operational Activation Readiness
 
 Outcome:
 
@@ -224,6 +280,7 @@ Acceptance gate:
 2. cost visibility can lag actual usage if token accounting is treated as optional,
 3. weak fallback behavior can make the platform harder to debug than the current stub path,
 4. live generation can weaken enterprise trust if it is activated before retrieval grounding and safety controls remain clearly enforced.
+5. provider credential handling can create avoidable risk if secret-management and audit-redaction rules are not explicit from the first slice.
 
 ## Alternatives Considered
 
@@ -255,6 +312,15 @@ Reason:
 2. text-generation rollout is the higher-value and higher-risk next phase,
 3. embedding-provider activation can be handled as a follow-on slice if still needed.
 
+### Alternative 4: Service-Wide Live Provider Enablement
+
+Rejected.
+
+Reason:
+
+1. bank-grade rollout should be task-bounded and reviewable,
+2. service-wide enablement would make fallback, evaluation, and support posture too coarse.
+
 ## Acceptance Criteria
 
 This RFC is complete when:
@@ -264,8 +330,9 @@ This RFC is complete when:
 3. task execution can use the live provider path only when rollout posture permits it,
 4. provider audit and evidence surfaces preserve meaningful execution detail,
 5. provider failure, timeout, and fallback behavior are evaluated and governed,
-6. provider operations and rollout readiness are documented and reviewable,
-7. the platform remains retrieval-grounded and citation-first where applicable.
+6. credentials, rollout state, and startup/readiness behavior are explicit and inspectable,
+7. provider operations and rollout readiness are documented and reviewable,
+8. the platform remains retrieval-grounded and citation-first where applicable.
 
 ## Approval Requested
 

--- a/docs/rfcs/RFC-0003-controlled-live-provider-backbone.md
+++ b/docs/rfcs/RFC-0003-controlled-live-provider-backbone.md
@@ -1,0 +1,277 @@
+# RFC-0003: Controlled Live Provider Backbone
+
+- Status: Proposed
+- Date: 2026-03-22
+- Owners: lotus-ai
+- Requires Approval From: lotus-ai maintainers
+
+## Summary
+
+`lotus-ai` should implement a controlled live provider backbone as the next major platform phase.
+
+This RFC moves provider execution from deterministic stub-only behavior to a governed live provider path for text generation, while keeping activation disabled by default until technical, operational, and evidence gates are satisfied.
+
+The goal is to make `knowledge_answer.v1` and the broader task runtime capable of enterprise-grade live generation without weakening retrieval grounding, auditability, safety posture, or operational control.
+
+## Why This Is Next
+
+The platform now has the right foundation for this phase:
+
+1. retrieval has a real governed backbone,
+2. prompt, provider, retrieval, async, and evaluation governance surfaces already exist,
+3. task execution is modular and auditable,
+4. audit and evidence surfaces are materially useful,
+5. the remaining major platform gap is real provider execution.
+
+Retrieval came first because grounded enterprise behavior matters more than generation breadth. That ordering is now complete enough that the next highest-value move is controlled live provider activation.
+
+## Problem Statement
+
+Current provider behavior is still intentionally conservative:
+
+1. supported provider modes are validated,
+2. execution always routes through the deterministic stub provider,
+3. provider governance surfaces describe activation, runbook, and evidence posture,
+4. no real provider SDK path exists yet,
+5. no live cost, timeout, retry, quota, or failover behavior exists yet.
+
+This keeps the platform safe, but it also means `lotus-ai` is still not exercising the core live model-execution path that a shared AI platform ultimately needs.
+
+## Goals
+
+1. Introduce one governed live text-generation provider path.
+2. Keep activation disabled by default until rollout criteria are met.
+3. Preserve retrieval-first grounding and citation-first answer behavior.
+4. Make provider execution bounded, observable, auditable, and testable.
+5. Add explicit failure taxonomy, timeouts, retries, and operator-facing evidence.
+6. Keep the provider layer modular enough to support future providers without premature abstraction.
+
+## Non-Goals
+
+1. Multi-provider rollout in the first implementation slice.
+2. Broad provider marketplace abstraction before one real provider is proven.
+3. Agentic/autonomous business actions.
+4. Unbounded prompt experimentation without rollout controls.
+5. Enabling embedding-provider activation in the same phase unless explicitly approved later.
+
+## Current State
+
+Today `lotus-ai` already has:
+
+1. an explicit provider gateway,
+2. deterministic stub-provider execution,
+3. provider activation, runbook, evidence, and governance surfaces,
+4. task execution evidence and audit persistence,
+5. retrieval-backed answer support and refusal behavior,
+6. evaluation fixtures for provider-policy posture,
+7. platform runtime surfaces that already embed provider governance posture.
+
+Those pieces should be retained and extended, not replaced.
+
+## Decision
+
+`lotus-ai` will implement live provider execution in controlled layers:
+
+1. a provider adapter and policy layer,
+2. a bounded live execution path for one allowlisted text-generation provider,
+3. a rollout and operations layer that controls when the live path can be used.
+
+The first live provider rollout should:
+
+1. support text generation only,
+2. remain disabled by default,
+3. be enabled only through explicit reviewed configuration and governance evidence,
+4. preserve the current stub path as the fallback and safe default.
+
+## Architecture Direction
+
+### Provider Adapter Layer
+
+Add or extend:
+
+1. a live provider adapter interface beside the stub provider,
+2. explicit provider capability metadata,
+3. request/response normalization for provider-specific payloads,
+4. a provider failure taxonomy that preserves root-cause clarity.
+
+### Execution Controls
+
+Live provider execution must include:
+
+1. bounded request timeouts,
+2. retry rules with explicit safe-retry boundaries,
+3. request-size and token budgeting,
+4. rate-limit and quota controls,
+5. fallback behavior when the live path is unavailable or blocked.
+
+### Audit and Evidence
+
+The live path must preserve:
+
+1. provider execution mode,
+2. provider identifier and model identifier,
+3. timeout/retry/failure posture,
+4. token and cost accounting where available,
+5. enough structured evidence for support review and rollout governance.
+
+### Safety and Grounding
+
+The provider backbone must not weaken existing controls:
+
+1. retrieval-backed answers remain citation-first,
+2. unsupported retrieval answers still refuse conservatively,
+3. safety posture remains explicit and inspectable,
+4. live generation must not bypass task-level output contracts.
+
+## Data and Operational Requirements
+
+1. Live provider activation remains disabled by default until governance gates are satisfied.
+2. The configured live provider must be allowlisted explicitly.
+3. Missing credentials or blocked rollout state must fail clearly.
+4. Operational runbooks must exist for rate limits, outages, degraded fallback, and cost anomalies.
+5. Provider execution telemetry must be inspectable without reading raw SDK logs.
+6. CI and evaluation assets must cover provider failure and fallback behavior, not only happy-path execution.
+
+## Delivery Slices
+
+### Slice 1: Provider Adapter and Mode Contracts
+
+Outcome:
+
+1. a real live-provider adapter seam exists beside the stub path,
+2. provider mode and provider identifier semantics are explicit,
+3. provider failure taxonomy is introduced.
+
+Acceptance gate:
+
+1. no live provider is enabled yet,
+2. contracts are stable and tested,
+3. the gateway is cleaner and more modular than the current stub-only branch.
+
+### Slice 2: Controlled Live Text Generation Path
+
+Outcome:
+
+1. one allowlisted live provider is integrated for text generation,
+2. the path remains disabled by default,
+3. configuration explicitly distinguishes stub, blocked-live, and enabled-live execution.
+
+Acceptance gate:
+
+1. unsupported or unapproved modes fail clearly,
+2. stub fallback remains intact,
+3. no hidden runtime enablement exists.
+
+### Slice 3: Execution Hardening
+
+Outcome:
+
+1. provider timeouts, retries, and request bounds are enforced,
+2. token and cost metadata are captured where available,
+3. failure classification is explicit and auditable.
+
+Acceptance gate:
+
+1. timeout and failure paths are directly tested,
+2. audit evidence preserves execution posture,
+3. operator-facing runtime surfaces reflect the live path honestly.
+
+### Slice 4: Task Runtime Integration
+
+Outcome:
+
+1. approved tasks can route through the live provider path when rollout allows it,
+2. retrieval-backed tasks still preserve citation-first behavior,
+3. provider execution is reflected in task runtime and evidence summaries.
+
+Acceptance gate:
+
+1. retrieval-backed answers do not regress in support/refusal posture,
+2. non-retrieval tasks remain contract-bound,
+3. task audit and evidence surfaces remain clear.
+
+### Slice 5: Evaluation and Failure-Mode Evidence
+
+Outcome:
+
+1. provider eval fixtures cover success, timeout, rejection, and fallback behavior,
+2. evidence readiness reflects real live-provider risks rather than only policy posture,
+3. provider activation is blocked until meaningful evidence exists.
+
+Acceptance gate:
+
+1. provider evaluation assets are file-backed and governed,
+2. failure-mode evidence is visible in provider governance posture,
+3. CI gates protect core provider contracts.
+
+### Slice 6: Operational Activation Readiness
+
+Outcome:
+
+1. runbooks and rollout posture reflect the real live provider path,
+2. observability, quota handling, and incident response expectations are explicit,
+3. the platform can eventually move from disabled-by-default to governed activation.
+
+Acceptance gate:
+
+1. provider governance remains blocked until the required runbook items are complete,
+2. runtime status exposes live-provider posture honestly,
+3. the activation path is reviewable end to end.
+
+## Risks
+
+1. live provider execution can create operational volatility through latency, outages, and rate limits,
+2. cost visibility can lag actual usage if token accounting is treated as optional,
+3. weak fallback behavior can make the platform harder to debug than the current stub path,
+4. live generation can weaken enterprise trust if it is activated before retrieval grounding and safety controls remain clearly enforced.
+
+## Alternatives Considered
+
+### Alternative 1: Continue Stub-Only Execution Longer
+
+Rejected as the next major phase.
+
+Reason:
+
+1. the platform would remain structurally strong but functionally incomplete,
+2. downstream Lotus apps need a real provider path to validate shared AI value.
+
+### Alternative 2: Enable Multiple Providers Immediately
+
+Rejected for now.
+
+Reason:
+
+1. multi-provider breadth adds complexity before one provider path is proven,
+2. one high-quality governed provider path is the right first enterprise move.
+
+### Alternative 3: Activate Embedding Providers in the Same RFC
+
+Deferred.
+
+Reason:
+
+1. retrieval already has a functional deterministic preview-vector path,
+2. text-generation rollout is the higher-value and higher-risk next phase,
+3. embedding-provider activation can be handled as a follow-on slice if still needed.
+
+## Acceptance Criteria
+
+This RFC is complete when:
+
+1. one live text-generation provider path exists behind the provider gateway,
+2. that path is disabled by default and allowlisted explicitly,
+3. task execution can use the live provider path only when rollout posture permits it,
+4. provider audit and evidence surfaces preserve meaningful execution detail,
+5. provider failure, timeout, and fallback behavior are evaluated and governed,
+6. provider operations and rollout readiness are documented and reviewable,
+7. the platform remains retrieval-grounded and citation-first where applicable.
+
+## Approval Requested
+
+Approve this RFC if the team agrees that:
+
+1. controlled live provider execution is the next major platform phase,
+2. rollout should begin with one governed text-generation provider only,
+3. activation must remain disabled by default until technical, evidence, and runbook gates are satisfied,
+4. retrieval grounding and citation-first behavior must remain stronger priorities than generative breadth.


### PR DESCRIPTION
## Summary
- add RFC-0003 for the next major lotus-ai phase: a controlled live provider backbone
- define the provider rollout shape as one allowlisted live text-generation provider, disabled by default, with retrieval grounding and citation-first behavior preserved
- break delivery into explicit slices for adapter contracts, controlled live execution, execution hardening, task integration, evaluation evidence, and operational activation readiness

## Included docs
- docs/rfcs/RFC-0003-controlled-live-provider-backbone.md
- docs/rfcs/README.md

## Notes
- docs-only PR for approval
- no code changes or tests required for this slice