### PR TITLE
feat: complete RFC-0007 evaluation execution gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The current execution posture is:
 - platform runtime status now summarizes evaluation runtime posture too,
 - evaluation fixture inventory is now backed by a versioned in-repo manifest,
 - allowlisted evaluation fixture families can now be submitted into durable runtime-backed run state, while historical file-backed run artifacts remain visible only as labeled baseline records,
+- allowlisted evaluation fixture families can now also execute through the durable async worker path, with persisted run attempts, per-case outcomes, and derived pass/fail verdicts recorded in the evaluation runtime store,
 - evaluation inventory now also includes an explicit async-runtime seam, so durable submission, lease recovery, and retrieval-indexing linkage are represented in the staged eval baseline instead of only in runtime tests,
 - the first real file-backed fixture family now exists for `explain.v1`,
 - a second file-backed fixture family now exists for `summarize.v1`,
@@ -145,6 +146,7 @@ The current persistence posture is:
 - explicit provider-operations repository seams and migration-managed SQL tables now back durable quota, budget, and degradation state when the SQL-backed provider-operations path is enabled,
 - explicit async-runtime repository seams and migration-managed SQL tables now exist for jobs, attempts, and worker leases when the SQL-backed async-runtime path is enabled in later rollout slices,
 - explicit evaluation-runtime repository seams and migration-managed SQL tables now exist for runs, attempts, and per-case outcomes when the SQL-backed evaluation-runtime path is enabled in later rollout slices, while public evaluation APIs remain artifact-backed until runtime execution cutover happens,
+- evaluation runtime-backed run detail now exposes persisted attempts and case-level outcomes directly, while historical file-backed baseline runs remain clearly labeled as non-runtime records,
 - Alembic-managed schema migrations for relational persistence; repository adapters do not create tables at runtime.
 - prompt promotion remains read-only at runtime and is governed through reviewed repository changes plus Alembic-managed persistence updates.
 - startup readiness policy defaults to `warn` and can be raised to `enforce` for SQL-backed enterprise environments.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The current execution posture is:
 - evaluation fixture family detail is now inspectable through a dedicated read-only endpoint,
 - platform runtime status now summarizes evaluation runtime posture too,
 - evaluation fixture inventory is now backed by a versioned in-repo manifest,
+- allowlisted evaluation fixture families can now be submitted into durable runtime-backed run state, while historical file-backed run artifacts remain visible only as labeled baseline records,
 - evaluation inventory now also includes an explicit async-runtime seam, so durable submission, lease recovery, and retrieval-indexing linkage are represented in the staged eval baseline instead of only in runtime tests,
 - the first real file-backed fixture family now exists for `explain.v1`,
 - a second file-backed fixture family now exists for `summarize.v1`,

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The current execution posture is:
 - async job artifacts can now reference related evaluation run artifacts for cross-seam traceability,
 - async runtime now also has an explicit repository and store seam plus migration-managed durable schema for jobs, attempts, and worker leases, even though public async execution behavior remains foundation-phase only for now,
 - the active async queue backend is now the service database for durable submission state, while worker execution is currently available only through a stubbed in-process posture rather than a dedicated worker fleet,
-- async runtime now also supports stubbed worker claim, heartbeat, completion, failure, and lease-expiry recovery semantics for a narrow allowlist of runtime-backed job types,
+- async runtime now also supports stubbed worker claim, heartbeat, completion, failure, and lease-expiry recovery semantics for a narrow allowlist of runtime-backed job types, with retrieval indexing and allowlisted evaluation execution both active on that in-process worker path,
 - retrieval indexing is now the first runtime-backed async consumer, with concrete retrieval index jobs submitted into the durable async runtime and reflected back into retrieval job catalog/detail state,
 - async evaluation assets and runbook guidance now explicitly cover runtime-backed submission, lease-expiry recovery, and retrieval-indexing linkage, so the async control plane is no longer described as documentation-only where runtime truth already exists,
 - retrieval execution posture now distinguishes runtime-backed indexing from still-disabled live search, so indexing rollout no longer depends on staged-only retrieval job artifacts,

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The current execution posture is:
 - allowlisted evaluation fixture families can now be submitted into durable runtime-backed run state, while historical file-backed run artifacts remain visible only as labeled baseline records,
 - allowlisted evaluation fixture families can now also execute through the durable async worker path, with persisted run attempts, per-case outcomes, and derived pass/fail verdicts recorded in the evaluation runtime store,
 - provider and retrieval evidence-readiness surfaces now expose explicit approval-gate summaries derived from runtime-backed evaluation runs, so staged baselines cannot silently satisfy current rollout posture,
+- runtime-backed evaluation replay and async lease-recovery paths now preserve explicit evaluation attempt history and replay-safe case-result records instead of overwriting prior evidence,
 - evaluation inventory now also includes an explicit async-runtime seam, so durable submission, lease recovery, and retrieval-indexing linkage are represented in the staged eval baseline instead of only in runtime tests,
 - the first real file-backed fixture family now exists for `explain.v1`,
 - a second file-backed fixture family now exists for `summarize.v1`,

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The current execution posture is:
 - evaluation fixture inventory is now backed by a versioned in-repo manifest,
 - allowlisted evaluation fixture families can now be submitted into durable runtime-backed run state, while historical file-backed run artifacts remain visible only as labeled baseline records,
 - allowlisted evaluation fixture families can now also execute through the durable async worker path, with persisted run attempts, per-case outcomes, and derived pass/fail verdicts recorded in the evaluation runtime store,
+- provider and retrieval evidence-readiness surfaces now expose explicit approval-gate summaries derived from runtime-backed evaluation runs, so staged baselines cannot silently satisfy current rollout posture,
 - evaluation inventory now also includes an explicit async-runtime seam, so durable submission, lease recovery, and retrieval-indexing linkage are represented in the staged eval baseline instead of only in runtime tests,
 - the first real file-backed fixture family now exists for `explain.v1`,
 - a second file-backed fixture family now exists for `summarize.v1`,

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The current persistence posture is:
 - explicit configuration to move between the two without changing API contracts,
 - explicit provider-operations repository seams and migration-managed SQL tables now back durable quota, budget, and degradation state when the SQL-backed provider-operations path is enabled,
 - explicit async-runtime repository seams and migration-managed SQL tables now exist for jobs, attempts, and worker leases when the SQL-backed async-runtime path is enabled in later rollout slices,
+- explicit evaluation-runtime repository seams and migration-managed SQL tables now exist for runs, attempts, and per-case outcomes when the SQL-backed evaluation-runtime path is enabled in later rollout slices, while public evaluation APIs remain artifact-backed until runtime execution cutover happens,
 - Alembic-managed schema migrations for relational persistence; repository adapters do not create tables at runtime.
 - prompt promotion remains read-only at runtime and is governed through reviewed repository changes plus Alembic-managed persistence updates.
 - startup readiness policy defaults to `warn` and can be raised to `enforce` for SQL-backed enterprise environments.

--- a/alembic/versions/0014_add_evaluation_runtime_state_tables.py
+++ b/alembic/versions/0014_add_evaluation_runtime_state_tables.py
@@ -1,0 +1,116 @@
+"""add evaluation runtime state tables
+
+Revision ID: 0014_add_evaluation_runtime_state_tables
+Revises: 0013_add_async_control_events
+Create Date: 2026-03-23
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0014_add_evaluation_runtime_state_tables"
+down_revision = "0013_add_async_control_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "evaluation_runs",
+        sa.Column("run_id", sa.String(length=128), primary_key=True, nullable=False),
+        sa.Column("fixture_id", sa.String(length=128), nullable=False),
+        sa.Column("manifest_version", sa.String(length=64), nullable=False),
+        sa.Column("lifecycle_status", sa.String(length=64), nullable=False),
+        sa.Column("triggered_by", sa.String(length=256), nullable=False),
+        sa.Column("submitted_at", sa.String(length=64), nullable=False),
+        sa.Column("async_job_id", sa.String(length=128), nullable=True),
+        sa.Column("latest_message", sa.Text(), nullable=False),
+        sa.Column("verdict", sa.String(length=64), nullable=True),
+        sa.Column("case_count", sa.Integer(), nullable=False),
+    )
+    op.create_index("ix_evaluation_runs_fixture_id", "evaluation_runs", ["fixture_id"])
+    op.create_index(
+        "ix_evaluation_runs_lifecycle_status",
+        "evaluation_runs",
+        ["lifecycle_status"],
+    )
+    op.create_index("ix_evaluation_runs_submitted_at", "evaluation_runs", ["submitted_at"])
+    op.create_index("ix_evaluation_runs_async_job_id", "evaluation_runs", ["async_job_id"])
+
+    op.create_table(
+        "evaluation_run_attempts",
+        sa.Column("attempt_id", sa.String(length=128), primary_key=True, nullable=False),
+        sa.Column("run_id", sa.String(length=128), nullable=False),
+        sa.Column("attempt_number", sa.Integer(), nullable=False),
+        sa.Column("lifecycle_status", sa.String(length=64), nullable=False),
+        sa.Column("started_at", sa.String(length=64), nullable=True),
+        sa.Column("completed_at", sa.String(length=64), nullable=True),
+        sa.Column("worker_id", sa.String(length=128), nullable=True),
+        sa.Column("latest_message", sa.Text(), nullable=False),
+        sa.Column("verdict", sa.String(length=64), nullable=True),
+        sa.Column("failure_reason", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["run_id"], ["evaluation_runs.run_id"]),
+    )
+    op.create_index("ix_evaluation_run_attempts_run_id", "evaluation_run_attempts", ["run_id"])
+    op.create_index(
+        "ix_evaluation_run_attempts_lifecycle_status",
+        "evaluation_run_attempts",
+        ["lifecycle_status"],
+    )
+
+    op.create_table(
+        "evaluation_case_results",
+        sa.Column("case_result_id", sa.String(length=128), primary_key=True, nullable=False),
+        sa.Column("run_id", sa.String(length=128), nullable=False),
+        sa.Column("attempt_id", sa.String(length=128), nullable=False),
+        sa.Column("case_id", sa.String(length=128), nullable=False),
+        sa.Column("fixture_id", sa.String(length=128), nullable=False),
+        sa.Column("outcome", sa.String(length=64), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("evidence_refs", sa.JSON(), nullable=False),
+        sa.Column("recorded_at", sa.String(length=64), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], ["evaluation_runs.run_id"]),
+    )
+    op.create_index("ix_evaluation_case_results_run_id", "evaluation_case_results", ["run_id"])
+    op.create_index(
+        "ix_evaluation_case_results_attempt_id",
+        "evaluation_case_results",
+        ["attempt_id"],
+    )
+    op.create_index(
+        "ix_evaluation_case_results_fixture_id",
+        "evaluation_case_results",
+        ["fixture_id"],
+    )
+    op.create_index("ix_evaluation_case_results_outcome", "evaluation_case_results", ["outcome"])
+    op.create_index(
+        "ix_evaluation_case_results_recorded_at",
+        "evaluation_case_results",
+        ["recorded_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_evaluation_case_results_recorded_at", table_name="evaluation_case_results")
+    op.drop_index("ix_evaluation_case_results_outcome", table_name="evaluation_case_results")
+    op.drop_index("ix_evaluation_case_results_fixture_id", table_name="evaluation_case_results")
+    op.drop_index("ix_evaluation_case_results_attempt_id", table_name="evaluation_case_results")
+    op.drop_index("ix_evaluation_case_results_run_id", table_name="evaluation_case_results")
+    op.drop_table("evaluation_case_results")
+
+    op.drop_index(
+        "ix_evaluation_run_attempts_lifecycle_status",
+        table_name="evaluation_run_attempts",
+    )
+    op.drop_index("ix_evaluation_run_attempts_run_id", table_name="evaluation_run_attempts")
+    op.drop_table("evaluation_run_attempts")
+
+    op.drop_index("ix_evaluation_runs_async_job_id", table_name="evaluation_runs")
+    op.drop_index("ix_evaluation_runs_submitted_at", table_name="evaluation_runs")
+    op.drop_index("ix_evaluation_runs_lifecycle_status", table_name="evaluation_runs")
+    op.drop_index("ix_evaluation_runs_fixture_id", table_name="evaluation_runs")
+    op.drop_table("evaluation_runs")
+

--- a/alembic/versions/0014_add_evaluation_runtime_state_tables.py
+++ b/alembic/versions/0014_add_evaluation_runtime_state_tables.py
@@ -113,4 +113,3 @@ def downgrade() -> None:
     op.drop_index("ix_evaluation_runs_lifecycle_status", table_name="evaluation_runs")
     op.drop_index("ix_evaluation_runs_fixture_id", table_name="evaluation_runs")
     op.drop_table("evaluation_runs")
-

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -143,6 +143,11 @@ Allowlisted fixture families can now create authoritative durable run records li
 jobs, and evaluation run catalog/detail views merge those runtime-backed records with clearly
 labeled historical artifact baselines.
 
+RFC-0007 Slice 3 activates worker-backed execution for that same narrow evaluation allowlist.
+Runtime-backed evaluation runs now move through persisted queued, running, completed, and failed
+states; attempt history is recorded durably; and per-case outcomes plus derived run verdicts are
+stored in the evaluation runtime store instead of being implied only by staged artifact files.
+
 Retrieval services also use a dedicated inventory-summary helper now, so source-level and
 runtime-level document and chunk counts are derived in one place instead of being recomputed
 independently by retrieval status and job builders.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -153,6 +153,11 @@ Provider and retrieval evidence-readiness surfaces now expose explicit approval-
 that distinguish staged-only baselines, partial runtime coverage, runtime pass, runtime failure,
 and stale runtime evidence by governed fixture family.
 
+RFC-0007 Slice 5 closes the runtime-convergence loop around those approval gates. Async replay,
+requeue, and lease-expiry recovery now preserve explicit evaluation attempt history rather than
+only async attempt history, and evaluation runtime status now exposes approval-gate posture
+directly so platform-level status and rollout review use the same evaluation truth model.
+
 Retrieval services also use a dedicated inventory-summary helper now, so source-level and
 runtime-level document and chunk counts are derived in one place instead of being recomputed
 independently by retrieval status and job builders.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -313,10 +313,10 @@ retrieval index jobs can now be submitted into the durable async backbone, execu
 stubbed worker lifecycle, and reflected back into retrieval job catalog/detail plus retrieval
 document/chunk index-status surfaces. Live retrieval search rollout remains a separate concern.
 
-Async evaluation and runbook surfaces now reflect that same runtime truth explicitly: staged
-evaluation coverage includes durable submission, lease-expiry recovery, and retrieval-indexing
-linkage, while the service runbook documents restart-survival and recovery expectations for the
-SQL-backed async runtime path.
+Async evaluation and runbook surfaces now reflect that same runtime truth explicitly: runtime-backed
+evaluation execution is active for the allowlisted fixture families, staged evaluation assets remain
+as governed continuity baselines, and the service runbook documents restart-survival plus recovery
+expectations for the SQL-backed async runtime path.
 
 Async runtime-backed jobs now also expose a narrow control-plane surface for retry, replay,
 requeue, and manual abandon actions. Those operator actions are recorded durably as async

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -138,6 +138,11 @@ migration-managed durable schema for evaluation runs, attempts, and per-case out
 evaluation APIs remain artifact-backed for now, but later runtime-backed execution slices no
 longer need to invent persistence ad hoc.
 
+RFC-0007 Slice 2 activates narrow runtime-backed evaluation submission on top of that seam.
+Allowlisted fixture families can now create authoritative durable run records linked to async
+jobs, and evaluation run catalog/detail views merge those runtime-backed records with clearly
+labeled historical artifact baselines.
+
 Retrieval services also use a dedicated inventory-summary helper now, so source-level and
 runtime-level document and chunk counts are derived in one place instead of being recomputed
 independently by retrieval status and job builders.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -148,6 +148,11 @@ Runtime-backed evaluation runs now move through persisted queued, running, compl
 states; attempt history is recorded durably; and per-case outcomes plus derived run verdicts are
 stored in the evaluation runtime store instead of being implied only by staged artifact files.
 
+RFC-0007 Slice 4 then feeds that same runtime-backed evaluation state into rollout governance.
+Provider and retrieval evidence-readiness surfaces now expose explicit approval-gate summaries
+that distinguish staged-only baselines, partial runtime coverage, runtime pass, runtime failure,
+and stale runtime evidence by governed fixture family.
+
 Retrieval services also use a dedicated inventory-summary helper now, so source-level and
 runtime-level document and chunk counts are derived in one place instead of being recomputed
 independently by retrieval status and job builders.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -133,6 +133,11 @@ filtering in separate builders.
 Evaluation runtime services also use a dedicated inventory-summary helper now, so fixture and
 case-count derivation is isolated from the final runtime-status response assembly.
 
+RFC-0007 Slice 1 also adds an explicit evaluation-runtime repository and store seam plus
+migration-managed durable schema for evaluation runs, attempts, and per-case outcomes. Public
+evaluation APIs remain artifact-backed for now, but later runtime-backed execution slices no
+longer need to invent persistence ad hoc.
+
 Retrieval services also use a dedicated inventory-summary helper now, so source-level and
 runtime-level document and chunk counts are derived in one place instead of being recomputed
 independently by retrieval status and job builders.

--- a/docs/evals/run-artifacts.json
+++ b/docs/evals/run-artifacts.json
@@ -55,7 +55,7 @@
           "staged_case_count": 2
         }
       ],
-      "notes": "Baseline foundation-phase evaluation inventory snapshot recorded after durable async submission, lease-recovery, and retrieval-indexing linkage fixtures were staged alongside provider operations durability coverage."
+      "notes": "Historical foundation-phase baseline recorded after durable async submission, lease-recovery, and retrieval-indexing linkage fixtures were staged alongside provider operations durability coverage. This artifact remains a staged continuity record and does not satisfy current runtime-backed approval posture by itself."
     },
     {
       "run_id": "foundation_eval_2026_03_21_001",
@@ -106,7 +106,7 @@
           "staged_case_count": 0
         }
       ],
-      "notes": "Earlier foundation snapshot retained for lifecycle tracking before safety-policy evaluation fixtures were staged."
+      "notes": "Earlier historical foundation snapshot retained for lifecycle tracking before safety-policy evaluation fixtures were staged. This artifact remains a staged continuity record and does not satisfy current runtime-backed approval posture by itself."
     }
   ]
 }

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -6,4 +6,4 @@
 - `RFC-0004-provider-operations-hardening.md` - Implemented
 - `RFC-0005-durable-provider-operations-state.md` - Implemented
 - `RFC-0006-durable-async-execution-backbone.md` - Implemented
-- `RFC-0007-runtime-backed-evaluation-execution-and-approval-gates.md` - Proposed
+- `RFC-0007-runtime-backed-evaluation-execution-and-approval-gates.md` - Implemented

--- a/docs/rfcs/RFC-0007-runtime-backed-evaluation-execution-and-approval-gates.md
+++ b/docs/rfcs/RFC-0007-runtime-backed-evaluation-execution-and-approval-gates.md
@@ -1,6 +1,6 @@
 # RFC-0007: Runtime-Backed Evaluation Execution and Approval Gates
 
-- Status: Proposed
+- Status: Implemented
 - Date: 2026-03-23
 - Owners: lotus-ai
 - Requires Approval From: lotus-ai maintainers
@@ -321,6 +321,26 @@ This RFC is complete when:
 6. stale or staged-only evidence cannot silently satisfy current approval posture,
 7. runbooks and governance assets reflect the runtime-backed evaluation model,
 8. the platform is materially closer to bank-grade rollout evidence and approval discipline.
+
+## Implementation Notes
+
+Implemented on `codex/rfc-runtime-eval-execution-gates`.
+
+Delivered outcomes:
+
+1. durable evaluation runtime state now exists for runs, attempts, and per-case outcomes,
+2. allowlisted evaluation families can be submitted and executed through the authoritative async backbone,
+3. evaluation run detail now exposes persisted attempt history and replay-safe case-result history,
+4. provider and retrieval governance surfaces now consume explicit runtime-backed approval-gate summaries instead of relying on staged baselines alone,
+5. async replay, requeue, abandon, and lease-expiry recovery now preserve matching evaluation attempt truth rather than updating only async job state,
+6. evaluation runtime status, runbooks, and historical baseline wording now describe staged continuity records versus current runtime-backed approval posture explicitly.
+
+The implemented result is:
+
+1. runtime-backed evaluation evidence is now durable, replayable, and reviewable through platform APIs,
+2. retrieval and provider rollout review can distinguish staged-only, partial runtime, passing runtime, failing runtime, and stale runtime evaluation posture,
+3. historical `foundation_eval_*` artifacts remain visible for continuity but no longer masquerade as current approval proof,
+4. the platform is materially closer to bank-grade rollout evidence and approval discipline than the artifact-only posture that existed before RFC-0007.
 
 ## Approval Requested
 

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -38,6 +38,7 @@
 - Retrieval evidence readiness: /platform/retrieval/evidence-readiness
 - Retrieval governance status: /platform/retrieval/governance-status
 - Evaluation runtime status: /platform/evals/runtime-status
+- Evaluation run catalog: /platform/evals/runs
 - Safety runtime status: /platform/safety/runtime-status
 - Retrieval runtime status: /platform/retrieval/runtime-status
 
@@ -101,6 +102,7 @@ Current recovery expectations:
 4. duplicate runtime-backed retrieval-index submissions should be rejected while an active queued, claimed, or running job already owns the same caller and target
 5. operator retry, replay, requeue, and abandon actions should be applied through `/platform/async/control-plane-actions/apply` rather than ad hoc table edits
 6. dedicated queue-backed worker fleet procedures remain out of scope until a later rollout slice activates them
+7. runtime-backed evaluation runs should preserve queued, claimed, running, completed, failed, and abandoned attempt history across async replay and recovery actions
 
 Current governed control-action procedure:
 
@@ -109,6 +111,17 @@ Current governed control-action procedure:
 3. apply `POST /platform/async/control-plane-actions/apply` with explicit operator reason and approver metadata
 4. verify the resulting control-plane event is visible in both `/platform/async/control-plane-actions` and `/platform/async/jobs/{job_id}`
 5. confirm the resulting job status and attempt history match the intended retry, replay, requeue, or abandon action
+
+## Evaluation Approval Review
+
+Before treating retrieval or provider evaluation evidence as approval-ready:
+
+1. verify `GET /platform/evals/runtime-status`
+2. confirm the `approval_gates` block distinguishes `STAGED_ONLY`, `RUNTIME_PARTIAL`, `RUNTIME_PASS`, `RUNTIME_FAIL`, or `RUNTIME_STALE`
+3. inspect `GET /platform/evals/runs` to confirm the latest runtime-backed run is newer than historical staged baselines for the target rollout domain
+4. inspect `GET /platform/evals/runs/{run_id}` to confirm attempt history and case outcomes explain the verdict
+5. if replay or retry is required, apply the governed async control action first and then verify a new evaluation attempt appears instead of mutating prior case evidence in place
+6. treat `foundation_eval_*` run artifacts as historical baselines only; they do not satisfy current runtime-backed approval posture by themselves
 
 ## Provider Activation Governance
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     retrieval_store_mode: str = "memory"
     provider_operations_store_mode: str = "memory"
     async_runtime_store_mode: str = "memory"
+    evaluation_runtime_store_mode: str = "memory"
     startup_readiness_policy: str = "warn"
     readiness_probe_policy: str = "observe"
     database_url: str | None = None

--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -41,6 +41,16 @@ class EvaluationRunVerdict(str, Enum):
     FAIL = "FAIL"
 
 
+class EvaluationApprovalEvidenceState(str, Enum):
+    NO_EVIDENCE = "NO_EVIDENCE"
+    STAGED_ONLY = "STAGED_ONLY"
+    RUNTIME_IN_PROGRESS = "RUNTIME_IN_PROGRESS"
+    RUNTIME_PARTIAL = "RUNTIME_PARTIAL"
+    RUNTIME_PASS = "RUNTIME_PASS"
+    RUNTIME_FAIL = "RUNTIME_FAIL"
+    RUNTIME_STALE = "RUNTIME_STALE"
+
+
 class EvaluationEvidenceCategoryDescriptor(BaseModel):
     category_id: str = Field(description="Stable execution evidence category identifier.")
     description: str = Field(description="Human-readable description of the evidence category.")
@@ -233,6 +243,69 @@ class EvaluationCaseResultDescriptor(BaseModel):
         description="Bounded evidence references supporting the recorded case outcome."
     )
     recorded_at: str = Field(description="UTC timestamp when the case outcome was recorded.")
+
+
+class EvaluationApprovalFixtureSummaryDescriptor(BaseModel):
+    fixture_id: str = Field(description="Evaluation fixture family identifier.")
+    latest_runtime_run_id: str | None = Field(
+        default=None,
+        description="Most recent runtime-backed evaluation run id for this fixture family, when one exists.",
+    )
+    latest_runtime_recorded_at: str | None = Field(
+        default=None,
+        description="Timestamp of the most recent runtime-backed evaluation run for this fixture family, when one exists.",
+    )
+    latest_runtime_status: EvaluationRunStatus | None = Field(
+        default=None,
+        description="Most recent runtime-backed lifecycle status for this fixture family, when one exists.",
+    )
+    latest_runtime_verdict: EvaluationRunVerdict | None = Field(
+        default=None,
+        description="Most recent runtime-backed verdict for this fixture family, when one exists.",
+    )
+    evidence_state: EvaluationApprovalEvidenceState = Field(
+        description="Current approval evidence posture for this specific fixture family."
+    )
+    notes: str = Field(
+        description="Human-readable explanation of the current approval evidence posture for the fixture family."
+    )
+
+
+class EvaluationApprovalGateSummaryDescriptor(BaseModel):
+    domain_id: str = Field(description="Stable rollout domain identifier.")
+    domain_label: str = Field(description="Human-readable rollout domain label.")
+    approval_ready: bool = Field(
+        description="Whether the rollout domain currently has sufficient runtime-backed evaluation evidence to satisfy approval posture."
+    )
+    evidence_state: EvaluationApprovalEvidenceState = Field(
+        description="Current overall approval evidence posture for the rollout domain."
+    )
+    required_fixture_count: int = Field(
+        description="Number of governed fixture families required for this rollout domain."
+    )
+    runtime_backed_fixture_count: int = Field(
+        description="Number of governed fixture families with current runtime-backed evaluation evidence."
+    )
+    latest_runtime_run_id: str | None = Field(
+        default=None,
+        description="Most recent runtime-backed evaluation run id across the rollout domain, when one exists.",
+    )
+    latest_runtime_recorded_at: str | None = Field(
+        default=None,
+        description="Timestamp of the most recent runtime-backed evaluation run across the rollout domain, when one exists.",
+    )
+    latest_historical_baseline_run_id: str | None = Field(
+        default=None,
+        description="Most recent staged historical baseline run covering the rollout domain, when one exists.",
+    )
+    fixture_summaries: list[EvaluationApprovalFixtureSummaryDescriptor] = Field(
+        default_factory=list,
+        description="Per-fixture approval evidence posture contributing to the rollout-domain summary.",
+    )
+    notes: list[str] = Field(
+        default_factory=list,
+        description="Human-readable explanation of the rollout-domain approval evidence posture.",
+    )
 
 
 class EvaluationRunSubmissionRequest(BaseModel):

--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -14,6 +14,7 @@ class EvaluationRunStatus(str, Enum):
     RECORDED = "RECORDED"
     SUPERSEDED = "SUPERSEDED"
     QUEUED = "QUEUED"
+    CLAIMED = "CLAIMED"
     RUNNING = "RUNNING"
     FAILED = "FAILED"
     COMPLETED = "COMPLETED"
@@ -374,6 +375,9 @@ class EvaluationRuntimeStatusResponse(BaseModel):
     )
     seam_coverage: list[EvaluationSeamCoverageDescriptor] = Field(
         description="Staged evaluation coverage summarized by major lotus-ai platform seam."
+    )
+    approval_gates: list[EvaluationApprovalGateSummaryDescriptor] = Field(
+        description="Runtime-backed approval-gating posture for governed rollout domains."
     )
     recorded_run_count: int = Field(
         description="Number of evaluation runs currently exposed across runtime-backed and historical records."

--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -31,6 +31,16 @@ class EvaluationRunSubmissionStatus(str, Enum):
     DUPLICATE_REJECTED = "DUPLICATE_REJECTED"
 
 
+class EvaluationCaseOutcome(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+
+
+class EvaluationRunVerdict(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+
+
 class EvaluationEvidenceCategoryDescriptor(BaseModel):
     category_id: str = Field(description="Stable execution evidence category identifier.")
     description: str = Field(description="Human-readable description of the evidence category.")
@@ -173,6 +183,56 @@ class EvaluationRunDetailResponse(BaseModel):
     run: EvaluationRunArtifactDescriptor = Field(
         description="Evaluation run detail from historical artifacts or durable runtime state."
     )
+    attempts: list["EvaluationRunAttemptDescriptor"] = Field(
+        default_factory=list,
+        description="Persisted runtime-backed attempt history for the evaluation run.",
+    )
+    case_results: list["EvaluationCaseResultDescriptor"] = Field(
+        default_factory=list,
+        description="Persisted runtime-backed case outcomes for the evaluation run.",
+    )
+
+
+class EvaluationRunAttemptDescriptor(BaseModel):
+    attempt_id: str = Field(description="Stable evaluation run attempt identifier.")
+    attempt_number: int = Field(description="Monotonic attempt number for the evaluation run.")
+    status: EvaluationRunStatus = Field(description="Lifecycle status for the recorded attempt.")
+    started_at: str | None = Field(
+        default=None,
+        description="UTC timestamp when the attempt entered running execution.",
+    )
+    completed_at: str | None = Field(
+        default=None,
+        description="UTC timestamp when the attempt reached a terminal state.",
+    )
+    worker_id: str | None = Field(
+        default=None,
+        description="Worker identity that executed the attempt when one exists.",
+    )
+    message: str = Field(description="Human-readable attempt lifecycle message.")
+    verdict: EvaluationRunVerdict | None = Field(
+        default=None,
+        description="Attempt-level verdict derived from persisted case outcomes.",
+    )
+    failure_reason: str | None = Field(
+        default=None,
+        description="Terminal failure reason when the attempt does not complete successfully.",
+    )
+
+
+class EvaluationCaseResultDescriptor(BaseModel):
+    case_result_id: str = Field(description="Stable persisted evaluation case-result identifier.")
+    attempt_id: str = Field(description="Evaluation attempt identifier associated with the case.")
+    case_id: str = Field(description="Governed evaluation case identifier.")
+    fixture_id: str = Field(description="Evaluation fixture family identifier for the case.")
+    outcome: EvaluationCaseOutcome = Field(
+        description="Persisted evaluation outcome for the case."
+    )
+    summary: str = Field(description="Human-readable explanation of the case outcome.")
+    evidence_refs: list[str] = Field(
+        description="Bounded evidence references supporting the recorded case outcome."
+    )
+    recorded_at: str = Field(description="UTC timestamp when the case outcome was recorded.")
 
 
 class EvaluationRunSubmissionRequest(BaseModel):

--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -159,9 +159,7 @@ class EvaluationRunArtifactDescriptor(BaseModel):
     seam_coverage: list[EvaluationSeamCoverageDescriptor] = Field(
         description="Seam-oriented coverage associated with the exposed evaluation run."
     )
-    notes: str = Field(
-        description="Human-readable description of the exposed evaluation run."
-    )
+    notes: str = Field(description="Human-readable description of the exposed evaluation run.")
 
 
 class EvaluationRunCatalogResponse(BaseModel):
@@ -236,9 +234,7 @@ class EvaluationCaseResultDescriptor(BaseModel):
     attempt_id: str = Field(description="Evaluation attempt identifier associated with the case.")
     case_id: str = Field(description="Governed evaluation case identifier.")
     fixture_id: str = Field(description="Evaluation fixture family identifier for the case.")
-    outcome: EvaluationCaseOutcome = Field(
-        description="Persisted evaluation outcome for the case."
-    )
+    outcome: EvaluationCaseOutcome = Field(description="Persisted evaluation outcome for the case.")
     summary: str = Field(description="Human-readable explanation of the case outcome.")
     evidence_refs: list[str] = Field(
         description="Bounded evidence references supporting the recorded case outcome."
@@ -325,7 +321,9 @@ class EvaluationRunSubmissionRequest(BaseModel):
 
 
 class EvaluationRunSubmissionResponse(BaseModel):
-    service: str = Field(description="Service name emitting the evaluation run submission response.")
+    service: str = Field(
+        description="Service name emitting the evaluation run submission response."
+    )
     version: str = Field(description="Current lotus-ai service version.")
     delivery_phase: str = Field(description="Current lotus-ai delivery phase.")
     submission_status: EvaluationRunSubmissionStatus = Field(

--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -13,6 +13,22 @@ class EvaluationAssetStatus(str, Enum):
 class EvaluationRunStatus(str, Enum):
     RECORDED = "RECORDED"
     SUPERSEDED = "SUPERSEDED"
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    FAILED = "FAILED"
+    COMPLETED = "COMPLETED"
+    ABANDONED = "ABANDONED"
+
+
+class EvaluationRunRecordSource(str, Enum):
+    STAGED_ARTIFACT = "STAGED_ARTIFACT"
+    RUNTIME_STATE = "RUNTIME_STATE"
+
+
+class EvaluationRunSubmissionStatus(str, Enum):
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+    DUPLICATE_REJECTED = "DUPLICATE_REJECTED"
 
 
 class EvaluationEvidenceCategoryDescriptor(BaseModel):
@@ -88,24 +104,42 @@ class EvaluationSeamCoverageDescriptor(BaseModel):
 
 class EvaluationRunArtifactDescriptor(BaseModel):
     run_id: str = Field(description="Stable evaluation run artifact identifier.")
-    recorded_at: str = Field(description="UTC timestamp when the evaluation artifact was recorded.")
+    recorded_at: str = Field(
+        description="UTC timestamp when the evaluation run was recorded or submitted."
+    )
     status: EvaluationRunStatus = Field(
-        description="Lifecycle status for the recorded evaluation artifact."
+        description="Lifecycle status for the exposed evaluation run."
+    )
+    record_source: EvaluationRunRecordSource = Field(
+        default=EvaluationRunRecordSource.STAGED_ARTIFACT,
+        description="Whether the run comes from historical staged artifacts or durable runtime state.",
     )
     manifest_version: str = Field(
-        description="Evaluation fixture manifest version associated with the recorded artifact."
+        description="Evaluation fixture manifest version associated with the run."
+    )
+    fixture_id: str | None = Field(
+        default=None,
+        description="Fixture family identifier for runtime-backed evaluation runs when one exists.",
+    )
+    async_job_id: str | None = Field(
+        default=None,
+        description="Related async job identifier for runtime-backed evaluation runs when one exists.",
+    )
+    triggered_by: str | None = Field(
+        default=None,
+        description="Operator or system identity that triggered the runtime-backed evaluation run.",
     )
     staged_fixture_count: int = Field(
-        description="Number of staged fixture families represented in the recorded artifact."
+        description="Number of staged fixture families represented in the exposed run."
     )
     staged_case_count: int = Field(
-        description="Number of staged cases represented in the recorded artifact."
+        description="Number of staged cases represented in the exposed run."
     )
     seam_coverage: list[EvaluationSeamCoverageDescriptor] = Field(
-        description="Seam-oriented coverage captured in the recorded evaluation artifact."
+        description="Seam-oriented coverage associated with the exposed evaluation run."
     )
     notes: str = Field(
-        description="Human-readable description of the recorded evaluation artifact."
+        description="Human-readable description of the exposed evaluation run."
     )
 
 
@@ -113,18 +147,22 @@ class EvaluationRunCatalogResponse(BaseModel):
     service: str = Field(description="Service name emitting the evaluation run catalog.")
     version: str = Field(description="Current lotus-ai service version.")
     delivery_phase: str = Field(description="Current lotus-ai delivery phase.")
-    run_count: int = Field(
-        description="Number of recorded evaluation run artifacts currently exposed."
-    )
+    run_count: int = Field(description="Number of evaluation runs currently exposed.")
     latest_run_id: str | None = Field(
         default=None,
-        description="Most recent evaluation run artifact identifier when one exists.",
+        description="Most recent evaluation run identifier when one exists.",
+    )
+    runtime_backed_run_count: int = Field(
+        description="Number of durable runtime-backed evaluation runs currently exposed."
+    )
+    historical_run_count: int = Field(
+        description="Number of historical staged-artifact evaluation runs currently exposed."
     )
     status_counts: dict[EvaluationRunStatus, int] = Field(
-        description="Recorded evaluation run counts by lifecycle status."
+        description="Evaluation run counts by lifecycle status across runtime-backed and historical records."
     )
     runs: list[EvaluationRunArtifactDescriptor] = Field(
-        description="Recorded evaluation run artifacts available for inspection."
+        description="Evaluation runs available for inspection."
     )
 
 
@@ -133,8 +171,53 @@ class EvaluationRunDetailResponse(BaseModel):
     version: str = Field(description="Current lotus-ai service version.")
     delivery_phase: str = Field(description="Current lotus-ai delivery phase.")
     run: EvaluationRunArtifactDescriptor = Field(
-        description="Recorded evaluation run artifact detail."
+        description="Evaluation run detail from historical artifacts or durable runtime state."
     )
+
+
+class EvaluationRunSubmissionRequest(BaseModel):
+    fixture_id: str = Field(
+        description="Governed evaluation fixture family identifier requested for runtime-backed submission."
+    )
+    caller_app: str = Field(
+        description="Calling Lotus application requesting the evaluation run submission."
+    )
+    correlation_id: str = Field(
+        description="Caller-provided correlation identifier for the evaluation run request."
+    )
+    triggered_by: str = Field(
+        description="Operator or system identity triggering the evaluation run submission."
+    )
+
+
+class EvaluationRunSubmissionResponse(BaseModel):
+    service: str = Field(description="Service name emitting the evaluation run submission response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    delivery_phase: str = Field(description="Current lotus-ai delivery phase.")
+    submission_status: EvaluationRunSubmissionStatus = Field(
+        description="Submission outcome under the current evaluation runtime posture."
+    )
+    fixture_id: str = Field(
+        description="Governed evaluation fixture family identifier evaluated for submission."
+    )
+    accepted: bool = Field(description="Whether the evaluation run submission was accepted.")
+    run_id: str | None = Field(
+        default=None,
+        description="Assigned durable evaluation run identifier when submission is accepted.",
+    )
+    async_job_id: str | None = Field(
+        default=None,
+        description="Related async job identifier when submission is accepted.",
+    )
+    existing_run_id: str | None = Field(
+        default=None,
+        description="Existing active evaluation run identifier when a duplicate submission is rejected.",
+    )
+    existing_async_job_id: str | None = Field(
+        default=None,
+        description="Related async job identifier for the existing active evaluation run when duplicate submission is rejected.",
+    )
+    message: str = Field(description="Human-readable explanation of the submission outcome.")
 
 
 class EvaluationRuntimeStatusResponse(BaseModel):
@@ -160,15 +243,21 @@ class EvaluationRuntimeStatusResponse(BaseModel):
         description="Staged evaluation coverage summarized by major lotus-ai platform seam."
     )
     recorded_run_count: int = Field(
-        description="Number of recorded evaluation run artifacts currently exposed."
+        description="Number of evaluation runs currently exposed across runtime-backed and historical records."
+    )
+    runtime_backed_run_count: int = Field(
+        description="Number of durable runtime-backed evaluation runs currently exposed."
+    )
+    historical_run_count: int = Field(
+        description="Number of historical staged-artifact evaluation runs currently exposed."
     )
     latest_recorded_run_id: str | None = Field(
         default=None,
-        description="Most recent recorded evaluation run artifact identifier when one exists.",
+        description="Most recent evaluation run identifier when one exists.",
     )
     latest_recorded_run_status: EvaluationRunStatus | None = Field(
         default=None,
-        description="Lifecycle status for the most recent recorded evaluation run artifact.",
+        description="Lifecycle status for the most recent evaluation run.",
     )
     evaluation_runner_active: bool = Field(
         description="Whether a live evaluation runner is active in the current phase."

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
 
 class ProviderCapability(str, Enum):
     TEXT_GENERATION = "TEXT_GENERATION"
@@ -606,6 +607,9 @@ class ProviderEvidenceReadinessResponse(BaseModel):
     )
     items: list[ProviderEvidenceReadinessItem] = Field(
         description="Governed provider evidence-readiness items."
+    )
+    approval_gate: EvaluationApprovalGateSummaryDescriptor = Field(
+        description="Runtime-backed approval evidence summary for the provider rollout domain."
     )
 
 

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
 
+
 class ProviderCapability(str, Enum):
     TEXT_GENERATION = "TEXT_GENERATION"
     EMBEDDINGS = "EMBEDDINGS"

--- a/src/app/contracts/retrieval.py
+++ b/src/app/contracts/retrieval.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
 from app.contracts.runtime_readiness import RuntimeReadinessStatus
 
 
@@ -361,6 +362,9 @@ class RetrievalEvidenceReadinessResponse(BaseModel):
     )
     items: list[RetrievalEvidenceReadinessItem] = Field(
         description="Governed retrieval evidence-readiness items."
+    )
+    approval_gate: EvaluationApprovalGateSummaryDescriptor = Field(
+        description="Runtime-backed approval evidence summary for the retrieval rollout domain."
     )
 
 

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -212,3 +212,58 @@ class AsyncControlEventModel(Base):
     resulting_status: Mapped[str] = mapped_column(String(64), nullable=False)
     affected_attempt_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
+class EvaluationRunModel(Base):
+    __tablename__ = "evaluation_runs"
+
+    run_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    fixture_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    manifest_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    lifecycle_status: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    triggered_by: Mapped[str] = mapped_column(String(256), nullable=False)
+    submitted_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    async_job_id: Mapped[str | None] = mapped_column(String(128), nullable=True, index=True)
+    latest_message: Mapped[str] = mapped_column(Text, nullable=False)
+    verdict: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    case_count: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    attempts: Mapped[list["EvaluationRunAttemptModel"]] = relationship(back_populates="run")
+    case_results: Mapped[list["EvaluationCaseResultModel"]] = relationship(back_populates="run")
+
+
+class EvaluationRunAttemptModel(Base):
+    __tablename__ = "evaluation_run_attempts"
+
+    attempt_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    run_id: Mapped[str] = mapped_column(
+        ForeignKey("evaluation_runs.run_id"), nullable=False, index=True
+    )
+    attempt_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    lifecycle_status: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    started_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    completed_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    worker_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    latest_message: Mapped[str] = mapped_column(Text, nullable=False)
+    verdict: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    run: Mapped["EvaluationRunModel"] = relationship(back_populates="attempts")
+
+
+class EvaluationCaseResultModel(Base):
+    __tablename__ = "evaluation_case_results"
+
+    case_result_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    run_id: Mapped[str] = mapped_column(
+        ForeignKey("evaluation_runs.run_id"), nullable=False, index=True
+    )
+    attempt_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    case_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    fixture_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    outcome: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    evidence_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+    run: Mapped["EvaluationRunModel"] = relationship(back_populates="case_results")

--- a/src/app/evals/fixture_manifest.py
+++ b/src/app/evals/fixture_manifest.py
@@ -39,6 +39,21 @@ class EvaluationFixtureFamily:
         self.cases = cases
 
 
+class EvaluationFixtureRuntimeCase:
+    def __init__(
+        self,
+        *,
+        case_id: str,
+        summary: str,
+        input_payload: dict[str, Any],
+        expected_payload: dict[str, Any],
+    ) -> None:
+        self.case_id = case_id
+        self.summary = summary
+        self.input_payload = input_payload
+        self.expected_payload = expected_payload
+
+
 class EvaluationFixtureManifestValidationError(ValueError):
     """Raised when the governed evaluation fixture manifest is malformed."""
 
@@ -87,6 +102,43 @@ def load_evaluation_fixture_family(*, fixture_id: str) -> EvaluationFixtureFamil
         manifest_path=fixture.manifest_path,
     )
     return EvaluationFixtureFamily(descriptor=fixture, task_id=task_id, cases=cases)
+
+
+def load_evaluation_fixture_runtime_cases(
+    *, fixture_id: str
+) -> tuple[str | None, list[EvaluationFixtureRuntimeCase]]:
+    repo_root = Path(__file__).resolve().parents[3]
+    manifest = load_evaluation_fixture_manifest()
+    fixture = next(
+        (fixture for fixture in manifest.fixture_families if fixture.fixture_id == fixture_id),
+        None,
+    )
+    if fixture is None:
+        raise EvaluationFixtureManifestValidationError(
+            f"Unknown evaluation fixture family '{fixture_id}'."
+        )
+    if fixture.manifest_path is None:
+        return (None, [])
+    fixture_path = repo_root / fixture.manifest_path
+    with fixture_path.open("r", encoding="utf-8") as fixture_file:
+        payload = json.load(fixture_file)
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list):
+        raise EvaluationFixtureManifestValidationError(
+            f"Fixture manifest file has non-list cases payload: {fixture_path}"
+        )
+    return (
+        payload.get("task_id"),
+        [
+            EvaluationFixtureRuntimeCase(
+                case_id=case["case_id"],
+                summary=case["summary"],
+                input_payload=cast(dict[str, Any], case["input"]),
+                expected_payload=cast(dict[str, Any], case["expected"]),
+            )
+            for case in cases
+        ],
+    )
 
 
 def validate_evaluation_fixture_manifest(

--- a/src/app/repositories/async_runtime_repository.py
+++ b/src/app/repositories/async_runtime_repository.py
@@ -102,6 +102,7 @@ class AsyncRuntimeRepository(Protocol):
         self,
         *,
         worker_id: str,
+        job_types: tuple[str, ...] | None,
         claimed_at: str,
         heartbeat_at: str,
         lease_expires_at: str,

--- a/src/app/repositories/evaluation_runtime_repository.py
+++ b/src/app/repositories/evaluation_runtime_repository.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class EvaluationRunRecord:
+    run_id: str
+    fixture_id: str
+    manifest_version: str
+    lifecycle_status: str
+    triggered_by: str
+    submitted_at: str
+    async_job_id: str | None
+    latest_message: str
+    verdict: str | None
+    case_count: int
+
+
+@dataclass(frozen=True)
+class EvaluationRunAttemptRecord:
+    attempt_id: str
+    run_id: str
+    attempt_number: int
+    lifecycle_status: str
+    started_at: str | None
+    completed_at: str | None
+    worker_id: str | None
+    latest_message: str
+    verdict: str | None
+    failure_reason: str | None
+
+
+@dataclass(frozen=True)
+class EvaluationCaseResultRecord:
+    case_result_id: str
+    run_id: str
+    attempt_id: str
+    case_id: str
+    fixture_id: str
+    outcome: str
+    summary: str
+    evidence_refs: list[str]
+    recorded_at: str
+
+
+class EvaluationRuntimeRepository(Protocol):
+    def list_runs(self) -> list[EvaluationRunRecord]:
+        """List all persisted evaluation runs."""
+
+    def get_run(self, *, run_id: str) -> EvaluationRunRecord | None:
+        """Fetch one persisted evaluation run."""
+
+    def save_run(self, record: EvaluationRunRecord) -> None:
+        """Persist one evaluation run."""
+
+    def list_attempts(self, *, run_id: str) -> list[EvaluationRunAttemptRecord]:
+        """List persisted attempts for one evaluation run."""
+
+    def save_attempt(self, record: EvaluationRunAttemptRecord) -> None:
+        """Persist one evaluation run attempt."""
+
+    def get_attempt(self, *, attempt_id: str) -> EvaluationRunAttemptRecord | None:
+        """Fetch one persisted evaluation run attempt."""
+
+    def list_case_results(self, *, run_id: str) -> list[EvaluationCaseResultRecord]:
+        """List persisted case outcomes for one evaluation run."""
+
+    def save_case_result(self, record: EvaluationCaseResultRecord) -> None:
+        """Persist one evaluation case result."""
+

--- a/src/app/repositories/evaluation_runtime_repository.py
+++ b/src/app/repositories/evaluation_runtime_repository.py
@@ -69,4 +69,3 @@ class EvaluationRuntimeRepository(Protocol):
 
     def save_case_result(self, record: EvaluationCaseResultRecord) -> None:
         """Persist one evaluation case result."""
-

--- a/src/app/repositories/memory_async_runtime_repository.py
+++ b/src/app/repositories/memory_async_runtime_repository.py
@@ -89,6 +89,7 @@ class InMemoryAsyncRuntimeRepository(AsyncRuntimeRepository):
         self,
         *,
         worker_id: str,
+        job_types: tuple[str, ...] | None,
         claimed_at: str,
         heartbeat_at: str,
         lease_expires_at: str,
@@ -98,6 +99,8 @@ class InMemoryAsyncRuntimeRepository(AsyncRuntimeRepository):
         for job_id in sorted(self._jobs, key=lambda item: self._jobs[item].submitted_at):
             job = self._jobs[job_id]
             if job.lifecycle_status != "QUEUED":
+                continue
+            if job_types is not None and job.job_type not in job_types:
                 continue
             if job_id in self._leases_by_job:
                 continue

--- a/src/app/repositories/memory_evaluation_runtime_repository.py
+++ b/src/app/repositories/memory_evaluation_runtime_repository.py
@@ -73,4 +73,3 @@ class InMemoryEvaluationRuntimeRepository(EvaluationRuntimeRepository):
         ]
         results.append(deepcopy(record))
         self._case_results[record.run_id] = results
-

--- a/src/app/repositories/memory_evaluation_runtime_repository.py
+++ b/src/app/repositories/memory_evaluation_runtime_repository.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+    EvaluationRuntimeRepository,
+)
+
+
+class InMemoryEvaluationRuntimeRepository(EvaluationRuntimeRepository):
+    def __init__(self) -> None:
+        self._runs: dict[str, EvaluationRunRecord] = {}
+        self._attempts: dict[str, list[EvaluationRunAttemptRecord]] = {}
+        self._case_results: dict[str, list[EvaluationCaseResultRecord]] = {}
+
+    def list_runs(self) -> list[EvaluationRunRecord]:
+        return [
+            deepcopy(self._runs[run_id])
+            for run_id in sorted(self._runs, key=lambda item: self._runs[item].submitted_at)
+        ]
+
+    def get_run(self, *, run_id: str) -> EvaluationRunRecord | None:
+        record = self._runs.get(run_id)
+        if record is None:
+            return None
+        return deepcopy(record)
+
+    def save_run(self, record: EvaluationRunRecord) -> None:
+        self._runs[record.run_id] = deepcopy(record)
+
+    def list_attempts(self, *, run_id: str) -> list[EvaluationRunAttemptRecord]:
+        return [
+            deepcopy(record)
+            for record in sorted(
+                self._attempts.get(run_id, []),
+                key=lambda item: item.attempt_number,
+            )
+        ]
+
+    def save_attempt(self, record: EvaluationRunAttemptRecord) -> None:
+        attempts = [
+            existing
+            for existing in self._attempts.get(record.run_id, [])
+            if existing.attempt_id != record.attempt_id
+        ]
+        attempts.append(deepcopy(record))
+        self._attempts[record.run_id] = attempts
+
+    def get_attempt(self, *, attempt_id: str) -> EvaluationRunAttemptRecord | None:
+        for attempts in self._attempts.values():
+            for record in attempts:
+                if record.attempt_id == attempt_id:
+                    return deepcopy(record)
+        return None
+
+    def list_case_results(self, *, run_id: str) -> list[EvaluationCaseResultRecord]:
+        return [
+            deepcopy(record)
+            for record in sorted(
+                self._case_results.get(run_id, []),
+                key=lambda item: item.case_result_id,
+            )
+        ]
+
+    def save_case_result(self, record: EvaluationCaseResultRecord) -> None:
+        results = [
+            existing
+            for existing in self._case_results.get(record.run_id, [])
+            if existing.case_result_id != record.case_result_id
+        ]
+        results.append(deepcopy(record))
+        self._case_results[record.run_id] = results
+

--- a/src/app/repositories/sqlalchemy_async_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_async_runtime_repository.py
@@ -137,6 +137,7 @@ class SqlAlchemyAsyncRuntimeRepository(AsyncRuntimeRepository):
         self,
         *,
         worker_id: str,
+        job_types: tuple[str, ...] | None,
         claimed_at: str,
         heartbeat_at: str,
         lease_expires_at: str,
@@ -144,11 +145,10 @@ class SqlAlchemyAsyncRuntimeRepository(AsyncRuntimeRepository):
         attempt_message: str,
     ) -> AsyncRuntimeClaimRecord | None:
         with self._session_factory() as session:
-            job_model = session.scalars(
-                select(AsyncJobModel)
-                .where(AsyncJobModel.lifecycle_status == "QUEUED")
-                .order_by(AsyncJobModel.submitted_at)
-            ).first()
+            statement = select(AsyncJobModel).where(AsyncJobModel.lifecycle_status == "QUEUED")
+            if job_types is not None:
+                statement = statement.where(AsyncJobModel.job_type.in_(job_types))
+            job_model = session.scalars(statement.order_by(AsyncJobModel.submitted_at)).first()
             if job_model is None:
                 return None
 

--- a/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.db.models import EvaluationCaseResultModel, EvaluationRunAttemptModel, EvaluationRunModel
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+    EvaluationRuntimeRepository,
+)
+
+
+class SqlAlchemyEvaluationRuntimeRepository(EvaluationRuntimeRepository):
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+        self._ensure_sqlite_parent_directory()
+        self._engine = create_engine(database_url, future=True)
+        self._session_factory = sessionmaker(bind=self._engine, autoflush=False, future=True)
+
+    def list_runs(self) -> list[EvaluationRunRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(EvaluationRunModel).order_by(EvaluationRunModel.submitted_at)
+            ).all()
+            return [self._to_run_record(model) for model in models]
+
+    def get_run(self, *, run_id: str) -> EvaluationRunRecord | None:
+        with self._session_factory() as session:
+            model = session.get(EvaluationRunModel, run_id)
+            if model is None:
+                return None
+            return self._to_run_record(model)
+
+    def save_run(self, record: EvaluationRunRecord) -> None:
+        model = EvaluationRunModel(
+            run_id=record.run_id,
+            fixture_id=record.fixture_id,
+            manifest_version=record.manifest_version,
+            lifecycle_status=record.lifecycle_status,
+            triggered_by=record.triggered_by,
+            submitted_at=record.submitted_at,
+            async_job_id=record.async_job_id,
+            latest_message=record.latest_message,
+            verdict=record.verdict,
+            case_count=record.case_count,
+        )
+        with self._session_factory() as session:
+            session.merge(model)
+            session.commit()
+
+    def list_attempts(self, *, run_id: str) -> list[EvaluationRunAttemptRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(EvaluationRunAttemptModel)
+                .where(EvaluationRunAttemptModel.run_id == run_id)
+                .order_by(EvaluationRunAttemptModel.attempt_number)
+            ).all()
+            return [self._to_attempt_record(model) for model in models]
+
+    def save_attempt(self, record: EvaluationRunAttemptRecord) -> None:
+        model = EvaluationRunAttemptModel(
+            attempt_id=record.attempt_id,
+            run_id=record.run_id,
+            attempt_number=record.attempt_number,
+            lifecycle_status=record.lifecycle_status,
+            started_at=record.started_at,
+            completed_at=record.completed_at,
+            worker_id=record.worker_id,
+            latest_message=record.latest_message,
+            verdict=record.verdict,
+            failure_reason=record.failure_reason,
+        )
+        with self._session_factory() as session:
+            session.merge(model)
+            session.commit()
+
+    def get_attempt(self, *, attempt_id: str) -> EvaluationRunAttemptRecord | None:
+        with self._session_factory() as session:
+            model = session.get(EvaluationRunAttemptModel, attempt_id)
+            if model is None:
+                return None
+            return self._to_attempt_record(model)
+
+    def list_case_results(self, *, run_id: str) -> list[EvaluationCaseResultRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(EvaluationCaseResultModel)
+                .where(EvaluationCaseResultModel.run_id == run_id)
+                .order_by(EvaluationCaseResultModel.case_result_id)
+            ).all()
+            return [self._to_case_result_record(model) for model in models]
+
+    def save_case_result(self, record: EvaluationCaseResultRecord) -> None:
+        model = EvaluationCaseResultModel(
+            case_result_id=record.case_result_id,
+            run_id=record.run_id,
+            attempt_id=record.attempt_id,
+            case_id=record.case_id,
+            fixture_id=record.fixture_id,
+            outcome=record.outcome,
+            summary=record.summary,
+            evidence_refs=record.evidence_refs,
+            recorded_at=record.recorded_at,
+        )
+        with self._session_factory() as session:
+            session.merge(model)
+            session.commit()
+
+    def _to_run_record(self, model: EvaluationRunModel) -> EvaluationRunRecord:
+        return EvaluationRunRecord(
+            run_id=model.run_id,
+            fixture_id=model.fixture_id,
+            manifest_version=model.manifest_version,
+            lifecycle_status=model.lifecycle_status,
+            triggered_by=model.triggered_by,
+            submitted_at=model.submitted_at,
+            async_job_id=model.async_job_id,
+            latest_message=model.latest_message,
+            verdict=model.verdict,
+            case_count=model.case_count,
+        )
+
+    def _to_attempt_record(self, model: EvaluationRunAttemptModel) -> EvaluationRunAttemptRecord:
+        return EvaluationRunAttemptRecord(
+            attempt_id=model.attempt_id,
+            run_id=model.run_id,
+            attempt_number=model.attempt_number,
+            lifecycle_status=model.lifecycle_status,
+            started_at=model.started_at,
+            completed_at=model.completed_at,
+            worker_id=model.worker_id,
+            latest_message=model.latest_message,
+            verdict=model.verdict,
+            failure_reason=model.failure_reason,
+        )
+
+    def _to_case_result_record(self, model: EvaluationCaseResultModel) -> EvaluationCaseResultRecord:
+        return EvaluationCaseResultRecord(
+            case_result_id=model.case_result_id,
+            run_id=model.run_id,
+            attempt_id=model.attempt_id,
+            case_id=model.case_id,
+            fixture_id=model.fixture_id,
+            outcome=model.outcome,
+            summary=model.summary,
+            evidence_refs=list(model.evidence_refs),
+            recorded_at=model.recorded_at,
+        )
+
+    def _ensure_sqlite_parent_directory(self) -> None:
+        prefix = "sqlite:///"
+        if not self._database_url.startswith(prefix):
+            return
+        db_path = self._database_url.removeprefix(prefix)
+        if db_path == ":memory:":
+            return
+        path = Path(db_path)
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        path.parent.mkdir(parents=True, exist_ok=True)
+

--- a/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
@@ -138,7 +138,9 @@ class SqlAlchemyEvaluationRuntimeRepository(EvaluationRuntimeRepository):
             failure_reason=model.failure_reason,
         )
 
-    def _to_case_result_record(self, model: EvaluationCaseResultModel) -> EvaluationCaseResultRecord:
+    def _to_case_result_record(
+        self, model: EvaluationCaseResultModel
+    ) -> EvaluationCaseResultRecord:
         return EvaluationCaseResultRecord(
             case_result_id=model.case_result_id,
             run_id=model.run_id,
@@ -162,4 +164,3 @@ class SqlAlchemyEvaluationRuntimeRepository(EvaluationRuntimeRepository):
         if not path.is_absolute():
             path = Path.cwd() / path
         path.parent.mkdir(parents=True, exist_ok=True)
-

--- a/src/app/routers/evals.py
+++ b/src/app/routers/evals.py
@@ -7,11 +7,14 @@ from app.contracts.evals import (
     EvaluationFixtureDetailResponse,
     EvaluationRunCatalogResponse,
     EvaluationRunDetailResponse,
+    EvaluationRunSubmissionRequest,
+    EvaluationRunSubmissionResponse,
     EvaluationRuntimeStatusResponse,
 )
 from app.services.eval_catalog import build_evaluation_catalog
 from app.services.eval_fixture_service import build_evaluation_fixture_detail
 from app.services.eval_run_service import build_evaluation_run_catalog, build_evaluation_run_detail
+from app.services.eval_run_submission_service import submit_evaluation_run
 from app.services.eval_status import build_evaluation_runtime_status
 
 router = APIRouter(prefix="/platform/evals", tags=["platform"])
@@ -57,10 +60,10 @@ async def get_evaluation_runtime_status_route() -> EvaluationRuntimeStatusRespon
     "/runs",
     response_model=EvaluationRunCatalogResponse,
     operation_id="getEvaluationRunCatalog",
-    summary="Get lotus-ai recorded evaluation run artifacts",
+    summary="Get lotus-ai evaluation runs",
     description=(
-        "Returns read-only recorded evaluation run artifacts that capture governed evaluation "
-        "inventory snapshots without requiring a live evaluation runner."
+        "Returns evaluation runs from historical staged artifacts and durable runtime-backed "
+        "submission state."
     ),
     responses={
         200: {"description": "Evaluation run catalog returned successfully."},
@@ -69,6 +72,30 @@ async def get_evaluation_runtime_status_route() -> EvaluationRuntimeStatusRespon
 )
 async def get_evaluation_run_catalog_route() -> EvaluationRunCatalogResponse:
     return build_evaluation_run_catalog()
+
+
+@router.post(
+    "/runs/submit",
+    response_model=EvaluationRunSubmissionResponse,
+    operation_id="submitEvaluationRun",
+    summary="Submit a runtime-backed evaluation run",
+    description=(
+        "Submits an allowlisted evaluation fixture family into durable runtime state and links it "
+        "to the async backbone without starting worker-backed case execution yet."
+    ),
+    responses={
+        200: {"description": "Evaluation run submission evaluated successfully."},
+        404: {"description": "Evaluation fixture family not found."},
+        409: {
+            "description": "Evaluation fixture family is not allowlisted for runtime-backed submission."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def submit_evaluation_run_route(
+    request: EvaluationRunSubmissionRequest,
+) -> EvaluationRunSubmissionResponse:
+    return submit_evaluation_run(request)
 
 
 @router.get(
@@ -94,10 +121,10 @@ async def get_evaluation_fixture_detail_route(fixture_id: str) -> EvaluationFixt
     "/runs/{run_id}",
     response_model=EvaluationRunDetailResponse,
     operation_id="getEvaluationRunDetail",
-    summary="Get lotus-ai recorded evaluation run artifact detail",
+    summary="Get lotus-ai evaluation run detail",
     description=(
-        "Returns detail for a specific recorded evaluation run artifact, including seam-oriented "
-        "coverage captured at recording time."
+        "Returns detail for a specific evaluation run from historical staged artifacts or durable "
+        "runtime-backed submission state."
     ),
     responses={
         200: {"description": "Evaluation run artifact detail returned successfully."},

--- a/src/app/services/async_activation_readiness_service.py
+++ b/src/app/services/async_activation_readiness_service.py
@@ -9,7 +9,7 @@ def build_async_activation_readiness() -> AsyncActivationReadinessResponse:
     runtime = build_async_runtime_status()
     blocking_findings = [
         "Dedicated queue-backed worker execution remains disabled; the current durable in-process worker posture is reviewable but not yet horizontally isolated.",
-        "Only a narrow allowlist of async job types is runtime-backed today; broader async surfaces such as evaluation execution remain staged.",
+        "Only a narrow allowlist of async job types is runtime-backed today; retrieval indexing and evaluation execution are active, but broader async surfaces remain staged or documented-only.",
     ]
     activation_path = [
         "Activate an isolated queue-backed worker execution strategy on top of the durable submission, claim, lease, and recovery model.",

--- a/src/app/services/async_governance_status_service.py
+++ b/src/app/services/async_governance_status_service.py
@@ -15,7 +15,7 @@ def build_async_governance_status() -> AsyncGovernanceStatusResponse:
         runbook_readiness.runbook_ready,
     )
     governance_summary = [
-        "Async technical activation remains partially blocked in foundation phase: durable submission, worker claim, lease recovery, and retrieval-indexing execution are active for a narrow allowlist, but dedicated worker fleet rollout and broader job enablement are still gated.",
+        "Async technical activation remains partially blocked in foundation phase: durable submission, worker claim, lease recovery, retrieval-indexing execution, and evaluation execution are active for a narrow allowlist, but dedicated worker fleet rollout and broader job enablement are still gated.",
         "Async operational runbook readiness remains incomplete until on-call, observability, and queue-backed recovery procedures are fully documented and approved.",
     ]
     return AsyncGovernanceStatusResponse(

--- a/src/app/services/async_job_type_catalog.py
+++ b/src/app/services/async_job_type_catalog.py
@@ -17,10 +17,10 @@ def list_async_job_types() -> list[AsyncJobTypeDescriptor]:
         AsyncJobTypeDescriptor(
             job_type="evaluation_execution",
             enabled=True,
-            execution_path="durable_runtime_submission",
+            execution_path="durable_runtime_worker_execution",
             notes=(
-                "Evaluation execution now supports narrow runtime-backed submission for allowlisted "
-                "fixture families, while worker-backed case execution remains a later slice."
+                "Evaluation execution now supports narrow runtime-backed submission, worker claim, "
+                "case execution, and persisted verdict history for allowlisted fixture families."
             ),
         ),
         AsyncJobTypeDescriptor(

--- a/src/app/services/async_job_type_catalog.py
+++ b/src/app/services/async_job_type_catalog.py
@@ -16,11 +16,11 @@ def list_async_job_types() -> list[AsyncJobTypeDescriptor]:
         ),
         AsyncJobTypeDescriptor(
             job_type="evaluation_execution",
-            enabled=False,
-            execution_path="future_worker_queue",
+            enabled=True,
+            execution_path="durable_runtime_submission",
             notes=(
-                "Evaluation execution remains staged and artifact-backed until a later async "
-                "execution slice activates runtime-backed evaluation jobs."
+                "Evaluation execution now supports narrow runtime-backed submission for allowlisted "
+                "fixture families, while worker-backed case execution remains a later slice."
             ),
         ),
         AsyncJobTypeDescriptor(

--- a/src/app/services/async_runtime_control.py
+++ b/src/app/services/async_runtime_control.py
@@ -18,6 +18,10 @@ from app.repositories.async_runtime_repository import (
     AsyncRuntimeControlEventRecord,
     AsyncRuntimeJobRecord,
 )
+from app.services.eval_attempt_runtime import (
+    abandon_active_evaluation_attempt,
+    queue_next_evaluation_attempt,
+)
 from app.services.async_job_mapping import map_async_runtime_control_event
 from app.services.async_runtime_store import get_async_runtime_store
 from app.services.async_runtime_transitions import queue_next_async_attempt
@@ -78,18 +82,22 @@ def _apply_control_action(
     action_type = request.action_type
     if action_type == AsyncControlActionType.RETRY_FAILED_JOB:
         created_attempt = _retry_failed_job(job=job, reason=request.reason)
+        _sync_evaluation_retryable_action(job=job, reason=request.reason, prefix="Manual retry")
         resulting_status = AsyncJobStatus.QUEUED.value
         affected_attempt_id = created_attempt.attempt_id
     elif action_type == AsyncControlActionType.REPLAY_TERMINAL_JOB:
         created_attempt = _replay_terminal_job(job=job, reason=request.reason)
+        _sync_evaluation_retryable_action(job=job, reason=request.reason, prefix="Manual replay")
         resulting_status = AsyncJobStatus.QUEUED.value
         affected_attempt_id = created_attempt.attempt_id
     elif action_type == AsyncControlActionType.REQUEUE_ABANDONED_JOB:
         created_attempt = _requeue_abandoned_job(job=job, reason=request.reason)
+        _sync_evaluation_retryable_action(job=job, reason=request.reason, prefix="Manual requeue")
         resulting_status = AsyncJobStatus.QUEUED.value
         affected_attempt_id = created_attempt.attempt_id
     elif action_type == AsyncControlActionType.ABANDON_ACTIVE_JOB:
         affected_attempt_id = _abandon_active_job(job=job, reason=request.reason)
+        _sync_evaluation_abandon(job=job, reason=request.reason)
         resulting_status = AsyncJobStatus.ABANDONED.value
     else:
         raise RuntimeError("Unsupported async control action.")
@@ -211,3 +219,27 @@ def _abandon_active_job(*, job: AsyncRuntimeJobRecord, reason: str) -> str:
 
 def _utcnow() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _sync_evaluation_retryable_action(
+    *,
+    job: AsyncRuntimeJobRecord,
+    reason: str,
+    prefix: str,
+) -> None:
+    if job.related_evaluation_run_id is None:
+        return
+    queue_next_evaluation_attempt(
+        run_id=job.related_evaluation_run_id,
+        reason_message=f"{prefix} queued after operator action: {reason}",
+    )
+
+
+def _sync_evaluation_abandon(*, job: AsyncRuntimeJobRecord, reason: str) -> None:
+    if job.related_evaluation_run_id is None:
+        return
+    abandon_active_evaluation_attempt(
+        run_id=job.related_evaluation_run_id,
+        reason_message=f"Evaluation attempt manually abandoned: {reason}",
+        failure_reason="MANUAL_ABANDON",
+    )

--- a/src/app/services/async_runtime_status.py
+++ b/src/app/services/async_runtime_status.py
@@ -34,7 +34,8 @@ def build_async_runtime_status() -> AsyncRuntimeStatusResponse:
         supported_job_types=list_async_job_types(),
         message=(
             "Async submission, claim, lease, recovery, and terminal-state tracking are durable "
-            "for a narrow allowlist, with retrieval indexing already running through the runtime-backed "
-            "in-process worker path. Dedicated queue-backed worker fleet execution is still disabled."
+            "for a narrow allowlist, with retrieval indexing and evaluation execution already running "
+            "through the runtime-backed in-process worker path. Dedicated queue-backed worker fleet "
+            "execution is still disabled."
         ),
     )

--- a/src/app/services/async_submission_service.py
+++ b/src/app/services/async_submission_service.py
@@ -21,9 +21,12 @@ from app.repositories.async_runtime_repository import (
 from app.services.retrieval_catalog_service import get_retrieval_job_detail_or_raise
 from app.services.async_job_type_catalog import get_async_job_type_descriptor
 from app.services.async_runtime_store import get_async_runtime_store
+from app.services.eval_run_submission_service import submit_evaluation_execution_async_job
 
 
 def submit_async_job(request: AsyncJobSubmissionRequest) -> AsyncJobSubmissionResponse:
+    if request.job_type == "evaluation_execution":
+        return submit_evaluation_execution_async_job(request)
     job_type = get_async_job_type_descriptor(job_type=request.job_type)
     if job_type is None:
         raise HTTPException(

--- a/src/app/services/async_worker_runtime.py
+++ b/src/app/services/async_worker_runtime.py
@@ -25,10 +25,19 @@ class AsyncWorkerClaimResult:
 
 
 def claim_next_async_job(*, worker_id: str) -> AsyncWorkerClaimResult | None:
+    return claim_next_async_job_for_types(worker_id=worker_id, job_types=None)
+
+
+def claim_next_async_job_for_types(
+    *,
+    worker_id: str,
+    job_types: tuple[str, ...] | None,
+) -> AsyncWorkerClaimResult | None:
     now = _utcnow()
     recover_expired_async_jobs(now=now)
     claimed = get_async_runtime_store().claim_next_runnable_job(
         worker_id=worker_id,
+        job_types=job_types,
         claimed_at=_isoformat(now),
         heartbeat_at=_isoformat(now),
         lease_expires_at=_isoformat(now + timedelta(seconds=_LEASE_SECONDS)),

--- a/src/app/services/async_worker_runtime.py
+++ b/src/app/services/async_worker_runtime.py
@@ -11,6 +11,11 @@ from app.repositories.async_runtime_repository import (
     AsyncRuntimeJobRecord,
     AsyncRuntimeLeaseRecord,
 )
+from app.services.eval_attempt_runtime import (
+    abandon_active_evaluation_attempt,
+    claim_active_evaluation_attempt,
+    queue_next_evaluation_attempt,
+)
 from app.services.async_runtime_store import get_async_runtime_store
 from app.services.async_runtime_transitions import queue_next_async_attempt
 
@@ -48,6 +53,14 @@ def claim_next_async_job_for_types(
     )
     if claimed is None:
         return None
+    if claimed.job.related_evaluation_run_id is not None:
+        claim_active_evaluation_attempt(
+            run_id=claimed.job.related_evaluation_run_id,
+            worker_id=worker_id,
+            reason_message=(
+                f"Evaluation attempt claimed by worker '{worker_id}' and is waiting for explicit execution start."
+            ),
+        )
     return AsyncWorkerClaimResult(
         job=claimed.job,
         attempt=claimed.attempt,
@@ -265,6 +278,16 @@ def recover_expired_async_jobs(*, now: datetime | None = None) -> list[str]:
             job=job,
             reason_message="Retry queued after lease expiry recovery.",
         )
+        if job.related_evaluation_run_id is not None:
+            abandon_active_evaluation_attempt(
+                run_id=job.related_evaluation_run_id,
+                reason_message="Evaluation attempt abandoned after async lease expiry recovery.",
+                failure_reason="LEASE_EXPIRED",
+            )
+            queue_next_evaluation_attempt(
+                run_id=job.related_evaluation_run_id,
+                reason_message="Evaluation retry queued after async lease expiry recovery.",
+            )
         recovered_job_ids.append(job.job_id)
     return recovered_job_ids
 

--- a/src/app/services/eval_approval_gate_summary.py
+++ b/src/app/services/eval_approval_gate_summary.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.contracts.evals import (
+    EvaluationApprovalEvidenceState,
+    EvaluationApprovalFixtureSummaryDescriptor,
+    EvaluationApprovalGateSummaryDescriptor,
+    EvaluationRunRecordSource,
+    EvaluationRunStatus,
+    EvaluationRunVerdict,
+)
+from app.evals.fixture_manifest import load_evaluation_fixture_manifest
+from app.evals.run_registry import load_evaluation_run_artifacts
+from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+_PROVIDER_APPROVAL_FIXTURE_IDS = (
+    "provider_policy_examples",
+    "provider_runtime_examples",
+    "provider_failure_mode_examples",
+    "provider_operations_examples",
+    "provider_degradation_examples",
+)
+
+_RETRIEVAL_APPROVAL_FIXTURE_IDS = ("retrieval_citation_examples",)
+
+
+@dataclass(frozen=True)
+class _FixtureApprovalSummary:
+    fixture_id: str
+    state: EvaluationApprovalEvidenceState
+    runtime_run: EvaluationRunRecord | None
+    notes: str
+
+
+def build_provider_approval_gate_summary() -> EvaluationApprovalGateSummaryDescriptor:
+    return _build_approval_gate_summary(
+        domain_id="provider_execution",
+        domain_label="Provider Execution",
+        required_fixture_ids=_PROVIDER_APPROVAL_FIXTURE_IDS,
+    )
+
+
+def build_retrieval_approval_gate_summary() -> EvaluationApprovalGateSummaryDescriptor:
+    return _build_approval_gate_summary(
+        domain_id="retrieval_execution",
+        domain_label="Retrieval Execution",
+        required_fixture_ids=_RETRIEVAL_APPROVAL_FIXTURE_IDS,
+    )
+
+
+def _build_approval_gate_summary(
+    *,
+    domain_id: str,
+    domain_label: str,
+    required_fixture_ids: tuple[str, ...],
+) -> EvaluationApprovalGateSummaryDescriptor:
+    manifest_version = load_evaluation_fixture_manifest().manifest_version
+    fixture_summaries = [
+        _summarize_fixture_approval(fixture_id=fixture_id, manifest_version=manifest_version)
+        for fixture_id in required_fixture_ids
+    ]
+    historical_runs = [
+        run
+        for run in load_evaluation_run_artifacts()
+        if run.record_source == EvaluationRunRecordSource.STAGED_ARTIFACT
+        and any(
+            fixture_id in seam.fixture_ids
+            for seam in run.seam_coverage
+            for fixture_id in required_fixture_ids
+        )
+    ]
+    historical_runs.sort(key=lambda item: item.recorded_at, reverse=True)
+    latest_historical_baseline_run_id = historical_runs[0].run_id if historical_runs else None
+
+    evidence_state = _derive_domain_state(fixture_summaries=fixture_summaries)
+    latest_runtime_run = max(
+        (summary.runtime_run for summary in fixture_summaries if summary.runtime_run is not None),
+        key=lambda item: item.submitted_at,
+        default=None,
+    )
+    runtime_backed_fixture_count = sum(
+        1
+        for summary in fixture_summaries
+        if summary.state
+        in {
+            EvaluationApprovalEvidenceState.RUNTIME_PASS,
+            EvaluationApprovalEvidenceState.RUNTIME_FAIL,
+            EvaluationApprovalEvidenceState.RUNTIME_IN_PROGRESS,
+            EvaluationApprovalEvidenceState.RUNTIME_STALE,
+        }
+    )
+    notes = _build_domain_notes(
+        domain_label=domain_label,
+        evidence_state=evidence_state,
+        fixture_summaries=fixture_summaries,
+        latest_historical_baseline_run_id=latest_historical_baseline_run_id,
+    )
+    return EvaluationApprovalGateSummaryDescriptor(
+        domain_id=domain_id,
+        domain_label=domain_label,
+        approval_ready=evidence_state == EvaluationApprovalEvidenceState.RUNTIME_PASS,
+        evidence_state=evidence_state,
+        required_fixture_count=len(required_fixture_ids),
+        runtime_backed_fixture_count=runtime_backed_fixture_count,
+        latest_runtime_run_id=None if latest_runtime_run is None else latest_runtime_run.run_id,
+        latest_runtime_recorded_at=(
+            None if latest_runtime_run is None else latest_runtime_run.submitted_at
+        ),
+        latest_historical_baseline_run_id=latest_historical_baseline_run_id,
+        fixture_summaries=[
+            EvaluationApprovalFixtureSummaryDescriptor(
+                fixture_id=summary.fixture_id,
+                latest_runtime_run_id=(
+                    None if summary.runtime_run is None else summary.runtime_run.run_id
+                ),
+                latest_runtime_recorded_at=(
+                    None if summary.runtime_run is None else summary.runtime_run.submitted_at
+                ),
+                latest_runtime_status=(
+                    None
+                    if summary.runtime_run is None
+                    else EvaluationRunStatus(summary.runtime_run.lifecycle_status)
+                ),
+                latest_runtime_verdict=(
+                    None
+                    if summary.runtime_run is None or summary.runtime_run.verdict is None
+                    else EvaluationRunVerdict(summary.runtime_run.verdict)
+                ),
+                evidence_state=summary.state,
+                notes=summary.notes,
+            )
+            for summary in fixture_summaries
+        ],
+        notes=notes,
+    )
+
+
+def _summarize_fixture_approval(
+    *,
+    fixture_id: str,
+    manifest_version: str,
+) -> _FixtureApprovalSummary:
+    runs = [
+        run
+        for run in get_evaluation_runtime_store().list_runs()
+        if run.fixture_id == fixture_id
+    ]
+    runs.sort(key=lambda item: item.submitted_at, reverse=True)
+    latest_runtime_run = runs[0] if runs else None
+    if latest_runtime_run is None:
+        return _FixtureApprovalSummary(
+            fixture_id=fixture_id,
+            state=EvaluationApprovalEvidenceState.STAGED_ONLY,
+            runtime_run=None,
+            notes="No runtime-backed evaluation run has been recorded for this fixture family yet.",
+        )
+    if latest_runtime_run.manifest_version != manifest_version:
+        return _FixtureApprovalSummary(
+            fixture_id=fixture_id,
+            state=EvaluationApprovalEvidenceState.RUNTIME_STALE,
+            runtime_run=latest_runtime_run,
+            notes=(
+                f"Latest runtime-backed evaluation run '{latest_runtime_run.run_id}' uses "
+                f"manifest version '{latest_runtime_run.manifest_version}' instead of the current "
+                f"'{manifest_version}'."
+            ),
+        )
+    if latest_runtime_run.lifecycle_status in {"QUEUED", "CLAIMED", "RUNNING"}:
+        return _FixtureApprovalSummary(
+            fixture_id=fixture_id,
+            state=EvaluationApprovalEvidenceState.RUNTIME_IN_PROGRESS,
+            runtime_run=latest_runtime_run,
+            notes=(
+                f"Latest runtime-backed evaluation run '{latest_runtime_run.run_id}' is still "
+                f"{latest_runtime_run.lifecycle_status.lower()}."
+            ),
+        )
+    if latest_runtime_run.lifecycle_status == "COMPLETED" and latest_runtime_run.verdict == "PASS":
+        return _FixtureApprovalSummary(
+            fixture_id=fixture_id,
+            state=EvaluationApprovalEvidenceState.RUNTIME_PASS,
+            runtime_run=latest_runtime_run,
+            notes=(
+                f"Latest runtime-backed evaluation run '{latest_runtime_run.run_id}' passed under "
+                "the current fixture manifest."
+            ),
+        )
+    return _FixtureApprovalSummary(
+        fixture_id=fixture_id,
+        state=EvaluationApprovalEvidenceState.RUNTIME_FAIL,
+        runtime_run=latest_runtime_run,
+        notes=(
+            f"Latest runtime-backed evaluation run '{latest_runtime_run.run_id}' did not produce "
+            "an approval-satisfying passing verdict."
+        ),
+    )
+
+
+def _derive_domain_state(
+    *,
+    fixture_summaries: list[_FixtureApprovalSummary],
+) -> EvaluationApprovalEvidenceState:
+    states = {summary.state for summary in fixture_summaries}
+    if states == {EvaluationApprovalEvidenceState.RUNTIME_PASS}:
+        return EvaluationApprovalEvidenceState.RUNTIME_PASS
+    if EvaluationApprovalEvidenceState.RUNTIME_FAIL in states:
+        return EvaluationApprovalEvidenceState.RUNTIME_FAIL
+    if EvaluationApprovalEvidenceState.RUNTIME_IN_PROGRESS in states:
+        return EvaluationApprovalEvidenceState.RUNTIME_IN_PROGRESS
+    if EvaluationApprovalEvidenceState.RUNTIME_STALE in states:
+        return EvaluationApprovalEvidenceState.RUNTIME_STALE
+    if EvaluationApprovalEvidenceState.RUNTIME_PASS in states:
+        return EvaluationApprovalEvidenceState.RUNTIME_PARTIAL
+    if states == {EvaluationApprovalEvidenceState.STAGED_ONLY}:
+        return EvaluationApprovalEvidenceState.STAGED_ONLY
+    return EvaluationApprovalEvidenceState.NO_EVIDENCE
+
+
+def _build_domain_notes(
+    *,
+    domain_label: str,
+    evidence_state: EvaluationApprovalEvidenceState,
+    fixture_summaries: list[_FixtureApprovalSummary],
+    latest_historical_baseline_run_id: str | None,
+) -> list[str]:
+    if evidence_state == EvaluationApprovalEvidenceState.RUNTIME_PASS:
+        return [
+            f"{domain_label} approval posture is currently backed by passing runtime-produced evaluation evidence.",
+            "Current runtime-backed fixture coverage satisfies all governed approval fixture families.",
+        ]
+    if evidence_state == EvaluationApprovalEvidenceState.RUNTIME_FAIL:
+        failing_fixtures = [
+            summary.fixture_id
+            for summary in fixture_summaries
+            if summary.state == EvaluationApprovalEvidenceState.RUNTIME_FAIL
+        ]
+        return [
+            f"{domain_label} approval posture is blocked by failing runtime-backed evaluation evidence.",
+            f"Failing fixture families: {', '.join(sorted(failing_fixtures))}.",
+        ]
+    if evidence_state == EvaluationApprovalEvidenceState.RUNTIME_IN_PROGRESS:
+        return [
+            f"{domain_label} approval posture is waiting on in-flight runtime-backed evaluation execution.",
+            "Staged historical baselines remain visible, but they do not satisfy current approval posture while runtime execution is in progress.",
+        ]
+    if evidence_state == EvaluationApprovalEvidenceState.RUNTIME_STALE:
+        return [
+            f"{domain_label} approval posture is blocked by stale runtime-backed evaluation evidence.",
+            "A newer fixture manifest exists than the latest runtime-backed evaluation result.",
+        ]
+    if evidence_state == EvaluationApprovalEvidenceState.RUNTIME_PARTIAL:
+        covered = [
+            summary.fixture_id
+            for summary in fixture_summaries
+            if summary.state == EvaluationApprovalEvidenceState.RUNTIME_PASS
+        ]
+        return [
+            f"{domain_label} approval posture has partial runtime-backed evaluation coverage but is not yet complete.",
+            f"Runtime-backed passing fixtures: {', '.join(sorted(covered))}.",
+        ]
+    if latest_historical_baseline_run_id is not None:
+        return [
+            f"{domain_label} approval posture still relies on staged historical baseline '{latest_historical_baseline_run_id}'.",
+            "Historical artifacts remain visible for continuity, but they do not satisfy current runtime-backed approval requirements.",
+        ]
+    return [
+        f"{domain_label} approval posture has no historical or runtime-backed evaluation evidence yet."
+    ]

--- a/src/app/services/eval_approval_gate_summary.py
+++ b/src/app/services/eval_approval_gate_summary.py
@@ -143,9 +143,7 @@ def _summarize_fixture_approval(
     manifest_version: str,
 ) -> _FixtureApprovalSummary:
     runs = [
-        run
-        for run in get_evaluation_runtime_store().list_runs()
-        if run.fixture_id == fixture_id
+        run for run in get_evaluation_runtime_store().list_runs() if run.fixture_id == fixture_id
     ]
     runs.sort(key=lambda item: item.submitted_at, reverse=True)
     latest_runtime_run = runs[0] if runs else None

--- a/src/app/services/eval_async_execution.py
+++ b/src/app/services/eval_async_execution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.services.eval_attempt_runtime import fail_active_evaluation_attempt
 from app.services.async_worker_runtime import (
     claim_next_async_job_for_types,
     complete_async_job,
@@ -10,7 +10,6 @@ from app.services.async_worker_runtime import (
     start_async_job,
 )
 from app.services.eval_runtime_execution import execute_runtime_backed_evaluation_run
-from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 
 
 @dataclass(frozen=True)
@@ -50,22 +49,13 @@ def run_next_evaluation_execution_job(*, worker_id: str) -> EvaluationAsyncExecu
             failure_reason=type(exc).__name__,
             retryable=False,
         )
-        run = get_evaluation_runtime_store().get_run(run_id=claim.job.related_evaluation_run_id)
-        if run is not None:
-            get_evaluation_runtime_store().save_run(
-                EvaluationRunRecord(
-                    run_id=run.run_id,
-                    fixture_id=run.fixture_id,
-                    manifest_version=run.manifest_version,
-                    lifecycle_status="FAILED",
-                    triggered_by=run.triggered_by,
-                    submitted_at=run.submitted_at,
-                    async_job_id=run.async_job_id,
-                    latest_message=f"Runtime-backed evaluation execution failed with {type(exc).__name__}.",
-                    verdict=None,
-                    case_count=run.case_count,
-                )
-            )
+        fail_active_evaluation_attempt(
+            run_id=claim.job.related_evaluation_run_id,
+            reason_message=(
+                f"Runtime-backed evaluation execution failed with {type(exc).__name__}."
+            ),
+            failure_reason=type(exc).__name__,
+        )
         raise
 
     completion_message = (

--- a/src/app/services/eval_async_execution.py
+++ b/src/app/services/eval_async_execution.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.services.async_worker_runtime import (
+    claim_next_async_job_for_types,
+    complete_async_job,
+    fail_async_job,
+    start_async_job,
+)
+from app.services.eval_runtime_execution import execute_runtime_backed_evaluation_run
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+
+@dataclass(frozen=True)
+class EvaluationAsyncExecutionResult:
+    async_job_id: str
+    evaluation_run_id: str
+    verdict: str
+    case_result_count: int
+
+
+def run_next_evaluation_execution_job(*, worker_id: str) -> EvaluationAsyncExecutionResult | None:
+    claim = claim_next_async_job_for_types(
+        worker_id=worker_id,
+        job_types=("evaluation_execution",),
+    )
+    if claim is None:
+        return None
+    if claim.job.job_type != "evaluation_execution" or claim.job.related_evaluation_run_id is None:
+        fail_async_job(
+            job_id=claim.job.job_id,
+            worker_id=worker_id,
+            failure_reason="UNSUPPORTED_ASYNC_JOB_TYPE",
+            retryable=False,
+        )
+        return None
+
+    start_async_job(job_id=claim.job.job_id, worker_id=worker_id)
+    try:
+        result = execute_runtime_backed_evaluation_run(
+            run_id=claim.job.related_evaluation_run_id,
+            worker_id=worker_id,
+        )
+    except Exception as exc:
+        fail_async_job(
+            job_id=claim.job.job_id,
+            worker_id=worker_id,
+            failure_reason=type(exc).__name__,
+            retryable=False,
+        )
+        run = get_evaluation_runtime_store().get_run(run_id=claim.job.related_evaluation_run_id)
+        if run is not None:
+            get_evaluation_runtime_store().save_run(
+                EvaluationRunRecord(
+                    run_id=run.run_id,
+                    fixture_id=run.fixture_id,
+                    manifest_version=run.manifest_version,
+                    lifecycle_status="FAILED",
+                    triggered_by=run.triggered_by,
+                    submitted_at=run.submitted_at,
+                    async_job_id=run.async_job_id,
+                    latest_message=f"Runtime-backed evaluation execution failed with {type(exc).__name__}.",
+                    verdict=None,
+                    case_count=run.case_count,
+                )
+            )
+        raise
+
+    completion_message = (
+        f"Runtime-backed evaluation execution completed with verdict '{result.verdict.value}'."
+    )
+    complete_async_job(
+        job_id=claim.job.job_id,
+        worker_id=worker_id,
+        message=completion_message,
+    )
+    return EvaluationAsyncExecutionResult(
+        async_job_id=claim.job.job_id,
+        evaluation_run_id=result.run_id,
+        verdict=result.verdict.value,
+        case_result_count=result.case_result_count,
+    )

--- a/src/app/services/eval_attempt_runtime.py
+++ b/src/app/services/eval_attempt_runtime.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+)
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+
+def queue_next_evaluation_attempt(*, run_id: str, reason_message: str) -> EvaluationRunAttemptRecord:
+    store = get_evaluation_runtime_store()
+    run = _get_run_or_raise(run_id=run_id)
+    attempts = store.list_attempts(run_id=run_id)
+    next_attempt_number = (attempts[-1].attempt_number + 1) if attempts else 1
+    attempt = EvaluationRunAttemptRecord(
+        attempt_id=f"{run_id}_attempt_{next_attempt_number:03d}",
+        run_id=run_id,
+        attempt_number=next_attempt_number,
+        lifecycle_status="QUEUED",
+        started_at=None,
+        completed_at=None,
+        worker_id=None,
+        latest_message=reason_message,
+        verdict=None,
+        failure_reason=None,
+    )
+    store.save_attempt(attempt)
+    store.save_run(
+        EvaluationRunRecord(
+            run_id=run.run_id,
+            fixture_id=run.fixture_id,
+            manifest_version=run.manifest_version,
+            lifecycle_status="QUEUED",
+            triggered_by=run.triggered_by,
+            submitted_at=run.submitted_at,
+            async_job_id=run.async_job_id,
+            latest_message=reason_message,
+            verdict=None,
+            case_count=run.case_count,
+        )
+    )
+    return attempt
+
+
+def claim_active_evaluation_attempt(
+    *,
+    run_id: str,
+    worker_id: str,
+    reason_message: str,
+) -> EvaluationRunAttemptRecord | None:
+    store = get_evaluation_runtime_store()
+    run = store.get_run(run_id=run_id)
+    if run is None:
+        return None
+    attempt = _get_latest_active_attempt(run_id=run_id)
+    if attempt is None:
+        return None
+    claimed = EvaluationRunAttemptRecord(
+        attempt_id=attempt.attempt_id,
+        run_id=attempt.run_id,
+        attempt_number=attempt.attempt_number,
+        lifecycle_status="CLAIMED",
+        started_at=attempt.started_at,
+        completed_at=attempt.completed_at,
+        worker_id=worker_id,
+        latest_message=reason_message,
+        verdict=None,
+        failure_reason=None,
+    )
+    store.save_attempt(claimed)
+    store.save_run(
+        EvaluationRunRecord(
+            run_id=run.run_id,
+            fixture_id=run.fixture_id,
+            manifest_version=run.manifest_version,
+            lifecycle_status="QUEUED",
+            triggered_by=run.triggered_by,
+            submitted_at=run.submitted_at,
+            async_job_id=run.async_job_id,
+            latest_message=reason_message,
+            verdict=None,
+            case_count=run.case_count,
+        )
+    )
+    return claimed
+
+
+def abandon_active_evaluation_attempt(
+    *,
+    run_id: str,
+    reason_message: str,
+    failure_reason: str,
+) -> EvaluationRunAttemptRecord | None:
+    store = get_evaluation_runtime_store()
+    run = store.get_run(run_id=run_id)
+    if run is None:
+        return None
+    attempt = _get_latest_active_attempt(run_id=run_id)
+    if attempt is None:
+        return None
+    abandoned = EvaluationRunAttemptRecord(
+        attempt_id=attempt.attempt_id,
+        run_id=attempt.run_id,
+        attempt_number=attempt.attempt_number,
+        lifecycle_status="ABANDONED",
+        started_at=attempt.started_at,
+        completed_at=attempt.completed_at,
+        worker_id=attempt.worker_id,
+        latest_message=reason_message,
+        verdict=None,
+        failure_reason=failure_reason,
+    )
+    store.save_attempt(abandoned)
+    store.save_run(
+        EvaluationRunRecord(
+            run_id=run.run_id,
+            fixture_id=run.fixture_id,
+            manifest_version=run.manifest_version,
+            lifecycle_status="ABANDONED",
+            triggered_by=run.triggered_by,
+            submitted_at=run.submitted_at,
+            async_job_id=run.async_job_id,
+            latest_message=reason_message,
+            verdict=None,
+            case_count=run.case_count,
+        )
+    )
+    return abandoned
+
+
+def fail_active_evaluation_attempt(
+    *,
+    run_id: str,
+    reason_message: str,
+    failure_reason: str,
+) -> EvaluationRunAttemptRecord | None:
+    store = get_evaluation_runtime_store()
+    run = store.get_run(run_id=run_id)
+    if run is None:
+        return None
+    attempt = _get_latest_active_attempt(run_id=run_id)
+    if attempt is None:
+        return None
+    failed = EvaluationRunAttemptRecord(
+        attempt_id=attempt.attempt_id,
+        run_id=attempt.run_id,
+        attempt_number=attempt.attempt_number,
+        lifecycle_status="FAILED",
+        started_at=attempt.started_at,
+        completed_at=attempt.completed_at,
+        worker_id=attempt.worker_id,
+        latest_message=reason_message,
+        verdict=None,
+        failure_reason=failure_reason,
+    )
+    store.save_attempt(failed)
+    store.save_run(
+        EvaluationRunRecord(
+            run_id=run.run_id,
+            fixture_id=run.fixture_id,
+            manifest_version=run.manifest_version,
+            lifecycle_status="FAILED",
+            triggered_by=run.triggered_by,
+            submitted_at=run.submitted_at,
+            async_job_id=run.async_job_id,
+            latest_message=reason_message,
+            verdict=None,
+            case_count=run.case_count,
+        )
+    )
+    return failed
+
+
+def _get_latest_active_attempt(*, run_id: str) -> EvaluationRunAttemptRecord | None:
+    attempts = get_evaluation_runtime_store().list_attempts(run_id=run_id)
+    for attempt in reversed(attempts):
+        if attempt.lifecycle_status in {"QUEUED", "CLAIMED", "RUNNING"}:
+            return attempt
+    return None
+
+
+def _get_run_or_raise(*, run_id: str) -> EvaluationRunRecord:
+    run = get_evaluation_runtime_store().get_run(run_id=run_id)
+    if run is None:
+        raise RuntimeError(f"Evaluation run '{run_id}' was not found in runtime state.")
+    return run

--- a/src/app/services/eval_attempt_runtime.py
+++ b/src/app/services/eval_attempt_runtime.py
@@ -7,7 +7,9 @@ from app.repositories.evaluation_runtime_repository import (
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 
 
-def queue_next_evaluation_attempt(*, run_id: str, reason_message: str) -> EvaluationRunAttemptRecord:
+def queue_next_evaluation_attempt(
+    *, run_id: str, reason_message: str
+) -> EvaluationRunAttemptRecord:
     store = get_evaluation_runtime_store()
     run = _get_run_or_raise(run_id=run_id)
     attempts = store.list_attempts(run_id=run_id)

--- a/src/app/services/eval_run_service.py
+++ b/src/app/services/eval_run_service.py
@@ -4,15 +4,28 @@ from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.evals import (
+    EvaluationRunArtifactDescriptor,
+    EvaluationRunRecordSource,
     EvaluationRunCatalogResponse,
     EvaluationRunDetailResponse,
+    EvaluationSeamCoverageDescriptor,
     EvaluationRunStatus,
 )
+from app.evals.fixture_manifest import load_evaluation_fixture_manifest
 from app.evals.run_registry import load_evaluation_run_artifacts
+from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.services.eval_seam_summary import SEAM_FIXTURE_MAP
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+_FIXTURE_SEAM_LOOKUP = {
+    fixture_id: seam_id
+    for seam_id, fixture_ids in SEAM_FIXTURE_MAP.items()
+    for fixture_id in fixture_ids
+}
 
 
 def build_evaluation_run_catalog() -> EvaluationRunCatalogResponse:
-    runs = load_evaluation_run_artifacts()
+    runs = _list_evaluation_runs()
     latest_run_id = runs[0].run_id if runs else None
     status_counts = {
         status: sum(1 for run in runs if run.status == status) for status in EvaluationRunStatus
@@ -23,22 +36,67 @@ def build_evaluation_run_catalog() -> EvaluationRunCatalogResponse:
         delivery_phase=settings.delivery_phase,
         run_count=len(runs),
         latest_run_id=latest_run_id,
+        runtime_backed_run_count=sum(
+            1 for run in runs if run.record_source == EvaluationRunRecordSource.RUNTIME_STATE
+        ),
+        historical_run_count=sum(
+            1 for run in runs if run.record_source == EvaluationRunRecordSource.STAGED_ARTIFACT
+        ),
         status_counts=status_counts,
         runs=runs,
     )
 
 
 def build_evaluation_run_detail(*, run_id: str) -> EvaluationRunDetailResponse:
-    runs = load_evaluation_run_artifacts()
-    run = next((item for item in runs if item.run_id == run_id), None)
+    run = next((item for item in _list_evaluation_runs() if item.run_id == run_id), None)
     if run is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Evaluation run artifact '{run_id}' was not found.",
+            detail=f"Evaluation run '{run_id}' was not found.",
         )
     return EvaluationRunDetailResponse(
         service=settings.service_name,
         version=settings.service_version,
         delivery_phase=settings.delivery_phase,
         run=run,
+    )
+
+
+def _list_evaluation_runs() -> list[EvaluationRunArtifactDescriptor]:
+    runtime_runs = [
+        _map_runtime_evaluation_run(record)
+        for record in get_evaluation_runtime_store().list_runs()
+    ]
+    historical_runs = load_evaluation_run_artifacts()
+    return sorted(runtime_runs + historical_runs, key=lambda run: run.recorded_at, reverse=True)
+
+
+def _map_runtime_evaluation_run(record: EvaluationRunRecord) -> EvaluationRunArtifactDescriptor:
+    fixture_manifest = load_evaluation_fixture_manifest()
+    fixture_descriptor = next(
+        fixture
+        for fixture in fixture_manifest.fixture_families
+        if fixture.fixture_id == record.fixture_id
+    )
+    seam_id = _FIXTURE_SEAM_LOOKUP.get(record.fixture_id, "task_execution")
+    return EvaluationRunArtifactDescriptor(
+        run_id=record.run_id,
+        recorded_at=record.submitted_at,
+        status=EvaluationRunStatus(record.lifecycle_status),
+        record_source=EvaluationRunRecordSource.RUNTIME_STATE,
+        manifest_version=record.manifest_version,
+        fixture_id=record.fixture_id,
+        async_job_id=record.async_job_id,
+        triggered_by=record.triggered_by,
+        staged_fixture_count=1,
+        staged_case_count=record.case_count,
+        seam_coverage=[
+            EvaluationSeamCoverageDescriptor(
+                seam_id=seam_id,
+                fixture_ids=[record.fixture_id],
+                staged_fixture_count=1,
+                staged_case_count=fixture_descriptor.case_count,
+            )
+        ],
+        notes=record.latest_message,
     )

--- a/src/app/services/eval_run_service.py
+++ b/src/app/services/eval_run_service.py
@@ -5,15 +5,23 @@ from fastapi import HTTPException, status
 from app.config import settings
 from app.contracts.evals import (
     EvaluationRunArtifactDescriptor,
+    EvaluationCaseOutcome,
+    EvaluationCaseResultDescriptor,
     EvaluationRunRecordSource,
     EvaluationRunCatalogResponse,
     EvaluationRunDetailResponse,
+    EvaluationRunAttemptDescriptor,
+    EvaluationRunVerdict,
     EvaluationSeamCoverageDescriptor,
     EvaluationRunStatus,
 )
 from app.evals.fixture_manifest import load_evaluation_fixture_manifest
 from app.evals.run_registry import load_evaluation_run_artifacts
-from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+)
 from app.services.eval_seam_summary import SEAM_FIXTURE_MAP
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 
@@ -59,6 +67,22 @@ def build_evaluation_run_detail(*, run_id: str) -> EvaluationRunDetailResponse:
         version=settings.service_version,
         delivery_phase=settings.delivery_phase,
         run=run,
+        attempts=(
+            []
+            if run.record_source != EvaluationRunRecordSource.RUNTIME_STATE
+            else [
+                _map_runtime_attempt(item)
+                for item in get_evaluation_runtime_store().list_attempts(run_id=run_id)
+            ]
+        ),
+        case_results=(
+            []
+            if run.record_source != EvaluationRunRecordSource.RUNTIME_STATE
+            else [
+                _map_runtime_case_result(item)
+                for item in get_evaluation_runtime_store().list_case_results(run_id=run_id)
+            ]
+        ),
     )
 
 
@@ -99,4 +123,31 @@ def _map_runtime_evaluation_run(record: EvaluationRunRecord) -> EvaluationRunArt
             )
         ],
         notes=record.latest_message,
+    )
+
+
+def _map_runtime_attempt(record: EvaluationRunAttemptRecord) -> EvaluationRunAttemptDescriptor:
+    return EvaluationRunAttemptDescriptor(
+        attempt_id=record.attempt_id,
+        attempt_number=record.attempt_number,
+        status=EvaluationRunStatus(record.lifecycle_status),
+        started_at=record.started_at,
+        completed_at=record.completed_at,
+        worker_id=record.worker_id,
+        message=record.latest_message,
+        verdict=None if record.verdict is None else EvaluationRunVerdict(record.verdict),
+        failure_reason=record.failure_reason,
+    )
+
+
+def _map_runtime_case_result(record: EvaluationCaseResultRecord) -> EvaluationCaseResultDescriptor:
+    return EvaluationCaseResultDescriptor(
+        case_result_id=record.case_result_id,
+        attempt_id=record.attempt_id,
+        case_id=record.case_id,
+        fixture_id=record.fixture_id,
+        outcome=EvaluationCaseOutcome(record.outcome),
+        summary=record.summary,
+        evidence_refs=record.evidence_refs,
+        recorded_at=record.recorded_at,
     )

--- a/src/app/services/eval_run_service.py
+++ b/src/app/services/eval_run_service.py
@@ -88,8 +88,7 @@ def build_evaluation_run_detail(*, run_id: str) -> EvaluationRunDetailResponse:
 
 def _list_evaluation_runs() -> list[EvaluationRunArtifactDescriptor]:
     runtime_runs = [
-        _map_runtime_evaluation_run(record)
-        for record in get_evaluation_runtime_store().list_runs()
+        _map_runtime_evaluation_run(record) for record in get_evaluation_runtime_store().list_runs()
     ]
     historical_runs = load_evaluation_run_artifacts()
     return sorted(runtime_runs + historical_runs, key=lambda run: run.recorded_at, reverse=True)

--- a/src/app/services/eval_run_submission_service.py
+++ b/src/app/services/eval_run_submission_service.py
@@ -19,7 +19,10 @@ from app.contracts.evals import (
     EvaluationRunSubmissionResponse,
     EvaluationRunSubmissionStatus,
 )
-from app.evals.fixture_manifest import load_evaluation_fixture_family, load_evaluation_fixture_manifest
+from app.evals.fixture_manifest import (
+    load_evaluation_fixture_family,
+    load_evaluation_fixture_manifest,
+)
 from app.repositories.async_runtime_repository import (
     AsyncRuntimeAttemptRecord,
     AsyncRuntimeJobRecord,

--- a/src/app/services/eval_run_submission_service.py
+++ b/src/app/services/eval_run_submission_service.py
@@ -25,6 +25,7 @@ from app.repositories.async_runtime_repository import (
     AsyncRuntimeJobRecord,
 )
 from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.repositories.evaluation_runtime_repository import EvaluationRunAttemptRecord
 from app.services.async_job_type_catalog import get_async_job_type_descriptor
 from app.services.async_runtime_store import get_async_runtime_store
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
@@ -63,7 +64,7 @@ def submit_evaluation_run(
             message=(
                 f"Evaluation fixture family '{request.fixture_id}' is allowlisted for durable "
                 "runtime-backed submission. The run is queued in evaluation runtime state and linked "
-                "to a durable async job. Worker execution remains a later slice."
+                "to a durable async job for worker-backed evaluation execution."
             ),
         )
     if submission["submission_status"] == EvaluationRunSubmissionStatus.DUPLICATE_REJECTED.value:
@@ -123,7 +124,8 @@ def submit_evaluation_execution_async_job(
             job_id=submission["async_job_id"],
             message=(
                 f"Evaluation fixture family '{fixture_id}' is allowlisted for durable runtime-backed "
-                "submission. The async job is linked to an authoritative evaluation run record."
+                "submission and worker-backed execution. The async job is linked to an authoritative "
+                "evaluation run record."
             ),
         )
     if submission["submission_status"] == EvaluationRunSubmissionStatus.DUPLICATE_REJECTED.value:
@@ -199,10 +201,24 @@ def _submit_runtime_backed_evaluation_run(
             async_job_id=async_job_id,
             latest_message=(
                 f"Evaluation fixture family '{fixture_id}' accepted into durable runtime state and "
-                "queued for later worker-backed execution."
+                "queued for worker-backed evaluation execution."
             ),
             verdict=None,
             case_count=len(fixture_family.cases),
+        )
+    )
+    get_evaluation_runtime_store().save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id=f"{run_id}_attempt_001",
+            run_id=run_id,
+            attempt_number=1,
+            lifecycle_status=AsyncJobStatus.QUEUED.value,
+            started_at=None,
+            completed_at=None,
+            worker_id=None,
+            latest_message="Initial runtime-backed evaluation attempt queued.",
+            verdict=None,
+            failure_reason=None,
         )
     )
     get_async_runtime_store().save_job(

--- a/src/app/services/eval_run_submission_service.py
+++ b/src/app/services/eval_run_submission_service.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+
+from app.config import settings
+from app.contracts.async_runtime import (
+    AsyncJobStatus,
+    AsyncJobSubmissionRequest,
+    AsyncJobSubmissionResponse,
+    AsyncQueueMode,
+    AsyncSubmissionStatus,
+    AsyncWorkerMode,
+)
+from app.contracts.evals import (
+    EvaluationRunSubmissionRequest,
+    EvaluationRunSubmissionResponse,
+    EvaluationRunSubmissionStatus,
+)
+from app.evals.fixture_manifest import load_evaluation_fixture_family, load_evaluation_fixture_manifest
+from app.repositories.async_runtime_repository import (
+    AsyncRuntimeAttemptRecord,
+    AsyncRuntimeJobRecord,
+)
+from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.services.async_job_type_catalog import get_async_job_type_descriptor
+from app.services.async_runtime_store import get_async_runtime_store
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+RUNTIME_BACKED_EVALUATION_FIXTURE_IDS = {
+    "retrieval_citation_examples",
+    "provider_policy_examples",
+    "provider_runtime_examples",
+    "provider_failure_mode_examples",
+    "provider_operations_examples",
+    "provider_degradation_examples",
+}
+
+
+def submit_evaluation_run(
+    request: EvaluationRunSubmissionRequest,
+) -> EvaluationRunSubmissionResponse:
+    submission = _submit_runtime_backed_evaluation_run(
+        fixture_id=request.fixture_id,
+        caller_app=request.caller_app,
+        correlation_id=request.correlation_id,
+        triggered_by=request.triggered_by,
+    )
+    if submission["submission_status"] == EvaluationRunSubmissionStatus.ACCEPTED.value:
+        return EvaluationRunSubmissionResponse(
+            service=settings.service_name,
+            version=settings.service_version,
+            delivery_phase=settings.delivery_phase,
+            submission_status=EvaluationRunSubmissionStatus.ACCEPTED,
+            fixture_id=request.fixture_id,
+            accepted=True,
+            run_id=submission["run_id"],
+            async_job_id=submission["async_job_id"],
+            existing_run_id=None,
+            existing_async_job_id=None,
+            message=(
+                f"Evaluation fixture family '{request.fixture_id}' is allowlisted for durable "
+                "runtime-backed submission. The run is queued in evaluation runtime state and linked "
+                "to a durable async job. Worker execution remains a later slice."
+            ),
+        )
+    if submission["submission_status"] == EvaluationRunSubmissionStatus.DUPLICATE_REJECTED.value:
+        return EvaluationRunSubmissionResponse(
+            service=settings.service_name,
+            version=settings.service_version,
+            delivery_phase=settings.delivery_phase,
+            submission_status=EvaluationRunSubmissionStatus.DUPLICATE_REJECTED,
+            fixture_id=request.fixture_id,
+            accepted=False,
+            run_id=None,
+            async_job_id=None,
+            existing_run_id=submission["run_id"],
+            existing_async_job_id=submission["async_job_id"],
+            message=(
+                f"Duplicate evaluation submission rejected because active run '{submission['run_id']}' "
+                f"already owns fixture family '{request.fixture_id}'."
+            ),
+        )
+    return EvaluationRunSubmissionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        delivery_phase=settings.delivery_phase,
+        submission_status=EvaluationRunSubmissionStatus.REJECTED,
+        fixture_id=request.fixture_id,
+        accepted=False,
+        run_id=None,
+        async_job_id=None,
+        existing_run_id=None,
+        existing_async_job_id=None,
+        message=submission["message"],
+    )
+
+
+def submit_evaluation_execution_async_job(
+    request: AsyncJobSubmissionRequest,
+) -> AsyncJobSubmissionResponse:
+    fixture_id = _validate_evaluation_fixture_target(target_id=request.target_id)
+    submission = _submit_runtime_backed_evaluation_run(
+        fixture_id=fixture_id,
+        caller_app=request.caller_app,
+        correlation_id=request.correlation_id,
+        triggered_by=request.caller_app,
+    )
+    if submission["submission_status"] == EvaluationRunSubmissionStatus.ACCEPTED.value:
+        return AsyncJobSubmissionResponse(
+            service=settings.service_name,
+            version=settings.service_version,
+            delivery_phase=settings.delivery_phase,
+            submission_status=AsyncSubmissionStatus.ACCEPTED,
+            queue_mode=AsyncQueueMode.STUBBED,
+            worker_mode=AsyncWorkerMode.STUBBED,
+            job_type=request.job_type,
+            target_id=fixture_id,
+            existing_job_id=None,
+            accepted=True,
+            job_id=submission["async_job_id"],
+            message=(
+                f"Evaluation fixture family '{fixture_id}' is allowlisted for durable runtime-backed "
+                "submission. The async job is linked to an authoritative evaluation run record."
+            ),
+        )
+    if submission["submission_status"] == EvaluationRunSubmissionStatus.DUPLICATE_REJECTED.value:
+        return AsyncJobSubmissionResponse(
+            service=settings.service_name,
+            version=settings.service_version,
+            delivery_phase=settings.delivery_phase,
+            submission_status=AsyncSubmissionStatus.DUPLICATE_REJECTED,
+            queue_mode=AsyncQueueMode.STUBBED,
+            worker_mode=AsyncWorkerMode.STUBBED,
+            job_type=request.job_type,
+            target_id=fixture_id,
+            existing_job_id=submission["async_job_id"],
+            accepted=False,
+            job_id=None,
+            message=(
+                f"Duplicate async evaluation submission rejected because active evaluation run "
+                f"'{submission['run_id']}' already owns fixture family '{fixture_id}'."
+            ),
+        )
+    return AsyncJobSubmissionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        delivery_phase=settings.delivery_phase,
+        submission_status=AsyncSubmissionStatus.REJECTED,
+        queue_mode=AsyncQueueMode.STUBBED,
+        worker_mode=AsyncWorkerMode.STUBBED,
+        job_type=request.job_type,
+        target_id=fixture_id,
+        existing_job_id=None,
+        accepted=False,
+        job_id=None,
+        message=submission["message"],
+    )
+
+
+def _submit_runtime_backed_evaluation_run(
+    *,
+    fixture_id: str,
+    caller_app: str,
+    correlation_id: str,
+    triggered_by: str,
+) -> dict[str, str]:
+    fixture_family = load_evaluation_fixture_family(fixture_id=fixture_id)
+    _require_allowlisted_runtime_fixture(fixture_id=fixture_id)
+    existing_run = _find_active_duplicate_runtime_run(fixture_id=fixture_id)
+    if existing_run is not None:
+        return {
+            "submission_status": EvaluationRunSubmissionStatus.DUPLICATE_REJECTED.value,
+            "run_id": existing_run.run_id,
+            "async_job_id": existing_run.async_job_id or "",
+            "message": "Active runtime-backed evaluation run already exists for this fixture family.",
+        }
+
+    submitted_at = _utcnow().isoformat().replace("+00:00", "Z")
+    run_id = f"evalrun_{uuid4().hex[:12]}"
+    async_job_id = f"asyncjob_evaluation_execution_{uuid4().hex[:12]}"
+    job_type = get_async_job_type_descriptor(job_type="evaluation_execution")
+    if job_type is None or not job_type.enabled:
+        return {
+            "submission_status": EvaluationRunSubmissionStatus.REJECTED.value,
+            "message": "Evaluation execution is not allowlisted for runtime-backed submission.",
+        }
+
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id=run_id,
+            fixture_id=fixture_id,
+            manifest_version=load_evaluation_fixture_manifest().manifest_version,
+            lifecycle_status=AsyncJobStatus.QUEUED.value,
+            triggered_by=triggered_by,
+            submitted_at=submitted_at,
+            async_job_id=async_job_id,
+            latest_message=(
+                f"Evaluation fixture family '{fixture_id}' accepted into durable runtime state and "
+                "queued for later worker-backed execution."
+            ),
+            verdict=None,
+            case_count=len(fixture_family.cases),
+        )
+    )
+    get_async_runtime_store().save_job(
+        AsyncRuntimeJobRecord(
+            job_id=async_job_id,
+            job_type="evaluation_execution",
+            target_id=fixture_id,
+            lifecycle_status=AsyncJobStatus.QUEUED.value,
+            submitted_at=submitted_at,
+            caller_app=caller_app,
+            correlation_id=correlation_id,
+            payload_summary=f"Run evaluation fixture family '{fixture_id}'.",
+            execution_path=job_type.execution_path,
+            related_evaluation_run_id=run_id,
+            latest_message=(
+                f"Evaluation execution job linked to runtime-backed run '{run_id}' is queued."
+            ),
+            attempt_count=1,
+        )
+    )
+    get_async_runtime_store().save_attempt(
+        AsyncRuntimeAttemptRecord(
+            attempt_id=f"{async_job_id}_attempt_001",
+            job_id=async_job_id,
+            attempt_number=1,
+            lifecycle_status="SUBMITTED",
+            worker_id=None,
+            claimed_at=None,
+            heartbeat_at=None,
+            started_at=None,
+            completed_at=None,
+            failure_reason=None,
+            recorded_message="Initial runtime-backed evaluation submission recorded.",
+        )
+    )
+    return {
+        "submission_status": EvaluationRunSubmissionStatus.ACCEPTED.value,
+        "run_id": run_id,
+        "async_job_id": async_job_id,
+    }
+
+
+def _require_allowlisted_runtime_fixture(*, fixture_id: str) -> None:
+    if fixture_id not in RUNTIME_BACKED_EVALUATION_FIXTURE_IDS:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Evaluation fixture family '{fixture_id}' remains staged-only and is not yet "
+                "allowlisted for runtime-backed execution submission."
+            ),
+        )
+
+
+def _validate_evaluation_fixture_target(*, target_id: str | None) -> str:
+    if not target_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Async evaluation_execution submission requires a concrete evaluation fixture target_id.",
+        )
+    try:
+        load_evaluation_fixture_family(fixture_id=target_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown evaluation fixture family: {target_id}",
+        ) from exc
+    return target_id
+
+
+def _find_active_duplicate_runtime_run(*, fixture_id: str) -> EvaluationRunRecord | None:
+    for record in reversed(get_evaluation_runtime_store().list_runs()):
+        if record.fixture_id != fixture_id:
+            continue
+        if record.lifecycle_status not in {
+            AsyncJobStatus.QUEUED.value,
+            AsyncJobStatus.CLAIMED.value,
+            AsyncJobStatus.RUNNING.value,
+        }:
+            continue
+        return record
+    return None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -18,7 +18,10 @@ from app.contracts.tasks import (
     TaskExecutionRequest,
     TaskInputMode,
 )
-from app.evals.fixture_manifest import EvaluationFixtureRuntimeCase, load_evaluation_fixture_runtime_cases
+from app.evals.fixture_manifest import (
+    EvaluationFixtureRuntimeCase,
+    load_evaluation_fixture_runtime_cases,
+)
 from app.repositories.evaluation_runtime_repository import (
     EvaluationCaseResultRecord,
     EvaluationRunAttemptRecord,
@@ -27,7 +30,10 @@ from app.repositories.evaluation_runtime_repository import (
 from app.services.eval_run_submission_service import RUNTIME_BACKED_EVALUATION_FIXTURE_IDS
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 from app.services.provider_budget_policy import build_provider_budget_policy
-from app.services.provider_degradation_state import record_provider_failure, reset_provider_degradation_state
+from app.services.provider_degradation_state import (
+    record_provider_failure,
+    reset_provider_degradation_state,
+)
 from app.services.provider_operations_status import build_provider_operations_status
 from app.services.provider_policy import build_provider_policy
 from app.services.provider_operations_store import (
@@ -47,7 +53,9 @@ class EvaluationExecutionResult:
     case_result_count: int
 
 
-def execute_runtime_backed_evaluation_run(*, run_id: str, worker_id: str) -> EvaluationExecutionResult:
+def execute_runtime_backed_evaluation_run(
+    *, run_id: str, worker_id: str
+) -> EvaluationExecutionResult:
     store = get_evaluation_runtime_store()
     run = store.get_run(run_id=run_id)
     if run is None:
@@ -195,7 +203,11 @@ def _execute_fixture_case(
         status = build_retrieval_execution_status()
         search_disabled = not status.live_search_enabled
         expected_disabled = case.expected_payload.get("execution_stage") == "SEARCH_DISABLED"
-        outcome = EvaluationCaseOutcome.PASS if search_disabled and expected_disabled else EvaluationCaseOutcome.FAIL
+        outcome = (
+            EvaluationCaseOutcome.PASS
+            if search_disabled and expected_disabled
+            else EvaluationCaseOutcome.FAIL
+        )
         return (
             (
                 "Retrieval execution status matched the expected disabled-search posture."
@@ -207,12 +219,20 @@ def _execute_fixture_case(
         )
 
     if fixture_id == "provider_policy_examples":
-        policy = build_provider_policy().policies[0 if case.input_payload["capability"] == "TEXT_GENERATION" else 1]
-        selected_matches = policy.selected_provider_id == case.expected_payload["selected_provider_id"]
+        policy = build_provider_policy().policies[
+            0 if case.input_payload["capability"] == "TEXT_GENERATION" else 1
+        ]
+        selected_matches = (
+            policy.selected_provider_id == case.expected_payload["selected_provider_id"]
+        )
         live_flag_matches = (
             policy.live_execution_enabled == case.expected_payload["live_execution_enabled"]
         )
-        outcome = EvaluationCaseOutcome.PASS if selected_matches and live_flag_matches else EvaluationCaseOutcome.FAIL
+        outcome = (
+            EvaluationCaseOutcome.PASS
+            if selected_matches and live_flag_matches
+            else EvaluationCaseOutcome.FAIL
+        )
         return (
             (
                 "Provider policy matched the expected selected provider and live-execution posture."
@@ -232,7 +252,11 @@ def _execute_fixture_case(
                 and response.result.structured_output.get("timeout_ms") is not None
             )
             stubbed = response is not None and response.audit.stubbed is True
-            outcome = EvaluationCaseOutcome.PASS if controls_present and stubbed else EvaluationCaseOutcome.FAIL
+            outcome = (
+                EvaluationCaseOutcome.PASS
+                if controls_present and stubbed
+                else EvaluationCaseOutcome.FAIL
+            )
             return (
                 (
                     "Task execution preserved bounded provider controls in stub runtime."
@@ -293,7 +317,9 @@ def _execute_fixture_case(
 
     if fixture_id in {"provider_operations_examples", "provider_degradation_examples"}:
         task_id = str(case.input_payload.get("task_id", fixture_task_id))
-        if fixture_id == "provider_operations_examples" and case.expected_payload.get("budget_state"):
+        if fixture_id == "provider_operations_examples" and case.expected_payload.get(
+            "budget_state"
+        ):
             budget_policy = build_provider_budget_policy()
             budget_match = budget_policy.budget_state.value == case.expected_payload["budget_state"]
             outcome = EvaluationCaseOutcome.PASS if budget_match else EvaluationCaseOutcome.FAIL
@@ -315,7 +341,11 @@ def _execute_fixture_case(
         if expected_failure is not None:
             _response, observed_failure = _execute_task_case(task_id=task_id, case=case)
             failure_match = observed_failure == expected_failure
-        outcome = EvaluationCaseOutcome.PASS if state_match and failure_match else EvaluationCaseOutcome.FAIL
+        outcome = (
+            EvaluationCaseOutcome.PASS
+            if state_match and failure_match
+            else EvaluationCaseOutcome.FAIL
+        )
         summary = "Provider operations posture matched expected runtime evidence."
         if outcome == EvaluationCaseOutcome.FAIL:
             summary = "Provider operations posture did not match expected runtime evidence."
@@ -348,9 +378,7 @@ def _execute_task_case(
                     source_refs=[],
                 ),
                 expected_output_label=(
-                    OutputLabel.RETRIEVAL_ANSWER
-                    if task_id.startswith("knowledge_")
-                    else None
+                    OutputLabel.RETRIEVAL_ANSWER if task_id.startswith("knowledge_") else None
                 ),
             )
         )
@@ -394,7 +422,10 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
             settings.provider_mode = str(input_payload["provider_mode"])
         if "rollout_state" in input_payload:
             settings.provider_rollout_state = str(input_payload["rollout_state"])
-        if input_payload.get("provider_operations_store_mode") == "sqlalchemy" and settings.database_url:
+        if (
+            input_payload.get("provider_operations_store_mode") == "sqlalchemy"
+            and settings.database_url
+        ):
             settings.provider_operations_store_mode = "sqlalchemy"
             reset_provider_operations_store_cache()
         live_execution_signals = any(
@@ -437,7 +468,9 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
             settings.live_text_soft_budget_usd = float(
                 cast(
                     int | float | str,
-                    input_payload.get("recorded_spend_usd", input_payload.get("tracked_spend_usd", 0.5)),
+                    input_payload.get(
+                        "recorded_spend_usd", input_payload.get("tracked_spend_usd", 0.5)
+                    ),
                 )
             )
             settings.live_text_input_cost_per_1k_tokens = 0.01
@@ -445,7 +478,9 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
             tracked_spend = float(
                 cast(
                     int | float | str,
-                    input_payload.get("tracked_spend_usd", input_payload.get("recorded_spend_usd", 0.0)),
+                    input_payload.get(
+                        "tracked_spend_usd", input_payload.get("recorded_spend_usd", 0.0)
+                    ),
                 )
             )
             if tracked_spend > 0:
@@ -478,9 +513,7 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
         ):
             settings.live_text_circuit_open_seconds = 60
         if "degraded_failure_count_threshold" in input_payload:
-            failure_count = int(
-                cast(int | str, input_payload["degraded_failure_count_threshold"])
-            )
+            failure_count = int(cast(int | str, input_payload["degraded_failure_count_threshold"]))
             for _ in range(failure_count):
                 record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
             if settings.provider_operations_store_mode == "sqlalchemy":

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -154,7 +154,7 @@ def execute_runtime_backed_evaluation_run(*, run_id: str, worker_id: str) -> Eva
 def _get_active_attempt(*, run_id: str) -> EvaluationRunAttemptRecord | None:
     attempts = get_evaluation_runtime_store().list_attempts(run_id=run_id)
     for attempt in reversed(attempts):
-        if attempt.lifecycle_status in {"QUEUED", "SUBMITTED"}:
+        if attempt.lifecycle_status in {"QUEUED", "SUBMITTED", "CLAIMED"}:
             return attempt
     return None
 
@@ -173,7 +173,7 @@ def _evaluate_case(
             case=case,
         )
     return EvaluationCaseResultRecord(
-        case_result_id=f"{run.run_id}_{case.case_id}",
+        case_result_id=f"{attempt_id}_{case.case_id}",
         run_id=run.run_id,
         attempt_id=attempt_id,
         case_id=case.case_id,

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Iterator, cast
+
+from fastapi import HTTPException
+
+from app.config import settings
+from app.contracts.evals import EvaluationCaseOutcome, EvaluationRunVerdict
+from app.contracts.providers import ProviderFailureCategory, ProviderQuotaScope
+from app.contracts.tasks import (
+    CallerMetadata,
+    OutputLabel,
+    TaskContextEnvelope,
+    TaskExecutionResponse,
+    TaskExecutionRequest,
+    TaskInputMode,
+)
+from app.evals.fixture_manifest import EvaluationFixtureRuntimeCase, load_evaluation_fixture_runtime_cases
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+)
+from app.services.eval_run_submission_service import RUNTIME_BACKED_EVALUATION_FIXTURE_IDS
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+from app.services.provider_budget_policy import build_provider_budget_policy
+from app.services.provider_degradation_state import record_provider_failure, reset_provider_degradation_state
+from app.services.provider_operations_status import build_provider_operations_status
+from app.services.provider_policy import build_provider_policy
+from app.services.provider_operations_store import (
+    get_provider_operations_store,
+    reset_provider_operations_store_cache,
+)
+from app.services.provider_quota_policy import reset_provider_quota_counters
+from app.services.retrieval_execution_status import build_retrieval_execution_status
+from app.services.task_executor import execute_task
+
+
+@dataclass(frozen=True)
+class EvaluationExecutionResult:
+    run_id: str
+    attempt_id: str
+    verdict: EvaluationRunVerdict
+    case_result_count: int
+
+
+def execute_runtime_backed_evaluation_run(*, run_id: str, worker_id: str) -> EvaluationExecutionResult:
+    store = get_evaluation_runtime_store()
+    run = store.get_run(run_id=run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Evaluation run '{run_id}' was not found.")
+
+    attempt = _get_active_attempt(run_id=run_id)
+    if attempt is None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Evaluation run '{run_id}' has no queued runtime attempt to execute.",
+        )
+
+    task_id, cases = load_evaluation_fixture_runtime_cases(fixture_id=run.fixture_id)
+    if run.fixture_id not in RUNTIME_BACKED_EVALUATION_FIXTURE_IDS or task_id is None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Evaluation fixture family '{run.fixture_id}' is not executable in runtime-backed mode.",
+        )
+
+    started_at = _utcnow_iso()
+    store.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id=attempt.attempt_id,
+            run_id=attempt.run_id,
+            attempt_number=attempt.attempt_number,
+            lifecycle_status="RUNNING",
+            started_at=started_at,
+            completed_at=None,
+            worker_id=worker_id,
+            latest_message=f"Runtime-backed evaluation attempt started by worker '{worker_id}'.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+    store.save_run(
+        EvaluationRunRecord(
+            run_id=run.run_id,
+            fixture_id=run.fixture_id,
+            manifest_version=run.manifest_version,
+            lifecycle_status="RUNNING",
+            triggered_by=run.triggered_by,
+            submitted_at=run.submitted_at,
+            async_job_id=run.async_job_id,
+            latest_message=f"Evaluation run is executing under worker '{worker_id}'.",
+            verdict=None,
+            case_count=run.case_count,
+        )
+    )
+
+    persisted_results = [
+        _evaluate_case(
+            run=run,
+            attempt_id=attempt.attempt_id,
+            fixture_task_id=task_id,
+            case=case,
+        )
+        for case in cases
+    ]
+    for result in persisted_results:
+        store.save_case_result(result)
+
+    verdict = (
+        EvaluationRunVerdict.PASS
+        if all(result.outcome == EvaluationCaseOutcome.PASS.value for result in persisted_results)
+        else EvaluationRunVerdict.FAIL
+    )
+    completed_at = _utcnow_iso()
+    store.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id=attempt.attempt_id,
+            run_id=attempt.run_id,
+            attempt_number=attempt.attempt_number,
+            lifecycle_status="COMPLETED",
+            started_at=started_at,
+            completed_at=completed_at,
+            worker_id=worker_id,
+            latest_message=f"Runtime-backed evaluation attempt completed with verdict '{verdict.value}'.",
+            verdict=verdict.value,
+            failure_reason=None,
+        )
+    )
+    store.save_run(
+        EvaluationRunRecord(
+            run_id=run.run_id,
+            fixture_id=run.fixture_id,
+            manifest_version=run.manifest_version,
+            lifecycle_status="COMPLETED" if verdict == EvaluationRunVerdict.PASS else "FAILED",
+            triggered_by=run.triggered_by,
+            submitted_at=run.submitted_at,
+            async_job_id=run.async_job_id,
+            latest_message=f"Runtime-backed evaluation run completed with verdict '{verdict.value}'.",
+            verdict=verdict.value,
+            case_count=run.case_count,
+        )
+    )
+    return EvaluationExecutionResult(
+        run_id=run.run_id,
+        attempt_id=attempt.attempt_id,
+        verdict=verdict,
+        case_result_count=len(persisted_results),
+    )
+
+
+def _get_active_attempt(*, run_id: str) -> EvaluationRunAttemptRecord | None:
+    attempts = get_evaluation_runtime_store().list_attempts(run_id=run_id)
+    for attempt in reversed(attempts):
+        if attempt.lifecycle_status in {"QUEUED", "SUBMITTED"}:
+            return attempt
+    return None
+
+
+def _evaluate_case(
+    *,
+    run: EvaluationRunRecord,
+    attempt_id: str,
+    fixture_task_id: str,
+    case: EvaluationFixtureRuntimeCase,
+) -> EvaluationCaseResultRecord:
+    with _apply_case_configuration(case.input_payload):
+        summary, outcome, evidence_refs = _execute_fixture_case(
+            fixture_id=run.fixture_id,
+            fixture_task_id=fixture_task_id,
+            case=case,
+        )
+    return EvaluationCaseResultRecord(
+        case_result_id=f"{run.run_id}_{case.case_id}",
+        run_id=run.run_id,
+        attempt_id=attempt_id,
+        case_id=case.case_id,
+        fixture_id=run.fixture_id,
+        outcome=outcome.value,
+        summary=summary,
+        evidence_refs=evidence_refs,
+        recorded_at=_utcnow_iso(),
+    )
+
+
+def _execute_fixture_case(
+    *,
+    fixture_id: str,
+    fixture_task_id: str,
+    case: EvaluationFixtureRuntimeCase,
+) -> tuple[str, EvaluationCaseOutcome, list[str]]:
+    if fixture_id == "retrieval_citation_examples":
+        status = build_retrieval_execution_status()
+        search_disabled = not status.live_search_enabled
+        expected_disabled = case.expected_payload.get("execution_stage") == "SEARCH_DISABLED"
+        outcome = EvaluationCaseOutcome.PASS if search_disabled and expected_disabled else EvaluationCaseOutcome.FAIL
+        return (
+            (
+                "Retrieval execution status matched the expected disabled-search posture."
+                if outcome == EvaluationCaseOutcome.PASS
+                else "Retrieval execution status did not match the expected disabled-search posture."
+            ),
+            outcome,
+            ["service://platform/retrieval/execution-status"],
+        )
+
+    if fixture_id == "provider_policy_examples":
+        policy = build_provider_policy().policies[0 if case.input_payload["capability"] == "TEXT_GENERATION" else 1]
+        selected_matches = policy.selected_provider_id == case.expected_payload["selected_provider_id"]
+        live_flag_matches = (
+            policy.live_execution_enabled == case.expected_payload["live_execution_enabled"]
+        )
+        outcome = EvaluationCaseOutcome.PASS if selected_matches and live_flag_matches else EvaluationCaseOutcome.FAIL
+        return (
+            (
+                "Provider policy matched the expected selected provider and live-execution posture."
+                if outcome == EvaluationCaseOutcome.PASS
+                else "Provider policy did not match the expected selected provider or live-execution posture."
+            ),
+            outcome,
+            ["service://platform/providers/policy"],
+        )
+
+    task_id = str(case.input_payload.get("task_id", fixture_task_id))
+    response, failure_category = _execute_task_case(task_id=task_id, case=case)
+    if fixture_id == "provider_runtime_examples":
+        if case.expected_payload["expected_outcome"] == "SUCCESS":
+            controls_present = (
+                response is not None
+                and response.result.structured_output.get("timeout_ms") is not None
+            )
+            stubbed = response is not None and response.audit.stubbed is True
+            outcome = EvaluationCaseOutcome.PASS if controls_present and stubbed else EvaluationCaseOutcome.FAIL
+            return (
+                (
+                    "Task execution preserved bounded provider controls in stub runtime."
+                    if outcome == EvaluationCaseOutcome.PASS
+                    else "Task execution did not preserve the expected bounded provider controls."
+                ),
+                outcome,
+                ["service://ai/tasks/execute"],
+            )
+        expected_failure = case.expected_payload["failure_category"]
+        outcome = (
+            EvaluationCaseOutcome.PASS
+            if failure_category == expected_failure
+            else EvaluationCaseOutcome.FAIL
+        )
+        return (
+            (
+                f"Live-provider rejection matched expected failure category '{expected_failure}'."
+                if outcome == EvaluationCaseOutcome.PASS
+                else f"Live-provider rejection did not match expected failure category '{expected_failure}'."
+            ),
+            outcome,
+            ["service://ai/tasks/execute"],
+        )
+
+    if fixture_id == "provider_failure_mode_examples":
+        if case.expected_payload["expected_outcome"] == "TIMEOUT_GUARDRAIL":
+            controls_present = (
+                response is not None
+                and response.result.structured_output.get("timeout_ms") is not None
+            )
+            outcome = EvaluationCaseOutcome.PASS if controls_present else EvaluationCaseOutcome.FAIL
+            return (
+                (
+                    "Provider timeout budget remained explicit in task execution evidence."
+                    if outcome == EvaluationCaseOutcome.PASS
+                    else "Provider timeout budget was not preserved in task execution evidence."
+                ),
+                outcome,
+                ["service://ai/tasks/execute"],
+            )
+        outcome = (
+            EvaluationCaseOutcome.PASS
+            if failure_category == "LIVE_EXECUTION_NOT_ENABLED"
+            else EvaluationCaseOutcome.FAIL
+        )
+        return (
+            (
+                "Blocked live-provider path rejected explicitly without silent drift."
+                if outcome == EvaluationCaseOutcome.PASS
+                else "Blocked live-provider path did not reject explicitly as expected."
+            ),
+            outcome,
+            ["service://ai/tasks/execute"],
+        )
+
+    if fixture_id in {"provider_operations_examples", "provider_degradation_examples"}:
+        if fixture_id == "provider_operations_examples" and case.expected_payload.get("budget_state"):
+            budget_policy = build_provider_budget_policy()
+            budget_match = budget_policy.budget_state.value == case.expected_payload["budget_state"]
+            outcome = EvaluationCaseOutcome.PASS if budget_match else EvaluationCaseOutcome.FAIL
+            return (
+                (
+                    "Provider budget posture matched the expected durable runtime evidence."
+                    if outcome == EvaluationCaseOutcome.PASS
+                    else "Provider budget posture did not match the expected durable runtime evidence."
+                ),
+                outcome,
+                ["service://platform/providers/budget-policy"],
+            )
+
+        operations = build_provider_operations_status()
+        expected_state = case.expected_payload.get("operations_state")
+        expected_failure = case.expected_payload.get("failure_category")
+        state_match = expected_state is None or operations.operations_state.value == expected_state
+        failure_match = True
+        if expected_failure is not None:
+            _response, observed_failure = _execute_task_case(task_id=task_id, case=case)
+            failure_match = observed_failure == expected_failure
+        outcome = EvaluationCaseOutcome.PASS if state_match and failure_match else EvaluationCaseOutcome.FAIL
+        summary = "Provider operations posture matched expected runtime evidence."
+        if outcome == EvaluationCaseOutcome.FAIL:
+            summary = "Provider operations posture did not match expected runtime evidence."
+        return (summary, outcome, ["service://platform/providers/operations-status"])
+
+    return (
+        f"Fixture family '{fixture_id}' does not yet have runtime-backed execution semantics.",
+        EvaluationCaseOutcome.FAIL,
+        [f"fixture://{fixture_id}"],
+    )
+
+
+def _execute_task_case(
+    *,
+    task_id: str,
+    case: EvaluationFixtureRuntimeCase,
+) -> tuple[TaskExecutionResponse | None, str | None]:
+    try:
+        response = execute_task(
+            TaskExecutionRequest(
+                task_id=task_id,
+                input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+                caller=CallerMetadata(
+                    caller_app=case.input_payload.get("caller_app", "lotus-ai"),
+                    correlation_id=case.input_payload.get("correlation_id", f"eval-{case.case_id}"),
+                ),
+                context=TaskContextEnvelope(
+                    summary=case.summary,
+                    payload={"evaluation_case_id": case.case_id},
+                    source_refs=[],
+                ),
+                expected_output_label=(
+                    OutputLabel.RETRIEVAL_ANSWER
+                    if task_id.startswith("knowledge_")
+                    else None
+                ),
+            )
+        )
+        return (response, None)
+    except HTTPException as exc:
+        detail = str(exc.detail)
+        failure_category = detail.split(":", 1)[0] if ":" in detail else detail
+        return (None, failure_category)
+
+
+@contextmanager
+def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None]:
+    original_values = {
+        "provider_mode": settings.provider_mode,
+        "provider_rollout_state": settings.provider_rollout_state,
+        "live_text_provider_id": settings.live_text_provider_id,
+        "live_text_model_id": settings.live_text_model_id,
+        "live_text_provider_api_key": settings.live_text_provider_api_key,
+        "live_text_allowed_task_ids": settings.live_text_allowed_task_ids,
+        "live_text_quota_enforced": settings.live_text_quota_enforced,
+        "live_text_default_quota_limit": settings.live_text_default_quota_limit,
+        "live_text_task_quota_limits": settings.live_text_task_quota_limits,
+        "live_text_budget_enforced": settings.live_text_budget_enforced,
+        "live_text_soft_budget_usd": settings.live_text_soft_budget_usd,
+        "live_text_degraded_failure_count_threshold": settings.live_text_degraded_failure_count_threshold,
+        "live_text_circuit_open_failure_count_threshold": settings.live_text_circuit_open_failure_count_threshold,
+        "live_text_circuit_open_seconds": settings.live_text_circuit_open_seconds,
+        "live_text_hard_budget_usd": settings.live_text_hard_budget_usd,
+        "live_text_input_cost_per_1k_tokens": settings.live_text_input_cost_per_1k_tokens,
+        "live_text_output_cost_per_1k_tokens": settings.live_text_output_cost_per_1k_tokens,
+        "live_text_degradation_enforced": settings.live_text_degradation_enforced,
+        "provider_operations_store_mode": settings.provider_operations_store_mode,
+    }
+    try:
+        reset_provider_operations_store_cache()
+        reset_provider_quota_counters()
+        reset_provider_degradation_state()
+        if "configured_mode" in input_payload:
+            settings.provider_mode = str(input_payload["configured_mode"])
+        if "provider_mode" in input_payload:
+            settings.provider_mode = str(input_payload["provider_mode"])
+        if "rollout_state" in input_payload:
+            settings.provider_rollout_state = str(input_payload["rollout_state"])
+        if input_payload.get("provider_operations_store_mode") == "sqlalchemy" and settings.database_url:
+            settings.provider_operations_store_mode = "sqlalchemy"
+            reset_provider_operations_store_cache()
+        if settings.provider_mode == "openai":
+            if "rollout_state" not in input_payload:
+                settings.provider_rollout_state = "CANARY_ENABLED"
+            settings.live_text_provider_id = "text.openai"
+            settings.live_text_model_id = "gpt-5.4"
+            settings.live_text_provider_api_key = "eval-secret"
+            settings.live_text_allowed_task_ids = str(input_payload.get("task_id", ""))
+        if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
+            settings.live_text_quota_enforced = True
+            settings.live_text_task_quota_limits = (
+                f"{input_payload['task_id']}={int(cast(int | str, input_payload['request_limit']))}"
+            )
+            get_provider_operations_store().increment_quota_state(
+                scope=ProviderQuotaScope.TASK,
+                scope_key=str(input_payload["task_id"]),
+                amount=int(cast(int | str, input_payload["request_limit"])),
+                updated_at=_utcnow_iso(),
+            )
+        if "hard_budget_usd" in input_payload:
+            settings.live_text_budget_enforced = True
+            settings.live_text_hard_budget_usd = float(
+                cast(int | float | str, input_payload["hard_budget_usd"])
+            )
+            settings.live_text_soft_budget_usd = float(
+                cast(
+                    int | float | str,
+                    input_payload.get("recorded_spend_usd", input_payload.get("tracked_spend_usd", 0.5)),
+                )
+            )
+            settings.live_text_input_cost_per_1k_tokens = 0.01
+            settings.live_text_output_cost_per_1k_tokens = 0.03
+            tracked_spend = float(
+                cast(
+                    int | float | str,
+                    input_payload.get("tracked_spend_usd", input_payload.get("recorded_spend_usd", 0.0)),
+                )
+            )
+            if tracked_spend > 0:
+                get_provider_operations_store().add_budget_spend(
+                    budget_key="live_text_generation",
+                    amount_usd=tracked_spend,
+                    updated_at=_utcnow_iso(),
+                )
+                if settings.provider_operations_store_mode == "sqlalchemy":
+                    reset_provider_operations_store_cache()
+        if "degraded_failure_count_threshold" in input_payload:
+            settings.live_text_degradation_enforced = True
+            settings.live_text_degraded_failure_count_threshold = int(
+                cast(int | str, input_payload["degraded_failure_count_threshold"])
+            )
+        if "circuit_open_failure_count_threshold" in input_payload:
+            settings.live_text_circuit_open_failure_count_threshold = int(
+                cast(int | str, input_payload["circuit_open_failure_count_threshold"])
+            )
+        if "circuit_open_seconds" in input_payload:
+            settings.live_text_circuit_open_seconds = int(
+                cast(int | str, input_payload["circuit_open_seconds"])
+            )
+        if "degraded_failure_count_threshold" in input_payload:
+            failure_count = int(
+                cast(int | str, input_payload["degraded_failure_count_threshold"])
+            )
+            for _ in range(failure_count):
+                record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
+            if settings.provider_operations_store_mode == "sqlalchemy":
+                reset_provider_operations_store_cache()
+        elif "circuit_open_seconds" in input_payload:
+            settings.live_text_degradation_enforced = True
+            settings.live_text_degraded_failure_count_threshold = 1
+            settings.live_text_circuit_open_failure_count_threshold = 1
+            record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
+            if settings.provider_operations_store_mode == "sqlalchemy":
+                reset_provider_operations_store_cache()
+        yield
+    finally:
+        for key, value in original_values.items():
+            setattr(settings, key, value)
+        reset_provider_operations_store_cache()
+        reset_provider_quota_counters()
+        reset_provider_degradation_state()
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -223,9 +223,9 @@ def _execute_fixture_case(
             ["service://platform/providers/policy"],
         )
 
-    task_id = str(case.input_payload.get("task_id", fixture_task_id))
-    response, failure_category = _execute_task_case(task_id=task_id, case=case)
     if fixture_id == "provider_runtime_examples":
+        task_id = str(case.input_payload.get("task_id", fixture_task_id))
+        response, failure_category = _execute_task_case(task_id=task_id, case=case)
         if case.expected_payload["expected_outcome"] == "SUCCESS":
             controls_present = (
                 response is not None
@@ -259,6 +259,8 @@ def _execute_fixture_case(
         )
 
     if fixture_id == "provider_failure_mode_examples":
+        task_id = str(case.input_payload.get("task_id", fixture_task_id))
+        response, failure_category = _execute_task_case(task_id=task_id, case=case)
         if case.expected_payload["expected_outcome"] == "TIMEOUT_GUARDRAIL":
             controls_present = (
                 response is not None
@@ -290,6 +292,7 @@ def _execute_fixture_case(
         )
 
     if fixture_id in {"provider_operations_examples", "provider_degradation_examples"}:
+        task_id = str(case.input_payload.get("task_id", fixture_task_id))
         if fixture_id == "provider_operations_examples" and case.expected_payload.get("budget_state"):
             budget_policy = build_provider_budget_policy()
             budget_match = budget_policy.budget_state.value == case.expected_payload["budget_state"]
@@ -394,7 +397,21 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
         if input_payload.get("provider_operations_store_mode") == "sqlalchemy" and settings.database_url:
             settings.provider_operations_store_mode = "sqlalchemy"
             reset_provider_operations_store_cache()
-        if settings.provider_mode == "openai":
+        live_execution_signals = any(
+            key in input_payload
+            for key in (
+                "request_limit",
+                "hard_budget_usd",
+                "tracked_spend_usd",
+                "recorded_spend_usd",
+                "degraded_failure_count_threshold",
+                "circuit_open_seconds",
+            )
+        )
+        if settings.provider_mode == "openai" and (
+            input_payload.get("rollout_state") in {"CANARY_ENABLED", "ROLLED_OUT"}
+            or live_execution_signals
+        ):
             if "rollout_state" not in input_payload:
                 settings.provider_rollout_state = "CANARY_ENABLED"
             settings.live_text_provider_id = "text.openai"
@@ -452,6 +469,14 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
             settings.live_text_circuit_open_seconds = int(
                 cast(int | str, input_payload["circuit_open_seconds"])
             )
+        elif any(
+            key in input_payload
+            for key in (
+                "degraded_failure_count_threshold",
+                "circuit_open_failure_count_threshold",
+            )
+        ):
+            settings.live_text_circuit_open_seconds = 60
         if "degraded_failure_count_threshold" in input_payload:
             failure_count = int(
                 cast(int | str, input_payload["degraded_failure_count_threshold"])

--- a/src/app/services/eval_status.py
+++ b/src/app/services/eval_status.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from app.contracts.evals import EvaluationRuntimeStatusResponse
+from app.services.eval_approval_gate_summary import (
+    build_provider_approval_gate_summary,
+    build_retrieval_approval_gate_summary,
+)
 from app.services.eval_catalog import build_evaluation_catalog
 from app.services.eval_inventory_summary import summarize_evaluation_inventory
 from app.services.eval_run_service import build_evaluation_run_catalog
@@ -13,6 +17,10 @@ def build_evaluation_runtime_status() -> EvaluationRuntimeStatusResponse:
     seam_coverage = build_evaluation_seam_coverage()
     run_catalog = build_evaluation_run_catalog()
     latest_run = run_catalog.runs[0] if run_catalog.runs else None
+    approval_gates = [
+        build_retrieval_approval_gate_summary(),
+        build_provider_approval_gate_summary(),
+    ]
     return EvaluationRuntimeStatusResponse(
         service=catalog.service,
         version=catalog.version,
@@ -23,6 +31,7 @@ def build_evaluation_runtime_status() -> EvaluationRuntimeStatusResponse:
         documented_fixture_count=inventory_summary.documented_fixture_count,
         staged_case_count=inventory_summary.staged_case_count,
         seam_coverage=seam_coverage,
+        approval_gates=approval_gates,
         recorded_run_count=run_catalog.run_count,
         runtime_backed_run_count=run_catalog.runtime_backed_run_count,
         historical_run_count=run_catalog.historical_run_count,
@@ -31,6 +40,6 @@ def build_evaluation_runtime_status() -> EvaluationRuntimeStatusResponse:
         evaluation_runner_active=True,
         message=(
             "Allowlisted evaluation families now run through the durable async backbone with "
-            "persisted attempt and case-result state."
+            "persisted attempts, replay-safe case-result history, and runtime-backed approval-gate summaries."
         ),
     )

--- a/src/app/services/eval_status.py
+++ b/src/app/services/eval_status.py
@@ -28,14 +28,9 @@ def build_evaluation_runtime_status() -> EvaluationRuntimeStatusResponse:
         historical_run_count=run_catalog.historical_run_count,
         latest_recorded_run_id=run_catalog.latest_run_id,
         latest_recorded_run_status=latest_run.status if latest_run is not None else None,
-        evaluation_runner_active=False,
+        evaluation_runner_active=True,
         message=(
-            "Allowlisted evaluation families can now be submitted into durable runtime state, but "
-            "no worker-backed evaluation runner is active yet."
-            if run_catalog.runtime_backed_run_count > 0
-            else (
-                "Evaluation assets are cataloged and partially staged, but no live evaluation runner "
-                "is active in the foundation phase."
-            )
+            "Allowlisted evaluation families now run through the durable async backbone with "
+            "persisted attempt and case-result state."
         ),
     )

--- a/src/app/services/eval_status.py
+++ b/src/app/services/eval_status.py
@@ -24,11 +24,18 @@ def build_evaluation_runtime_status() -> EvaluationRuntimeStatusResponse:
         staged_case_count=inventory_summary.staged_case_count,
         seam_coverage=seam_coverage,
         recorded_run_count=run_catalog.run_count,
+        runtime_backed_run_count=run_catalog.runtime_backed_run_count,
+        historical_run_count=run_catalog.historical_run_count,
         latest_recorded_run_id=run_catalog.latest_run_id,
         latest_recorded_run_status=latest_run.status if latest_run is not None else None,
         evaluation_runner_active=False,
         message=(
-            "Evaluation assets are cataloged and partially staged, but no live evaluation runner "
-            "is active in the foundation phase."
+            "Allowlisted evaluation families can now be submitted into durable runtime state, but "
+            "no worker-backed evaluation runner is active yet."
+            if run_catalog.runtime_backed_run_count > 0
+            else (
+                "Evaluation assets are cataloged and partially staged, but no live evaluation runner "
+                "is active in the foundation phase."
+            )
         ),
     )

--- a/src/app/services/evaluation_runtime_store.py
+++ b/src/app/services/evaluation_runtime_store.py
@@ -36,4 +36,3 @@ def reset_evaluation_runtime_store_cache() -> None:
     global _sqlalchemy_repository
     _memory_repository = None
     _sqlalchemy_repository = None
-

--- a/src/app/services/evaluation_runtime_store.py
+++ b/src/app/services/evaluation_runtime_store.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.repositories.evaluation_runtime_repository import EvaluationRuntimeRepository
+from app.repositories.memory_evaluation_runtime_repository import (
+    InMemoryEvaluationRuntimeRepository,
+)
+from app.repositories.sqlalchemy_evaluation_runtime_repository import (
+    SqlAlchemyEvaluationRuntimeRepository,
+)
+
+_memory_repository: InMemoryEvaluationRuntimeRepository | None = None
+_sqlalchemy_repository: SqlAlchemyEvaluationRuntimeRepository | None = None
+
+
+def get_evaluation_runtime_store() -> EvaluationRuntimeRepository:
+    if settings.evaluation_runtime_store_mode == "memory":
+        global _memory_repository
+        if _memory_repository is None:
+            _memory_repository = InMemoryEvaluationRuntimeRepository()
+        return _memory_repository
+    if settings.evaluation_runtime_store_mode == "sqlalchemy":
+        if not settings.database_url:
+            raise RuntimeError(
+                "LOTUS_AI_DATABASE_URL is required when LOTUS_AI_EVALUATION_RUNTIME_STORE_MODE=sqlalchemy."
+            )
+        global _sqlalchemy_repository
+        if _sqlalchemy_repository is None:
+            _sqlalchemy_repository = SqlAlchemyEvaluationRuntimeRepository(settings.database_url)
+        return _sqlalchemy_repository
+    raise RuntimeError("Unsupported LOTUS_AI_EVALUATION_RUNTIME_STORE_MODE.")
+
+
+def reset_evaluation_runtime_store_cache() -> None:
+    global _memory_repository
+    global _sqlalchemy_repository
+    _memory_repository = None
+    _sqlalchemy_repository = None
+

--- a/src/app/services/provider_evidence_readiness.py
+++ b/src/app/services/provider_evidence_readiness.py
@@ -5,6 +5,7 @@ from app.contracts.providers import (
     ProviderEvidenceReadinessItem,
     ProviderEvidenceReadinessResponse,
 )
+from app.services.eval_approval_gate_summary import build_provider_approval_gate_summary
 from app.services.governance_readiness import summarize_activation_items
 from app.services.provider_evidence_inventory import build_provider_evidence_inventory
 
@@ -24,6 +25,7 @@ _PROVIDER_RECORDED_BASELINE_FIXTURE_IDS = (
 
 def build_provider_evidence_readiness() -> ProviderEvidenceReadinessResponse:
     inventory = build_provider_evidence_inventory()
+    approval_gate = build_provider_approval_gate_summary()
     policy_fixture_ready = _PROVIDER_POLICY_FIXTURE_IDS.issubset(inventory.staged_fixture_ids)
     runtime_fixture_ready = _PROVIDER_RUNTIME_FIXTURE_IDS.issubset(inventory.staged_fixture_ids)
     failure_fixture_ready = _PROVIDER_FAILURE_FIXTURE_IDS.issubset(inventory.staged_fixture_ids)
@@ -134,4 +136,5 @@ def build_provider_evidence_readiness() -> ProviderEvidenceReadinessResponse:
         required_item_count=required_item_count,
         completed_required_item_count=completed_required_item_count,
         items=items,
+        approval_gate=approval_gate,
     )

--- a/src/app/services/provider_governance_status.py
+++ b/src/app/services/provider_governance_status.py
@@ -20,7 +20,10 @@ def build_provider_governance_status() -> ProviderGovernanceStatusResponse:
     governance_summary = [
         "Provider technical activation remains blocked in foundation phase until allowlisted live execution modes and controls are explicitly rolled out.",
         "Provider operational runbook readiness remains incomplete until escalation, spend-anomaly, degradation-response, and observability procedures are fully documented and approved.",
-        "Provider evidence readiness now includes staged runtime, operations, and degradation fixtures plus a recorded regression baseline that reflects the durable provider-operations control plane, but live audit traceability and failover-proof evidence still block activation.",
+        (
+            "Provider evidence readiness now includes a runtime-backed approval gate summary derived "
+            f"from governed provider evaluation runs, currently reporting '{evidence_readiness.approval_gate.evidence_state.value}'."
+        ),
     ]
     return ProviderGovernanceStatusResponse(
         service=settings.service_name,

--- a/src/app/services/retrieval_async_execution.py
+++ b/src/app/services/retrieval_async_execution.py
@@ -10,7 +10,7 @@ from app.contracts.retrieval import (
 )
 from app.services.async_submission_service import submit_async_job
 from app.services.async_worker_runtime import (
-    claim_next_async_job,
+    claim_next_async_job_for_types,
     complete_async_job,
     fail_async_job,
     start_async_job,
@@ -48,7 +48,10 @@ def submit_retrieval_index_job_async(
 
 
 def run_next_retrieval_index_job(*, worker_id: str) -> RetrievalAsyncExecutionResult | None:
-    claim = claim_next_async_job(worker_id=worker_id)
+    claim = claim_next_async_job_for_types(
+        worker_id=worker_id,
+        job_types=("retrieval_indexing",),
+    )
     if claim is None:
         return None
     if claim.job.job_type != "retrieval_indexing" or claim.job.target_id is None:

--- a/src/app/services/retrieval_evidence_readiness.py
+++ b/src/app/services/retrieval_evidence_readiness.py
@@ -5,10 +5,12 @@ from app.contracts.retrieval import (
     RetrievalEvidenceReadinessItem,
     RetrievalEvidenceReadinessResponse,
 )
+from app.services.eval_approval_gate_summary import build_retrieval_approval_gate_summary
 from app.services.governance_readiness import summarize_activation_items
 
 
 def build_retrieval_evidence_readiness() -> RetrievalEvidenceReadinessResponse:
+    approval_gate = build_retrieval_approval_gate_summary()
     items = [
         RetrievalEvidenceReadinessItem(
             evidence_id="retrieval_fixture_coverage_pack",
@@ -55,4 +57,5 @@ def build_retrieval_evidence_readiness() -> RetrievalEvidenceReadinessResponse:
         required_item_count=required_item_count,
         completed_required_item_count=completed_required_item_count,
         items=items,
+        approval_gate=approval_gate,
     )

--- a/src/app/services/retrieval_governance_status.py
+++ b/src/app/services/retrieval_governance_status.py
@@ -20,7 +20,10 @@ def build_retrieval_governance_status() -> RetrievalGovernanceStatusResponse:
     governance_summary = [
         "Retrieval technical activation remains blocked in foundation phase until live indexing, search, and embedding controls are explicitly rolled out.",
         "Retrieval operational runbook readiness remains incomplete until reindex, replay, and observability procedures are fully documented and approved.",
-        "Retrieval evidence readiness remains incomplete until regression baselines, citation traceability, and rollback-proof evidence are explicitly assembled.",
+        (
+            "Retrieval evidence readiness now includes a runtime-backed approval gate summary derived "
+            f"from governed retrieval evaluation runs, currently reporting '{evidence_readiness.approval_gate.evidence_state.value}'."
+        ),
     ]
     return RetrievalGovernanceStatusResponse(
         service=settings.service_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from app.config import settings
 from app.services.audit_store import reset_audit_store_cache
 from app.services.async_runtime_store import reset_async_runtime_store_cache
+from app.services.evaluation_runtime_store import reset_evaluation_runtime_store_cache
 from app.services.prompt_store import reset_prompt_store_cache
 from app.services.provider_budget_policy import reset_provider_budget_state
 from app.services.provider_degradation_state import reset_provider_degradation_state
@@ -45,6 +46,7 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         "retrieval_store_mode": settings.retrieval_store_mode,
         "provider_operations_store_mode": settings.provider_operations_store_mode,
         "async_runtime_store_mode": settings.async_runtime_store_mode,
+        "evaluation_runtime_store_mode": settings.evaluation_runtime_store_mode,
         "startup_readiness_policy": settings.startup_readiness_policy,
         "readiness_probe_policy": settings.readiness_probe_policy,
         "database_url": settings.database_url,
@@ -62,3 +64,4 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         reset_provider_quota_counters()
         reset_provider_operations_store_cache()
         reset_async_runtime_store_cache()
+        reset_evaluation_runtime_store_cache()

--- a/tests/integration/test_async_api_contract.py
+++ b/tests/integration/test_async_api_contract.py
@@ -296,6 +296,7 @@ def test_async_job_submit_route_rejects_documentation_only_job_type(client: Test
         "/platform/async/jobs/submit",
         json={
             "job_type": "evaluation_execution",
+            "target_id": "provider_runtime_examples",
             "caller_app": "lotus-platform",
             "correlation_id": "corr-async-submit-001-eval",
             "payload_summary": "Run staged evaluation family.",
@@ -304,9 +305,9 @@ def test_async_job_submit_route_rejects_documentation_only_job_type(client: Test
 
     assert response.status_code == 200
     body = response.json()
-    assert body["submission_status"] == "REJECTED"
-    assert body["accepted"] is False
-    assert body["job_id"] is None
+    assert body["submission_status"] == "ACCEPTED"
+    assert body["accepted"] is True
+    assert body["job_id"] is not None
     assert body["queue_mode"] == "STUBBED"
     assert body["worker_mode"] == "STUBBED"
 

--- a/tests/integration/test_async_api_contract.py
+++ b/tests/integration/test_async_api_contract.py
@@ -3,6 +3,7 @@ from app.services.async_worker_runtime import (
     complete_async_job,
     start_async_job,
 )
+from app.services.eval_async_execution import run_next_evaluation_execution_job
 from fastapi.testclient import TestClient
 
 
@@ -310,6 +311,32 @@ def test_async_job_submit_route_rejects_documentation_only_job_type(client: Test
     assert body["job_id"] is not None
     assert body["queue_mode"] == "STUBBED"
     assert body["worker_mode"] == "STUBBED"
+
+
+def test_async_job_detail_route_exposes_runtime_backed_evaluation_execution(
+    client: TestClient,
+) -> None:
+    submission = client.post(
+        "/platform/async/jobs/submit",
+        json={
+            "job_type": "evaluation_execution",
+            "target_id": "provider_policy_examples",
+            "caller_app": "lotus-platform",
+            "correlation_id": "corr-async-submit-001-eval-run",
+            "payload_summary": "Run provider policy evaluation family.",
+        },
+    ).json()
+
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    detail_response = client.get(f"/platform/async/jobs/{submission['job_id']}")
+
+    assert detail_response.status_code == 200
+    body = detail_response.json()
+    assert body["job"]["job_type"] == "evaluation_execution"
+    assert body["job"]["status"] == "COMPLETED"
+    assert body["job"]["related_evaluation_run_id"] is not None
+    assert body["attempts"][0]["status"] == "COMPLETED"
 
 
 def test_async_job_submit_route_rejects_missing_retrieval_target_id(client: TestClient) -> None:

--- a/tests/integration/test_eval_api_contract.py
+++ b/tests/integration/test_eval_api_contract.py
@@ -1,5 +1,7 @@
 from fastapi.testclient import TestClient
 
+from app.services.eval_async_execution import run_next_evaluation_execution_job
+
 
 def test_evaluation_catalog_route(client: TestClient) -> None:
     response = client.get("/platform/evals/catalog")
@@ -109,7 +111,7 @@ def test_evaluation_runtime_status_route(client: TestClient) -> None:
     assert body["historical_run_count"] == 2
     assert body["latest_recorded_run_id"] == "foundation_eval_2026_03_22_001"
     assert body["latest_recorded_run_status"] == "RECORDED"
-    assert body["evaluation_runner_active"] is False
+    assert body["evaluation_runner_active"] is True
 
 
 def test_evaluation_run_catalog_route(client: TestClient) -> None:
@@ -189,6 +191,33 @@ def test_evaluation_run_submit_route_accepts_runtime_backed_allowlisted_fixture(
     assert runtime_run["record_source"] == "RUNTIME_STATE"
     assert runtime_run["fixture_id"] == "retrieval_citation_examples"
     assert runtime_run["status"] == "QUEUED"
+
+
+def test_evaluation_run_detail_route_exposes_runtime_attempt_and_case_history(
+    client: TestClient,
+) -> None:
+    submission = client.post(
+        "/platform/evals/runs/submit",
+        json={
+            "fixture_id": "provider_policy_examples",
+            "caller_app": "lotus-platform",
+            "correlation_id": "corr-eval-submit-003",
+            "triggered_by": "operator-a",
+        },
+    ).json()
+
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    detail_response = client.get(f"/platform/evals/runs/{submission['run_id']}")
+
+    assert detail_response.status_code == 200
+    body = detail_response.json()
+    assert body["run"]["record_source"] == "RUNTIME_STATE"
+    assert body["run"]["status"] == "COMPLETED"
+    assert body["attempts"][0]["status"] == "COMPLETED"
+    assert body["attempts"][0]["verdict"] == "PASS"
+    assert len(body["case_results"]) == 2
+    assert body["case_results"][0]["outcome"] == "PASS"
 
 
 def test_evaluation_run_submit_route_rejects_staged_only_fixture(client: TestClient) -> None:

--- a/tests/integration/test_eval_api_contract.py
+++ b/tests/integration/test_eval_api_contract.py
@@ -105,6 +105,8 @@ def test_evaluation_runtime_status_route(client: TestClient) -> None:
     assert body["seam_coverage"][3]["staged_fixture_count"] == 5
     assert body["seam_coverage"][3]["staged_case_count"] == 12
     assert body["recorded_run_count"] == 2
+    assert body["runtime_backed_run_count"] == 0
+    assert body["historical_run_count"] == 2
     assert body["latest_recorded_run_id"] == "foundation_eval_2026_03_22_001"
     assert body["latest_recorded_run_status"] == "RECORDED"
     assert body["evaluation_runner_active"] is False
@@ -117,9 +119,12 @@ def test_evaluation_run_catalog_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["run_count"] == 2
+    assert body["runtime_backed_run_count"] == 0
+    assert body["historical_run_count"] == 2
     assert body["latest_run_id"] == "foundation_eval_2026_03_22_001"
     assert body["status_counts"]["RECORDED"] == 1
     assert body["status_counts"]["SUPERSEDED"] == 1
+    assert body["runs"][0]["record_source"] == "STAGED_ARTIFACT"
     assert body["runs"][0]["staged_case_count"] == 25
     assert body["runs"][1]["status"] == "SUPERSEDED"
 
@@ -131,6 +136,7 @@ def test_evaluation_run_detail_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["run"]["run_id"] == "foundation_eval_2026_03_22_001"
+    assert body["run"]["record_source"] == "STAGED_ARTIFACT"
     assert body["run"]["seam_coverage"][0]["seam_id"] == "async_execution"
 
 
@@ -151,7 +157,53 @@ def test_evaluation_run_detail_route_returns_not_found_for_unknown_run(
     response = client.get("/platform/evals/runs/missing_run")
 
     assert response.status_code == 404
-    assert response.json()["detail"] == "Evaluation run artifact 'missing_run' was not found."
+    assert response.json()["detail"] == "Evaluation run 'missing_run' was not found."
+
+
+def test_evaluation_run_submit_route_accepts_runtime_backed_allowlisted_fixture(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/platform/evals/runs/submit",
+        json={
+            "fixture_id": "retrieval_citation_examples",
+            "caller_app": "lotus-platform",
+            "correlation_id": "corr-eval-submit-001",
+            "triggered_by": "operator-a",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["submission_status"] == "ACCEPTED"
+    assert body["accepted"] is True
+    assert body["run_id"] is not None
+    assert body["async_job_id"] is not None
+
+    catalog_response = client.get("/platform/evals/runs")
+    catalog_body = catalog_response.json()
+    runtime_run = next(run for run in catalog_body["runs"] if run["run_id"] == body["run_id"])
+
+    assert catalog_body["run_count"] == 3
+    assert catalog_body["runtime_backed_run_count"] == 1
+    assert runtime_run["record_source"] == "RUNTIME_STATE"
+    assert runtime_run["fixture_id"] == "retrieval_citation_examples"
+    assert runtime_run["status"] == "QUEUED"
+
+
+def test_evaluation_run_submit_route_rejects_staged_only_fixture(client: TestClient) -> None:
+    response = client.post(
+        "/platform/evals/runs/submit",
+        json={
+            "fixture_id": "explanation_task_examples",
+            "caller_app": "lotus-platform",
+            "correlation_id": "corr-eval-submit-002",
+            "triggered_by": "operator-a",
+        },
+    )
+
+    assert response.status_code == 409
+    assert "staged-only" in response.json()["detail"]
 
 
 def test_evaluation_fixture_detail_route(client: TestClient) -> None:

--- a/tests/integration/test_eval_api_contract.py
+++ b/tests/integration/test_eval_api_contract.py
@@ -112,6 +112,9 @@ def test_evaluation_runtime_status_route(client: TestClient) -> None:
     assert body["latest_recorded_run_id"] == "foundation_eval_2026_03_22_001"
     assert body["latest_recorded_run_status"] == "RECORDED"
     assert body["evaluation_runner_active"] is True
+    assert body["approval_gates"][0]["domain_id"] == "retrieval_execution"
+    assert body["approval_gates"][1]["domain_id"] == "provider_execution"
+    assert body["approval_gates"][0]["evidence_state"] == "STAGED_ONLY"
 
 
 def test_evaluation_run_catalog_route(client: TestClient) -> None:

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -259,9 +259,11 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["evaluation_runtime"]["seam_coverage"][1]["staged_fixture_count"] == 3
     assert body["evaluation_runtime"]["seam_coverage"][3]["staged_fixture_count"] == 5
     assert body["evaluation_runtime"]["seam_coverage"][3]["staged_case_count"] == 12
+    assert body["evaluation_runtime"]["approval_gates"][0]["domain_id"] == "retrieval_execution"
+    assert body["evaluation_runtime"]["approval_gates"][1]["domain_id"] == "provider_execution"
     assert body["evaluation_runtime"]["recorded_run_count"] == 2
     assert body["evaluation_runtime"]["latest_recorded_run_id"] == "foundation_eval_2026_03_22_001"
-    assert body["evaluation_runtime"]["evaluation_runner_active"] is False
+    assert body["evaluation_runtime"]["evaluation_runner_active"] is True
     assert body["prompt_runtime"]["selection_mode"] == "STATIC_ACTIVE"
     assert body["prompt_runtime"]["active_prompt_count"] >= 7
     assert any(

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -225,7 +225,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["async_runtime"]["enqueued_job_count"] == 0
     assert body["async_runtime"]["recorded_job_count"] == 2
     assert (
-        "retrieval indexing already running through the runtime-backed in-process worker path"
+        "retrieval indexing and evaluation execution already running through the runtime-backed in-process worker path"
         in body["async_runtime"]["message"]
     )
     assert body["async_governance"]["governance_ready"] is False

--- a/tests/integration/test_provider_api_contract.py
+++ b/tests/integration/test_provider_api_contract.py
@@ -17,6 +17,9 @@ from app.services.provider_operations_store import reset_provider_operations_sto
 from app.services.provider_quota_policy import enforce_provider_quota
 from app.services.provider_request_builder import build_provider_execution_request
 from app.services.task_execution_pipeline import validate_task_request
+from app.services.eval_async_execution import run_next_evaluation_execution_job
+from app.services.eval_run_submission_service import submit_evaluation_run
+from app.contracts.evals import EvaluationRunSubmissionRequest
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.unit.test_task_executor import _request
 
@@ -321,6 +324,9 @@ def test_provider_evidence_readiness_route(client: TestClient) -> None:
     assert body["items"][5]["evidence_id"] == "provider_regression_run_baseline"
     assert body["items"][5]["status"] == "READY"
     assert body["items"][6]["status"] == "FOUNDATION_STAGED"
+    assert body["approval_gate"]["domain_id"] == "provider_execution"
+    assert body["approval_gate"]["evidence_state"] == "STAGED_ONLY"
+    assert body["approval_gate"]["latest_historical_baseline_run_id"] == "foundation_eval_2026_03_22_001"
 
 
 def test_provider_governance_status_route(client: TestClient) -> None:
@@ -334,4 +340,26 @@ def test_provider_governance_status_route(client: TestClient) -> None:
     assert body["activation_readiness"]["activation_ready"] is False
     assert body["runbook_readiness"]["runbook_ready"] is False
     assert body["evidence_readiness"]["evidence_ready"] is False
+    assert body["evidence_readiness"]["approval_gate"]["domain_id"] == "provider_execution"
     assert len(body["governance_summary"]) == 3
+
+
+def test_provider_evidence_readiness_route_reports_partial_runtime_coverage(
+    client: TestClient,
+) -> None:
+    submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-provider-approval-001",
+            triggered_by="operator-a",
+        )
+    )
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    response = client.get("/platform/providers/evidence-readiness")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["approval_gate"]["evidence_state"] == "RUNTIME_PARTIAL"
+    assert body["approval_gate"]["approval_ready"] is False

--- a/tests/integration/test_provider_api_contract.py
+++ b/tests/integration/test_provider_api_contract.py
@@ -326,7 +326,10 @@ def test_provider_evidence_readiness_route(client: TestClient) -> None:
     assert body["items"][6]["status"] == "FOUNDATION_STAGED"
     assert body["approval_gate"]["domain_id"] == "provider_execution"
     assert body["approval_gate"]["evidence_state"] == "STAGED_ONLY"
-    assert body["approval_gate"]["latest_historical_baseline_run_id"] == "foundation_eval_2026_03_22_001"
+    assert (
+        body["approval_gate"]["latest_historical_baseline_run_id"]
+        == "foundation_eval_2026_03_22_001"
+    )
 
 
 def test_provider_governance_status_route(client: TestClient) -> None:

--- a/tests/integration/test_retrieval_api_contract.py
+++ b/tests/integration/test_retrieval_api_contract.py
@@ -1,3 +1,6 @@
+from app.contracts.evals import EvaluationRunSubmissionRequest
+from app.services.eval_async_execution import run_next_evaluation_execution_job
+from app.services.eval_run_submission_service import submit_evaluation_run
 from app.services.retrieval_async_execution import run_next_retrieval_index_job
 from fastapi.testclient import TestClient
 
@@ -101,6 +104,9 @@ def test_retrieval_evidence_readiness_route(client: TestClient) -> None:
     assert body["completed_required_item_count"] == 0
     assert body["items"][0]["evidence_id"] == "retrieval_fixture_coverage_pack"
     assert body["items"][1]["status"] == "NOT_READY"
+    assert body["approval_gate"]["domain_id"] == "retrieval_execution"
+    assert body["approval_gate"]["evidence_state"] == "STAGED_ONLY"
+    assert body["approval_gate"]["latest_historical_baseline_run_id"] == "foundation_eval_2026_03_22_001"
 
 
 def test_retrieval_governance_status_route(client: TestClient) -> None:
@@ -114,7 +120,29 @@ def test_retrieval_governance_status_route(client: TestClient) -> None:
     assert body["activation_readiness"]["activation_ready"] is False
     assert body["runbook_readiness"]["runbook_ready"] is False
     assert body["evidence_readiness"]["evidence_ready"] is False
+    assert body["evidence_readiness"]["approval_gate"]["domain_id"] == "retrieval_execution"
     assert len(body["governance_summary"]) == 3
+
+
+def test_retrieval_evidence_readiness_route_prefers_runtime_backed_pass_evidence(
+    client: TestClient,
+) -> None:
+    submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="retrieval_citation_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-retrieval-approval-001",
+            triggered_by="operator-a",
+        )
+    )
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    response = client.get("/platform/retrieval/evidence-readiness")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["approval_gate"]["evidence_state"] == "RUNTIME_PASS"
+    assert body["approval_gate"]["approval_ready"] is True
 
 
 def test_retrieval_index_jobs_route(client: TestClient) -> None:

--- a/tests/integration/test_retrieval_api_contract.py
+++ b/tests/integration/test_retrieval_api_contract.py
@@ -106,7 +106,10 @@ def test_retrieval_evidence_readiness_route(client: TestClient) -> None:
     assert body["items"][1]["status"] == "NOT_READY"
     assert body["approval_gate"]["domain_id"] == "retrieval_execution"
     assert body["approval_gate"]["evidence_state"] == "STAGED_ONLY"
-    assert body["approval_gate"]["latest_historical_baseline_run_id"] == "foundation_eval_2026_03_22_001"
+    assert (
+        body["approval_gate"]["latest_historical_baseline_run_id"]
+        == "foundation_eval_2026_03_22_001"
+    )
 
 
 def test_retrieval_governance_status_route(client: TestClient) -> None:

--- a/tests/unit/test_async_activation_readiness_service.py
+++ b/tests/unit/test_async_activation_readiness_service.py
@@ -11,4 +11,5 @@ def test_async_activation_readiness_reports_foundation_blockers() -> None:
     assert readiness.supported_job_type_count == 3
     assert len(readiness.blocking_findings) == 2
     assert "durable in-process worker posture" in readiness.blocking_findings[0]
+    assert "evaluation execution are active" in readiness.blocking_findings[1]
     assert len(readiness.activation_path) == 2

--- a/tests/unit/test_async_governance_status_service.py
+++ b/tests/unit/test_async_governance_status_service.py
@@ -10,4 +10,4 @@ def test_async_governance_status_reports_blocked_foundation_posture() -> None:
     assert status.activation_readiness.activation_ready is False
     assert status.runbook_readiness.runbook_ready is False
     assert len(status.governance_summary) == 2
-    assert "retrieval-indexing execution are active" in status.governance_summary[0]
+    assert "evaluation execution are active" in status.governance_summary[0]

--- a/tests/unit/test_async_runtime_control.py
+++ b/tests/unit/test_async_runtime_control.py
@@ -17,9 +17,12 @@ from app.services.async_runtime_store import (
     get_async_runtime_store,
     reset_async_runtime_store_cache,
 )
+from app.services.eval_run_submission_service import submit_evaluation_run
+from app.services.eval_run_service import build_evaluation_run_detail
 from app.services.async_submission_service import submit_async_job
 from app.services.async_worker_runtime import claim_next_async_job, fail_async_job, start_async_job
 from app.contracts.async_runtime import AsyncJobSubmissionRequest
+from app.contracts.evals import EvaluationRunSubmissionRequest
 from tests.support.migration_runner import upgrade_database_to_head
 
 
@@ -279,3 +282,34 @@ def test_async_control_action_rejects_missing_attempt_for_active_lease() -> None
         )
 
     assert exc_info.value.status_code == 409
+
+
+def test_async_control_action_abandon_updates_linked_evaluation_attempt() -> None:
+    response = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-async-eval-abandon-001",
+            triggered_by="operator-a",
+        )
+    )
+    claim = claim_next_async_job(worker_id="worker-a")
+    assert claim is not None
+    start_async_job(job_id=response.async_job_id or "", worker_id="worker-a")
+
+    action = apply_async_control_action(
+        AsyncControlActionRequest(
+            job_id=response.async_job_id or "",
+            action_type=AsyncControlActionType.ABANDON_ACTIVE_JOB,
+            requested_by="operator-a",
+            approved_by="approver-a",
+            reason="Abandon linked evaluation.",
+        )
+    )
+
+    detail = build_evaluation_run_detail(run_id=response.run_id or "")
+
+    assert action.event.resulting_status == "ABANDONED"
+    assert detail.run.status.value == "ABANDONED"
+    assert detail.attempts[0].status.value == "ABANDONED"
+    assert detail.attempts[0].failure_reason == "MANUAL_ABANDON"

--- a/tests/unit/test_async_runtime_status_service.py
+++ b/tests/unit/test_async_runtime_status_service.py
@@ -17,6 +17,6 @@ def test_async_runtime_status_reports_durable_submission_posture() -> None:
     assert status.enqueued_job_count == 0
     assert status.recorded_job_count == 2
     assert (
-        "retrieval indexing already running through the runtime-backed in-process worker path"
+        "retrieval indexing and evaluation execution already running through the runtime-backed in-process worker path"
         in status.message
     )

--- a/tests/unit/test_async_submission_service.py
+++ b/tests/unit/test_async_submission_service.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
+import pytest
 from fastapi import HTTPException
+from unittest.mock import patch
 
 from app.contracts.async_runtime import AsyncJobSubmissionRequest
 from app.repositories.async_runtime_repository import (
@@ -145,6 +147,31 @@ def test_submit_async_job_raises_not_found_for_unknown_job_type() -> None:
         raise AssertionError("Expected async submission to raise HTTPException.")
 
 
+def test_submit_async_job_rejects_disabled_non_evaluation_job_type() -> None:
+    with patch("app.services.async_submission_service.get_async_job_type_descriptor") as descriptor:
+        descriptor.return_value = type(
+            "JobTypeDescriptor",
+            (),
+            {
+                "enabled": False,
+                "execution_path": "future_worker_queue",
+            },
+        )()
+        response = submit_async_job(
+            AsyncJobSubmissionRequest(
+                job_type="document_ingestion",
+                target_id="doc-001",
+                caller_app="lotus-platform",
+                correlation_id="corr-async-disabled-doc-ingestion",
+                payload_summary="Ingest large document.",
+            )
+        )
+
+    assert response.accepted is False
+    assert response.submission_status == "REJECTED"
+    assert "staged-only" in response.message
+
+
 def test_validate_async_job_target_ignores_non_retrieval_job_types() -> None:
     _validate_async_job_target(
         request=AsyncJobSubmissionRequest(
@@ -197,6 +224,53 @@ def test_find_active_duplicate_submission_ignores_non_matching_runtime_jobs() ->
             target_id="retjob_lotus_platform_rfcs",
             caller_app="lotus-platform",
             correlation_id="corr-async-duplicate-ignore",
+            payload_summary="Fresh request.",
+        )
+    )
+
+    assert duplicate is None
+
+
+def test_submit_async_job_rejects_unknown_retrieval_target() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        submit_async_job(
+            AsyncJobSubmissionRequest(
+                job_type="retrieval_indexing",
+                target_id="missing_retrieval_job",
+                caller_app="lotus-platform",
+                correlation_id="corr-async-missing-retrieval-job",
+                payload_summary="Index missing retrieval target.",
+            )
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+def test_find_active_duplicate_submission_ignores_same_target_for_different_caller() -> None:
+    store = get_async_runtime_store()
+    store.save_job(
+        AsyncRuntimeJobRecord(
+            job_id="async-job-duplicate-other-caller",
+            job_type="retrieval_indexing",
+            target_id="retjob_lotus_platform_rfcs",
+            lifecycle_status="RUNNING",
+            submitted_at="2026-03-23T00:00:00Z",
+            caller_app="other-app",
+            correlation_id="corr-001",
+            payload_summary="Running job for different caller.",
+            execution_path="durable_runtime_worker_execution",
+            related_evaluation_run_id=None,
+            latest_message="Running.",
+            attempt_count=1,
+        )
+    )
+
+    duplicate = _find_active_duplicate_submission(
+        request=AsyncJobSubmissionRequest(
+            job_type="retrieval_indexing",
+            target_id="retjob_lotus_platform_rfcs",
+            caller_app="lotus-platform",
+            correlation_id="corr-async-different-caller",
             payload_summary="Fresh request.",
         )
     )

--- a/tests/unit/test_async_submission_service.py
+++ b/tests/unit/test_async_submission_service.py
@@ -113,6 +113,7 @@ def test_submit_async_job_rejects_documentation_only_job_type() -> None:
     response = submit_async_job(
         AsyncJobSubmissionRequest(
             job_type="evaluation_execution",
+            target_id="provider_runtime_examples",
             caller_app="lotus-platform",
             correlation_id="corr-async-001-eval",
             payload_summary="Run staged evaluation family.",
@@ -120,9 +121,9 @@ def test_submit_async_job_rejects_documentation_only_job_type() -> None:
     )
 
     assert response.service == "lotus-ai"
-    assert response.submission_status == "REJECTED"
-    assert response.accepted is False
-    assert response.job_id is None
+    assert response.submission_status == "ACCEPTED"
+    assert response.accepted is True
+    assert response.job_id is not None
     assert response.queue_mode == "STUBBED"
     assert response.worker_mode == "STUBBED"
 
@@ -148,6 +149,7 @@ def test_validate_async_job_target_ignores_non_retrieval_job_types() -> None:
     _validate_async_job_target(
         request=AsyncJobSubmissionRequest(
             job_type="evaluation_execution",
+            target_id="provider_runtime_examples",
             caller_app="lotus-platform",
             correlation_id="corr-async-ignore-target",
             payload_summary="Run evaluation family.",

--- a/tests/unit/test_async_worker_runtime.py
+++ b/tests/unit/test_async_worker_runtime.py
@@ -7,6 +7,8 @@ import pytest
 from app.config import settings
 from app.repositories.memory_async_runtime_repository import InMemoryAsyncRuntimeRepository
 from fastapi import HTTPException
+from app.services.eval_run_service import build_evaluation_run_detail
+from app.services.eval_run_submission_service import submit_evaluation_run
 from app.services.async_job_service import build_async_job_detail
 from app.services.async_runtime_store import (
     get_async_runtime_store,
@@ -20,6 +22,7 @@ from app.services.async_worker_runtime import (
     heartbeat_async_job,
     start_async_job,
 )
+from app.contracts.evals import EvaluationRunSubmissionRequest
 from app.contracts.async_runtime import AsyncJobSubmissionRequest
 from tests.support.migration_runner import upgrade_database_to_head
 
@@ -305,3 +308,37 @@ def test_async_worker_runtime_recovery_survives_sql_store_reset(
     assert detail.attempts[0].status == "ABANDONED"
     assert detail.attempts[0].failure_reason == "LEASE_EXPIRED"
     assert detail.attempts[1].status == "CLAIMED"
+
+
+def test_async_worker_runtime_recovery_updates_evaluation_attempt_history(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.async_worker_runtime._utcnow",
+        lambda: datetime(2026, 3, 23, 22, 0, tzinfo=UTC),
+    )
+    submission = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-async-worker-eval-001",
+            triggered_by="operator-a",
+        )
+    )
+    claim_next_async_job(worker_id="worker-a")
+    start_async_job(job_id=submission.async_job_id or "", worker_id="worker-a")
+
+    monkeypatch.setattr(
+        "app.services.async_worker_runtime._utcnow",
+        lambda: datetime(2026, 3, 23, 22, 10, tzinfo=UTC),
+    )
+    recovered_claim = claim_next_async_job(worker_id="worker-b")
+
+    assert recovered_claim is not None
+    detail = build_evaluation_run_detail(run_id=submission.run_id or "")
+    assert detail.run.status.value == "QUEUED"
+    assert len(detail.attempts) == 2
+    assert detail.attempts[0].status.value == "ABANDONED"
+    assert detail.attempts[0].failure_reason == "LEASE_EXPIRED"
+    assert detail.attempts[1].status.value == "CLAIMED"
+    assert detail.attempts[1].worker_id == "worker-b"

--- a/tests/unit/test_eval_approval_gate_summary.py
+++ b/tests/unit/test_eval_approval_gate_summary.py
@@ -89,3 +89,49 @@ def test_retrieval_approval_gate_reports_runtime_stale_for_old_manifest_version(
     assert summary.approval_ready is False
     assert summary.runtime_backed_fixture_count == 1
     assert summary.fixture_summaries[0].evidence_state.value == "RUNTIME_STALE"
+
+
+def test_provider_approval_gate_reports_runtime_fail_for_terminal_non_passing_run() -> None:
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id="runtime_eval_provider_fail_001",
+            fixture_id="provider_policy_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="FAILED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T12:00:00Z",
+            async_job_id="async_eval_provider_fail_001",
+            latest_message="Provider policy evaluation failed.",
+            verdict=None,
+            case_count=2,
+        )
+    )
+
+    summary = build_provider_approval_gate_summary()
+
+    assert summary.evidence_state.value == "RUNTIME_FAIL"
+    assert summary.approval_ready is False
+    assert summary.fixture_summaries[0].evidence_state.value == "RUNTIME_FAIL"
+
+
+def test_retrieval_approval_gate_reports_runtime_in_progress() -> None:
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id="runtime_eval_retrieval_in_progress_001",
+            fixture_id="retrieval_citation_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="RUNNING",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T13:00:00Z",
+            async_job_id="async_eval_retrieval_in_progress_001",
+            latest_message="Retrieval citation evaluation running.",
+            verdict=None,
+            case_count=2,
+        )
+    )
+
+    summary = build_retrieval_approval_gate_summary()
+
+    assert summary.evidence_state.value == "RUNTIME_IN_PROGRESS"
+    assert summary.approval_ready is False
+    assert summary.fixture_summaries[0].evidence_state.value == "RUNTIME_IN_PROGRESS"

--- a/tests/unit/test_eval_approval_gate_summary.py
+++ b/tests/unit/test_eval_approval_gate_summary.py
@@ -1,0 +1,91 @@
+from app.contracts.evals import EvaluationRunSubmissionRequest
+from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.services.eval_approval_gate_summary import (
+    build_provider_approval_gate_summary,
+    build_retrieval_approval_gate_summary,
+)
+from app.services.eval_async_execution import run_next_evaluation_execution_job
+from app.services.eval_run_submission_service import submit_evaluation_run
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+
+def test_provider_approval_gate_reports_staged_only_without_runtime_runs() -> None:
+    summary = build_provider_approval_gate_summary()
+
+    assert summary.domain_id == "provider_execution"
+    assert summary.evidence_state.value == "STAGED_ONLY"
+    assert summary.approval_ready is False
+    assert summary.required_fixture_count == 5
+    assert summary.runtime_backed_fixture_count == 0
+    assert summary.latest_historical_baseline_run_id == "foundation_eval_2026_03_22_001"
+
+
+def test_provider_approval_gate_reports_partial_runtime_coverage() -> None:
+    submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-provider-approval-partial-001",
+            triggered_by="operator-a",
+        )
+    )
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    summary = build_provider_approval_gate_summary()
+
+    assert summary.evidence_state.value == "RUNTIME_PARTIAL"
+    assert summary.approval_ready is False
+    assert summary.runtime_backed_fixture_count == 1
+    assert summary.fixture_summaries[0].evidence_state.value == "RUNTIME_PASS"
+    assert summary.fixture_summaries[1].evidence_state.value == "STAGED_ONLY"
+
+
+def test_provider_approval_gate_reports_runtime_pass_when_all_required_fixtures_pass() -> None:
+    for fixture_id in (
+        "provider_policy_examples",
+        "provider_runtime_examples",
+        "provider_failure_mode_examples",
+        "provider_operations_examples",
+        "provider_degradation_examples",
+    ):
+        submit_evaluation_run(
+            EvaluationRunSubmissionRequest(
+                fixture_id=fixture_id,
+                caller_app="lotus-platform",
+                correlation_id=f"corr-{fixture_id}",
+                triggered_by="operator-a",
+            )
+        )
+        run_next_evaluation_execution_job(worker_id="worker-a")
+
+    summary = build_provider_approval_gate_summary()
+
+    assert summary.evidence_state.value == "RUNTIME_PASS"
+    assert summary.approval_ready is True
+    assert summary.runtime_backed_fixture_count == 5
+    assert all(item.evidence_state.value == "RUNTIME_PASS" for item in summary.fixture_summaries)
+
+
+def test_retrieval_approval_gate_reports_runtime_stale_for_old_manifest_version() -> None:
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id="runtime_eval_retrieval_stale_001",
+            fixture_id="retrieval_citation_examples",
+            manifest_version="foundation.v0",
+            lifecycle_status="COMPLETED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T10:00:00Z",
+            async_job_id="async_eval_retrieval_stale_001",
+            latest_message="Stale retrieval runtime run.",
+            verdict="PASS",
+            case_count=2,
+        )
+    )
+
+    summary = build_retrieval_approval_gate_summary()
+
+    assert summary.domain_id == "retrieval_execution"
+    assert summary.evidence_state.value == "RUNTIME_STALE"
+    assert summary.approval_ready is False
+    assert summary.runtime_backed_fixture_count == 1
+    assert summary.fixture_summaries[0].evidence_state.value == "RUNTIME_STALE"

--- a/tests/unit/test_eval_async_execution.py
+++ b/tests/unit/test_eval_async_execution.py
@@ -1,17 +1,35 @@
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
 
 from app.config import settings
 from app.contracts.async_runtime import AsyncControlActionRequest, AsyncControlActionType
 from app.contracts.async_runtime import AsyncJobSubmissionRequest
+from app.repositories.async_runtime_repository import (
+    AsyncRuntimeAttemptRecord as AsyncAttemptRecord,
+    AsyncRuntimeClaimRecord,
+    AsyncRuntimeJobRecord as AsyncJobRecord,
+    AsyncRuntimeLeaseRecord,
+)
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+)
 from app.services.async_job_service import build_async_job_detail
 from app.services.async_runtime_control import apply_async_control_action
 from app.services.eval_async_execution import run_next_evaluation_execution_job
+from app.services.eval_runtime_execution import execute_runtime_backed_evaluation_run
 from app.services.eval_run_service import build_evaluation_run_detail
 from app.services.eval_run_submission_service import submit_evaluation_run
 from app.services.async_submission_service import submit_async_job
 from app.services.async_runtime_store import reset_async_runtime_store_cache
 from app.contracts.evals import EvaluationRunSubmissionRequest
-from app.services.evaluation_runtime_store import reset_evaluation_runtime_store_cache
+from app.services.evaluation_runtime_store import (
+    get_evaluation_runtime_store,
+    reset_evaluation_runtime_store_cache,
+)
 from tests.support.migration_runner import upgrade_database_to_head
 
 
@@ -130,3 +148,158 @@ def test_evaluation_replay_preserves_prior_case_history_and_creates_new_attempt(
     assert len({case.case_result_id for case in run_detail.case_results}) == 4
     assert len({case.attempt_id for case in run_detail.case_results}) == 2
     assert async_detail.attempts[-1].status == "COMPLETED"
+
+
+def test_run_next_evaluation_execution_job_marks_async_and_eval_attempt_failed_on_exception() -> (
+    None
+):
+    submission = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-failure-001",
+            triggered_by="operator-a",
+        )
+    )
+
+    with patch(
+        "app.services.eval_async_execution.execute_runtime_backed_evaluation_run",
+        side_effect=RuntimeError("boom"),
+    ):
+        try:
+            run_next_evaluation_execution_job(worker_id="worker-a")
+        except RuntimeError as exc:
+            assert str(exc) == "boom"
+        else:
+            raise AssertionError("Expected evaluation execution to raise RuntimeError.")
+
+    run_detail = build_evaluation_run_detail(run_id=submission.run_id or "")
+    async_detail = build_async_job_detail(job_id=submission.async_job_id or "")
+
+    assert run_detail.run.status.value == "FAILED"
+    assert run_detail.attempts[0].status.value == "FAILED"
+    assert run_detail.attempts[0].failure_reason == "RuntimeError"
+    assert async_detail.job.status.value == "FAILED"
+    assert async_detail.attempts[-1].failure_reason == "RuntimeError"
+
+
+def test_execute_runtime_backed_evaluation_run_rejects_missing_run() -> None:
+    with pytest.raises(HTTPException, match="was not found"):
+        execute_runtime_backed_evaluation_run(
+            run_id="missing-run",
+            worker_id="worker-a",
+        )
+
+
+def test_execute_runtime_backed_evaluation_run_rejects_without_active_attempt() -> None:
+    store = get_evaluation_runtime_store()
+    store.save_run(
+        EvaluationRunRecord(
+            run_id="evalrun_no_attempt",
+            fixture_id="provider_policy_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="QUEUED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T00:00:00Z",
+            async_job_id="asyncjob_no_attempt",
+            latest_message="Queued without attempt.",
+            verdict=None,
+            case_count=2,
+        )
+    )
+
+    with pytest.raises(HTTPException, match="has no queued runtime attempt"):
+        execute_runtime_backed_evaluation_run(
+            run_id="evalrun_no_attempt",
+            worker_id="worker-a",
+        )
+
+
+def test_execute_runtime_backed_evaluation_run_rejects_staged_only_fixture_family() -> None:
+    store = get_evaluation_runtime_store()
+    store.save_run(
+        EvaluationRunRecord(
+            run_id="evalrun_staged_only",
+            fixture_id="explanation_task_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="QUEUED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T00:00:00Z",
+            async_job_id="asyncjob_staged_only",
+            latest_message="Queued staged-only fixture.",
+            verdict=None,
+            case_count=1,
+        )
+    )
+    store.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_staged_only_attempt_001",
+            run_id="evalrun_staged_only",
+            attempt_number=1,
+            lifecycle_status="QUEUED",
+            started_at=None,
+            completed_at=None,
+            worker_id=None,
+            latest_message="Queued.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+
+    with pytest.raises(HTTPException, match="is not executable in runtime-backed mode"):
+        execute_runtime_backed_evaluation_run(
+            run_id="evalrun_staged_only",
+            worker_id="worker-a",
+        )
+
+
+def test_run_next_evaluation_execution_job_fails_unsupported_claim() -> None:
+    with (
+        patch(
+            "app.services.eval_async_execution.claim_next_async_job_for_types",
+            return_value=AsyncRuntimeClaimRecord(
+                job=AsyncJobRecord(
+                    job_id="async-job-unsupported-eval",
+                    job_type="retrieval_indexing",
+                    target_id="retjob_lotus_platform_rfcs",
+                    lifecycle_status="CLAIMED",
+                    submitted_at="2026-03-23T00:00:00Z",
+                    caller_app="lotus-platform",
+                    correlation_id="corr-eval-unsupported-claim",
+                    payload_summary="Wrong job type claimed.",
+                    execution_path="durable_runtime_worker_execution",
+                    related_evaluation_run_id=None,
+                    latest_message="Claimed.",
+                    attempt_count=1,
+                ),
+                attempt=AsyncAttemptRecord(
+                    attempt_id="async-job-unsupported-eval_attempt_001",
+                    job_id="async-job-unsupported-eval",
+                    attempt_number=1,
+                    lifecycle_status="CLAIMED",
+                    worker_id="worker-a",
+                    claimed_at="2026-03-23T00:01:00Z",
+                    heartbeat_at="2026-03-23T00:01:00Z",
+                    started_at=None,
+                    completed_at=None,
+                    failure_reason=None,
+                    recorded_message="Claimed.",
+                ),
+                lease=AsyncRuntimeLeaseRecord(
+                    lease_id="lease-unsupported-eval",
+                    job_id="async-job-unsupported-eval",
+                    attempt_id="async-job-unsupported-eval_attempt_001",
+                    worker_id="worker-a",
+                    claimed_at="2026-03-23T00:01:00Z",
+                    heartbeat_at="2026-03-23T00:01:00Z",
+                    lease_expires_at="2026-03-23T00:06:00Z",
+                ),
+            ),
+        ),
+        patch("app.services.eval_async_execution.fail_async_job") as fail_async_job,
+    ):
+        result = run_next_evaluation_execution_job(worker_id="worker-a")
+
+    assert result is None
+    fail_async_job.assert_called_once()
+    assert fail_async_job.call_args.kwargs["failure_reason"] == "UNSUPPORTED_ASYNC_JOB_TYPE"

--- a/tests/unit/test_eval_async_execution.py
+++ b/tests/unit/test_eval_async_execution.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 from app.config import settings
+from app.contracts.async_runtime import AsyncControlActionRequest, AsyncControlActionType
 from app.contracts.async_runtime import AsyncJobSubmissionRequest
 from app.services.async_job_service import build_async_job_detail
+from app.services.async_runtime_control import apply_async_control_action
 from app.services.eval_async_execution import run_next_evaluation_execution_job
 from app.services.eval_run_service import build_evaluation_run_detail
 from app.services.eval_run_submission_service import submit_evaluation_run
@@ -93,3 +95,38 @@ def test_run_next_evaluation_execution_job_survives_sql_store_reset(tmp_path: Pa
     assert len(run_detail.case_results) == 2
     assert all(case.outcome.value == "PASS" for case in run_detail.case_results)
     assert async_detail.job.status.value == "COMPLETED"
+
+
+def test_evaluation_replay_preserves_prior_case_history_and_creates_new_attempt() -> None:
+    submission = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-replay-001",
+            triggered_by="operator-a",
+        )
+    )
+
+    run_next_evaluation_execution_job(worker_id="worker-a")
+    apply_async_control_action(
+        AsyncControlActionRequest(
+            job_id=submission.async_job_id or "",
+            action_type=AsyncControlActionType.REPLAY_TERMINAL_JOB,
+            requested_by="operator-a",
+            approved_by="approver-a",
+            reason="Replay runtime-backed evaluation after review.",
+        )
+    )
+    run_next_evaluation_execution_job(worker_id="worker-b")
+
+    run_detail = build_evaluation_run_detail(run_id=submission.run_id or "")
+    async_detail = build_async_job_detail(job_id=submission.async_job_id or "")
+
+    assert run_detail.run.status.value == "COMPLETED"
+    assert len(run_detail.attempts) == 2
+    assert run_detail.attempts[0].status.value == "COMPLETED"
+    assert run_detail.attempts[1].status.value == "COMPLETED"
+    assert len(run_detail.case_results) == 4
+    assert len({case.case_result_id for case in run_detail.case_results}) == 4
+    assert len({case.attempt_id for case in run_detail.case_results}) == 2
+    assert async_detail.attempts[-1].status == "COMPLETED"

--- a/tests/unit/test_eval_async_execution.py
+++ b/tests/unit/test_eval_async_execution.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+from app.config import settings
+from app.contracts.async_runtime import AsyncJobSubmissionRequest
+from app.services.async_job_service import build_async_job_detail
+from app.services.eval_async_execution import run_next_evaluation_execution_job
+from app.services.eval_run_service import build_evaluation_run_detail
+from app.services.eval_run_submission_service import submit_evaluation_run
+from app.services.async_submission_service import submit_async_job
+from app.services.async_runtime_store import reset_async_runtime_store_cache
+from app.contracts.evals import EvaluationRunSubmissionRequest
+from app.services.evaluation_runtime_store import reset_evaluation_runtime_store_cache
+from tests.support.migration_runner import upgrade_database_to_head
+
+
+def test_run_next_evaluation_execution_job_persists_attempts_case_results_and_verdict() -> None:
+    submission = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-exec-001",
+            triggered_by="operator-a",
+        )
+    )
+
+    result = run_next_evaluation_execution_job(worker_id="worker-a")
+
+    assert result is not None
+    assert result.async_job_id == submission.async_job_id
+    assert result.evaluation_run_id == submission.run_id
+    assert result.verdict == "PASS"
+    assert result.case_result_count == 2
+
+    run_detail = build_evaluation_run_detail(run_id=submission.run_id or "")
+    async_detail = build_async_job_detail(job_id=submission.async_job_id or "")
+
+    assert run_detail.run.status.value == "COMPLETED"
+    assert run_detail.attempts[0].status.value == "COMPLETED"
+    assert run_detail.attempts[0].worker_id == "worker-a"
+    assert run_detail.attempts[0].verdict is not None
+    assert run_detail.attempts[0].verdict.value == "PASS"
+    assert len(run_detail.case_results) == 2
+    assert all(case.outcome.value == "PASS" for case in run_detail.case_results)
+    assert async_detail.job.status.value == "COMPLETED"
+
+
+def test_run_next_evaluation_execution_job_returns_none_when_no_jobs_are_available() -> None:
+    assert run_next_evaluation_execution_job(worker_id="worker-a") is None
+
+
+def test_run_next_evaluation_execution_job_does_not_claim_non_evaluation_jobs() -> None:
+    submission = submit_async_job(
+        AsyncJobSubmissionRequest(
+            job_type="retrieval_indexing",
+            target_id="retjob_lotus_platform_rfcs",
+            caller_app="lotus-platform",
+            correlation_id="corr-async-eval-worker-skip-001",
+            payload_summary="Refresh retrieval documents.",
+        )
+    )
+
+    result = run_next_evaluation_execution_job(worker_id="worker-a")
+    detail = build_async_job_detail(job_id=submission.job_id or "")
+
+    assert result is None
+    assert detail.job.status.value == "QUEUED"
+
+
+def test_run_next_evaluation_execution_job_survives_sql_store_reset(tmp_path: Path) -> None:
+    settings.async_runtime_store_mode = "sqlalchemy"
+    settings.evaluation_runtime_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-exec.db'}"
+    upgrade_database_to_head(settings.database_url)
+
+    submission = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-exec-sql-001",
+            triggered_by="operator-a",
+        )
+    )
+
+    run_next_evaluation_execution_job(worker_id="worker-a")
+    reset_async_runtime_store_cache()
+    reset_evaluation_runtime_store_cache()
+
+    run_detail = build_evaluation_run_detail(run_id=submission.run_id or "")
+    async_detail = build_async_job_detail(job_id=submission.async_job_id or "")
+
+    assert run_detail.run.status.value == "COMPLETED"
+    assert run_detail.attempts[0].status.value == "COMPLETED"
+    assert len(run_detail.case_results) == 2
+    assert all(case.outcome.value == "PASS" for case in run_detail.case_results)
+    assert async_detail.job.status.value == "COMPLETED"

--- a/tests/unit/test_eval_attempt_runtime.py
+++ b/tests/unit/test_eval_attempt_runtime.py
@@ -1,0 +1,107 @@
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+)
+from app.services.eval_attempt_runtime import (
+    abandon_active_evaluation_attempt,
+    claim_active_evaluation_attempt,
+    fail_active_evaluation_attempt,
+    queue_next_evaluation_attempt,
+)
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+
+def test_queue_next_evaluation_attempt_raises_for_missing_run() -> None:
+    try:
+        queue_next_evaluation_attempt(
+            run_id="missing-run",
+            reason_message="Queue missing run.",
+        )
+    except RuntimeError as exc:
+        assert "missing-run" in str(exc)
+    else:
+        raise AssertionError("Expected missing runtime evaluation run to raise.")
+
+
+def test_claim_abandon_and_fail_active_attempt_return_none_when_run_missing() -> None:
+    assert (
+        claim_active_evaluation_attempt(
+            run_id="missing-run",
+            worker_id="worker-a",
+            reason_message="Claim missing run.",
+        )
+        is None
+    )
+    assert (
+        abandon_active_evaluation_attempt(
+            run_id="missing-run",
+            reason_message="Abandon missing run.",
+            failure_reason="MISSING_RUN",
+        )
+        is None
+    )
+    assert (
+        fail_active_evaluation_attempt(
+            run_id="missing-run",
+            reason_message="Fail missing run.",
+            failure_reason="MISSING_RUN",
+        )
+        is None
+    )
+
+
+def test_claim_abandon_and_fail_active_attempt_return_none_without_active_attempt() -> None:
+    store = get_evaluation_runtime_store()
+    store.save_run(
+        EvaluationRunRecord(
+            run_id="evalrun_terminal_only",
+            fixture_id="provider_policy_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="COMPLETED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T00:00:00Z",
+            async_job_id="asyncjob_terminal_only",
+            latest_message="Completed already.",
+            verdict="PASS",
+            case_count=2,
+        )
+    )
+    store.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_terminal_only_attempt_001",
+            run_id="evalrun_terminal_only",
+            attempt_number=1,
+            lifecycle_status="COMPLETED",
+            started_at="2026-03-23T00:01:00Z",
+            completed_at="2026-03-23T00:02:00Z",
+            worker_id="worker-a",
+            latest_message="Completed already.",
+            verdict="PASS",
+            failure_reason=None,
+        )
+    )
+
+    assert (
+        claim_active_evaluation_attempt(
+            run_id="evalrun_terminal_only",
+            worker_id="worker-b",
+            reason_message="Claim terminal run.",
+        )
+        is None
+    )
+    assert (
+        abandon_active_evaluation_attempt(
+            run_id="evalrun_terminal_only",
+            reason_message="Abandon terminal run.",
+            failure_reason="NOT_ACTIVE",
+        )
+        is None
+    )
+    assert (
+        fail_active_evaluation_attempt(
+            run_id="evalrun_terminal_only",
+            reason_message="Fail terminal run.",
+            failure_reason="NOT_ACTIVE",
+        )
+        is None
+    )

--- a/tests/unit/test_eval_run_service.py
+++ b/tests/unit/test_eval_run_service.py
@@ -1,7 +1,9 @@
 from fastapi import HTTPException
 
-from app.contracts.evals import EvaluationRunStatus
+from app.contracts.evals import EvaluationRunRecordSource, EvaluationRunStatus
+from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
 from app.services.eval_run_service import build_evaluation_run_catalog, build_evaluation_run_detail
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 
 
 def test_evaluation_run_catalog_reports_recorded_artifacts() -> None:
@@ -9,12 +11,15 @@ def test_evaluation_run_catalog_reports_recorded_artifacts() -> None:
 
     assert catalog.service == "lotus-ai"
     assert catalog.run_count == 2
+    assert catalog.runtime_backed_run_count == 0
+    assert catalog.historical_run_count == 2
     assert catalog.latest_run_id == "foundation_eval_2026_03_22_001"
     assert catalog.status_counts[EvaluationRunStatus.RECORDED] == 1
     assert catalog.status_counts[EvaluationRunStatus.SUPERSEDED] == 1
     assert catalog.runs[0].manifest_version == "foundation.v1"
     assert catalog.runs[0].staged_case_count == 25
     assert catalog.runs[1].status == "SUPERSEDED"
+    assert catalog.runs[0].record_source == EvaluationRunRecordSource.STAGED_ARTIFACT
 
 
 def test_evaluation_run_detail_returns_requested_artifact() -> None:
@@ -22,6 +27,7 @@ def test_evaluation_run_detail_returns_requested_artifact() -> None:
 
     assert detail.service == "lotus-ai"
     assert detail.run.run_id == "foundation_eval_2026_03_22_001"
+    assert detail.run.record_source == EvaluationRunRecordSource.STAGED_ARTIFACT
     assert detail.run.seam_coverage[0].seam_id == "async_execution"
 
 
@@ -39,6 +45,58 @@ def test_evaluation_run_detail_raises_not_found_for_unknown_run() -> None:
         build_evaluation_run_detail(run_id="missing_run")
     except HTTPException as exc:
         assert exc.status_code == 404
-        assert exc.detail == "Evaluation run artifact 'missing_run' was not found."
+        assert exc.detail == "Evaluation run 'missing_run' was not found."
     else:
         raise AssertionError("Expected evaluation run lookup to raise HTTPException.")
+
+
+def test_evaluation_run_catalog_merges_runtime_backed_runs() -> None:
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id="evalrun_runtime_001",
+            fixture_id="retrieval_citation_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="QUEUED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T10:00:00Z",
+            async_job_id="asyncjob_evaluation_execution_001",
+            latest_message="Runtime-backed evaluation submission queued.",
+            verdict=None,
+            case_count=2,
+        )
+    )
+
+    catalog = build_evaluation_run_catalog()
+
+    assert catalog.run_count == 3
+    assert catalog.runtime_backed_run_count == 1
+    assert catalog.historical_run_count == 2
+    assert catalog.latest_run_id == "evalrun_runtime_001"
+    assert catalog.status_counts[EvaluationRunStatus.QUEUED] == 1
+    assert catalog.runs[0].record_source == EvaluationRunRecordSource.RUNTIME_STATE
+    assert catalog.runs[0].fixture_id == "retrieval_citation_examples"
+    assert catalog.runs[0].async_job_id == "asyncjob_evaluation_execution_001"
+    assert catalog.runs[0].seam_coverage[0].seam_id == "retrieval"
+
+
+def test_evaluation_run_detail_returns_runtime_backed_run() -> None:
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id="evalrun_runtime_001",
+            fixture_id="provider_runtime_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="QUEUED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T10:00:00Z",
+            async_job_id="asyncjob_evaluation_execution_001",
+            latest_message="Runtime-backed evaluation submission queued.",
+            verdict=None,
+            case_count=2,
+        )
+    )
+
+    detail = build_evaluation_run_detail(run_id="evalrun_runtime_001")
+
+    assert detail.run.record_source == EvaluationRunRecordSource.RUNTIME_STATE
+    assert detail.run.fixture_id == "provider_runtime_examples"
+    assert detail.run.seam_coverage[0].seam_id == "provider_execution"

--- a/tests/unit/test_eval_run_service.py
+++ b/tests/unit/test_eval_run_service.py
@@ -100,3 +100,5 @@ def test_evaluation_run_detail_returns_runtime_backed_run() -> None:
     assert detail.run.record_source == EvaluationRunRecordSource.RUNTIME_STATE
     assert detail.run.fixture_id == "provider_runtime_examples"
     assert detail.run.seam_coverage[0].seam_id == "provider_execution"
+    assert detail.attempts == []
+    assert detail.case_results == []

--- a/tests/unit/test_eval_run_submission_service.py
+++ b/tests/unit/test_eval_run_submission_service.py
@@ -2,15 +2,23 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from unittest.mock import patch
 
 from app.config import settings
 from app.contracts.async_runtime import AsyncJobSubmissionRequest
 from app.contracts.evals import EvaluationRunSubmissionRequest
+from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
 from app.services.async_job_service import build_async_job_catalog
-from app.services.eval_run_service import build_evaluation_run_catalog, build_evaluation_run_detail
-from app.services.eval_run_submission_service import submit_evaluation_execution_async_job, submit_evaluation_run
+from app.services.eval_run_service import build_evaluation_run_catalog
+from app.services.eval_run_submission_service import (
+    submit_evaluation_execution_async_job,
+    submit_evaluation_run,
+)
 from app.services.async_runtime_store import reset_async_runtime_store_cache
-from app.services.evaluation_runtime_store import reset_evaluation_runtime_store_cache
+from app.services.evaluation_runtime_store import (
+    get_evaluation_runtime_store,
+    reset_evaluation_runtime_store_cache,
+)
 from tests.support.migration_runner import upgrade_database_to_head
 
 
@@ -31,12 +39,12 @@ def test_submit_evaluation_run_accepts_allowlisted_fixture_family() -> None:
 
     catalog = build_evaluation_run_catalog()
     runtime_run = next(run for run in catalog.runs if run.run_id == response.run_id)
-    detail = build_evaluation_run_detail(run_id=response.run_id or "")
+    detail = get_evaluation_runtime_store().list_attempts(run_id=response.run_id or "")
 
     assert runtime_run.record_source == "RUNTIME_STATE"
     assert runtime_run.fixture_id == "retrieval_citation_examples"
-    assert detail.attempts[0].status.value == "QUEUED"
-    assert detail.case_results == []
+    assert detail[0].lifecycle_status == "QUEUED"
+    assert get_evaluation_runtime_store().list_case_results(run_id=response.run_id or "") == []
 
 
 def test_submit_evaluation_run_persists_sql_backed_runtime_submission(tmp_path: Path) -> None:
@@ -56,11 +64,11 @@ def test_submit_evaluation_run_persists_sql_backed_runtime_submission(tmp_path: 
     reset_async_runtime_store_cache()
     reset_evaluation_runtime_store_cache()
 
-    detail = build_evaluation_run_detail(run_id=response.run_id or "")
+    detail = get_evaluation_runtime_store().get_run(run_id=response.run_id or "")
 
     assert response.accepted is True
-    assert detail.run.record_source == "RUNTIME_STATE"
-    assert detail.run.fixture_id == "provider_runtime_examples"
+    assert detail is not None
+    assert detail.fixture_id == "provider_runtime_examples"
 
 
 def test_submit_evaluation_run_rejects_duplicate_active_fixture_family() -> None:
@@ -121,3 +129,133 @@ def test_submit_evaluation_execution_async_job_accepts_allowlisted_fixture_famil
     assert runtime_job.job_type == "evaluation_execution"
     assert runtime_job.related_evaluation_run_id is not None
     assert runtime_job.target_id == "provider_operations_examples"
+
+
+def test_submit_evaluation_execution_async_job_rejects_missing_target() -> None:
+    with pytest.raises(HTTPException, match="requires a concrete evaluation fixture target_id"):
+        submit_evaluation_execution_async_job(
+            AsyncJobSubmissionRequest(
+                job_type="evaluation_execution",
+                target_id=None,
+                caller_app="lotus-platform",
+                correlation_id="corr-async-eval-missing-target-001",
+                payload_summary="Run evaluation family without target.",
+            )
+        )
+
+
+def test_submit_evaluation_execution_async_job_rejects_unknown_target() -> None:
+    with pytest.raises(HTTPException, match="Unknown evaluation fixture family"):
+        submit_evaluation_execution_async_job(
+            AsyncJobSubmissionRequest(
+                job_type="evaluation_execution",
+                target_id="unknown_fixture_family",
+                caller_app="lotus-platform",
+                correlation_id="corr-async-eval-unknown-target-001",
+                payload_summary="Run unknown evaluation family.",
+            )
+        )
+
+
+def test_submit_evaluation_run_rejects_when_runtime_job_type_is_disabled() -> None:
+    with patch(
+        "app.services.eval_run_submission_service.get_async_job_type_descriptor",
+        return_value=None,
+    ):
+        response = submit_evaluation_run(
+            EvaluationRunSubmissionRequest(
+                fixture_id="provider_runtime_examples",
+                caller_app="lotus-platform",
+                correlation_id="corr-eval-disabled-job-type-001",
+                triggered_by="operator-a",
+            )
+        )
+
+    assert response.accepted is False
+    assert response.submission_status == "REJECTED"
+    assert "not allowlisted for runtime-backed submission" in response.message
+
+
+def test_submit_evaluation_execution_async_job_rejects_duplicate_active_run() -> None:
+    first = submit_evaluation_execution_async_job(
+        AsyncJobSubmissionRequest(
+            job_type="evaluation_execution",
+            target_id="provider_runtime_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-async-eval-duplicate-001",
+            payload_summary="Run provider runtime family.",
+        )
+    )
+
+    duplicate = submit_evaluation_execution_async_job(
+        AsyncJobSubmissionRequest(
+            job_type="evaluation_execution",
+            target_id="provider_runtime_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-async-eval-duplicate-002",
+            payload_summary="Run provider runtime family again.",
+        )
+    )
+
+    assert first.accepted is True
+    assert duplicate.accepted is False
+    assert duplicate.submission_status == "DUPLICATE_REJECTED"
+    assert duplicate.existing_job_id == first.job_id
+
+
+def test_submit_evaluation_execution_async_job_rejects_when_runtime_job_type_disabled() -> None:
+    with patch(
+        "app.services.eval_run_submission_service.get_async_job_type_descriptor",
+        return_value=None,
+    ):
+        response = submit_evaluation_execution_async_job(
+            AsyncJobSubmissionRequest(
+                job_type="evaluation_execution",
+                target_id="provider_runtime_examples",
+                caller_app="lotus-platform",
+                correlation_id="corr-async-eval-disabled-001",
+                payload_summary="Run disabled evaluation family.",
+            )
+        )
+
+    assert response.accepted is False
+    assert response.submission_status == "REJECTED"
+    assert "not allowlisted for runtime-backed submission" in response.message
+
+
+def test_submit_evaluation_run_ignores_terminal_prior_run_when_accepting_new_submission() -> None:
+    first = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-terminal-prior-001",
+            triggered_by="operator-a",
+        )
+    )
+    store = get_evaluation_runtime_store()
+    store.save_run(
+        EvaluationRunRecord(
+            run_id=first.run_id or "",
+            fixture_id="provider_policy_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="FAILED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T00:00:00Z",
+            async_job_id=first.async_job_id,
+            latest_message="Terminal prior run.",
+            verdict="FAIL",
+            case_count=2,
+        )
+    )
+    second = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-terminal-prior-002",
+            triggered_by="operator-a",
+        )
+    )
+
+    assert second.accepted is True
+    assert second.run_id is not None
+    assert second.run_id != first.run_id

--- a/tests/unit/test_eval_run_submission_service.py
+++ b/tests/unit/test_eval_run_submission_service.py
@@ -31,9 +31,12 @@ def test_submit_evaluation_run_accepts_allowlisted_fixture_family() -> None:
 
     catalog = build_evaluation_run_catalog()
     runtime_run = next(run for run in catalog.runs if run.run_id == response.run_id)
+    detail = build_evaluation_run_detail(run_id=response.run_id or "")
 
     assert runtime_run.record_source == "RUNTIME_STATE"
     assert runtime_run.fixture_id == "retrieval_citation_examples"
+    assert detail.attempts[0].status.value == "QUEUED"
+    assert detail.case_results == []
 
 
 def test_submit_evaluation_run_persists_sql_backed_runtime_submission(tmp_path: Path) -> None:

--- a/tests/unit/test_eval_run_submission_service.py
+++ b/tests/unit/test_eval_run_submission_service.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from app.config import settings
+from app.contracts.async_runtime import AsyncJobSubmissionRequest
+from app.contracts.evals import EvaluationRunSubmissionRequest
+from app.services.async_job_service import build_async_job_catalog
+from app.services.eval_run_service import build_evaluation_run_catalog, build_evaluation_run_detail
+from app.services.eval_run_submission_service import submit_evaluation_execution_async_job, submit_evaluation_run
+from app.services.async_runtime_store import reset_async_runtime_store_cache
+from app.services.evaluation_runtime_store import reset_evaluation_runtime_store_cache
+from tests.support.migration_runner import upgrade_database_to_head
+
+
+def test_submit_evaluation_run_accepts_allowlisted_fixture_family() -> None:
+    response = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="retrieval_citation_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-001",
+            triggered_by="operator-a",
+        )
+    )
+
+    assert response.accepted is True
+    assert response.submission_status == "ACCEPTED"
+    assert response.run_id is not None
+    assert response.async_job_id is not None
+
+    catalog = build_evaluation_run_catalog()
+    runtime_run = next(run for run in catalog.runs if run.run_id == response.run_id)
+
+    assert runtime_run.record_source == "RUNTIME_STATE"
+    assert runtime_run.fixture_id == "retrieval_citation_examples"
+
+
+def test_submit_evaluation_run_persists_sql_backed_runtime_submission(tmp_path: Path) -> None:
+    settings.async_runtime_store_mode = "sqlalchemy"
+    settings.evaluation_runtime_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime-submission.db'}"
+    upgrade_database_to_head(settings.database_url)
+
+    response = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_runtime_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-sql-001",
+            triggered_by="operator-a",
+        )
+    )
+    reset_async_runtime_store_cache()
+    reset_evaluation_runtime_store_cache()
+
+    detail = build_evaluation_run_detail(run_id=response.run_id or "")
+
+    assert response.accepted is True
+    assert detail.run.record_source == "RUNTIME_STATE"
+    assert detail.run.fixture_id == "provider_runtime_examples"
+
+
+def test_submit_evaluation_run_rejects_duplicate_active_fixture_family() -> None:
+    first = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-duplicate-001",
+            triggered_by="operator-a",
+        )
+    )
+
+    duplicate = submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="provider_policy_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-eval-duplicate-002",
+            triggered_by="operator-a",
+        )
+    )
+
+    assert first.accepted is True
+    assert duplicate.accepted is False
+    assert duplicate.submission_status == "DUPLICATE_REJECTED"
+    assert duplicate.existing_run_id == first.run_id
+    assert duplicate.existing_async_job_id == first.async_job_id
+
+
+def test_submit_evaluation_run_rejects_staged_only_fixture_family() -> None:
+    with pytest.raises(HTTPException, match="staged-only"):
+        submit_evaluation_run(
+            EvaluationRunSubmissionRequest(
+                fixture_id="explanation_task_examples",
+                caller_app="lotus-platform",
+                correlation_id="corr-eval-staged-only-001",
+                triggered_by="operator-a",
+            )
+        )
+
+
+def test_submit_evaluation_execution_async_job_accepts_allowlisted_fixture_family() -> None:
+    response = submit_evaluation_execution_async_job(
+        AsyncJobSubmissionRequest(
+            job_type="evaluation_execution",
+            target_id="provider_operations_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-async-eval-001",
+            payload_summary="Run provider operations evaluation family.",
+        )
+    )
+
+    assert response.accepted is True
+    assert response.job_id is not None
+
+    async_catalog = build_async_job_catalog()
+    runtime_job = next(job for job in async_catalog.jobs if job.job_id == response.job_id)
+
+    assert runtime_job.job_type == "evaluation_execution"
+    assert runtime_job.related_evaluation_run_id is not None
+    assert runtime_job.target_id == "provider_operations_examples"

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+from app.config import settings
+from app.contracts.evals import EvaluationCaseOutcome
+from app.evals.fixture_manifest import EvaluationFixtureRuntimeCase
+from app.services.eval_runtime_execution import (
+    _apply_case_configuration,
+    _execute_fixture_case,
+)
+from app.services.provider_operations_store import reset_provider_operations_store_cache
+from tests.support.migration_runner import upgrade_database_to_head
+
+
+def test_execute_fixture_case_reports_failure_for_provider_operations_state_mismatch() -> None:
+    summary, outcome, evidence_refs = _execute_fixture_case(
+        fixture_id="provider_operations_examples",
+        fixture_task_id="provider_operations_examples",
+        case=EvaluationFixtureRuntimeCase(
+            case_id="provider_ops_mismatch_case",
+            summary="Expect the wrong provider operations state.",
+            input_payload={},
+            expected_payload={"operations_state": "CIRCUIT_OPEN"},
+        ),
+    )
+
+    assert outcome == EvaluationCaseOutcome.FAIL
+    assert "did not match expected runtime evidence" in summary
+    assert evidence_refs == ["service://platform/providers/operations-status"]
+
+
+def test_execute_fixture_case_reports_unknown_runtime_semantics_for_unmapped_fixture() -> None:
+    summary, outcome, evidence_refs = _execute_fixture_case(
+        fixture_id="unknown_fixture_family",
+        fixture_task_id="unknown_fixture_family",
+        case=EvaluationFixtureRuntimeCase(
+            case_id="unknown_fixture_case",
+            summary="Unknown fixture family.",
+            input_payload={},
+            expected_payload={},
+        ),
+    )
+
+    assert outcome == EvaluationCaseOutcome.FAIL
+    assert "does not yet have runtime-backed execution semantics" in summary
+    assert evidence_refs == ["fixture://unknown_fixture_family"]
+
+
+def test_apply_case_configuration_supports_sqlalchemy_budget_and_degradation_paths(
+    tmp_path: Path,
+) -> None:
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime-config.db'}"
+    upgrade_database_to_head(settings.database_url)
+
+    with _apply_case_configuration(
+        {
+            "provider_operations_store_mode": "sqlalchemy",
+            "hard_budget_usd": 5.0,
+            "tracked_spend_usd": 1.25,
+            "degraded_failure_count_threshold": 1,
+        }
+    ):
+        assert settings.provider_operations_store_mode == "sqlalchemy"
+        assert settings.live_text_budget_enforced is True
+        assert settings.live_text_degradation_enforced is True
+
+    reset_provider_operations_store_cache()
+
+
+def test_apply_case_configuration_supports_sqlalchemy_circuit_open_path(tmp_path: Path) -> None:
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime-circuit.db'}"
+    upgrade_database_to_head(settings.database_url)
+
+    with _apply_case_configuration(
+        {
+            "provider_operations_store_mode": "sqlalchemy",
+            "circuit_open_seconds": 30,
+        }
+    ):
+        assert settings.provider_operations_store_mode == "sqlalchemy"
+        assert settings.live_text_circuit_open_seconds == 30
+
+    reset_provider_operations_store_cache()

--- a/tests/unit/test_eval_status.py
+++ b/tests/unit/test_eval_status.py
@@ -24,9 +24,16 @@ def test_evaluation_runtime_status_reports_staged_assets() -> None:
     assert status.seam_coverage[1].staged_case_count == 6
     assert status.seam_coverage[3].staged_fixture_count == 5
     assert status.seam_coverage[3].staged_case_count == 12
+    assert [gate.domain_id for gate in status.approval_gates] == [
+        "retrieval_execution",
+        "provider_execution",
+    ]
+    assert status.approval_gates[0].evidence_state.value == "STAGED_ONLY"
+    assert status.approval_gates[1].evidence_state.value == "STAGED_ONLY"
     assert status.recorded_run_count == 2
     assert status.runtime_backed_run_count == 0
     assert status.historical_run_count == 2
     assert status.latest_recorded_run_id == "foundation_eval_2026_03_22_001"
     assert status.latest_recorded_run_status == "RECORDED"
     assert status.evaluation_runner_active is True
+    assert "approval-gate summaries" in status.message

--- a/tests/unit/test_eval_status.py
+++ b/tests/unit/test_eval_status.py
@@ -25,6 +25,8 @@ def test_evaluation_runtime_status_reports_staged_assets() -> None:
     assert status.seam_coverage[3].staged_fixture_count == 5
     assert status.seam_coverage[3].staged_case_count == 12
     assert status.recorded_run_count == 2
+    assert status.runtime_backed_run_count == 0
+    assert status.historical_run_count == 2
     assert status.latest_recorded_run_id == "foundation_eval_2026_03_22_001"
     assert status.latest_recorded_run_status == "RECORDED"
-    assert status.evaluation_runner_active is False
+    assert status.evaluation_runner_active is True

--- a/tests/unit/test_evaluation_runtime_store.py
+++ b/tests/unit/test_evaluation_runtime_store.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+
+from app.config import settings
+from app.repositories.memory_evaluation_runtime_repository import (
+    InMemoryEvaluationRuntimeRepository,
+)
+from app.repositories.sqlalchemy_evaluation_runtime_repository import (
+    SqlAlchemyEvaluationRuntimeRepository,
+)
+from app.services.evaluation_runtime_store import (
+    get_evaluation_runtime_store,
+    reset_evaluation_runtime_store_cache,
+)
+
+
+def test_evaluation_runtime_store_returns_cached_memory_repository() -> None:
+    settings.evaluation_runtime_store_mode = "memory"
+
+    first = get_evaluation_runtime_store()
+    second = get_evaluation_runtime_store()
+
+    assert isinstance(first, InMemoryEvaluationRuntimeRepository)
+    assert first is second
+
+
+def test_evaluation_runtime_store_returns_cached_sqlalchemy_repository(
+    tmp_path: Path,
+) -> None:
+    settings.evaluation_runtime_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime.db'}"
+
+    first = get_evaluation_runtime_store()
+    second = get_evaluation_runtime_store()
+
+    assert isinstance(first, SqlAlchemyEvaluationRuntimeRepository)
+    assert first is second
+
+
+def test_evaluation_runtime_store_requires_database_url_for_sqlalchemy_mode() -> None:
+    settings.evaluation_runtime_store_mode = "sqlalchemy"
+    settings.database_url = None
+
+    reset_evaluation_runtime_store_cache()
+
+    with pytest.raises(RuntimeError, match="LOTUS_AI_DATABASE_URL is required"):
+        get_evaluation_runtime_store()
+
+
+def test_evaluation_runtime_store_rejects_unsupported_mode() -> None:
+    settings.evaluation_runtime_store_mode = "unsupported"
+
+    reset_evaluation_runtime_store_cache()
+
+    with pytest.raises(RuntimeError, match="Unsupported"):
+        get_evaluation_runtime_store()

--- a/tests/unit/test_memory_async_runtime_repository.py
+++ b/tests/unit/test_memory_async_runtime_repository.py
@@ -166,6 +166,7 @@ def test_memory_async_runtime_repository_claims_next_runnable_job_once() -> None
 
     claim = repository.claim_next_runnable_job(
         worker_id="worker-a",
+        job_types=("retrieval_indexing",),
         claimed_at="2026-03-23T00:01:00Z",
         heartbeat_at="2026-03-23T00:01:00Z",
         lease_expires_at="2026-03-23T00:06:00Z",
@@ -181,6 +182,7 @@ def test_memory_async_runtime_repository_claims_next_runnable_job_once() -> None
     assert (
         repository.claim_next_runnable_job(
             worker_id="worker-b",
+            job_types=("retrieval_indexing",),
             claimed_at="2026-03-23T00:02:00Z",
             heartbeat_at="2026-03-23T00:02:00Z",
             lease_expires_at="2026-03-23T00:07:00Z",
@@ -272,6 +274,7 @@ def test_memory_async_runtime_repository_claim_skips_queued_jobs_without_attempt
     assert (
         repository.claim_next_runnable_job(
             worker_id="worker-a",
+            job_types=("retrieval_indexing",),
             claimed_at="2026-03-23T00:01:00Z",
             heartbeat_at="2026-03-23T00:01:00Z",
             lease_expires_at="2026-03-23T00:06:00Z",

--- a/tests/unit/test_memory_evaluation_runtime_repository.py
+++ b/tests/unit/test_memory_evaluation_runtime_repository.py
@@ -139,3 +139,25 @@ def test_memory_evaluation_runtime_repository_replaces_attempt_and_case_result_r
     assert len(results) == 1
     assert results[0].outcome == "PASS"
 
+
+def test_memory_evaluation_runtime_repository_get_attempt_returns_persisted_attempt() -> None:
+    repository = InMemoryEvaluationRuntimeRepository()
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_002_attempt_001",
+            run_id="evalrun_002",
+            attempt_number=1,
+            lifecycle_status="CLAIMED",
+            started_at=None,
+            completed_at=None,
+            worker_id="worker-a",
+            latest_message="Attempt claimed.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+
+    attempt = repository.get_attempt(attempt_id="evalrun_002_attempt_001")
+
+    assert attempt is not None
+    assert attempt.worker_id == "worker-a"

--- a/tests/unit/test_memory_evaluation_runtime_repository.py
+++ b/tests/unit/test_memory_evaluation_runtime_repository.py
@@ -1,0 +1,141 @@
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+)
+from app.repositories.memory_evaluation_runtime_repository import (
+    InMemoryEvaluationRuntimeRepository,
+)
+
+
+def test_memory_evaluation_runtime_repository_round_trip() -> None:
+    repository = InMemoryEvaluationRuntimeRepository()
+    repository.save_run(
+        EvaluationRunRecord(
+            run_id="evalrun_001",
+            fixture_id="retrieval.answer",
+            manifest_version="2026-03-23",
+            lifecycle_status="QUEUED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T00:00:00Z",
+            async_job_id=None,
+            latest_message="Evaluation run queued.",
+            verdict=None,
+            case_count=2,
+        )
+    )
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_001_attempt_001",
+            run_id="evalrun_001",
+            attempt_number=1,
+            lifecycle_status="QUEUED",
+            started_at=None,
+            completed_at=None,
+            worker_id=None,
+            latest_message="Attempt queued.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+    repository.save_case_result(
+        EvaluationCaseResultRecord(
+            case_result_id="evalcase_001",
+            run_id="evalrun_001",
+            attempt_id="evalrun_001_attempt_001",
+            case_id="retrieval.answer.case_001",
+            fixture_id="retrieval.answer",
+            outcome="PASS",
+            summary="Citations remained bounded and grounded.",
+            evidence_refs=["evidence://retrieval.answer.case_001"],
+            recorded_at="2026-03-23T00:05:00Z",
+        )
+    )
+
+    run = repository.get_run(run_id="evalrun_001")
+    attempts = repository.list_attempts(run_id="evalrun_001")
+    results = repository.list_case_results(run_id="evalrun_001")
+
+    assert run is not None
+    assert repository.list_runs() == [run]
+    assert len(attempts) == 1
+    assert attempts[0].attempt_id == "evalrun_001_attempt_001"
+    assert len(results) == 1
+    assert results[0].case_id == "retrieval.answer.case_001"
+
+
+def test_memory_evaluation_runtime_repository_returns_empty_results_for_unknown_records() -> None:
+    repository = InMemoryEvaluationRuntimeRepository()
+
+    assert repository.list_runs() == []
+    assert repository.get_run(run_id="missing-run") is None
+    assert repository.list_attempts(run_id="missing-run") == []
+    assert repository.get_attempt(attempt_id="missing-attempt") is None
+    assert repository.list_case_results(run_id="missing-run") == []
+
+
+def test_memory_evaluation_runtime_repository_replaces_attempt_and_case_result_records() -> None:
+    repository = InMemoryEvaluationRuntimeRepository()
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_001_attempt_001",
+            run_id="evalrun_001",
+            attempt_number=1,
+            lifecycle_status="QUEUED",
+            started_at=None,
+            completed_at=None,
+            worker_id=None,
+            latest_message="Attempt queued.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_001_attempt_001",
+            run_id="evalrun_001",
+            attempt_number=1,
+            lifecycle_status="COMPLETED",
+            started_at="2026-03-23T00:01:00Z",
+            completed_at="2026-03-23T00:02:00Z",
+            worker_id="worker-a",
+            latest_message="Attempt completed.",
+            verdict="PASS",
+            failure_reason=None,
+        )
+    )
+    repository.save_case_result(
+        EvaluationCaseResultRecord(
+            case_result_id="evalcase_001",
+            run_id="evalrun_001",
+            attempt_id="evalrun_001_attempt_001",
+            case_id="retrieval.answer.case_001",
+            fixture_id="retrieval.answer",
+            outcome="FAIL",
+            summary="Initial outcome.",
+            evidence_refs=["evidence://old"],
+            recorded_at="2026-03-23T00:01:00Z",
+        )
+    )
+    repository.save_case_result(
+        EvaluationCaseResultRecord(
+            case_result_id="evalcase_001",
+            run_id="evalrun_001",
+            attempt_id="evalrun_001_attempt_001",
+            case_id="retrieval.answer.case_001",
+            fixture_id="retrieval.answer",
+            outcome="PASS",
+            summary="Updated outcome.",
+            evidence_refs=["evidence://new"],
+            recorded_at="2026-03-23T00:02:00Z",
+        )
+    )
+
+    attempts = repository.list_attempts(run_id="evalrun_001")
+    results = repository.list_case_results(run_id="evalrun_001")
+
+    assert len(attempts) == 1
+    assert attempts[0].lifecycle_status == "COMPLETED"
+    assert len(results) == 1
+    assert results[0].outcome == "PASS"
+

--- a/tests/unit/test_openapi_contract.py
+++ b/tests/unit/test_openapi_contract.py
@@ -40,6 +40,9 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     assert spec["paths"]["/platform/capabilities"]["get"]["operationId"] == "getCapabilityCatalog"
     assert spec["paths"]["/platform/evals/catalog"]["get"]["operationId"] == "getEvaluationCatalog"
     assert spec["paths"]["/platform/evals/runs"]["get"]["operationId"] == "getEvaluationRunCatalog"
+    assert spec["paths"]["/platform/evals/runs/submit"]["post"]["operationId"] == (
+        "submitEvaluationRun"
+    )
     assert spec["paths"]["/platform/evals/fixtures/{fixture_id}"]["get"]["operationId"] == (
         "getEvaluationFixtureDetail"
     )

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -53,6 +53,8 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.retrieval_governance.blocking_area_count == 3
     assert status.prompt_governance.blocking_area_count == 3
     assert status.evaluation_runtime.manifest_version == "foundation.v1"
+    assert status.evaluation_runtime.approval_gates[0].domain_id == "retrieval_execution"
+    assert status.evaluation_runtime.approval_gates[1].domain_id == "provider_execution"
     assert status.task_runtime.enabled_task_count >= 7
     assert status.task_runtime.retrieval_backed_task_count == 2
     assert status.task_runtime.tasks[0].task_id == "explain.v1"

--- a/tests/unit/test_provider_evidence_readiness.py
+++ b/tests/unit/test_provider_evidence_readiness.py
@@ -22,3 +22,5 @@ def test_provider_evidence_readiness_reports_foundation_evidence_gaps() -> None:
     assert readiness.items[5].status == "READY"
     assert readiness.items[6].status == "FOUNDATION_STAGED"
     assert readiness.items[7].status == "NOT_READY"
+    assert readiness.approval_gate.domain_id == "provider_execution"
+    assert readiness.approval_gate.evidence_state.value == "STAGED_ONLY"

--- a/tests/unit/test_provider_governance_status.py
+++ b/tests/unit/test_provider_governance_status.py
@@ -11,4 +11,4 @@ def test_provider_governance_status_reports_blocked_foundation_posture() -> None
     assert status.runbook_readiness.runbook_ready is False
     assert status.evidence_readiness.evidence_ready is False
     assert len(status.governance_summary) == 3
-    assert "durable provider-operations control plane" in status.governance_summary[2]
+    assert "runtime-backed approval gate summary" in status.governance_summary[2]

--- a/tests/unit/test_retrieval_async_execution.py
+++ b/tests/unit/test_retrieval_async_execution.py
@@ -1,6 +1,10 @@
+from unittest.mock import patch
+
 from app.repositories.async_runtime_repository import (
+    AsyncRuntimeClaimRecord,
     AsyncRuntimeAttemptRecord,
     AsyncRuntimeJobRecord,
+    AsyncRuntimeLeaseRecord,
 )
 from app.services.async_runtime_store import get_async_runtime_store
 from app.services.async_job_service import build_async_job_detail
@@ -59,7 +63,7 @@ def test_run_next_retrieval_index_job_returns_none_when_no_jobs_are_claimed() ->
     assert run_next_retrieval_index_job(worker_id="worker-a") is None
 
 
-def test_run_next_retrieval_index_job_fails_unsupported_runtime_job_type() -> None:
+def test_run_next_retrieval_index_job_ignores_non_retrieval_job_types() -> None:
     store = get_async_runtime_store()
     store.save_job(
         AsyncRuntimeJobRecord(
@@ -97,5 +101,57 @@ def test_run_next_retrieval_index_job_fails_unsupported_runtime_job_type() -> No
 
     assert result is None
     detail = build_async_job_detail(job_id="async-job-unsupported")
-    assert detail.job.status.value == "FAILED"
-    assert detail.attempts[0].failure_reason == "UNSUPPORTED_ASYNC_JOB_TYPE"
+    assert detail.job.status.value == "QUEUED"
+    assert detail.attempts[0].failure_reason is None
+
+
+def test_run_next_retrieval_index_job_fails_claim_with_missing_target() -> None:
+    with (
+        patch(
+            "app.services.retrieval_async_execution.claim_next_async_job_for_types",
+            return_value=AsyncRuntimeClaimRecord(
+                job=AsyncRuntimeJobRecord(
+                    job_id="async-job-missing-target",
+                    job_type="retrieval_indexing",
+                    target_id=None,
+                    lifecycle_status="CLAIMED",
+                    submitted_at="2026-03-23T00:00:00Z",
+                    caller_app="lotus-platform",
+                    correlation_id="corr-ret-async-missing-target",
+                    payload_summary="Missing target.",
+                    execution_path="durable_runtime_worker_execution",
+                    related_evaluation_run_id=None,
+                    latest_message="Claimed.",
+                    attempt_count=1,
+                ),
+                attempt=AsyncRuntimeAttemptRecord(
+                    attempt_id="async-job-missing-target_attempt_001",
+                    job_id="async-job-missing-target",
+                    attempt_number=1,
+                    lifecycle_status="CLAIMED",
+                    worker_id="worker-a",
+                    claimed_at="2026-03-23T00:01:00Z",
+                    heartbeat_at="2026-03-23T00:01:00Z",
+                    started_at=None,
+                    completed_at=None,
+                    failure_reason=None,
+                    recorded_message="Claimed.",
+                ),
+                lease=AsyncRuntimeLeaseRecord(
+                    lease_id="lease-missing-target",
+                    job_id="async-job-missing-target",
+                    attempt_id="async-job-missing-target_attempt_001",
+                    worker_id="worker-a",
+                    claimed_at="2026-03-23T00:01:00Z",
+                    heartbeat_at="2026-03-23T00:01:00Z",
+                    lease_expires_at="2026-03-23T00:06:00Z",
+                ),
+            ),
+        ),
+        patch("app.services.retrieval_async_execution.fail_async_job") as fail_async_job,
+    ):
+        result = run_next_retrieval_index_job(worker_id="worker-a")
+
+    assert result is None
+    fail_async_job.assert_called_once()
+    assert fail_async_job.call_args.kwargs["failure_reason"] == "UNSUPPORTED_ASYNC_JOB_TYPE"

--- a/tests/unit/test_retrieval_evidence_readiness.py
+++ b/tests/unit/test_retrieval_evidence_readiness.py
@@ -10,3 +10,5 @@ def test_retrieval_evidence_readiness_reports_foundation_evidence_gaps() -> None
     assert readiness.completed_required_item_count == 0
     assert readiness.items[0].evidence_id == "retrieval_fixture_coverage_pack"
     assert readiness.items[1].status == "NOT_READY"
+    assert readiness.approval_gate.domain_id == "retrieval_execution"
+    assert readiness.approval_gate.evidence_state.value == "STAGED_ONLY"

--- a/tests/unit/test_retrieval_governance_status.py
+++ b/tests/unit/test_retrieval_governance_status.py
@@ -11,3 +11,4 @@ def test_retrieval_governance_status_reports_blocked_foundation_posture() -> Non
     assert status.runbook_readiness.runbook_ready is False
     assert status.evidence_readiness.evidence_ready is False
     assert len(status.governance_summary) == 3
+    assert "runtime-backed approval gate summary" in status.governance_summary[2]

--- a/tests/unit/test_sqlalchemy_async_runtime_repository.py
+++ b/tests/unit/test_sqlalchemy_async_runtime_repository.py
@@ -198,6 +198,7 @@ def test_sqlalchemy_async_runtime_repository_claims_next_runnable_job_once(
 
     claim = repository.claim_next_runnable_job(
         worker_id="worker-a",
+        job_types=("retrieval_indexing",),
         claimed_at="2026-03-23T00:01:00Z",
         heartbeat_at="2026-03-23T00:01:00Z",
         lease_expires_at="2026-03-23T00:06:00Z",
@@ -213,6 +214,7 @@ def test_sqlalchemy_async_runtime_repository_claims_next_runnable_job_once(
     assert (
         repository.claim_next_runnable_job(
             worker_id="worker-b",
+            job_types=("retrieval_indexing",),
             claimed_at="2026-03-23T00:02:00Z",
             heartbeat_at="2026-03-23T00:02:00Z",
             lease_expires_at="2026-03-23T00:07:00Z",
@@ -303,6 +305,7 @@ def test_sqlalchemy_async_runtime_repository_claim_returns_none_without_attempt(
     assert (
         repository.claim_next_runnable_job(
             worker_id="worker-a",
+            job_types=("retrieval_indexing",),
             claimed_at="2026-03-23T00:01:00Z",
             heartbeat_at="2026-03-23T00:01:00Z",
             lease_expires_at="2026-03-23T00:06:00Z",

--- a/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
+++ b/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from _pytest.monkeypatch import MonkeyPatch
+
 from app.repositories.evaluation_runtime_repository import (
     EvaluationCaseResultRecord,
     EvaluationRunAttemptRecord,
@@ -165,3 +167,43 @@ def test_sqlalchemy_evaluation_runtime_repository_replaces_attempt_and_case_resu
     assert len(results) == 1
     assert results[0].outcome == "PASS"
 
+
+def test_sqlalchemy_evaluation_runtime_repository_get_attempt_returns_persisted_attempt(
+    tmp_path: Path,
+) -> None:
+    database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyEvaluationRuntimeRepository(database_url)
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_002_attempt_001",
+            run_id="evalrun_002",
+            attempt_number=1,
+            lifecycle_status="CLAIMED",
+            started_at=None,
+            completed_at=None,
+            worker_id="worker-a",
+            latest_message="Attempt claimed.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+
+    attempt = repository.get_attempt(attempt_id="evalrun_002_attempt_001")
+
+    assert attempt is not None
+    assert attempt.worker_id == "worker-a"
+
+
+def test_sqlalchemy_evaluation_runtime_repository_ensure_sqlite_directory_skips_memory_and_non_sqlite(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    SqlAlchemyEvaluationRuntimeRepository("sqlite:///:memory:")
+    relative_path = tmp_path / "relative" / "lotus-ai-eval-runtime.db"
+    SqlAlchemyEvaluationRuntimeRepository(f"sqlite:///{relative_path}")
+    assert relative_path.parent.is_dir()
+    monkeypatch.setattr(
+        "app.repositories.sqlalchemy_evaluation_runtime_repository.create_engine",
+        lambda database_url, future=True: object(),
+    )
+    SqlAlchemyEvaluationRuntimeRepository("postgresql://user:pass@localhost/lotus")

--- a/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
+++ b/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunAttemptRecord,
+    EvaluationRunRecord,
+)
+from app.repositories.sqlalchemy_evaluation_runtime_repository import (
+    SqlAlchemyEvaluationRuntimeRepository,
+)
+from tests.support.migration_runner import upgrade_database_to_head
+
+
+def test_sqlalchemy_evaluation_runtime_repository_round_trip(tmp_path: Path) -> None:
+    database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyEvaluationRuntimeRepository(database_url)
+
+    repository.save_run(
+        EvaluationRunRecord(
+            run_id="evalrun_001",
+            fixture_id="retrieval.answer",
+            manifest_version="2026-03-23",
+            lifecycle_status="QUEUED",
+            triggered_by="operator-a",
+            submitted_at="2026-03-23T00:00:00Z",
+            async_job_id=None,
+            latest_message="Evaluation run queued.",
+            verdict=None,
+            case_count=2,
+        )
+    )
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_001_attempt_001",
+            run_id="evalrun_001",
+            attempt_number=1,
+            lifecycle_status="QUEUED",
+            started_at=None,
+            completed_at=None,
+            worker_id=None,
+            latest_message="Attempt queued.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+    repository.save_case_result(
+        EvaluationCaseResultRecord(
+            case_result_id="evalcase_001",
+            run_id="evalrun_001",
+            attempt_id="evalrun_001_attempt_001",
+            case_id="retrieval.answer.case_001",
+            fixture_id="retrieval.answer",
+            outcome="PASS",
+            summary="Citations remained bounded and grounded.",
+            evidence_refs=["evidence://retrieval.answer.case_001"],
+            recorded_at="2026-03-23T00:05:00Z",
+        )
+    )
+
+    run = repository.get_run(run_id="evalrun_001")
+    attempts = repository.list_attempts(run_id="evalrun_001")
+    results = repository.list_case_results(run_id="evalrun_001")
+
+    assert run is not None
+    assert repository.list_runs() == [run]
+    assert len(attempts) == 1
+    assert attempts[0].attempt_id == "evalrun_001_attempt_001"
+    assert len(results) == 1
+    assert results[0].case_id == "retrieval.answer.case_001"
+
+
+def test_sqlalchemy_evaluation_runtime_repository_returns_empty_results_for_unknown_records(
+    tmp_path: Path,
+) -> None:
+    database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyEvaluationRuntimeRepository(database_url)
+
+    assert repository.list_runs() == []
+    assert repository.get_run(run_id="missing-run") is None
+    assert repository.list_attempts(run_id="missing-run") == []
+    assert repository.get_attempt(attempt_id="missing-attempt") is None
+    assert repository.list_case_results(run_id="missing-run") == []
+
+
+def test_sqlalchemy_evaluation_runtime_repository_creates_parent_directory_for_sqlite_file(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "nested" / "db" / "lotus-ai-eval-runtime.db"
+    database_url = f"sqlite:///{db_path}"
+
+    SqlAlchemyEvaluationRuntimeRepository(database_url)
+
+    assert db_path.parent.is_dir()
+
+
+def test_sqlalchemy_evaluation_runtime_repository_replaces_attempt_and_case_result_records(
+    tmp_path: Path,
+) -> None:
+    database_url = f"sqlite:///{tmp_path / 'lotus-ai-eval-runtime.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyEvaluationRuntimeRepository(database_url)
+
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_001_attempt_001",
+            run_id="evalrun_001",
+            attempt_number=1,
+            lifecycle_status="QUEUED",
+            started_at=None,
+            completed_at=None,
+            worker_id=None,
+            latest_message="Attempt queued.",
+            verdict=None,
+            failure_reason=None,
+        )
+    )
+    repository.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="evalrun_001_attempt_001",
+            run_id="evalrun_001",
+            attempt_number=1,
+            lifecycle_status="COMPLETED",
+            started_at="2026-03-23T00:01:00Z",
+            completed_at="2026-03-23T00:02:00Z",
+            worker_id="worker-a",
+            latest_message="Attempt completed.",
+            verdict="PASS",
+            failure_reason=None,
+        )
+    )
+    repository.save_case_result(
+        EvaluationCaseResultRecord(
+            case_result_id="evalcase_001",
+            run_id="evalrun_001",
+            attempt_id="evalrun_001_attempt_001",
+            case_id="retrieval.answer.case_001",
+            fixture_id="retrieval.answer",
+            outcome="FAIL",
+            summary="Initial outcome.",
+            evidence_refs=["evidence://old"],
+            recorded_at="2026-03-23T00:01:00Z",
+        )
+    )
+    repository.save_case_result(
+        EvaluationCaseResultRecord(
+            case_result_id="evalcase_001",
+            run_id="evalrun_001",
+            attempt_id="evalrun_001_attempt_001",
+            case_id="retrieval.answer.case_001",
+            fixture_id="retrieval.answer",
+            outcome="PASS",
+            summary="Updated outcome.",
+            evidence_refs=["evidence://new"],
+            recorded_at="2026-03-23T00:02:00Z",
+        )
+    )
+
+    attempts = repository.list_attempts(run_id="evalrun_001")
+    results = repository.list_case_results(run_id="evalrun_001")
+
+    assert len(attempts) == 1
+    assert attempts[0].lifecycle_status == "COMPLETED"
+    assert len(results) == 1
+    assert results[0].outcome == "PASS"
+


### PR DESCRIPTION
## Summary
- complete RFC-0007 with runtime-backed evaluation submission, execution, approval gates, and replay-safe attempt history
- close remaining operator-truth gaps in async status/readiness/governance surfaces
- add meaningful coverage for eval runtime execution, duplicate submission handling, replay paths, and repository/store edge cases

## Validation
- make ci