### PR TITLE
docs: add feature status and roadmap guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ Shared AI platform service for Lotus applications.
 
 `lotus-ai` provides the reusable AI infrastructure layer for the Lotus estate. It exists to help the other Lotus apps build governed AI features without moving domain ownership out of the services that already own portfolio data, analytics, workflow state, and deterministic decision logic.
 
+## Start Here
+
+If you are new to the repo, read these first:
+
+1. [System Overview](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md)
+2. [Feature Status and Roadmap](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/feature-status-and-roadmap.md)
+3. [Phased Roadmap](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/phased-roadmap.md)
+4. [RFC Index](C:/Users/Sandeep/projects/lotus-ai/docs/rfcs/README.md)
+
+If you want the shortest summary:
+
+1. RFC-0001 through RFC-0012 are implemented,
+2. bounded task execution, retrieval, safety, prompt rollout, async workers, runtime-backed evals, and caller access control are real,
+3. broader production observability, artifact storage, embeddings expansion, document ingestion, and first-use-case onboarding are still roadmap items.
+
 ## Current Phase
 
 The repository is in foundation phase.

--- a/docs/architecture/feature-status-and-roadmap.md
+++ b/docs/architecture/feature-status-and-roadmap.md
@@ -1,0 +1,203 @@
+# Feature Status and Roadmap
+
+This document is the quickest way to understand what `lotus-ai` supports today, what is governed but still intentionally limited, and what major feature areas are next.
+
+## Current Product Shape
+
+`lotus-ai` is a shared AI platform service for Lotus applications. It currently provides:
+
+1. bounded AI task execution contracts,
+2. governed prompt selection and rollback,
+3. governed retrieval over approved platform documents,
+4. runtime safety enforcement for bounded outputs,
+5. runtime-backed evaluation and approval-gate evidence,
+6. durable async execution with dedicated worker and queue support,
+7. caller identity and tenant-aware authorization controls,
+8. audit, evidence, and operator-facing governance surfaces.
+
+The service is no longer only a documentation skeleton. It has real runtime control planes and durable platform state. It is still in a foundation phase because some important production-support features are intentionally deferred.
+
+## Supported Today
+
+### Bounded Task APIs
+
+Supported task families:
+
+1. `explain.v1`
+2. `summarize.v1`
+3. `generate_structured.v1`
+4. `knowledge_search.v1`
+5. `knowledge_answer.v1`
+
+What this means:
+
+1. task contracts are stable and typed,
+2. task execution passes through validation, prompt resolution, provider routing, evidence assembly, safety handling, and audit persistence,
+3. responses include structured audit and evidence metadata.
+
+### Retrieval
+
+Supported now:
+
+1. governed retrieval source and document catalog,
+2. live indexed search when `retrieval_mode=enabled`,
+3. citation-bearing `knowledge_search.v1`,
+4. citation-backed or refusal-style `knowledge_answer.v1`,
+5. retrieval governance, activation, runbook, and evidence-readiness endpoints.
+
+Important limitation:
+
+1. retrieval is live for the approved indexed corpus only,
+2. broader ingestion, corpus refresh, and embeddings expansion are not implemented yet.
+
+### Prompt Governance
+
+Supported now:
+
+1. durable prompt definition versions,
+2. durable rollout state,
+3. promote and rollback control-plane actions,
+4. prompt runtime status and control history,
+5. runtime-backed evaluation gating for prompt promotion,
+6. prompt-linked audit and execution evidence.
+
+Important limitation:
+
+1. prompt bodies are still repository-managed,
+2. the runtime only governs selection between approved prompt versions, not free-form editing.
+
+### Safety
+
+Supported now:
+
+1. output-label-aware safety policy,
+2. deterministic runtime redaction for bounded outputs,
+3. typed safety outcome persistence in audit and evidence,
+4. runtime-backed safety evaluation fixtures,
+5. safety runtime, evidence, runbook, and governance surfaces.
+
+Important limitation:
+
+1. this is not a general moderation platform,
+2. safety remains intentionally bounded to the existing task and output-contract model.
+
+### Async Runtime
+
+Supported now:
+
+1. durable async job, attempt, lease, and control-event state,
+2. queue-backed worker delivery with dedicated-worker activation,
+3. governed retry, replay, requeue, and abandon actions,
+4. retrieval indexing and evaluation execution as active async consumers,
+5. async runtime, activation, runbook, and governance surfaces.
+
+Important limitation:
+
+1. the async system is still intentionally narrow in job-type scope,
+2. it is not yet a general background-work platform for arbitrary domain tasks.
+
+### Evaluation and Approval Gates
+
+Supported now:
+
+1. runtime-backed evaluation submission and execution,
+2. durable run attempts and case outcomes,
+3. approval-gate summaries for provider, retrieval, prompt, and safety rollout domains,
+4. staged historical baseline visibility separated from current runtime truth.
+
+### Access Control
+
+Supported now:
+
+1. caller policy registry,
+2. task, retrieval, and live-provider authorization,
+3. async, prompt, and provider control-plane authorization,
+4. tenant-aware restrictions where tenant identity is part of the request contract,
+5. authorization outcome persistence in audit, evidence, and control history,
+6. access-control runtime, activation, runbook, and governance surfaces.
+
+## Intentionally Limited or Not Yet Live
+
+These areas are important because they are visible in the platform shape, but not fully delivered yet.
+
+### Live Model Execution
+
+Current state:
+
+1. live-provider seams exist,
+2. provider policy, quota, budget, degradation, and control-plane surfaces are implemented,
+3. live execution remains disabled by default unless explicitly enabled and governed.
+
+Practical meaning:
+
+1. `lotus-ai` is structurally ready for governed live provider rollout,
+2. it should still be treated as pre-rollout for production live-model traffic.
+
+### Embeddings and Corpus Growth
+
+Current state:
+
+1. retrieval works over the existing approved indexed corpus,
+2. embeddings expansion and broader document ingestion are not yet implemented as first-class governed features.
+
+### Observability and Incident Evidence
+
+Current state:
+
+1. many runtime and governance endpoints exist,
+2. platform-wide observability, dashboards, alerts, and incident evidence are not yet complete.
+
+### First Downstream Production Use Case
+
+Current state:
+
+1. the platform is ready enough for serious integration planning,
+2. first-use-case onboarding is still a roadmap item rather than a closed implementation.
+
+## Roadmap
+
+### Next Likely Feature Areas
+
+The next RFCs already identified in the repo describe the expected sequence:
+
+1. `RFC-0013` runtime observability and incident evidence
+2. `RFC-0014` governed artifact and object storage backbone
+3. `RFC-0015` controlled deployment split into runtime, retrieval, and evals
+4. `RFC-0016` first production use-case onboarding
+5. `RFC-0017` production resilience and disaster recovery
+6. `RFC-0018` governed embeddings and provider expansion
+7. `RFC-0019` governed document ingestion and corpus refresh
+
+### Why These Are Next
+
+In practical feature terms, the roadmap is:
+
+1. make the existing platform easier to operate in production,
+2. make large artifacts and evidence more scalable,
+3. make deployment topology cleaner,
+4. onboard the first real downstream use case,
+5. improve resilience,
+6. expand retrieval and provider breadth,
+7. broaden corpus management.
+
+## Recommended Reading Order
+
+For a new engineer:
+
+1. [README](C:/Users/Sandeep/projects/lotus-ai/README.md)
+2. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md)
+3. this document
+4. [phased-roadmap.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/phased-roadmap.md)
+5. [docs/rfcs/README.md](C:/Users/Sandeep/projects/lotus-ai/docs/rfcs/README.md)
+
+For someone integrating a client app:
+
+1. [integration-guide.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/integration-guide.md)
+2. [task-execution-contract.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/task-execution-contract.md)
+3. this document
+
+For an operator:
+
+1. [service-operations.md](C:/Users/Sandeep/projects/lotus-ai/docs/runbooks/service-operations.md)
+2. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md)
+3. this document

--- a/docs/architecture/phased-roadmap.md
+++ b/docs/architecture/phased-roadmap.md
@@ -2,6 +2,10 @@
 
 This roadmap is the canonical execution plan for `lotus-ai`.
 
+For the current implementation snapshot and near-term roadmap by feature area, read:
+
+- [feature-status-and-roadmap.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/feature-status-and-roadmap.md)
+
 The guiding principle is:
 
 build the minimum platform slice that is useful, well-governed, and easy to understand before expanding into more powerful AI behaviors.


### PR DESCRIPTION
## Summary
- add a feature status and roadmap document for lotus-ai
- add a short Start Here section to the README
- link the phased roadmap to the new feature-status doc

## Verification
1. git diff --check
2. docs-only change; no code paths changed