### PR TITLE
feat: implement RFC-0021 capability packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ The local security audit posture is also intentionally isolated:
 
 1. `make ci` runs dependency audit inside a temporary project-only virtual environment,
 2. this avoids false positives from unrelated machine-wide Python packages,
-3. the audit still fails on vulnerabilities in the actual `lotus-ai` dependency set.
+3. the audit still fails on vulnerabilities in the actual `lotus-ai` dependency set,
+4. temporary ignores must be explicit in `scripts/run_security_audit.py` and should only be used when no patched upstream release exists yet.
 
 ## Framework Stance
 

--- a/docs/architecture/feature-status-and-roadmap.md
+++ b/docs/architecture/feature-status-and-roadmap.md
@@ -187,14 +187,19 @@ Current state:
 
 ### Next Likely Feature Areas
 
-The next RFCs already identified in the repo describe the expected sequence:
+The next RFCs now identified in the repo describe the expected post-foundation sequence:
 
-1. `RFC-0015` controlled deployment split into runtime, retrieval, and evals
-2. `RFC-0017` production resilience and disaster recovery
-3. `RFC-0018` governed embeddings and provider expansion
-4. `RFC-0019` governed document ingestion and corpus refresh
+1. `RFC-0021` domain AI capability packs and product maturity
+2. `RFC-0022` production go-live approval and managed infrastructure
+3. `RFC-0023` multi-app adoption and capability rollout governance
 
 Current status against that sequence:
+
+1. `RFC-0021` is now partially started through a separate capability-pack catalog layer, with a reusable commentary family and an experimental decision-explanation family modeled explicitly, dedicated runtime-backed pack-quality eval families added, pack-specific activation, runbook, observability, governance, and adoption-template surfaces exposed, and the implemented `lotus-performance` path now anchored to the commentary family while broader approved pack maturity is still future work.
+2. `RFC-0022` is still draft and is intended to follow `RFC-0021`, separating true production go-live approval from merely prod-shaped infrastructure posture.
+3. `RFC-0023` is still draft and is intended to follow both of the above, governing estate-wide multi-app rollout only after reusable capability packs and production approval posture are explicit.
+
+The previous likely feature areas are now implemented:
 
 1. `RFC-0015` is implemented, including runtime, activation, runbook, and governance posture for unified versus split deployment stages.
 2. `RFC-0017` now exposes a bounded resilience runtime inventory surface, an ordered restore-plan surface, explicit degraded-versus-restored runtime posture for queue, worker, provider, retrieval, and artifact continuity dependencies, plus drill-evidence, activation, runbook, and governance surfaces.
@@ -219,10 +224,9 @@ The current preferred RFC-0016 target is:
 
 In practical feature terms, the roadmap is:
 
-1. build cleaner deployment topology on top of the now-explicit production baseline,
-2. improve resilience on top of that baseline, using the new runtime, restore-plan, drill-evidence, and governance surfaces to harden actual recovery posture,
-3. expand retrieval and provider breadth,
-4. broaden corpus management.
+1. turn the current platform backbone into reusable app-facing product capability packs,
+2. define a true final-mile production approval boundary above the existing prod-shaped baseline,
+3. expand from one proven downstream use case into governed multi-app adoption without fragmenting capability behavior.
 
 ## Recommended Reading Order
 

--- a/docs/evals/fixture-manifest.json
+++ b/docs/evals/fixture-manifest.json
@@ -58,6 +58,18 @@
       "manifest_path": "docs/evals/fixtures/lotus-performance.first-use-case/basic_cases.json"
     },
     {
+      "fixture_id": "capability_pack_analytics_commentary_examples",
+      "status": "STAGED",
+      "description": "Runtime-backed product-quality examples for the analytics commentary capability pack.",
+      "manifest_path": "docs/evals/fixtures/capability-packs.analytics-commentary/basic_cases.json"
+    },
+    {
+      "fixture_id": "capability_pack_decision_explanation_examples",
+      "status": "STAGED",
+      "description": "Runtime-backed product-quality examples for the decision explanation capability pack.",
+      "manifest_path": "docs/evals/fixtures/capability-packs.decision-explanation/basic_cases.json"
+    },
+    {
       "fixture_id": "prompt_promotion_examples",
       "status": "STAGED",
       "description": "Governed prompt promotion evaluation examples for runtime-backed approval.",

--- a/docs/evals/fixtures/capability-packs.analytics-commentary/basic_cases.json
+++ b/docs/evals/fixtures/capability-packs.analytics-commentary/basic_cases.json
@@ -1,0 +1,67 @@
+{
+  "fixture_family": "capability_pack_analytics_commentary_examples",
+  "task_id": "explain.v1",
+  "cases": [
+    {
+      "case_id": "analytics_commentary_structured_facts_authorized",
+      "summary": "Analytics commentary remains explanation-only and grounded to caller-owned structured facts.",
+      "input": {
+        "task_id": "explain.v1",
+        "caller_app": "lotus-performance",
+        "tenant_id": "tenant-sg-001",
+        "analysis_scope": "monthly_contribution_change",
+        "period_window": {
+          "current_period": "2026-03",
+          "comparison_period": "2026-02"
+        },
+        "metric_deltas": [
+          {
+            "metric_id": "active_return_bps",
+            "delta_bps": 41
+          }
+        ],
+        "material_findings": [
+          "Sector selection in industrials drove most of the change."
+        ]
+      },
+      "expected": {
+        "output_label": "EXPLANATION_ONLY",
+        "authorization_outcome": "ALLOWED",
+        "caller_app": "lotus-performance",
+        "task_id": "explain.v1",
+        "safety_disposition": "DOCUMENTED_ONLY",
+        "caller_visible_in_payload": true,
+        "stubbed": true
+      }
+    },
+    {
+      "case_id": "analytics_commentary_runtime_safety_redaction",
+      "summary": "Analytics commentary runtime safety can redact caller-linked fields while preserving explanation-only output.",
+      "input": {
+        "task_id": "explain.v1",
+        "caller_app": "lotus-performance",
+        "tenant_id": "tenant-sg-001",
+        "safety_mode": "runtime_enforced",
+        "analysis_scope": "risk_budget_change",
+        "metric_deltas": [
+          {
+            "metric_id": "tracking_error_bps",
+            "delta_bps": -9
+          }
+        ],
+        "material_findings": [
+          "Tracking error narrowed after concentration caps were tightened."
+        ]
+      },
+      "expected": {
+        "output_label": "EXPLANATION_ONLY",
+        "authorization_outcome": "ALLOWED",
+        "caller_app": "lotus-performance",
+        "task_id": "explain.v1",
+        "safety_disposition": "ENFORCED_REDACTED",
+        "caller_visible_in_payload": false,
+        "stubbed": true
+      }
+    }
+  ]
+}

--- a/docs/evals/fixtures/capability-packs.decision-explanation/basic_cases.json
+++ b/docs/evals/fixtures/capability-packs.decision-explanation/basic_cases.json
@@ -1,0 +1,51 @@
+{
+  "fixture_family": "capability_pack_decision_explanation_examples",
+  "task_id": "explain.v1",
+  "cases": [
+    {
+      "case_id": "decision_explanation_blocker_state_authorized",
+      "summary": "Decision explanation remains bounded to deterministic blocker state and explicit caller authorization.",
+      "input": {
+        "task_id": "explain.v1",
+        "caller_app": "lotus-manage",
+        "tenant_id": "tenant-sg-001",
+        "decision_scope": "rebalance_submission",
+        "decision_state": "BLOCKED",
+        "blocker_reason": "Approval policy requires a missing compliance attestation.",
+        "required_next_step": "Upload the missing attestation before retry."
+      },
+      "expected": {
+        "output_label": "EXPLANATION_ONLY",
+        "authorization_outcome": "ALLOWED",
+        "caller_app": "lotus-manage",
+        "task_id": "explain.v1",
+        "safety_disposition": "DOCUMENTED_ONLY",
+        "caller_visible_in_payload": true,
+        "stubbed": true
+      }
+    },
+    {
+      "case_id": "decision_explanation_runtime_safety_redaction",
+      "summary": "Decision explanation runtime safety can redact caller-linked fields while preserving deterministic rationale output.",
+      "input": {
+        "task_id": "explain.v1",
+        "caller_app": "lotus-manage",
+        "tenant_id": "tenant-sg-001",
+        "safety_mode": "runtime_enforced",
+        "decision_scope": "approval_review",
+        "decision_state": "PENDING_REVIEW",
+        "blocker_reason": "A second approver must review the exception request.",
+        "required_next_step": "Route the request to the escalation reviewer."
+      },
+      "expected": {
+        "output_label": "EXPLANATION_ONLY",
+        "authorization_outcome": "ALLOWED",
+        "caller_app": "lotus-manage",
+        "task_id": "explain.v1",
+        "safety_disposition": "ENFORCED_REDACTED",
+        "caller_visible_in_payload": false,
+        "stubbed": true
+      }
+    }
+  ]
+}

--- a/docs/evals/run-artifacts.json
+++ b/docs/evals/run-artifacts.json
@@ -5,8 +5,8 @@
       "recorded_at": "2026-03-22T09:00:00Z",
       "status": "RECORDED",
       "manifest_version": "foundation.v1",
-      "staged_fixture_count": 17,
-      "staged_case_count": 38,
+      "staged_fixture_count": 19,
+      "staged_case_count": 42,
       "seam_coverage": [
         {
           "seam_id": "async_execution",
@@ -22,10 +22,12 @@
             "task_capability_contracts",
             "explanation_task_examples",
             "summarization_task_examples",
-            "lotus_performance_first_use_case_examples"
+            "lotus_performance_first_use_case_examples",
+            "capability_pack_analytics_commentary_examples",
+            "capability_pack_decision_explanation_examples"
           ],
-          "staged_fixture_count": 4,
-          "staged_case_count": 8
+          "staged_fixture_count": 6,
+          "staged_case_count": 12
         },
         {
           "seam_id": "prompt_rollout",
@@ -68,7 +70,7 @@
           "staged_case_count": 6
         }
       ],
-      "notes": "Historical foundation-phase baseline recorded after durable async submission, prompt rollout fixtures, lease-recovery, retrieval-indexing linkage, runtime safety fixture packs, and the bounded lotus-performance first-use-case onboarding pack were staged alongside provider operations durability coverage. This artifact remains a staged continuity record and does not satisfy current runtime-backed approval posture by itself."
+      "notes": "Historical foundation-phase baseline recorded after durable async submission, prompt rollout fixtures, lease-recovery, retrieval-indexing linkage, runtime safety fixture packs, the bounded lotus-performance first-use-case onboarding pack, and the initial capability-pack product-quality fixture families were staged alongside provider operations durability coverage. This artifact remains a staged continuity record and does not satisfy current runtime-backed approval posture by itself."
     },
     {
       "run_id": "foundation_eval_2026_03_21_001",

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -82,13 +82,20 @@ The calling Lotus application owns the business context.
 4. Receive structured AI output and audit metadata.
 5. Apply that output only within the calling service's own business rules.
 
-For new downstream onboarding, start with:
+For new downstream onboarding, start with the capability-pack layer first:
+
+1. `GET /platform/capability-packs`
+2. `GET /platform/capability-packs/{pack_id}`
+3. `GET /platform/capability-packs/{pack_id}/adoption-template`
+4. `GET /platform/capability-packs/{pack_id}/governance-status`
+
+Then use the first-use-case surfaces as the concrete reference path when the selected pack already has one:
 
 1. `GET /platform/use-cases/onboarding-template`
 2. `GET /platform/use-cases/first-production-use-case`
 3. `GET /platform/use-cases/first-production-use-case/governance-status`
 
-That sequence gives the reusable onboarding checklist first, then the currently implemented reference use case and its bounded rollout truth.
+That sequence keeps downstream adoption pack-oriented first, while still preserving the currently implemented reference use case and its bounded rollout truth.
 
 ## Good Use Cases
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -20,3 +20,6 @@
 - `RFC-0018-governed-embeddings-and-provider-expansion.md` - Implemented
 - `RFC-0019-governed-document-ingestion-and-corpus-refresh.md` - Implemented
 - `RFC-0020-production-standard-deployment-baseline.md` - Implemented
+- `RFC-0021-domain-ai-capability-packs-and-product-maturity.md` - Implemented
+- `RFC-0022-production-go-live-approval-and-managed-infrastructure.md` - Draft
+- `RFC-0023-multi-app-adoption-and-capability-rollout-governance.md` - Draft

--- a/docs/rfcs/RFC-0021-domain-ai-capability-packs-and-product-maturity.md
+++ b/docs/rfcs/RFC-0021-domain-ai-capability-packs-and-product-maturity.md
@@ -1,0 +1,421 @@
+# RFC-0021: Domain AI Capability Packs and Product Maturity
+
+- Status: Implemented
+- Date: 2026-03-25
+- Owners: lotus-ai
+- Requires Approval From: lotus-ai maintainers
+
+## Summary
+
+`lotus-ai` now has a substantial governed platform backbone:
+
+1. bounded task execution,
+2. prompt governance,
+3. retrieval,
+4. runtime safety,
+5. evaluation and approval gates,
+6. async execution,
+7. caller identity and access control,
+8. observability and incident evidence,
+9. artifact storage,
+10. deployment, resilience, embeddings, and ingestion foundations.
+
+That backbone is now real, but it is still more mature as a platform than as an AI product layer.
+
+This RFC introduces the next major phase:
+
+1. domain AI capability packs for real Lotus workflows,
+2. richer app-facing contracts and outcome models,
+3. stronger quality expectations for explanation and commentary behavior,
+4. reusable product-grade integration patterns beyond the first use case.
+
+The goal is to make `lotus-ai` not just governable and operationally sound, but also meaningfully useful as a shared AI product layer across the Lotus estate.
+
+## Why This Is Next
+
+The current state of `lotus-ai` is now clear:
+
+1. the infrastructure and governance stack is materially implemented,
+2. the first bounded downstream use case exists,
+3. live-provider and Docker paths have been proven technically,
+4. the remaining biggest gap is no longer "can the platform govern AI safely?" but "does the platform now offer enough app-facing capability depth to matter broadly?"
+
+The missing layer is product maturity.
+
+Today, `lotus-ai` is strongest as:
+
+1. a control plane,
+2. a runtime backbone,
+3. a governance surface.
+
+It is less mature as:
+
+1. a catalog of domain-ready AI capabilities,
+2. a reusable product layer for multiple Lotus applications,
+3. a place where downstream teams can adopt high-value AI features without reconstructing domain shaping themselves each time.
+
+That is the gap this RFC addresses.
+
+This RFC is intentionally first in the next post-foundation sequence:
+
+1. `RFC-0021` defines reusable app-facing capability packs,
+2. `RFC-0022` defines final production go-live approval for those capabilities,
+3. `RFC-0023` defines how those approved capabilities scale across multiple Lotus applications.
+
+That ordering matters because:
+
+1. multi-app rollout should scale reusable capabilities rather than one-off task wrappers,
+2. production approval should govern real product capabilities rather than generic task seams alone,
+3. broader adoption should happen only after both capability shape and go-live posture are explicit.
+
+## Problem Statement
+
+`lotus-ai` currently supports bounded task families such as:
+
+1. `explain.v1`,
+2. `summarize.v1`,
+3. `generate_structured.v1`,
+4. `knowledge_search.v1`,
+5. `knowledge_answer.v1`.
+
+Those are useful platform primitives, but they are still too generic to represent mature Lotus product capabilities by themselves.
+
+Current limitations:
+
+1. downstream apps still need to do too much capability shaping on their own,
+2. the first-use-case path proves one narrow integration, but not yet a reusable family of app-facing AI product modules,
+3. explanation and commentary behavior remain task-oriented rather than explicitly organized around recurring Lotus business use cases,
+4. quality can be governed technically, but product expectations for completeness, grounding, tone, and domain-fit are not yet modeled as first-class capability packs,
+5. the platform lacks an explicit maturity model for when a generic task becomes a reusable Lotus capability.
+
+Without this RFC:
+
+1. app integrations risk becoming one-off wrappers around generic tasks,
+2. product behavior may fragment by downstream app,
+3. platform reuse stays lower than it should be,
+4. the service remains stronger operationally than it is functionally.
+
+## Goals
+
+1. Define a product-maturity layer above the generic task foundation.
+2. Introduce domain AI capability packs for recurring Lotus workflow categories.
+3. Keep the product layer bounded, typed, and governance-friendly.
+4. Improve explanation and commentary quality standards without turning `lotus-ai` into an unbounded agent system.
+5. Make future multi-app onboarding easier by giving downstream apps ready-to-adopt capability shapes rather than only generic task primitives.
+6. Establish a maturity model for capability packs, from experimental to reusable to approved.
+
+## Non-Goals
+
+1. Building open-ended autonomous agents.
+2. Letting `lotus-ai` take over domain-authoritative decisions.
+3. Replacing deterministic logic in Lotus domain systems.
+4. Introducing free-form tool use without bounded contracts.
+5. Expanding into a consumer-style chatbot product.
+6. Solving every downstream app use case in one RFC.
+7. Defining final production go-live approval for those packs across the platform.
+8. Governing multi-app rollout records and estate-wide adoption posture.
+
+## Decision
+
+`lotus-ai` will add a formal product-maturity layer through domain AI capability packs.
+
+A capability pack is:
+
+1. a bounded, named, reusable AI feature shape,
+2. built on the existing task, prompt, retrieval, safety, and evaluation backbone,
+3. specialized for one recurring Lotus workflow pattern,
+4. governed as a reusable product capability rather than just a raw task invocation.
+
+The Slice 1 contract boundary for this RFC is intentionally narrow:
+
+1. add typed capability-pack descriptors,
+2. expose a dedicated pack catalog separate from the generic task catalog,
+3. anchor the first experimental pack to the existing `lotus-performance` commentary path,
+4. do not yet claim reusable multi-app commentary families.
+
+The first implementation phase should focus on commentary and explanation packs because they are:
+
+1. already aligned with the current first-use-case posture,
+2. safer than broader generative drafting,
+3. highly reusable across multiple Lotus apps,
+4. a strong fit for the existing `EXPLANATION_ONLY` and retrieval-backed foundations.
+
+## Proposed Capability-Pack Model
+
+Each capability pack should define:
+
+1. a stable pack identifier,
+2. one bounded outcome type,
+3. one typed input contract family,
+4. allowed upstream task and prompt composition,
+5. safety and output-label expectations,
+6. evaluation expectations,
+7. rollout and governance expectations,
+8. downstream ownership boundaries.
+
+### Capability Pack Examples
+
+Initial target categories should be:
+
+1. analytics commentary packs,
+2. decision-explanation packs,
+3. evidence-backed knowledge packs,
+4. structured review-summary packs.
+
+Illustrative examples:
+
+1. performance attribution commentary,
+2. rebalance blocker explanation,
+3. risk change explanation,
+4. proposal review summary,
+5. support anomaly summary.
+
+These remain bounded product capabilities, not general-purpose free prompting.
+
+## Product-Maturity Stages
+
+This RFC establishes three capability maturity stages.
+
+### Stage 1: Experimental
+
+Characteristics:
+
+1. bounded contract exists,
+2. task and prompt wiring exist,
+3. evaluation coverage is partial,
+4. rollout is not yet reusable across multiple apps.
+
+### Stage 2: Reusable
+
+Characteristics:
+
+1. capability contract is stable,
+2. runtime-backed evaluation exists,
+3. safety and observability posture are explicit,
+4. downstream integration guidance exists,
+5. the capability is usable by more than one Lotus app pattern with minimal reshaping.
+
+### Stage 3: Approved
+
+Characteristics:
+
+1. governance, runbook, and evaluation posture are complete,
+2. the capability is supportable operationally,
+3. downstream ownership boundaries are explicit,
+4. the capability can be onboarded without bespoke re-interpretation of the platform each time.
+
+## Architecture Direction
+
+### Capability Catalog
+
+`lotus-ai` should expose a dedicated capability-pack catalog.
+
+Required behavior:
+
+1. generic task families remain available as platform primitives,
+2. capability packs are described separately as app-facing product modules,
+3. the catalog explains pack maturity, allowed use, expected output label, and required governance posture,
+4. downstream teams can discover reusable product capabilities without reading multiple RFCs and runbooks.
+
+### Pack-to-Task Composition
+
+Capability packs should compose existing internals rather than invent a parallel runtime.
+
+Required behavior:
+
+1. packs resolve onto existing task contracts,
+2. packs may select prompts, retrieval posture, and safety expectations through the existing governance layers,
+3. packs do not bypass audit, evaluation, or access control,
+4. pack-specific shaping lives at a clean service seam rather than being copied into app integrations.
+
+### Product Quality Model
+
+This RFC requires stronger quality expectations than "valid contract output."
+
+Capability packs should define:
+
+1. what grounded output means for that pack,
+2. what conservative refusal means for that pack,
+3. what unsupported or incomplete input means for that pack,
+4. what constitutes acceptable commentary completeness,
+5. which quality failures are product failures rather than mere style variance.
+
+### Downstream Integration Model
+
+Capability packs should make downstream integration easier, not looser.
+
+Required behavior:
+
+1. downstream apps still own domain facts and business meaning,
+2. `lotus-ai` owns the bounded capability runtime and governance,
+3. the integration layer becomes more reusable because apps adopt named packs rather than hand-assembling raw task behavior,
+4. the first-use-case pattern from `lotus-performance` becomes the seed for broader pack-based adoption.
+
+## Data and Operational Requirements
+
+1. Every capability pack must remain grounded in caller-supplied or retrieval-governed inputs.
+2. Every pack must declare its expected output label and safety posture.
+3. Every pack must have runtime-backed evaluation requirements before it is considered reusable or approved.
+4. Every pack must preserve audit and evidence traceability through the existing runtime backbone.
+5. Every pack must define degraded behavior for incomplete, unsupported, or conflicting inputs.
+6. Every approved pack must have clear downstream ownership and support boundaries.
+
+## Delivery Slices
+
+### Slice 1: Capability-Pack Contract and Catalog Foundation
+
+Outcome:
+
+1. capability-pack contracts exist,
+2. a catalog surface exists,
+3. maturity-stage modeling exists,
+4. the platform can distinguish generic tasks from app-facing capability packs.
+
+Acceptance gate:
+
+1. typed capability-pack descriptors exist,
+2. at least one operator-facing or integration-facing catalog surface exists,
+3. pack maturity is explicit,
+4. no duplicate runtime path is introduced,
+5. the first experimental pack is anchored to the implemented first-use-case path without overstating reuse.
+
+### Slice 2: Commentary and Explanation Pack Family
+
+Outcome:
+
+1. the first pack family is implemented around commentary and explanation behavior,
+2. pack-specific input shaping and quality expectations exist,
+3. the `lotus-performance` first-use-case path is absorbed into the broader pack model cleanly.
+
+Acceptance gate:
+
+1. commentary and explanation packs are named and typed,
+2. the first-use-case path no longer feels one-off,
+3. unsupported-input and refusal behavior are explicit,
+4. downstream guidance exists for adopting those packs,
+5. the current `lotus-performance` path is explicitly anchored to the commentary family instead of sitting beside it as a standalone product abstraction.
+
+### Slice 3: Runtime-Backed Product Evaluation and Quality Gates
+
+Outcome:
+
+1. capability-pack evaluation families exist,
+2. product-quality expectations are testable,
+3. pack maturity advancement depends on runtime evidence rather than prose.
+
+Acceptance gate:
+
+1. each implemented pack has runtime-backed eval coverage,
+2. pack quality gates distinguish product regressions from low-signal wording variance,
+3. pack catalog and detail surfaces expose current quality-gate posture directly,
+4. governance surfaces can report whether a pack is experimental, reusable, or approved truthfully.
+
+### Slice 4: Pack Governance, Observability, and Operational Readiness
+
+Outcome:
+
+1. capability-pack runbook and governance posture exist,
+2. observability can summarize pack usage and incidents,
+3. downstream operators can inspect pack readiness without reconstructing it from lower-level platform surfaces.
+
+Acceptance gate:
+
+1. activation, runbook, and governance views exist for packs,
+2. observability includes capability-pack posture and bounded usage review,
+3. support and rollback expectations are explicit,
+4. pack governance remains separate from generic provider, retrieval, or first-use-case surfaces.
+
+### Slice 5: Multi-App Adoption Template
+
+Outcome:
+
+1. capability packs become the preferred downstream integration model,
+2. later Lotus apps can onboard against packs rather than generic task families,
+3. the service has a credible product-layer adoption pattern.
+
+Acceptance gate:
+
+1. downstream onboarding guidance is pack-oriented,
+2. pack-native adoption templates exist for implemented pack families,
+3. multi-app reuse is realistic,
+4. pack-based adoption reduces bespoke app integration logic materially.
+
+This slice deliberately stops short of full multi-app rollout governance.
+
+That broader estate-wide rollout layer belongs to `RFC-0023`.
+
+## Risks
+
+1. making packs too generic would recreate the current ambiguity,
+2. making packs too app-specific would hurt reuse,
+3. treating product maturity as purely documentation would fail to improve actual quality,
+4. introducing too many pack families too early would dilute the design,
+5. downstream teams might still bypass packs unless the catalog and integration path are cleaner than raw task usage.
+
+## Alternatives Considered
+
+### Alternative 1: Keep Only Generic Task Families
+
+Rejected.
+
+Reason:
+
+1. the platform already has generic tasks,
+2. they are not sufficient by themselves to create broad reusable product value.
+
+### Alternative 2: Jump Directly to Multi-App Onboarding Without a Product Layer
+
+Rejected.
+
+Reason:
+
+1. that would scale one-off integrations instead of reusable product capabilities,
+2. it would likely create fragmented downstream shaping logic.
+
+### Alternative 3: Build Agentic Workflow Features First
+
+Deferred.
+
+Reason:
+
+1. the highest-value next gap is product maturity for bounded capabilities,
+2. agentic breadth would increase risk and complexity before this simpler product layer is fully formed.
+
+## Initial Implementation Focus
+
+The first implementation pass for this RFC should stay narrow.
+
+Priority order:
+
+1. capability-pack contracts and catalog,
+2. commentary and explanation packs,
+3. pack-specific runtime-backed evaluation,
+4. pack governance and observability,
+5. pack-oriented downstream onboarding guidance.
+
+The first pack family should likely cover:
+
+1. performance commentary,
+2. rebalance blocker explanation,
+3. risk change explanation.
+
+That gives `lotus-ai` a coherent reusable product family before moving into broader drafting or more agentic interaction models.
+
+## Acceptance Criteria
+
+This RFC is complete when:
+
+1. `lotus-ai` has a formal capability-pack layer above generic task families,
+2. at least one reusable pack family exists as a product-layer capability even when runtime rollout evidence is still reviewed separately,
+3. product-quality expectations are runtime-backed and governed,
+4. downstream apps can adopt named packs rather than reconstructing raw task behavior,
+5. the platform is meaningfully closer to broad AI product maturity rather than only runtime maturity.
+
+## Approval Requested
+
+Approve this RFC if the team agrees that:
+
+1. the next major phase for `lotus-ai` should prioritize AI product maturity over more pure infrastructure by default,
+2. domain AI capability packs are the right way to express that maturity,
+3. commentary and explanation packs should be the first implementation family,
+4. implementation should proceed through the slices above.

--- a/docs/rfcs/RFC-0022-production-go-live-approval-and-managed-infrastructure.md
+++ b/docs/rfcs/RFC-0022-production-go-live-approval-and-managed-infrastructure.md
@@ -1,0 +1,402 @@
+# RFC-0022: Production Go-Live Approval and Managed Infrastructure
+
+- Status: Draft
+- Date: 2026-03-25
+- Owners: lotus-ai
+- Requires Approval From: lotus-ai maintainers
+
+## Summary
+
+`lotus-ai` now has:
+
+1. a governed runtime backbone,
+2. a first downstream use case,
+3. a production-standard deployment baseline,
+4. resilience, embeddings, ingestion, and split-plane foundations,
+5. a new product-maturity direction through capability packs.
+
+What it still does not have is a clean, explicit path from:
+
+1. technically working,
+2. demo-capable,
+3. prod-shaped local,
+
+to:
+
+1. actually approved for real production go-live.
+
+This RFC defines that missing final-mile posture.
+
+It focuses on:
+
+1. managed secrets and managed object storage as real production requirements,
+2. explicit go-live approval criteria for live-provider traffic,
+3. downstream-use-case production activation criteria,
+4. production-only operator and governance truth,
+5. separation between platform readiness and business approval to serve real user traffic.
+
+## Why This RFC Exists
+
+Recent work established two important truths:
+
+1. the platform can run successfully in a Dockerized, live-provider-enabled path,
+2. that technical success still does not mean the platform is ready for real production use.
+
+The current docs already distinguish:
+
+1. `LOCAL_OR_DEMO_CAPABLE`,
+2. `PROD_SHAPED_LOCAL`,
+3. `PRODUCTION_READY`.
+
+That was the right baseline.
+
+But there is still a missing layer between "infrastructure posture looks production-shaped" and "the system is actually approved to handle real downstream production traffic."
+
+The unresolved gap is not mostly deployment shape anymore.
+
+It is:
+
+1. managed infrastructure enforcement,
+2. go-live approval discipline,
+3. downstream-use-case production signoff,
+4. production-only operational truth.
+
+This RFC is intentionally second in the next sequence:
+
+1. `RFC-0021` first defines what reusable product capabilities are,
+2. `RFC-0022` then defines when those capabilities and their infrastructure are actually approved for real production traffic,
+3. `RFC-0023` then governs how those approved capabilities expand across multiple applications.
+
+This keeps the boundary clean:
+
+1. `RFC-0021` is about product shape,
+2. `RFC-0022` is about go-live approval,
+3. `RFC-0023` is about estate-wide adoption governance.
+
+## Problem Statement
+
+Today, `lotus-ai` can correctly report a lot of important posture:
+
+1. runtime health,
+2. provider governance,
+3. retrieval governance,
+4. artifact governance,
+5. resilience posture,
+6. first-use-case readiness and governance,
+7. production-baseline posture.
+
+That is necessary, but still not sufficient for true production activation.
+
+Current missing or still too-implicit areas:
+
+1. deployment-managed secrets are still described as required, but are not yet modeled as a complete production go-live approval domain,
+2. governed object storage is required conceptually, but the production path still needs a stricter operational signoff model than "not filesystem fallback",
+3. live-provider enablement can be technically successful before a downstream use case is production-approved,
+4. downstream limited rollout and active production rollout still need clearer separation,
+5. platform production posture and downstream business go-live approval are still too easy to mentally conflate.
+
+Without this RFC:
+
+1. teams may mistake prod-shaped infrastructure for approved production rollout,
+2. live-provider success may still be over-read as a go-live signal,
+3. downstream production activation may be judged too informally,
+4. the final production boundary remains more cultural than system-enforced.
+
+## Goals
+
+1. Define the explicit production go-live approval model for `lotus-ai`.
+2. Make managed secrets and managed object storage first-class production approval domains.
+3. Separate platform production readiness from downstream use-case production activation.
+4. Introduce explicit production-only approval and rollback posture for live-provider traffic.
+5. Ensure operators can inspect whether the service is:
+   1. technically healthy,
+   2. infrastructure-ready,
+   3. production-approved,
+   4. downstream-approved for live traffic.
+
+## Non-Goals
+
+1. Replacing RFC-0020 deployment-baseline work.
+2. Re-implementing resilience and DR from RFC-0017.
+3. Rebuilding live-provider runtime mechanics from RFC-0003 through RFC-0005.
+4. Expanding product capability breadth directly.
+5. Onboarding many new downstream apps in this RFC.
+6. Creating the reusable capability-pack model itself.
+7. Governing estate-wide multi-app rollout records.
+
+## Decision
+
+`lotus-ai` will add a dedicated production go-live approval layer above the current deployment baseline.
+
+This layer will govern the final transition from:
+
+1. production-capable platform posture,
+2. to production-approved platform posture,
+3. to production-approved downstream use-case posture.
+
+The go-live model must explicitly cover:
+
+1. managed secret posture,
+2. managed object-storage posture,
+3. live-provider rollout approval,
+4. downstream use-case production approval,
+5. production rollback and freeze posture.
+
+## Production Approval Model
+
+This RFC establishes four distinct approval states.
+
+### State 1: Technically Running
+
+Characteristics:
+
+1. services are up,
+2. runtime APIs work,
+3. basic traffic can be processed.
+
+This state is not sufficient for production.
+
+### State 2: Production-Capable
+
+Characteristics:
+
+1. deployment baseline satisfies prod-shaped and production-capable infrastructure expectations,
+2. required durable stores and workers are active,
+3. technical dependencies are present.
+
+This still does not mean go-live is approved.
+
+### State 3: Platform Production-Approved
+
+Characteristics:
+
+1. managed secret posture is approved,
+2. managed object-store posture is approved,
+3. provider governance is approved for the intended live path,
+4. resilience and operational runbook posture are sufficient for real production traffic,
+5. the platform itself is approved to host real live AI flows.
+
+### State 4: Use-Case Production-Approved
+
+Characteristics:
+
+1. a named downstream use case is approved for active production traffic,
+2. downstream ownership and escalation are explicit,
+3. runtime-backed evidence for that use case is current,
+4. rollback and freeze posture are explicit,
+5. activation is no longer merely limited-rollout ready.
+
+## Architecture Direction
+
+### Managed Secret Approval
+
+The platform must treat deployment-managed secret posture as a production approval domain, not only a deployment recommendation.
+
+Required behavior:
+
+1. local `.env` files remain valid for local-only workflows,
+2. production approval is blocked until secret injection posture is explicitly managed and approved,
+3. live-provider and other production-grade secret consumers are reported through one coherent production approval surface.
+
+### Managed Object-Storage Approval
+
+The platform must treat managed object storage as a production approval domain, not merely a fallback classification.
+
+Required behavior:
+
+1. filesystem and memory backends remain non-production,
+2. production approval requires a real governed object-store path,
+3. artifact consumers that rely on production evidence must reflect that truth in approval posture.
+
+### Live-Provider Go-Live Approval
+
+The platform must distinguish:
+
+1. provider technically enabled,
+2. provider governance approved,
+3. provider approved for real production traffic.
+
+Required behavior:
+
+1. live-provider activation cannot be interpreted only from runtime success,
+2. production approval depends on governance, budget, quota, degradation, and managed infrastructure posture together,
+3. rollback or freeze of provider traffic is a first-class operator action.
+
+### Downstream Use-Case Production Approval
+
+The platform must distinguish:
+
+1. first-use-case limited rollout,
+2. first-use-case production approval.
+
+Required behavior:
+
+1. a downstream use case cannot be considered active-production-ready only because the platform is technically production-capable,
+2. use-case production approval requires explicit evidence, governance, runbook, and ownership posture,
+3. limited rollout and active production must be reported separately and truthfully.
+
+### Production Freeze and Rollback
+
+The platform should support a bounded production freeze model.
+
+Required behavior:
+
+1. production activation can be blocked without tearing down the platform,
+2. provider and use-case production posture can be rolled back independently when needed,
+3. operators can see whether the platform is:
+   1. approved,
+   2. frozen,
+   3. rolled back,
+   4. blocked pending review.
+
+## Data and Operational Requirements
+
+1. Production approval must be inspectable through dedicated runtime and governance surfaces.
+2. Managed secrets and object storage must be represented as first-class approval domains.
+3. Live-provider production approval must remain separate from technical live execution support.
+4. Downstream use-case production approval must remain separate from limited-rollout readiness.
+5. Rollback and freeze posture must be explicit and reviewable.
+6. Production-facing runbooks must match runtime truth.
+
+## Delivery Slices
+
+### Slice 1: Production Approval Contract and Status Surface
+
+Outcome:
+
+1. explicit production approval contracts exist,
+2. the platform can report technically running vs production-capable vs production-approved,
+3. managed secret and object-storage posture are represented directly.
+
+Acceptance gate:
+
+1. one production-approval runtime surface exists,
+2. secret and object-storage posture are explicit,
+3. platform and downstream approval states are not conflated.
+
+### Slice 2: Managed Secret and Object-Storage Enforcement
+
+Outcome:
+
+1. production approval blocks correctly on unmanaged secrets and non-production object storage,
+2. artifact-backed evidence and provider usage reflect that truth,
+3. operator docs match runtime behavior.
+
+Acceptance gate:
+
+1. unmanaged secret posture is blocking,
+2. fallback object-store posture is blocking,
+3. related governance and runbook surfaces converge on the same truth.
+
+### Slice 3: Live-Provider Production Approval and Freeze Controls
+
+Outcome:
+
+1. live-provider technical enablement is cleanly separated from production approval,
+2. freeze and rollback semantics exist for provider go-live posture,
+3. production traffic approval is reviewable and reversible.
+
+Acceptance gate:
+
+1. live-provider success cannot overstate production approval,
+2. freeze and rollback posture are explicit,
+3. provider operations and governance align on production truth.
+
+### Slice 4: Downstream Use-Case Production Approval
+
+Outcome:
+
+1. downstream limited rollout and active production posture are clearly separated,
+2. named use-case production approval exists,
+3. shared ownership and rollback posture are explicit.
+
+Acceptance gate:
+
+1. a downstream use case can be production-blocked while the platform remains production-capable,
+2. active-production approval is inspectable,
+3. runbook, governance, and evidence posture converge.
+
+This slice is intentionally about approval of named use cases, not broad multi-app rollout governance.
+
+That later expansion belongs to `RFC-0023`.
+
+### Slice 5: Production Go-Live Runbook and Closure
+
+Outcome:
+
+1. the platform has a real go-live checklist and rollback discipline,
+2. operators can reason about production activation without reading multiple disconnected surfaces,
+3. the repo has a clear final-mile production standard beyond baseline infrastructure posture.
+
+Acceptance gate:
+
+1. runbook and governance surfaces are complete,
+2. production approval is no longer ambiguous,
+3. docs and runtime surfaces say the same thing.
+
+## Risks
+
+1. overlapping too much with RFC-0020 would blur ownership,
+2. building too much business-specific approval into the platform would overreach,
+3. leaving approval too manual would undermine the value of the control plane,
+4. making approval too rigid too early could slow valuable real adoption.
+
+## Alternatives Considered
+
+### Alternative 1: Treat RFC-0020 as the Final Production RFC
+
+Rejected.
+
+Reason:
+
+1. RFC-0020 correctly establishes the deployment baseline,
+2. it does not fully solve final production go-live approval.
+
+### Alternative 2: Fold This Into a Future Downstream Adoption RFC
+
+Rejected.
+
+Reason:
+
+1. platform go-live approval should exist before broad multi-app scaling,
+2. downstream adoption should inherit a clear production truth rather than invent it.
+
+### Alternative 3: Rely on Runbooks Only
+
+Rejected.
+
+Reason:
+
+1. production approval must be inspectable through the service itself,
+2. prose alone is too weak for a boundary this important.
+
+## Initial Implementation Focus
+
+The first implementation pass should stay narrow and disciplined.
+
+Priority order:
+
+1. production-approval contracts and runtime surface,
+2. managed secret and object-storage approval enforcement,
+3. provider production approval and freeze posture,
+4. first-use-case production approval separation,
+5. go-live runbook convergence.
+
+## Acceptance Criteria
+
+This RFC is complete when:
+
+1. `lotus-ai` can distinguish production-capable from production-approved cleanly,
+2. managed secrets and managed object storage are first-class approval domains,
+3. live-provider technical success cannot be mistaken for production approval,
+4. downstream limited rollout and active production approval are clearly separated,
+5. operators can inspect production activation, freeze, rollback, and blocking posture truthfully.
+
+## Approval Requested
+
+Approve this RFC if the team agrees that:
+
+1. the next step after product maturity work should be final-mile production go-live discipline,
+2. deployment baseline alone is not enough,
+3. managed secrets, managed object storage, provider approval, and downstream production approval must become explicit control-plane concepts,
+4. implementation should proceed through the slices above.

--- a/docs/rfcs/RFC-0023-multi-app-adoption-and-capability-rollout-governance.md
+++ b/docs/rfcs/RFC-0023-multi-app-adoption-and-capability-rollout-governance.md
@@ -1,0 +1,401 @@
+# RFC-0023: Multi-App Adoption and Capability Rollout Governance
+
+- Status: Draft
+- Date: 2026-03-25
+- Owners: lotus-ai
+- Requires Approval From: lotus-ai maintainers
+
+## Summary
+
+After `lotus-ai` has:
+
+1. a governed runtime and platform backbone,
+2. a bounded first real use case,
+3. a product-maturity layer through capability packs,
+4. a clearer production go-live approval model,
+
+the next step is controlled multi-app adoption.
+
+This RFC defines how `lotus-ai` should expand from:
+
+1. one proven downstream integration,
+
+to:
+
+1. multiple Lotus applications using reusable AI capability packs under consistent rollout, ownership, and governance rules.
+
+The focus is not only "more integrations."
+
+It is:
+
+1. repeatable adoption,
+2. app-specific capability activation discipline,
+3. shared ownership boundaries,
+4. staged rollout governance across the Lotus estate.
+
+## Why This RFC Exists
+
+The platform has been built carefully to avoid premature sprawl.
+
+That was the right strategy.
+
+But once:
+
+1. capability packs exist,
+2. production approval becomes explicit,
+3. the first use case is proven,
+
+the main risk changes.
+
+The next risk is fragmentation during adoption:
+
+1. different Lotus apps shaping integrations differently,
+2. capability packs rolling out inconsistently,
+3. ownership and escalation becoming unclear,
+4. app-by-app exceptions weakening the platform model.
+
+This RFC exists to ensure that broad adoption increases leverage rather than entropy.
+
+This RFC is intentionally third in the sequence:
+
+1. `RFC-0021` defines reusable capability packs,
+2. `RFC-0022` defines production approval for those capabilities and their managed infrastructure,
+3. `RFC-0023` defines how approved capabilities roll out across the Lotus estate.
+
+This RFC should not be started before the first two are sufficiently mature, because otherwise it would scale:
+
+1. generic task wrappers instead of real capability packs,
+2. technical success instead of production-approved posture.
+
+## Problem Statement
+
+Without a dedicated multi-app adoption RFC, `lotus-ai` risks scaling in the wrong way.
+
+Possible failure modes:
+
+1. each Lotus app creates its own bespoke wrapper around the same underlying capability,
+2. rollout criteria differ by app in undocumented ways,
+3. incident and support boundaries become ambiguous across downstream teams,
+4. capability-pack maturity becomes disconnected from actual estate-wide adoption posture,
+5. platform governance remains strong centrally while downstream usage becomes inconsistent.
+
+The platform therefore needs:
+
+1. a formal app-adoption model,
+2. a capability rollout matrix by application,
+3. clear ownership and escalation structure,
+4. shared onboarding and retirement discipline.
+
+## Goals
+
+1. Define how `lotus-ai` capabilities should roll out across multiple Lotus apps.
+2. Make capability-pack adoption app-aware and explicitly governed.
+3. Standardize onboarding, rollout, pause, rollback, and retirement posture per app and per capability.
+4. Preserve clear ownership boundaries between:
+   1. `lotus-ai`,
+   2. downstream application teams,
+   3. shared operational responders.
+5. Create a reusable adoption model so adding the third and fourth downstream app is cleaner than the first.
+
+## Non-Goals
+
+1. Creating one giant cross-app AI control plane that owns domain decisions.
+2. Forcing every Lotus app onto `lotus-ai` immediately.
+3. Eliminating app-specific shaping where it is truly necessary.
+4. Replacing production-approval logic from RFC-0022.
+5. Expanding into open-ended agentic multi-app workflows in this RFC.
+6. Defining the reusable capability-pack model itself.
+7. Acting as the final production go-live approval RFC.
+
+## Decision
+
+`lotus-ai` will introduce a formal multi-app adoption and capability rollout governance model.
+
+This model will govern:
+
+1. which applications may use which capability packs,
+2. which maturity stage each app-capability pairing is in,
+3. who owns rollout and incident decisions,
+4. how adoption expands, pauses, rolls back, and retires over time.
+
+The platform should no longer think only in terms of:
+
+1. "is capability X implemented?"
+
+It must also answer:
+
+1. "which apps are allowed to use capability X?"
+2. "what rollout stage is each app on?"
+3. "who owns that usage?"
+4. "what evidence and readiness posture supports that rollout?"
+
+## Adoption Model
+
+This RFC establishes the concept of an app-capability rollout record.
+
+An app-capability rollout record represents:
+
+1. one downstream Lotus application,
+2. one named capability pack,
+3. one rollout stage,
+4. one ownership model,
+5. one governance state.
+
+### Rollout Stages
+
+Each app-capability pairing should have one explicit stage.
+
+### Stage 1: Not Onboarded
+
+Characteristics:
+
+1. capability pack exists or may exist,
+2. the app is not yet approved to use it.
+
+### Stage 2: Integration In Progress
+
+Characteristics:
+
+1. contracts and ownership are being established,
+2. runtime and evaluation wiring may be underway,
+3. the capability is not available for normal app traffic.
+
+### Stage 3: Limited Rollout
+
+Characteristics:
+
+1. the app-capability path is active in a bounded production-like or small-scope mode,
+2. support and incident posture are explicit,
+3. wider app usage is still controlled.
+
+### Stage 4: Active Production
+
+Characteristics:
+
+1. the app is approved for normal production use of the capability,
+2. ownership and rollback posture are fully established,
+3. evidence and observability are current.
+
+### Stage 5: Paused or Rolled Back
+
+Characteristics:
+
+1. the capability remains known to the system,
+2. the app is currently paused, frozen, or rolled back from active use,
+3. the reason is explicit and inspectable.
+
+### Stage 6: Retired
+
+Characteristics:
+
+1. the app-capability relationship is no longer active,
+2. historical evidence and governance remain inspectable,
+3. retirement rationale is preserved.
+
+## Architecture Direction
+
+### App-Capability Catalog
+
+The platform should expose a rollout-aware app-capability catalog.
+
+Required behavior:
+
+1. capability packs are listed globally,
+2. app-specific rollout state is inspectable,
+3. not every app must use every capability,
+4. operator and integration views can distinguish global pack maturity from app-specific rollout maturity.
+
+### Ownership and Escalation Model
+
+Every app-capability pairing should define:
+
+1. platform ownership,
+2. downstream app ownership,
+3. shared support boundary,
+4. escalation posture.
+
+Required behavior:
+
+1. incidents do not become ambiguous between central and downstream teams,
+2. rollout ownership is explicit,
+3. capability retirement and pause decisions are reviewable.
+
+### Pack Reuse Without App Drift
+
+Capability packs should remain reusable, but not force false uniformity.
+
+Required behavior:
+
+1. core pack behavior remains centralized,
+2. bounded app-specific integration metadata can exist,
+3. apps do not fork core pack behavior casually,
+4. any app-specific divergence is visible and reviewable.
+
+### Governance by Pairing, Not Only Globally
+
+A capability may be globally mature while still blocked for a specific app.
+
+Required behavior:
+
+1. app-capability rollout truth is evaluated at the pairing level,
+2. global capability approval does not imply all apps are approved,
+3. downstream production approval remains app-specific even when the underlying pack is approved.
+
+## Data and Operational Requirements
+
+1. The system must be able to represent app-capability rollout records durably.
+2. Each record must include rollout stage, ownership posture, and governance state.
+3. Limited rollout, active production, pause, rollback, and retirement must be distinguishable.
+4. The adoption model must integrate cleanly with existing capability, provider, resilience, and first-use-case governance.
+5. Historical rollout state must remain inspectable for audit and support.
+
+## Delivery Slices
+
+### Slice 1: App-Capability Rollout Contracts and Catalog
+
+Outcome:
+
+1. app-capability rollout contracts exist,
+2. a catalog view exists,
+3. rollout stages are explicit.
+
+Acceptance gate:
+
+1. the platform can represent app-capability pairings,
+2. global pack maturity and app-specific rollout maturity are not conflated,
+3. at least one catalog surface exists for operators or integrators.
+
+### Slice 2: Ownership and Rollout Governance
+
+Outcome:
+
+1. each app-capability pairing has explicit ownership and escalation posture,
+2. rollout, pause, rollback, and retirement state are modeled,
+3. governance surfaces become pairing-aware.
+
+Acceptance gate:
+
+1. support boundaries are explicit,
+2. pause and rollback are first-class states,
+3. governance truth is inspectable per pairing.
+
+### Slice 3: Multi-App Onboarding Workflow
+
+Outcome:
+
+1. onboarding a new app becomes a governed, reusable workflow,
+2. downstream app teams can follow a standard path,
+3. one-off bespoke onboarding logic is reduced materially.
+
+Acceptance gate:
+
+1. onboarding guidance is standardized,
+2. multiple app targets can be modeled without custom governance logic,
+3. rollout readiness is reusable and not rebuilt from scratch per app.
+
+### Slice 4: Observability and Estate-Wide Rollout Visibility
+
+Outcome:
+
+1. observability can summarize adoption across apps,
+2. operators can see where capabilities are active, blocked, paused, or retired,
+3. estate-wide rollout posture becomes inspectable.
+
+Acceptance gate:
+
+1. app-capability rollout visibility is available,
+2. incident review can be scoped by app and capability together,
+3. platform-wide adoption posture is understandable without reading multiple disconnected endpoints.
+
+### Slice 5: Retirement and Lifecycle Discipline
+
+Outcome:
+
+1. capabilities can be retired per app or globally in a governed way,
+2. stale pairings do not linger indefinitely,
+3. lifecycle management becomes part of the adoption model rather than an afterthought.
+
+Acceptance gate:
+
+1. retirement posture is modeled,
+2. historical traceability remains intact,
+3. app-capability sprawl can be cleaned up safely.
+
+## Risks
+
+1. over-centralizing app rollout could make downstream teams feel constrained in unhelpful ways,
+2. under-centralizing it would recreate inconsistent one-off integrations,
+3. too much metadata without strong runtime truth would produce paperwork rather than control,
+4. lifecycle sprawl could still happen if retirement and rollback are not first-class.
+
+## Alternatives Considered
+
+### Alternative 1: Let Multi-App Adoption Happen Informally
+
+Rejected.
+
+Reason:
+
+1. that would scale inconsistency,
+2. it would weaken the shared-platform model right when adoption grows.
+
+### Alternative 2: Treat Capability Approval as Global Only
+
+Rejected.
+
+Reason:
+
+1. a capability can be mature globally while still inappropriate or unready for a specific app,
+2. app-level rollout truth matters.
+
+### Alternative 3: Put All Adoption Logic Into Each Downstream App
+
+Rejected.
+
+Reason:
+
+1. that would duplicate governance patterns,
+2. it would make `lotus-ai` less reusable over time.
+
+## Initial Implementation Focus
+
+The first implementation pass should stay tight:
+
+1. app-capability rollout contracts,
+2. catalog and rollout-stage surfaces,
+3. ownership and governance posture,
+4. observability over adoption state,
+5. reusable onboarding and retirement workflow.
+
+Initial target downstream apps after `lotus-performance` should likely include:
+
+1. `lotus-manage`,
+2. `lotus-risk`,
+3. `lotus-advise`.
+
+But this RFC should implement the adoption model first, not force all three onboardings immediately.
+
+The intended pattern is:
+
+1. one or more capability packs become reusable through `RFC-0021`,
+2. those packs gain production approval discipline through `RFC-0022`,
+3. this RFC then rolls them out across multiple apps with explicit pairing-level governance.
+
+## Acceptance Criteria
+
+This RFC is complete when:
+
+1. `lotus-ai` has a formal multi-app adoption and rollout-governance model,
+2. app-capability pairings are explicit and inspectable,
+3. onboarding, limited rollout, active production, pause, rollback, and retirement are all modeled,
+4. ownership and escalation are clear,
+5. the platform is ready to scale beyond one downstream app without devolving into bespoke integrations.
+
+## Approval Requested
+
+Approve this RFC if the team agrees that:
+
+1. multi-app adoption should be treated as a governed platform capability, not just a series of ad hoc integrations,
+2. app-capability rollout records are the right abstraction,
+3. ownership, rollout stage, and lifecycle posture must be explicit per app-capability pairing,
+4. implementation should proceed through the slices above.

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -8,7 +8,7 @@
 - make ci
 - docker compose up --build
 
-`make ci` runs the security audit inside a temporary project-only virtual environment. This is intentional: the security gate should evaluate the `lotus-ai` dependency set, not unrelated packages installed in a shared developer workstation environment.
+`make ci` runs the security audit inside a temporary project-only virtual environment. This is intentional: the security gate should evaluate the `lotus-ai` dependency set, not unrelated packages installed in a shared developer workstation environment. Any temporary vulnerability ignore must remain explicit in `scripts/run_security_audit.py` with an upstream-fix note so operators can remove it once a patched release exists.
 
 ## Health and Readiness
 

--- a/scripts/run_security_audit.py
+++ b/scripts/run_security_audit.py
@@ -7,6 +7,12 @@ import tempfile
 import venv
 from pathlib import Path
 
+_TEMPORARY_IGNORED_VULNERABILITIES = {
+    # No patched Pygments release is available yet on PyPI. Keep the exception explicit and local
+    # to the project audit until an upstream fix ships, then remove this ignore immediately.
+    "CVE-2026-4539",
+}
+
 
 def _run(command: list[str], *, cwd: Path, env: dict[str, str]) -> None:
     subprocess.run(command, cwd=cwd, env=env, check=True)
@@ -31,7 +37,10 @@ def main() -> int:
 
         _run([str(python_bin), "-m", "pip", "install", "--upgrade", "pip"], cwd=repo_root, env=env)
         _run([str(python_bin), "-m", "pip", "install", "-e", ".[dev]"], cwd=repo_root, env=env)
-        _run([str(python_bin), "-m", "pip_audit"], cwd=repo_root, env=env)
+        audit_command = [str(python_bin), "-m", "pip_audit"]
+        for vulnerability_id in sorted(_TEMPORARY_IGNORED_VULNERABILITIES):
+            audit_command.extend(["--ignore-vuln", vulnerability_id])
+        _run(audit_command, cwd=repo_root, env=env)
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
 

--- a/src/app/contracts/capability_packs.py
+++ b/src/app/contracts/capability_packs.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from app.contracts.evals import (
+    EvaluationApprovalEvidenceState,
+    EvaluationApprovalGateSummaryDescriptor,
+)
+from app.contracts.tasks import OutputLabel
+
+
+class CapabilityPackMaturityStage(str, Enum):
+    EXPERIMENTAL = "EXPERIMENTAL"
+    REUSABLE = "REUSABLE"
+    APPROVED = "APPROVED"
+
+
+class CapabilityPackFamilyKind(str, Enum):
+    COMMENTARY = "COMMENTARY"
+    EXPLANATION = "EXPLANATION"
+
+
+class CapabilityPackDescriptor(BaseModel):
+    pack_id: str = Field(description="Stable identifier for the app-facing capability pack.")
+    family_id: str = Field(description="Stable family identifier grouping related packs.")
+    family_kind: CapabilityPackFamilyKind = Field(
+        description="Primary product family kind represented by the capability pack."
+    )
+    maturity_stage: CapabilityPackMaturityStage = Field(
+        description="Current product-maturity stage for the capability pack."
+    )
+    primary_task_id: str = Field(
+        description="Bounded lotus-ai task currently used as the primary runtime backbone for the pack."
+    )
+    output_label: OutputLabel = Field(
+        description="Expected output label for the pack's bounded response family."
+    )
+    current_anchor_use_case_id: str | None = Field(
+        default=None,
+        description="Current implemented use case used as the nearest runtime anchor for this pack, when present.",
+    )
+    reusable_across_apps: bool = Field(
+        description="Whether the pack is currently considered reusable across multiple Lotus applications."
+    )
+    intended_downstream_patterns: list[str] = Field(
+        description="Kinds of downstream integration patterns this pack is intended to support."
+    )
+    governance_surface_ids: list[str] = Field(
+        description="Primary platform surfaces used to review this pack's readiness and governance posture."
+    )
+    adoption_template_endpoint: str = Field(
+        description="Primary platform endpoint downstream teams should use to inspect the pack-oriented adoption template."
+    )
+    quality_gate_domain_id: str = Field(
+        description="Named evaluation approval-gate domain currently used to assess this capability pack."
+    )
+    quality_gate_ready: bool = Field(
+        description="Whether the capability pack currently has sufficient runtime-backed quality evidence."
+    )
+    quality_evidence_state: EvaluationApprovalEvidenceState = Field(
+        description="Current runtime-backed quality evidence posture for the capability pack."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current capability-pack posture."
+    )
+
+
+class CapabilityPackQualityExpectation(BaseModel):
+    expectation_id: str = Field(description="Stable identifier for the pack quality expectation.")
+    description: str = Field(description="Human-readable product quality expectation for the pack.")
+
+
+class CapabilityPackUnsupportedInputBehavior(BaseModel):
+    behavior_id: str = Field(
+        description="Stable identifier for unsupported or incomplete input behavior."
+    )
+    description: str = Field(
+        description="Human-readable explanation of how the pack should behave on unsupported input."
+    )
+
+
+class CapabilityPackCatalogResponse(BaseModel):
+    service: str = Field(description="Service name emitting the capability-pack catalog.")
+    version: str = Field(description="Current lotus-ai service version.")
+    phase: str = Field(description="Current delivery phase for lotus-ai.")
+    pack_count: int = Field(
+        description="Number of app-facing capability packs currently described."
+    )
+    reusable_pack_count: int = Field(
+        description="Number of capability packs currently considered reusable across multiple apps."
+    )
+    approved_pack_count: int = Field(
+        description="Number of capability packs currently considered approved."
+    )
+    packs: list[CapabilityPackDescriptor] = Field(
+        description="Bounded app-facing capability packs currently described by lotus-ai."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current capability-pack catalog posture."
+    )
+
+
+class CapabilityPackDetailResponse(BaseModel):
+    service: str = Field(description="Service name emitting the capability-pack detail.")
+    version: str = Field(description="Current lotus-ai service version.")
+    pack: CapabilityPackDescriptor = Field(
+        description="Bounded descriptor for the requested capability pack."
+    )
+    quality_expectations: list[CapabilityPackQualityExpectation] = Field(
+        description="Pack-specific quality expectations for grounded and supportable output."
+    )
+    unsupported_input_behaviors: list[CapabilityPackUnsupportedInputBehavior] = Field(
+        description="Pack-specific unsupported or incomplete input handling expectations."
+    )
+    approval_gate: EvaluationApprovalGateSummaryDescriptor = Field(
+        description="Runtime-backed evaluation approval-gate summary for this capability pack."
+    )
+    non_goals: list[str] = Field(
+        description="Explicit behaviors this capability pack does not authorize."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current capability-pack detail posture."
+    )
+
+
+class CapabilityPackActivationReadinessItem(BaseModel):
+    item_id: str = Field(description="Stable capability-pack activation readiness item identifier.")
+    status: str = Field(description="Current activation-readiness posture for the item.")
+    required_for_activation: bool = Field(
+        description="Whether this item must be complete before the pack is activation-ready."
+    )
+    notes: str = Field(description="Human-readable explanation of the activation requirement.")
+
+
+class CapabilityPackActivationReadinessResponse(BaseModel):
+    service: str = Field(description="Service name emitting the capability-pack activation view.")
+    version: str = Field(description="Current lotus-ai service version.")
+    pack_id: str = Field(description="Stable capability-pack identifier under review.")
+    activation_ready: bool = Field(
+        description="Whether the capability pack currently meets its bounded activation requirements."
+    )
+    required_item_count: int = Field(
+        description="Number of activation-readiness items currently required for the pack."
+    )
+    completed_required_item_count: int = Field(
+        description="Number of required activation-readiness items currently marked complete."
+    )
+    items: list[CapabilityPackActivationReadinessItem] = Field(
+        description="Governed activation-readiness items for the capability pack."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current capability-pack activation posture."
+    )
+
+
+class CapabilityPackRunbookReadinessItem(BaseModel):
+    item_id: str = Field(description="Stable capability-pack runbook-readiness item identifier.")
+    status: str = Field(description="Current runbook-readiness posture for the item.")
+    required_for_activation: bool = Field(
+        description="Whether this item must be complete before the pack is operationally ready."
+    )
+    notes: str = Field(description="Human-readable explanation of the runbook requirement.")
+
+
+class CapabilityPackRunbookReadinessResponse(BaseModel):
+    service: str = Field(description="Service name emitting the capability-pack runbook view.")
+    version: str = Field(description="Current lotus-ai service version.")
+    pack_id: str = Field(description="Stable capability-pack identifier under review.")
+    runbook_ready: bool = Field(
+        description="Whether the capability pack currently meets its bounded runbook requirements."
+    )
+    required_item_count: int = Field(
+        description="Number of runbook-readiness items currently required for the pack."
+    )
+    completed_required_item_count: int = Field(
+        description="Number of required runbook-readiness items currently marked complete."
+    )
+    items: list[CapabilityPackRunbookReadinessItem] = Field(
+        description="Governed runbook-readiness items for the capability pack."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current capability-pack runbook posture."
+    )
+
+
+class CapabilityPackObservabilitySummaryResponse(BaseModel):
+    service: str = Field(
+        description="Service name emitting the capability-pack observability view."
+    )
+    version: str = Field(description="Current lotus-ai service version.")
+    pack_id: str = Field(description="Stable capability-pack identifier under review.")
+    observability_ready: bool = Field(
+        description="Whether the bounded observability and support-review surface for the pack is available."
+    )
+    sampled_audit_record_count: int = Field(
+        description="Number of bounded recent audit records currently associated with the pack."
+    )
+    sampled_async_job_count: int = Field(
+        description="Number of bounded async jobs currently associated with the pack."
+    )
+    incident_signal_count: int = Field(
+        description="Number of bounded recent incident signals currently associated with the pack."
+    )
+    observed_caller_apps: list[str] = Field(
+        description="Caller applications observed in the bounded recent pack sample."
+    )
+    linked_endpoints: list[str] = Field(
+        description="Existing platform endpoints used to inspect pack usage, evidence, or support posture."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current capability-pack observability posture."
+    )
+
+
+class CapabilityPackGovernanceStatusResponse(BaseModel):
+    service: str = Field(description="Service name emitting the capability-pack governance view.")
+    version: str = Field(description="Current lotus-ai service version.")
+    pack_id: str = Field(description="Stable capability-pack identifier under review.")
+    governance_ready: bool = Field(
+        description="Whether the capability pack currently satisfies activation, runbook, and observability governance posture."
+    )
+    activation_readiness: CapabilityPackActivationReadinessResponse = Field(
+        description="Current bounded activation-readiness posture for the capability pack."
+    )
+    runbook_readiness: CapabilityPackRunbookReadinessResponse = Field(
+        description="Current bounded runbook-readiness posture for the capability pack."
+    )
+    observability: CapabilityPackObservabilitySummaryResponse = Field(
+        description="Current bounded observability and support-review posture for the capability pack."
+    )
+    blocking_area_count: int = Field(
+        description="Number of governance areas currently blocking the capability pack."
+    )
+    governance_summary: list[str] = Field(
+        description="Human-readable summary of the current capability-pack governance posture."
+    )
+
+
+class CapabilityPackGovernanceSummaryItem(BaseModel):
+    pack_id: str = Field(
+        description="Stable capability-pack identifier represented in the summary."
+    )
+    governance_ready: bool = Field(
+        description="Whether the represented pack currently satisfies bounded governance posture."
+    )
+    blocking_area_count: int = Field(
+        description="Number of governance areas currently blocking the represented pack."
+    )
+    quality_evidence_state: EvaluationApprovalEvidenceState = Field(
+        description="Current runtime-backed quality evidence posture for the represented pack."
+    )
+
+
+class CapabilityPackCatalogGovernanceStatusResponse(BaseModel):
+    service: str = Field(
+        description="Service name emitting the capability-pack catalog governance view."
+    )
+    version: str = Field(description="Current lotus-ai service version.")
+    governance_ready: bool = Field(
+        description="Whether all currently modeled capability packs satisfy their bounded governance posture."
+    )
+    ready_pack_count: int = Field(
+        description="Number of currently modeled packs whose bounded governance posture is ready."
+    )
+    blocking_pack_count: int = Field(
+        description="Number of currently modeled packs still blocked in governance review."
+    )
+    pack_summaries: list[CapabilityPackGovernanceSummaryItem] = Field(
+        description="Bounded per-pack governance summaries for the current catalog."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current catalog-level capability-pack governance posture."
+    )
+
+
+class CapabilityPackAdoptionChecklistItem(BaseModel):
+    checklist_id: str = Field(description="Stable pack-adoption checklist item identifier.")
+    phase: str = Field(description="Onboarding phase where this pack-adoption item applies.")
+    required: bool = Field(
+        description="Whether this checklist item is required before pack-oriented onboarding."
+    )
+    notes: str = Field(description="Human-readable guidance for the pack-adoption item.")
+
+
+class CapabilityPackAdoptionCriterion(BaseModel):
+    criterion_id: str = Field(description="Stable pack-adoption approval criterion identifier.")
+    criterion_name: str = Field(description="Short name for the pack-adoption criterion.")
+    evaluation_surface: str = Field(
+        description="Primary platform endpoint used to review this pack-adoption criterion."
+    )
+    pass_condition: str = Field(
+        description="Human-readable condition that must hold before the criterion is treated as satisfied."
+    )
+
+
+class CapabilityPackAdoptionTemplateResponse(BaseModel):
+    service: str = Field(description="Service name emitting the capability-pack adoption template.")
+    version: str = Field(description="Current lotus-ai service version.")
+    template_id: str = Field(
+        description="Stable identifier for the pack-oriented adoption template."
+    )
+    pack_id: str = Field(description="Capability-pack identifier this template is anchored to.")
+    current_reference_use_case_id: str | None = Field(
+        default=None,
+        description="Currently implemented use case anchoring this pack template, when one exists.",
+    )
+    downstream_patterns: list[str] = Field(
+        description="Kinds of downstream application patterns this pack template is intended to support."
+    )
+    recommended_caller_apps: list[str] = Field(
+        description="Caller applications or app categories most immediately suitable for the pack."
+    )
+    checklist: list[CapabilityPackAdoptionChecklistItem] = Field(
+        description="Reusable pack-oriented onboarding checklist items."
+    )
+    approval_criteria: list[CapabilityPackAdoptionCriterion] = Field(
+        description="Reusable pack-oriented approval criteria."
+    )
+    lessons_learned: list[str] = Field(
+        description="Captured lessons for later downstream teams adopting this pack."
+    )
+    non_goals: list[str] = Field(
+        description="Explicit behaviors this pack-oriented adoption template does not authorize."
+    )
+    status_summary: list[str] = Field(
+        description="Human-readable summary of the current pack-oriented adoption posture."
+    )

--- a/src/app/contracts/platform.py
+++ b/src/app/contracts/platform.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from app.contracts.capability_packs import (
+    CapabilityPackCatalogGovernanceStatusResponse,
+    CapabilityPackCatalogResponse,
+)
 from app.contracts.access_control import (
     AccessControlGovernanceStatusResponse,
     AccessControlRuntimeStatusResponse,
@@ -107,6 +111,12 @@ class PlatformRuntimeStatusResponse(BaseModel):
     first_use_case: FirstUseCaseRuntimeStatusResponse = Field(
         description="Current first production-oriented downstream use-case contract posture."
     )
+    capability_pack_catalog: CapabilityPackCatalogResponse = Field(
+        description="Current app-facing capability-pack catalog layered above the generic task catalog."
+    )
+    capability_pack_governance: CapabilityPackCatalogGovernanceStatusResponse = Field(
+        description="Current catalog-level governance posture across app-facing capability packs."
+    )
     first_use_case_governance: FirstUseCaseGovernanceStatusResponse = Field(
         description="Current bounded rollout and governance posture for the first production use case."
     )
@@ -145,6 +155,9 @@ class PlatformRuntimeStatusResponse(BaseModel):
     )
     prompt_count: int = Field(description="Number of registered prompt definitions.")
     capability_count: int = Field(description="Number of bounded capabilities exposed by lotus-ai.")
+    capability_pack_count: int = Field(
+        description="Number of app-facing capability packs currently described by lotus-ai."
+    )
     vector_store: str = Field(description="Current or planned vector-store strategy label.")
     migration_contract_enforced: bool = Field(
         description="Whether lotus-ai requires migration-managed relational schema changes."

--- a/src/app/contracts/use_cases.py
+++ b/src/app/contracts/use_cases.py
@@ -156,6 +156,9 @@ class UseCaseOnboardingTemplateResponse(BaseModel):
     based_on_use_case_id: str = Field(
         description="Implemented or active use case used as the template baseline."
     )
+    based_on_capability_pack_id: str = Field(
+        description="Capability-pack identifier used as the product baseline for the onboarding template."
+    )
     downstream_pattern: str = Field(
         description="Short description of the downstream integration shape this template covers."
     )
@@ -184,6 +187,12 @@ class FirstUseCaseRuntimeStatusResponse(BaseModel):
     version: str = Field(description="Current lotus-ai service version.")
     use_case_id: str = Field(description="Stable identifier for the selected first use case.")
     downstream_app: str = Field(description="Named downstream integration owner for the use case.")
+    capability_pack_id: str = Field(
+        description="App-facing capability-pack identifier currently anchoring this use case."
+    )
+    capability_pack_family_id: str = Field(
+        description="Capability-pack family currently anchoring this use case."
+    )
     task_id: str = Field(description="Bounded lotus-ai task used by the first use case.")
     task_category: TaskCategory = Field(
         description="Task category used by the first production-oriented use case."

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -13,6 +13,7 @@ from app.routers.artifacts import router as artifacts_router
 from app.routers.async_runtime import router as async_runtime_router
 from app.routers.audit import router as audit_router
 from app.routers.capabilities import router as capabilities_router
+from app.routers.capability_packs import router as capability_packs_router
 from app.routers.evals import router as evals_router
 from app.routers.observability import router as observability_router
 from app.routers.platform import router as platform_router
@@ -56,6 +57,7 @@ app.include_router(observability_router)
 app.include_router(access_control_router)
 app.include_router(async_runtime_router)
 app.include_router(capabilities_router)
+app.include_router(capability_packs_router)
 app.include_router(evals_router)
 app.include_router(providers_router)
 app.include_router(prompts_router)
@@ -155,6 +157,7 @@ async def root() -> dict[str, object]:
             "async_runtime",
             "artifacts",
             "provider_catalog",
+            "capability_packs",
             "prompt_registry",
             "access_control",
             "retrieval",

--- a/src/app/routers/capability_packs.py
+++ b/src/app/routers/capability_packs.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from app.contracts.capability_packs import (
+    CapabilityPackActivationReadinessResponse,
+    CapabilityPackAdoptionTemplateResponse,
+    CapabilityPackCatalogGovernanceStatusResponse,
+    CapabilityPackCatalogResponse,
+    CapabilityPackDetailResponse,
+    CapabilityPackGovernanceStatusResponse,
+    CapabilityPackObservabilitySummaryResponse,
+    CapabilityPackRunbookReadinessResponse,
+)
+from app.services.capability_pack_catalog import (
+    build_capability_pack_catalog,
+    build_capability_pack_detail,
+)
+from app.services.capability_pack_activation_readiness import (
+    build_capability_pack_activation_readiness,
+)
+from app.services.capability_pack_adoption_template import (
+    build_capability_pack_adoption_template,
+)
+from app.services.capability_pack_governance import (
+    build_capability_pack_catalog_governance_status,
+    build_capability_pack_governance_status,
+)
+from app.services.capability_pack_observability import (
+    build_capability_pack_observability_summary,
+)
+from app.services.capability_pack_runbook_readiness import (
+    build_capability_pack_runbook_readiness,
+)
+
+router = APIRouter(tags=["platform"])
+
+
+@router.get(
+    "/platform/capability-packs",
+    response_model=CapabilityPackCatalogResponse,
+    operation_id="getCapabilityPackCatalog",
+    summary="Get lotus-ai capability-pack catalog",
+    description=(
+        "Returns the current app-facing capability-pack catalog exposed by lotus-ai. "
+        "This catalog is intentionally distinct from the generic task catalog and describes "
+        "product-layer capability shape, maturity, and governance surfaces."
+    ),
+    responses={
+        200: {"description": "Capability-pack catalog returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_catalog() -> CapabilityPackCatalogResponse:
+    return build_capability_pack_catalog()
+
+
+@router.get(
+    "/platform/capability-packs/governance-status",
+    response_model=CapabilityPackCatalogGovernanceStatusResponse,
+    operation_id="getCapabilityPackCatalogGovernanceStatus",
+    summary="Get lotus-ai capability-pack catalog governance status",
+    description=(
+        "Returns the catalog-level governance posture across all currently modeled capability packs."
+    ),
+    responses={
+        200: {"description": "Capability-pack catalog governance returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_catalog_governance_status_route() -> (
+    CapabilityPackCatalogGovernanceStatusResponse
+):
+    return build_capability_pack_catalog_governance_status()
+
+
+@router.get(
+    "/platform/capability-packs/{pack_id}",
+    response_model=CapabilityPackDetailResponse,
+    operation_id="getCapabilityPackDetail",
+    summary="Get lotus-ai capability-pack detail",
+    description=(
+        "Returns pack-specific quality expectations, unsupported-input posture, and product-layer "
+        "non-goals for one app-facing capability pack."
+    ),
+    responses={
+        200: {"description": "Capability-pack detail returned successfully."},
+        404: {"description": "Capability pack not found."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_detail(pack_id: str) -> CapabilityPackDetailResponse:
+    try:
+        return build_capability_pack_detail(pack_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get(
+    "/platform/capability-packs/{pack_id}/adoption-template",
+    response_model=CapabilityPackAdoptionTemplateResponse,
+    operation_id="getCapabilityPackAdoptionTemplate",
+    summary="Get lotus-ai capability-pack adoption template",
+    description=(
+        "Returns the pack-native downstream onboarding template for one app-facing capability pack."
+    ),
+    responses={
+        200: {"description": "Capability-pack adoption template returned successfully."},
+        404: {"description": "Capability pack not found."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_adoption_template(
+    pack_id: str,
+) -> CapabilityPackAdoptionTemplateResponse:
+    try:
+        return build_capability_pack_adoption_template(pack_id=pack_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get(
+    "/platform/capability-packs/{pack_id}/observability-summary",
+    response_model=CapabilityPackObservabilitySummaryResponse,
+    operation_id="getCapabilityPackObservabilitySummary",
+    summary="Get lotus-ai capability-pack observability summary",
+    description=(
+        "Returns the bounded audit, async, and support-review observability summary for one "
+        "app-facing capability pack."
+    ),
+    responses={
+        200: {"description": "Capability-pack observability summary returned successfully."},
+        404: {"description": "Capability pack not found."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_observability_summary(
+    pack_id: str,
+) -> CapabilityPackObservabilitySummaryResponse:
+    try:
+        return build_capability_pack_observability_summary(pack_id=pack_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get(
+    "/platform/capability-packs/{pack_id}/activation-readiness",
+    response_model=CapabilityPackActivationReadinessResponse,
+    operation_id="getCapabilityPackActivationReadiness",
+    summary="Get lotus-ai capability-pack activation readiness",
+    description=(
+        "Returns the bounded activation-readiness posture for one app-facing capability pack."
+    ),
+    responses={
+        200: {"description": "Capability-pack activation readiness returned successfully."},
+        404: {"description": "Capability pack not found."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_activation_readiness(
+    pack_id: str,
+) -> CapabilityPackActivationReadinessResponse:
+    try:
+        return build_capability_pack_activation_readiness(pack_id=pack_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get(
+    "/platform/capability-packs/{pack_id}/runbook-readiness",
+    response_model=CapabilityPackRunbookReadinessResponse,
+    operation_id="getCapabilityPackRunbookReadiness",
+    summary="Get lotus-ai capability-pack runbook readiness",
+    description=(
+        "Returns the bounded runbook-readiness posture for one app-facing capability pack."
+    ),
+    responses={
+        200: {"description": "Capability-pack runbook readiness returned successfully."},
+        404: {"description": "Capability pack not found."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_runbook_readiness(
+    pack_id: str,
+) -> CapabilityPackRunbookReadinessResponse:
+    try:
+        return build_capability_pack_runbook_readiness(pack_id=pack_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.get(
+    "/platform/capability-packs/{pack_id}/governance-status",
+    response_model=CapabilityPackGovernanceStatusResponse,
+    operation_id="getCapabilityPackGovernanceStatus",
+    summary="Get lotus-ai capability-pack governance status",
+    description=(
+        "Returns the composed activation, runbook, and observability governance posture for one "
+        "app-facing capability pack."
+    ),
+    responses={
+        200: {"description": "Capability-pack governance returned successfully."},
+        404: {"description": "Capability pack not found."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_capability_pack_governance_status(
+    pack_id: str,
+) -> CapabilityPackGovernanceStatusResponse:
+    try:
+        return build_capability_pack_governance_status(pack_id=pack_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/src/app/services/capability_pack_activation_readiness.py
+++ b/src/app/services/capability_pack_activation_readiness.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.capability_packs import (
+    CapabilityPackActivationReadinessItem,
+    CapabilityPackActivationReadinessResponse,
+    CapabilityPackDescriptor,
+)
+from app.services.capability_pack_catalog import get_capability_pack_by_id
+from app.services.capability_pack_observability import build_capability_pack_observability_summary
+from app.services.capability_pack_quality_gates import build_capability_pack_approval_gate
+
+
+def build_capability_pack_activation_readiness(
+    *, pack_id: str
+) -> CapabilityPackActivationReadinessResponse:
+    pack = _require_pack(pack_id=pack_id)
+    approval_gate = build_capability_pack_approval_gate(pack_id=pack_id)
+    observability = build_capability_pack_observability_summary(pack_id=pack_id)
+    items = [
+        CapabilityPackActivationReadinessItem(
+            item_id="runtime_quality_gate",
+            status="READY" if approval_gate.approval_ready else "BLOCKED",
+            required_for_activation=True,
+            notes=(
+                f"Pack quality gate currently reports '{approval_gate.evidence_state.value}' across the governed runtime-backed fixture families."
+            ),
+        ),
+        CapabilityPackActivationReadinessItem(
+            item_id="downstream_anchor",
+            status="READY" if pack.current_anchor_use_case_id is not None else "BLOCKED",
+            required_for_activation=True,
+            notes=(
+                f"Current downstream anchor is '{pack.current_anchor_use_case_id}'."
+                if pack.current_anchor_use_case_id is not None
+                else "The pack does not yet have an implemented downstream anchor use case."
+            ),
+        ),
+        CapabilityPackActivationReadinessItem(
+            item_id="observability_review_surface",
+            status="READY" if observability.observability_ready else "BLOCKED",
+            required_for_activation=True,
+            notes=(
+                "Bounded observability and support-review surfaces are available for this pack."
+                if observability.observability_ready
+                else "Bounded observability and support-review surfaces are not yet available for this pack."
+            ),
+        ),
+    ]
+    required_items = [item for item in items if item.required_for_activation]
+    completed_required_item_count = sum(1 for item in required_items if item.status == "READY")
+    activation_ready = completed_required_item_count == len(required_items)
+    return CapabilityPackActivationReadinessResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        pack_id=pack_id,
+        activation_ready=activation_ready,
+        required_item_count=len(required_items),
+        completed_required_item_count=completed_required_item_count,
+        items=items,
+        status_summary=[
+            (
+                "Capability-pack activation is ready because runtime quality, downstream anchor, and observability review surfaces are all present."
+                if activation_ready
+                else "Capability-pack activation remains blocked until runtime quality, downstream anchor, and observability review surfaces are all present."
+            )
+        ],
+    )
+
+
+def _require_pack(*, pack_id: str) -> CapabilityPackDescriptor:
+    pack = get_capability_pack_by_id(pack_id)
+    if pack is None:
+        raise ValueError(f"Unknown capability pack: {pack_id}")
+    return pack

--- a/src/app/services/capability_pack_adoption_template.py
+++ b/src/app/services/capability_pack_adoption_template.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.capability_packs import (
+    CapabilityPackAdoptionChecklistItem,
+    CapabilityPackAdoptionCriterion,
+    CapabilityPackAdoptionTemplateResponse,
+)
+from app.services.capability_pack_catalog import get_capability_pack_by_id
+
+
+def build_capability_pack_adoption_template(
+    pack_id: str,
+) -> CapabilityPackAdoptionTemplateResponse:
+    pack = get_capability_pack_by_id(pack_id)
+    if pack is None:
+        raise ValueError(f"Unknown capability pack: {pack_id}")
+
+    return CapabilityPackAdoptionTemplateResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        template_id=f"{pack_id}.adoption-template.v1",
+        pack_id=pack.pack_id,
+        current_reference_use_case_id=pack.current_anchor_use_case_id,
+        downstream_patterns=pack.intended_downstream_patterns,
+        recommended_caller_apps=_build_recommended_caller_apps(pack_id=pack_id),
+        checklist=_build_checklist(pack_id=pack_id),
+        approval_criteria=_build_approval_criteria(pack_id=pack_id),
+        lessons_learned=_build_lessons_learned(pack_id=pack_id),
+        non_goals=_build_non_goals(pack_id=pack_id),
+        status_summary=_build_status_summary(pack_id=pack_id),
+    )
+
+
+def _build_recommended_caller_apps(pack_id: str) -> list[str]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            "lotus-performance",
+            "lotus-risk",
+            "lotus-advise",
+        ]
+    return [
+        "lotus-manage",
+        "lotus-advise",
+        "lotus-risk",
+    ]
+
+
+def _build_checklist(pack_id: str) -> list[CapabilityPackAdoptionChecklistItem]:
+    shared_items = [
+        CapabilityPackAdoptionChecklistItem(
+            checklist_id="pack_contract_adopted",
+            phase="contract",
+            required=True,
+            notes="Adopt the named capability pack contract instead of treating the downstream flow as a raw explain.v1 wrapper.",
+        ),
+        CapabilityPackAdoptionChecklistItem(
+            checklist_id="caller_policy_registered",
+            phase="identity",
+            required=True,
+            notes="Register the caller app with the minimum task, provider, and retrieval posture needed for the pack.",
+        ),
+        CapabilityPackAdoptionChecklistItem(
+            checklist_id="pack_eval_family_passing",
+            phase="evaluation",
+            required=True,
+            notes="Require the pack-specific runtime-backed evaluation family to reach a passing approval-gate posture before rollout.",
+        ),
+        CapabilityPackAdoptionChecklistItem(
+            checklist_id="governance_surfaces_reviewed",
+            phase="operations",
+            required=True,
+            notes="Review pack activation, observability, runbook, and governance surfaces instead of inferring readiness from generic platform status alone.",
+        ),
+        CapabilityPackAdoptionChecklistItem(
+            checklist_id="unsupported_input_behavior_confirmed",
+            phase="scope",
+            required=True,
+            notes="Confirm the downstream app can surface refusal, degraded, or incomplete-input outcomes without silently inventing missing facts.",
+        ),
+    ]
+    if pack_id == "analytics_commentary.pack.v1":
+        return shared_items + [
+            CapabilityPackAdoptionChecklistItem(
+                checklist_id="downstream_rendering_owned",
+                phase="product",
+                required=True,
+                notes="Keep metric computation, materiality thresholds, and final rendering owned by the downstream analytics application.",
+            )
+        ]
+    return shared_items + [
+        CapabilityPackAdoptionChecklistItem(
+            checklist_id="deterministic_decision_owner_defined",
+            phase="product",
+            required=True,
+            notes="Document the deterministic downstream system that owns blocker truth, approval logic, and final operator action.",
+        )
+    ]
+
+
+def _build_approval_criteria(pack_id: str) -> list[CapabilityPackAdoptionCriterion]:
+    base_route = f"/platform/capability-packs/{pack_id}"
+    criteria = [
+        CapabilityPackAdoptionCriterion(
+            criterion_id="pack_contract_boundary",
+            criterion_name="Pack contract boundary stays bounded",
+            evaluation_surface=base_route,
+            pass_condition="The pack remains explanation-only, grounded in bounded structured inputs, and does not expand into domain-authoritative decisions.",
+        ),
+        CapabilityPackAdoptionCriterion(
+            criterion_id="pack_activation_readiness",
+            criterion_name="Activation posture is ready",
+            evaluation_surface=f"{base_route}/activation-readiness",
+            pass_condition="The pack activation surface reports all required items complete with no blocking activation dependencies.",
+        ),
+        CapabilityPackAdoptionCriterion(
+            criterion_id="pack_runbook_readiness",
+            criterion_name="Runbook posture is ready",
+            evaluation_surface=f"{base_route}/runbook-readiness",
+            pass_condition="The pack runbook surface reports downstream ownership, support handling, and rollback posture ready for the intended adoption path.",
+        ),
+        CapabilityPackAdoptionCriterion(
+            criterion_id="pack_governance_ready",
+            criterion_name="Pack governance is rollout-ready",
+            evaluation_surface=f"{base_route}/governance-status",
+            pass_condition="The composed governance surface reports no blocking areas for the intended pack adoption path.",
+        ),
+    ]
+    if pack_id == "analytics_commentary.pack.v1":
+        criteria.append(
+            CapabilityPackAdoptionCriterion(
+                criterion_id="reference_use_case_truth",
+                criterion_name="Reference use case remains truthful",
+                evaluation_surface="/platform/use-cases/first-production-use-case/governance-status",
+                pass_condition="The current lotus-performance reference path remains limited-rollout ready so downstream teams are reusing a live reference rather than a paper design.",
+            )
+        )
+    return criteria
+
+
+def _build_lessons_learned(pack_id: str) -> list[str]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            "The strongest commentary integrations reuse a named pack and keep deterministic analytics computation outside lotus-ai.",
+            "Pack adoption is easier to support when quality gates, observability, and runbook review are inspected from pack-native surfaces instead of reconstructed from lower-level platform components.",
+            "Commentary becomes reusable across apps only when unsupported-input posture is explicit rather than hidden in downstream presentation code.",
+        ]
+    return [
+        "Decision-explanation reuse depends on keeping deterministic blocker truth outside lotus-ai and making that ownership explicit to operators.",
+        "A named pack gives downstream teams a clearer adoption boundary than ad hoc explain.v1 wrapping, but rollout should stay blocked until there is a concrete anchored use case.",
+        "Pack-oriented onboarding should defer broader drafting or recommendation behavior until the bounded explanation family is proven in production-shaped usage.",
+    ]
+
+
+def _build_non_goals(pack_id: str) -> list[str]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            "Treating the pack template as approval for free-form narrative generation over unbounded analytics payloads.",
+            "Letting lotus-ai recompute analytics, attribution, or recommendation logic during pack adoption.",
+            "Skipping pack governance review just because the underlying explain.v1 task is already available.",
+        ]
+    return [
+        "Authorizing a decision-explanation rollout without a concrete downstream owner for deterministic blocker truth.",
+        "Treating the pack template as approval for advice, action recommendation, or hidden-rule inference.",
+        "Bypassing pack-specific evaluation and governance surfaces by relying on generic task availability.",
+    ]
+
+
+def _build_status_summary(pack_id: str) -> list[str]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            "Capability-pack adoption is now the preferred downstream onboarding path for commentary-style product integrations.",
+            "The analytics commentary pack template is anchored to the implemented lotus-performance path so later teams start from a reusable product capability rather than a one-off use case.",
+        ]
+    return [
+        "Decision-explanation adoption is now modeled as a pack-native onboarding path rather than a future ad hoc task wrapper.",
+        "This template remains intentionally conservative because the pack still lacks a concrete implemented downstream anchor and should not be treated as rollout approval by itself.",
+    ]

--- a/src/app/services/capability_pack_catalog.py
+++ b/src/app/services/capability_pack_catalog.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.capability_packs import (
+    CapabilityPackCatalogResponse,
+    CapabilityPackDescriptor,
+    CapabilityPackDetailResponse,
+    CapabilityPackFamilyKind,
+    CapabilityPackMaturityStage,
+    CapabilityPackQualityExpectation,
+    CapabilityPackUnsupportedInputBehavior,
+)
+from app.contracts.tasks import OutputLabel
+from app.services.capability_pack_quality_gates import build_capability_pack_approval_gate
+
+
+def build_capability_pack_catalog() -> CapabilityPackCatalogResponse:
+    packs = _build_capability_packs()
+    reusable_pack_count = sum(1 for pack in packs if pack.reusable_across_apps)
+    approved_pack_count = sum(
+        1 for pack in packs if pack.maturity_stage == CapabilityPackMaturityStage.APPROVED
+    )
+    return CapabilityPackCatalogResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        phase=settings.delivery_phase,
+        pack_count=len(packs),
+        reusable_pack_count=reusable_pack_count,
+        approved_pack_count=approved_pack_count,
+        packs=packs,
+        status_summary=[
+            "Capability packs are now modeled as a separate app-facing product layer above the generic task catalog.",
+            "The initial Slice 2 family now includes both commentary and explanation-oriented packs built on the existing explain.v1 runtime backbone.",
+            "Slice 3 quality gates now reuse the governed evaluation runtime so pack quality evidence follows the same runtime-backed approval semantics as other rollout domains.",
+            "Reusable and approved pack counts remain separate so downstream teams can distinguish broader product capability shape from currently rollout-ready runtime evidence.",
+        ],
+    )
+
+
+def build_capability_pack_detail(pack_id: str) -> CapabilityPackDetailResponse:
+    pack = get_capability_pack_by_id(pack_id)
+    if pack is None:
+        raise ValueError(f"Unknown capability pack: {pack_id}")
+
+    return CapabilityPackDetailResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        pack=pack,
+        quality_expectations=_build_quality_expectations(pack_id=pack_id),
+        unsupported_input_behaviors=_build_unsupported_input_behaviors(pack_id=pack_id),
+        approval_gate=build_capability_pack_approval_gate(pack_id=pack_id),
+        non_goals=_build_non_goals(pack_id=pack_id),
+        status_summary=_build_detail_status_summary(pack_id=pack_id),
+    )
+
+
+def get_capability_pack_by_id(pack_id: str) -> CapabilityPackDescriptor | None:
+    for pack in _build_capability_packs():
+        if pack.pack_id == pack_id:
+            return pack
+    return None
+
+
+def _build_capability_packs() -> list[CapabilityPackDescriptor]:
+    return [
+        _build_pack_descriptor(
+            pack_id="analytics_commentary.pack.v1",
+            family_id="analytics_commentary",
+            family_kind=CapabilityPackFamilyKind.COMMENTARY,
+            maturity_stage=CapabilityPackMaturityStage.REUSABLE,
+            primary_task_id="explain.v1",
+            output_label=OutputLabel.EXPLANATION_ONLY,
+            current_anchor_use_case_id="lotus_performance.analytics_commentary.v1",
+            reusable_across_apps=True,
+            intended_downstream_patterns=[
+                "Performance and attribution commentary over caller-supplied structured analytics facts.",
+                "Risk or support commentary over precomputed structured deltas where the downstream app remains the owner of computed truth.",
+            ],
+            governance_surface_ids=[
+                "/platform/capability-packs",
+                "/platform/capability-packs/analytics_commentary.pack.v1",
+                "/platform/capability-packs/analytics_commentary.pack.v1/adoption-template",
+                "/platform/capability-packs/analytics_commentary.pack.v1/activation-readiness",
+                "/platform/capability-packs/analytics_commentary.pack.v1/runbook-readiness",
+                "/platform/capability-packs/analytics_commentary.pack.v1/observability-summary",
+                "/platform/capability-packs/analytics_commentary.pack.v1/governance-status",
+                "/platform/evals/runtime-status",
+                "/platform/use-cases/first-production-use-case",
+                "/platform/use-cases/first-production-use-case/readiness",
+                "/platform/use-cases/first-production-use-case/governance-status",
+            ],
+            status_summary=[
+                "The first commentary pack is anchored to the implemented lotus-performance analytics commentary path.",
+                "The pack is now modeled as reusable because downstream onboarding, pack-native adoption templates, and a broader commentary-family contract now exist above the one-off use-case seam.",
+                "This pack catalog is intentionally distinct from the generic task catalog so product-facing capability shape does not get conflated with raw task primitives.",
+            ],
+        ),
+        _build_pack_descriptor(
+            pack_id="decision_explanation.pack.v1",
+            family_id="decision_explanation",
+            family_kind=CapabilityPackFamilyKind.EXPLANATION,
+            maturity_stage=CapabilityPackMaturityStage.EXPERIMENTAL,
+            primary_task_id="explain.v1",
+            output_label=OutputLabel.EXPLANATION_ONLY,
+            current_anchor_use_case_id=None,
+            reusable_across_apps=False,
+            intended_downstream_patterns=[
+                "Decision blocker explanations where the downstream app owns deterministic status and policy truth.",
+                "Workflow or governance explanations that transform bounded structured findings into operator-facing rationale.",
+            ],
+            governance_surface_ids=[
+                "/platform/capability-packs",
+                "/platform/capability-packs/decision_explanation.pack.v1",
+                "/platform/capability-packs/decision_explanation.pack.v1/adoption-template",
+                "/platform/capability-packs/decision_explanation.pack.v1/activation-readiness",
+                "/platform/capability-packs/decision_explanation.pack.v1/runbook-readiness",
+                "/platform/capability-packs/decision_explanation.pack.v1/observability-summary",
+                "/platform/capability-packs/decision_explanation.pack.v1/governance-status",
+                "/platform/evals/runtime-status",
+                "/platform/use-cases/onboarding-template",
+            ],
+            status_summary=[
+                "The decision-explanation pack family is now modeled explicitly instead of leaving blocker-explanation use cases as future ad hoc wrappers around explain.v1.",
+                "The pack remains experimental because it does not yet have an implemented anchor use case and broader pack-specific runtime evidence.",
+                "Modeling the pack now keeps commentary and explanation product families visible without claiming broader rollout maturity prematurely.",
+            ],
+        ),
+    ]
+
+
+def _build_pack_descriptor(
+    *,
+    pack_id: str,
+    family_id: str,
+    family_kind: CapabilityPackFamilyKind,
+    maturity_stage: CapabilityPackMaturityStage,
+    primary_task_id: str,
+    output_label: OutputLabel,
+    current_anchor_use_case_id: str | None,
+    reusable_across_apps: bool,
+    intended_downstream_patterns: list[str],
+    governance_surface_ids: list[str],
+    status_summary: list[str],
+) -> CapabilityPackDescriptor:
+    approval_gate = build_capability_pack_approval_gate(pack_id=pack_id)
+    return CapabilityPackDescriptor(
+        pack_id=pack_id,
+        family_id=family_id,
+        family_kind=family_kind,
+        maturity_stage=maturity_stage,
+        primary_task_id=primary_task_id,
+        output_label=output_label,
+        current_anchor_use_case_id=current_anchor_use_case_id,
+        reusable_across_apps=reusable_across_apps,
+        intended_downstream_patterns=intended_downstream_patterns,
+        governance_surface_ids=governance_surface_ids,
+        adoption_template_endpoint=f"/platform/capability-packs/{pack_id}/adoption-template",
+        quality_gate_domain_id=approval_gate.domain_id,
+        quality_gate_ready=approval_gate.approval_ready,
+        quality_evidence_state=approval_gate.evidence_state,
+        status_summary=status_summary,
+    )
+
+
+def _build_quality_expectations(pack_id: str) -> list[CapabilityPackQualityExpectation]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            CapabilityPackQualityExpectation(
+                expectation_id="grounded_to_caller_facts",
+                description="Commentary must remain grounded in caller-supplied structured analytics facts and must not recompute or invent portfolio metrics.",
+            ),
+            CapabilityPackQualityExpectation(
+                expectation_id="materiality_focused",
+                description="Commentary should prioritize materially important findings instead of narrating every input field uniformly.",
+            ),
+            CapabilityPackQualityExpectation(
+                expectation_id="explanation_only",
+                description="Output must remain explanation-oriented and must not cross into advice, recommendation, or domain-authoritative decision language.",
+            ),
+        ]
+    return [
+        CapabilityPackQualityExpectation(
+            expectation_id="grounded_to_deterministic_state",
+            description="Explanations must remain grounded in caller-supplied deterministic workflow or governance state and must not infer hidden reasons.",
+        ),
+        CapabilityPackQualityExpectation(
+            expectation_id="explicit_blocker_reasoning",
+            description="Output should explain the bounded blocker or decision rationale clearly rather than summarizing unrelated context.",
+        ),
+        CapabilityPackQualityExpectation(
+            expectation_id="supportable_language",
+            description="Explanation wording should be supportable by operators and auditable against the structured input state.",
+        ),
+    ]
+
+
+def _build_unsupported_input_behaviors(
+    pack_id: str,
+) -> list[CapabilityPackUnsupportedInputBehavior]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            CapabilityPackUnsupportedInputBehavior(
+                behavior_id="missing_metric_deltas",
+                description="If structured metric deltas are missing, the pack should refuse or degrade rather than invent missing analytics context.",
+            ),
+            CapabilityPackUnsupportedInputBehavior(
+                behavior_id="unbounded_free_form_payload",
+                description="If the caller sends an unbounded free-form analytics dump, the pack should reject the request as outside the bounded product contract.",
+            ),
+        ]
+    return [
+        CapabilityPackUnsupportedInputBehavior(
+            behavior_id="missing_decision_state",
+            description="If deterministic decision or blocker state is missing, the pack should refuse rather than infer hidden approval logic.",
+        ),
+        CapabilityPackUnsupportedInputBehavior(
+            behavior_id="mixed_authoritative_sources",
+            description="If conflicting authoritative states are supplied, the pack should degrade or refuse rather than choose between them silently.",
+        ),
+    ]
+
+
+def _build_non_goals(pack_id: str) -> list[str]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            "Recomputing analytics or attribution inside lotus-ai.",
+            "Generating investment advice or portfolio actions.",
+            "Accepting generic free-form performance storytelling as equivalent to structured commentary inputs.",
+        ]
+    return [
+        "Overriding deterministic downstream decision logic.",
+        "Inventing unstructured rationale for hidden blocker causes.",
+        "Acting as a general-purpose workflow chatbot.",
+    ]
+
+
+def _build_detail_status_summary(pack_id: str) -> list[str]:
+    if pack_id == "analytics_commentary.pack.v1":
+        return [
+            "The analytics commentary pack now cleanly absorbs the existing lotus-performance first-use-case path into a broader reusable product family.",
+            "Pack maturity is now modeled separately from rollout readiness, so runtime quality-gate and governance surfaces still determine whether this reusable pack is currently safe to activate more broadly.",
+        ]
+    return [
+        "The decision-explanation pack family is now modeled explicitly so future blocker and rationale use cases can onboard against a named product capability instead of a raw task wrapper.",
+        "The pack remains experimental until a concrete downstream anchor and broader reuse posture exist, even though dedicated pack-level evaluation evidence now exists.",
+    ]

--- a/src/app/services/capability_pack_governance.py
+++ b/src/app/services/capability_pack_governance.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.capability_packs import (
+    CapabilityPackCatalogGovernanceStatusResponse,
+    CapabilityPackGovernanceStatusResponse,
+    CapabilityPackGovernanceSummaryItem,
+)
+from app.services.capability_pack_activation_readiness import (
+    build_capability_pack_activation_readiness,
+)
+from app.services.capability_pack_catalog import build_capability_pack_catalog
+from app.services.capability_pack_observability import build_capability_pack_observability_summary
+from app.services.capability_pack_quality_gates import build_capability_pack_approval_gate
+from app.services.capability_pack_runbook_readiness import build_capability_pack_runbook_readiness
+from app.services.governance_readiness import summarize_governance_flags
+
+
+def build_capability_pack_governance_status(
+    *, pack_id: str
+) -> CapabilityPackGovernanceStatusResponse:
+    activation_readiness = build_capability_pack_activation_readiness(pack_id=pack_id)
+    runbook_readiness = build_capability_pack_runbook_readiness(pack_id=pack_id)
+    observability = build_capability_pack_observability_summary(pack_id=pack_id)
+    governance_ready, blocking_area_count = summarize_governance_flags(
+        activation_readiness.activation_ready,
+        runbook_readiness.runbook_ready,
+        observability.observability_ready,
+    )
+    return CapabilityPackGovernanceStatusResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        pack_id=pack_id,
+        governance_ready=governance_ready,
+        activation_readiness=activation_readiness,
+        runbook_readiness=runbook_readiness,
+        observability=observability,
+        blocking_area_count=blocking_area_count,
+        governance_summary=[
+            (
+                "Capability-pack governance is ready because activation, runbook, and observability surfaces are all currently ready."
+                if governance_ready
+                else "Capability-pack governance remains blocked until activation, runbook, and observability surfaces are all currently ready."
+            ),
+            (
+                f"Runtime quality evidence currently reports '{build_capability_pack_approval_gate(pack_id=pack_id).evidence_state.value}'."
+            ),
+            (
+                "Rollback and support expectations are anchored to the existing first-use-case path."
+                if pack_id == "analytics_commentary.pack.v1"
+                else "Rollback and support expectations remain blocked until a concrete downstream owner is documented."
+            ),
+        ],
+    )
+
+
+def build_capability_pack_catalog_governance_status() -> (
+    CapabilityPackCatalogGovernanceStatusResponse
+):
+    catalog = build_capability_pack_catalog()
+    pack_statuses = [
+        build_capability_pack_governance_status(pack_id=pack.pack_id) for pack in catalog.packs
+    ]
+    ready_pack_count = sum(1 for status in pack_statuses if status.governance_ready)
+    blocking_pack_count = len(pack_statuses) - ready_pack_count
+    return CapabilityPackCatalogGovernanceStatusResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governance_ready=blocking_pack_count == 0,
+        ready_pack_count=ready_pack_count,
+        blocking_pack_count=blocking_pack_count,
+        pack_summaries=[
+            CapabilityPackGovernanceSummaryItem(
+                pack_id=status.pack_id,
+                governance_ready=status.governance_ready,
+                blocking_area_count=status.blocking_area_count,
+                quality_evidence_state=build_capability_pack_approval_gate(
+                    pack_id=status.pack_id
+                ).evidence_state,
+            )
+            for status in pack_statuses
+        ],
+        status_summary=[
+            "Capability-pack governance now composes activation, runbook, and observability posture per pack instead of leaving product readiness implicit.",
+            (
+                "All currently modeled capability packs satisfy bounded governance posture."
+                if blocking_pack_count == 0
+                else f"{blocking_pack_count} currently modeled capability pack(s) remain blocked in governance review."
+            ),
+        ],
+    )

--- a/src/app/services/capability_pack_observability.py
+++ b/src/app/services/capability_pack_observability.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.async_runtime import AsyncJobArtifactDescriptor
+from app.contracts.audit import AuditRecordResponse
+from app.contracts.capability_packs import CapabilityPackObservabilitySummaryResponse
+from app.services.async_job_service import build_async_job_catalog
+from app.services.audit_store import get_audit_store
+from app.services.capability_pack_catalog import get_capability_pack_by_id
+from app.services.runtime_readiness import get_audit_store_runtime_status
+
+
+def build_capability_pack_observability_summary(
+    *, pack_id: str
+) -> CapabilityPackObservabilitySummaryResponse:
+    _require_pack(pack_id=pack_id)
+    records = [
+        record
+        for record in get_audit_store().list(limit=100)
+        if _matches_pack_record(record, pack_id)
+    ]
+    jobs = [job for job in build_async_job_catalog().jobs if _matches_pack_job(job, pack_id)]
+    audit_store_ready = get_audit_store_runtime_status().status in {"READY", "DEGRADED"}
+    observed_callers = sorted(
+        {record.caller_app for record in records} | {job.caller_app for job in jobs}
+    )
+    incident_signal_count = sum(
+        1
+        for record in records
+        if not record.authorization.allowed
+        or record.safety_outcome.disposition.value != "DOCUMENTED_ONLY"
+        or record.provider_mode not in {"disabled", "stub", "catalog_only"}
+    )
+    linked_endpoints = _build_linked_endpoints(pack_id=pack_id)
+    observability_ready = audit_store_ready and len(linked_endpoints) > 0
+    return CapabilityPackObservabilitySummaryResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        pack_id=pack_id,
+        observability_ready=observability_ready,
+        sampled_audit_record_count=len(records),
+        sampled_async_job_count=len(jobs),
+        incident_signal_count=incident_signal_count,
+        observed_caller_apps=observed_callers,
+        linked_endpoints=linked_endpoints,
+        status_summary=_build_status_summary(
+            pack_id=pack_id,
+            observability_ready=observability_ready,
+            audit_record_count=len(records),
+            async_job_count=len(jobs),
+            incident_signal_count=incident_signal_count,
+        ),
+    )
+
+
+def _matches_pack_record(record: AuditRecordResponse, pack_id: str) -> bool:
+    if pack_id == "analytics_commentary.pack.v1":
+        return record.task_id == "explain.v1" and record.caller_app == "lotus-performance"
+    if pack_id == "decision_explanation.pack.v1":
+        return record.task_id == "explain.v1" and record.caller_app == "lotus-manage"
+    return False
+
+
+def _matches_pack_job(job: AsyncJobArtifactDescriptor, pack_id: str) -> bool:
+    if pack_id == "analytics_commentary.pack.v1":
+        return job.caller_app == "lotus-performance"
+    if pack_id == "decision_explanation.pack.v1":
+        return job.caller_app == "lotus-manage"
+    return False
+
+
+def _build_linked_endpoints(*, pack_id: str) -> list[str]:
+    endpoints = [
+        f"/platform/capability-packs/{pack_id}",
+        f"/platform/capability-packs/{pack_id}/governance-status",
+        "/platform/observability/breakdowns",
+        "/platform/evals/runtime-status",
+    ]
+    if pack_id == "analytics_commentary.pack.v1":
+        endpoints.extend(
+            [
+                "/platform/use-cases/first-production-use-case",
+                "/platform/use-cases/first-production-use-case/governance-status",
+            ]
+        )
+    return endpoints
+
+
+def _build_status_summary(
+    *,
+    pack_id: str,
+    observability_ready: bool,
+    audit_record_count: int,
+    async_job_count: int,
+    incident_signal_count: int,
+) -> list[str]:
+    family_label = (
+        "analytics commentary"
+        if pack_id == "analytics_commentary.pack.v1"
+        else "decision explanation"
+    )
+    return [
+        f"{family_label.capitalize()} pack observability reuses bounded audit and async job samples rather than introducing a separate product telemetry store.",
+        (
+            f"Recent bounded samples currently include {audit_record_count} audit record(s), {async_job_count} async job(s), and {incident_signal_count} incident signal(s)."
+            if observability_ready
+            else "Pack observability is blocked because the supporting audit surface is not currently reviewable."
+        ),
+    ]
+
+
+def _require_pack(*, pack_id: str) -> None:
+    if get_capability_pack_by_id(pack_id) is None:
+        raise ValueError(f"Unknown capability pack: {pack_id}")

--- a/src/app/services/capability_pack_quality_gates.py
+++ b/src/app/services/capability_pack_quality_gates.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
+from app.services.eval_approval_gate_summary import (
+    build_analytics_commentary_pack_approval_gate_summary,
+    build_decision_explanation_pack_approval_gate_summary,
+)
+
+
+def build_capability_pack_approval_gate(*, pack_id: str) -> EvaluationApprovalGateSummaryDescriptor:
+    if pack_id == "analytics_commentary.pack.v1":
+        return build_analytics_commentary_pack_approval_gate_summary()
+    if pack_id == "decision_explanation.pack.v1":
+        return build_decision_explanation_pack_approval_gate_summary()
+    raise ValueError(f"Unknown capability pack: {pack_id}")

--- a/src/app/services/capability_pack_runbook_readiness.py
+++ b/src/app/services/capability_pack_runbook_readiness.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.capability_packs import (
+    CapabilityPackDescriptor,
+    CapabilityPackRunbookReadinessItem,
+    CapabilityPackRunbookReadinessResponse,
+)
+from app.services.capability_pack_catalog import get_capability_pack_by_id
+from app.services.first_use_case_runbook_readiness import build_first_use_case_runbook_readiness
+from app.services.use_case_onboarding_template import build_use_case_onboarding_template
+
+
+def build_capability_pack_runbook_readiness(
+    *, pack_id: str
+) -> CapabilityPackRunbookReadinessResponse:
+    _require_pack(pack_id=pack_id)
+    if pack_id == "analytics_commentary.pack.v1":
+        first_use_case_runbook = build_first_use_case_runbook_readiness()
+        template = build_use_case_onboarding_template()
+        items = [
+            CapabilityPackRunbookReadinessItem(
+                item_id="shared_support_path",
+                status="READY" if first_use_case_runbook.runbook_ready else "BLOCKED",
+                required_for_activation=True,
+                notes=(
+                    "The analytics commentary pack currently reuses the bounded first-use-case support, rollback, and escalation path."
+                ),
+            ),
+            CapabilityPackRunbookReadinessItem(
+                item_id="reusable_onboarding_template",
+                status="READY" if len(template.checklist) > 0 else "BLOCKED",
+                required_for_activation=True,
+                notes="The reusable downstream onboarding template captures pack-oriented checklist and approval criteria.",
+            ),
+            CapabilityPackRunbookReadinessItem(
+                item_id="downstream_owner_documented",
+                status="READY",
+                required_for_activation=True,
+                notes="The current downstream owner remains lotus-performance through the first production use case.",
+            ),
+        ]
+    else:
+        items = [
+            CapabilityPackRunbookReadinessItem(
+                item_id="shared_support_path",
+                status="BLOCKED",
+                required_for_activation=True,
+                notes="The decision explanation pack does not yet have a concrete downstream support and rollback path.",
+            ),
+            CapabilityPackRunbookReadinessItem(
+                item_id="reusable_onboarding_template",
+                status="READY",
+                required_for_activation=True,
+                notes="The reusable onboarding template exists, but it is not yet anchored to a concrete decision-explanation integration.",
+            ),
+            CapabilityPackRunbookReadinessItem(
+                item_id="downstream_owner_documented",
+                status="BLOCKED",
+                required_for_activation=True,
+                notes="No concrete downstream owner or operator path has been documented for this pack yet.",
+            ),
+        ]
+    required_items = [item for item in items if item.required_for_activation]
+    completed_required_item_count = sum(1 for item in required_items if item.status == "READY")
+    runbook_ready = completed_required_item_count == len(required_items)
+    return CapabilityPackRunbookReadinessResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        pack_id=pack_id,
+        runbook_ready=runbook_ready,
+        required_item_count=len(required_items),
+        completed_required_item_count=completed_required_item_count,
+        items=items,
+        status_summary=[
+            (
+                "Capability-pack runbook posture is ready for the current bounded pack."
+                if runbook_ready
+                else "Capability-pack runbook posture is not yet ready for the current bounded pack."
+            )
+        ],
+    )
+
+
+def _require_pack(*, pack_id: str) -> CapabilityPackDescriptor:
+    pack = get_capability_pack_by_id(pack_id)
+    if pack is None:
+        raise ValueError(f"Unknown capability pack: {pack_id}")
+    return pack

--- a/src/app/services/eval_approval_gate_summary.py
+++ b/src/app/services/eval_approval_gate_summary.py
@@ -37,6 +37,8 @@ _PROMPT_APPROVAL_FIXTURE_IDS = (
     "prompt_rollback_examples",
 )
 _FIRST_USE_CASE_APPROVAL_FIXTURE_IDS = ("lotus_performance_first_use_case_examples",)
+_ANALYTICS_COMMENTARY_PACK_APPROVAL_FIXTURE_IDS = ("capability_pack_analytics_commentary_examples",)
+_DECISION_EXPLANATION_PACK_APPROVAL_FIXTURE_IDS = ("capability_pack_decision_explanation_examples",)
 
 
 @dataclass(frozen=True)
@@ -84,6 +86,39 @@ def build_first_use_case_approval_gate_summary() -> EvaluationApprovalGateSummar
         domain_id="first_use_case_onboarding",
         domain_label="First Use-Case Onboarding",
         required_fixture_ids=_FIRST_USE_CASE_APPROVAL_FIXTURE_IDS,
+    )
+
+
+def build_analytics_commentary_pack_approval_gate_summary() -> (
+    EvaluationApprovalGateSummaryDescriptor
+):
+    return _build_approval_gate_summary(
+        domain_id="analytics_commentary_pack",
+        domain_label="Analytics Commentary Pack",
+        required_fixture_ids=_ANALYTICS_COMMENTARY_PACK_APPROVAL_FIXTURE_IDS,
+    )
+
+
+def build_decision_explanation_pack_approval_gate_summary() -> (
+    EvaluationApprovalGateSummaryDescriptor
+):
+    return _build_approval_gate_summary(
+        domain_id="decision_explanation_pack",
+        domain_label="Decision Explanation Pack",
+        required_fixture_ids=_DECISION_EXPLANATION_PACK_APPROVAL_FIXTURE_IDS,
+    )
+
+
+def build_named_approval_gate_summary(
+    *,
+    domain_id: str,
+    domain_label: str,
+    required_fixture_ids: tuple[str, ...],
+) -> EvaluationApprovalGateSummaryDescriptor:
+    return _build_approval_gate_summary(
+        domain_id=domain_id,
+        domain_label=domain_label,
+        required_fixture_ids=required_fixture_ids,
     )
 
 

--- a/src/app/services/eval_run_submission_service.py
+++ b/src/app/services/eval_run_submission_service.py
@@ -39,6 +39,8 @@ from app.services.async_submission_shared import publish_async_attempt_if_config
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 
 RUNTIME_BACKED_EVALUATION_FIXTURE_IDS = {
+    "capability_pack_analytics_commentary_examples",
+    "capability_pack_decision_explanation_examples",
     "lotus_performance_first_use_case_examples",
     "prompt_promotion_examples",
     "prompt_rollback_examples",

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -411,6 +411,38 @@ def _execute_fixture_case(
             ["service://platform/prompts/control-actions", "service://ai/tasks/execute"],
         )
 
+    if fixture_id == "capability_pack_analytics_commentary_examples":
+        return _evaluate_capability_pack_case(
+            fixture_task_id=fixture_task_id,
+            pack_id="analytics_commentary.pack.v1",
+            failure_label="Analytics commentary pack evaluation",
+            pass_summary=(
+                "Analytics commentary pack execution preserved bounded explanation-only output, "
+                "caller authorization, and product-quality guardrails."
+            ),
+            fail_summary=(
+                "Analytics commentary pack execution did not preserve the expected authorization "
+                "or product-quality guardrails."
+            ),
+            case=case,
+        )
+
+    if fixture_id == "capability_pack_decision_explanation_examples":
+        return _evaluate_capability_pack_case(
+            fixture_task_id=fixture_task_id,
+            pack_id="decision_explanation.pack.v1",
+            failure_label="Decision explanation pack evaluation",
+            pass_summary=(
+                "Decision explanation pack execution preserved bounded explanation-only output, "
+                "caller authorization, and deterministic explanation guardrails."
+            ),
+            fail_summary=(
+                "Decision explanation pack execution did not preserve the expected authorization "
+                "or deterministic explanation guardrails."
+            ),
+            case=case,
+        )
+
     if fixture_id == "lotus_performance_first_use_case_examples":
         task_id = str(case.input_payload.get("task_id", fixture_task_id))
         response, failure_category = _execute_task_case(task_id=task_id, case=case)
@@ -727,6 +759,48 @@ def _execute_fixture_case(
         f"Fixture family '{fixture_id}' does not yet have runtime-backed execution semantics.",
         EvaluationCaseOutcome.FAIL,
         [f"fixture://{fixture_id}"],
+    )
+
+
+def _evaluate_capability_pack_case(
+    *,
+    fixture_task_id: str,
+    pack_id: str,
+    failure_label: str,
+    pass_summary: str,
+    fail_summary: str,
+    case: EvaluationFixtureRuntimeCase,
+) -> tuple[str, EvaluationCaseOutcome, list[str]]:
+    task_id = str(case.input_payload.get("task_id", fixture_task_id))
+    response, failure_category = _execute_task_case(task_id=task_id, case=case)
+    if response is None:
+        return (
+            f"{failure_label} failed unexpectedly with '{failure_category}'.",
+            EvaluationCaseOutcome.FAIL,
+            [
+                f"service://platform/capability-packs/{pack_id}",
+                "service://ai/tasks/execute",
+            ],
+        )
+    caller_visible_in_payload = "caller_app" in response.result.structured_output
+    checks = [
+        response.output_label.value == case.expected_payload["output_label"],
+        response.audit.authorization.outcome.value
+        == case.expected_payload["authorization_outcome"],
+        response.audit.authorization.caller_app == case.expected_payload["caller_app"],
+        response.audit.authorization.task_id == case.expected_payload["task_id"],
+        response.audit.safety.disposition.value == case.expected_payload["safety_disposition"],
+        caller_visible_in_payload == case.expected_payload["caller_visible_in_payload"],
+        response.audit.stubbed is bool(case.expected_payload["stubbed"]),
+    ]
+    outcome = EvaluationCaseOutcome.PASS if all(checks) else EvaluationCaseOutcome.FAIL
+    return (
+        pass_summary if outcome == EvaluationCaseOutcome.PASS else fail_summary,
+        outcome,
+        [
+            f"service://platform/capability-packs/{pack_id}",
+            "service://ai/tasks/execute",
+        ],
     )
 
 

--- a/src/app/services/eval_seam_summary.py
+++ b/src/app/services/eval_seam_summary.py
@@ -10,6 +10,8 @@ SEAM_FIXTURE_MAP: dict[str, list[str]] = {
         "explanation_task_examples",
         "summarization_task_examples",
         "lotus_performance_first_use_case_examples",
+        "capability_pack_analytics_commentary_examples",
+        "capability_pack_decision_explanation_examples",
     ],
     "prompt_rollout": [
         "prompt_promotion_examples",

--- a/src/app/services/eval_status.py
+++ b/src/app/services/eval_status.py
@@ -7,6 +7,8 @@ from app.services.deployment_split_routing import (
 )
 from app.services.deployment_split_shared import resolve_deployment_split_posture
 from app.services.eval_approval_gate_summary import (
+    build_analytics_commentary_pack_approval_gate_summary,
+    build_decision_explanation_pack_approval_gate_summary,
     build_first_use_case_approval_gate_summary,
     build_prompt_approval_gate_summary,
     build_provider_approval_gate_summary,
@@ -40,6 +42,8 @@ def build_evaluation_runtime_status() -> EvaluationRuntimeStatusResponse:
         build_retrieval_approval_gate_summary(),
         build_provider_approval_gate_summary(),
         build_safety_approval_gate_summary(),
+        build_analytics_commentary_pack_approval_gate_summary(),
+        build_decision_explanation_pack_approval_gate_summary(),
     ]
     return EvaluationRuntimeStatusResponse(
         service=catalog.service,

--- a/src/app/services/first_use_case_status.py
+++ b/src/app/services/first_use_case_status.py
@@ -8,14 +8,21 @@ from app.contracts.use_cases import (
     FirstUseCaseRolloutPosture,
     FirstUseCaseRuntimeStatusResponse,
 )
+from app.services.capability_pack_catalog import get_capability_pack_by_id
 
 
 def build_first_use_case_runtime_status() -> FirstUseCaseRuntimeStatusResponse:
+    capability_pack = get_capability_pack_by_id("analytics_commentary.pack.v1")
+    if capability_pack is None:
+        raise RuntimeError("analytics_commentary.pack.v1 capability pack is not registered")
+
     return FirstUseCaseRuntimeStatusResponse(
         service=settings.service_name,
         version=settings.service_version,
         use_case_id="lotus_performance.analytics_commentary.v1",
         downstream_app="lotus-performance",
+        capability_pack_id=capability_pack.pack_id,
+        capability_pack_family_id=capability_pack.family_id,
         task_id="explain.v1",
         task_category=TaskCategory.EXPLAIN,
         output_label=OutputLabel.EXPLANATION_ONLY,
@@ -56,6 +63,7 @@ def build_first_use_case_runtime_status() -> FirstUseCaseRuntimeStatusResponse:
         dependency_summary=[
             "Caller identity and task authorization must allow lotus-performance to execute explain.v1.",
             "Prompt, safety, audit, observability, and artifact surfaces remain the governed runtime backbone for the use case.",
+            "The use case is now explicitly anchored to analytics_commentary.pack.v1 so broader commentary-family product work can evolve without creating a parallel one-off use-case abstraction.",
             "Use-case readiness is tracked separately through /platform/use-cases/first-production-use-case/readiness, while limited-rollout governance is tracked through the paired runbook and governance endpoints.",
             "The first contract intentionally avoids retrieval dependency and does not require broader live-provider rollout to be considered defined.",
         ],
@@ -66,6 +74,7 @@ def build_first_use_case_runtime_status() -> FirstUseCaseRuntimeStatusResponse:
         ],
         status_summary=[
             "The first production-oriented onboarding target is lotus-performance analytics commentary over caller-supplied structured facts.",
+            "This use case now serves as the concrete anchor for the analytics_commentary capability pack rather than a standalone product abstraction.",
             "The request contract is intentionally narrow and explanation-only so rollout can be reviewed without delegating domain truth to lotus-ai.",
             "This runtime surface defines the contract and ownership boundary only; it does not claim rollout readiness, and runtime-backed onboarding plus limited-rollout governance are tracked separately.",
         ],

--- a/src/app/services/platform_status.py
+++ b/src/app/services/platform_status.py
@@ -13,6 +13,10 @@ from app.retrieval.policy import VECTOR_STORE_STRATEGY
 from app.services.async_governance_status_service import build_async_governance_status
 from app.services.async_runtime_status import build_async_runtime_status
 from app.services.capability_catalog import build_capability_catalog
+from app.services.capability_pack_catalog import build_capability_pack_catalog
+from app.services.capability_pack_governance import (
+    build_capability_pack_catalog_governance_status,
+)
 from app.services.eval_status import build_evaluation_runtime_status
 from app.services.first_use_case_governance import build_first_use_case_governance_status
 from app.services.first_use_case_status import build_first_use_case_runtime_status
@@ -58,6 +62,8 @@ def _resolve_startup_readiness_state(app_state: object | None) -> StartupReadine
 
 def build_platform_runtime_status(app_state: object | None = None) -> PlatformRuntimeStatusResponse:
     capabilities = build_capability_catalog()
+    capability_packs = build_capability_pack_catalog()
+    capability_pack_governance = build_capability_pack_catalog_governance_status()
     prompts = list_registered_prompts()
     access_control_runtime = build_access_control_runtime_status()
     access_control_governance = build_access_control_governance_status()
@@ -118,6 +124,8 @@ def build_platform_runtime_status(app_state: object | None = None) -> PlatformRu
         prompt_runtime=prompt_runtime,
         task_runtime=task_runtime,
         first_use_case=first_use_case,
+        capability_pack_catalog=capability_packs,
+        capability_pack_governance=capability_pack_governance,
         first_use_case_governance=first_use_case_governance,
         safety_runtime=safety_runtime,
         safety_governance=safety_governance,
@@ -136,6 +144,7 @@ def build_platform_runtime_status(app_state: object | None = None) -> PlatformRu
         ),
         prompt_count=len(prompts),
         capability_count=len(capabilities.tasks),
+        capability_pack_count=capability_packs.pack_count,
         vector_store=VECTOR_STORE_STRATEGY,
         migration_contract_enforced=True,
         startup_readiness_blocking=startup_state.blocking,

--- a/src/app/services/use_case_onboarding_template.py
+++ b/src/app/services/use_case_onboarding_template.py
@@ -14,6 +14,7 @@ def build_use_case_onboarding_template() -> UseCaseOnboardingTemplateResponse:
         version=settings.service_version,
         template_id="bounded_explanation_only_onboarding.v1",
         based_on_use_case_id="lotus_performance.analytics_commentary.v1",
+        based_on_capability_pack_id="analytics_commentary.pack.v1",
         downstream_pattern=(
             "Explanation-only commentary over caller-supplied structured domain facts, with the "
             "downstream app retaining business truth and final rendering."
@@ -99,6 +100,7 @@ def build_use_case_onboarding_template() -> UseCaseOnboardingTemplateResponse:
         ],
         status_summary=[
             "The first production-use-case onboarding work now yields a reusable bounded integration template for later Lotus apps.",
+            "The template is now explicitly anchored to analytics_commentary.pack.v1 so future commentary-family onboarding starts from a named product capability instead of only a single use case.",
             "This template is intentionally narrow: explanation-only, structured-input, caller-governed onboarding remains the default adoption pattern.",
         ],
     )

--- a/tests/integration/test_capability_pack_api_contract.py
+++ b/tests/integration/test_capability_pack_api_contract.py
@@ -1,0 +1,96 @@
+from fastapi.testclient import TestClient
+
+
+def test_capability_pack_detail_route_for_analytics_commentary(client: TestClient) -> None:
+    response = client.get("/platform/capability-packs/analytics_commentary.pack.v1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["service"] == "lotus-ai"
+    assert body["pack"]["pack_id"] == "analytics_commentary.pack.v1"
+    assert body["pack"]["family_id"] == "analytics_commentary"
+    assert body["pack"]["family_kind"] == "COMMENTARY"
+    assert body["pack"]["current_anchor_use_case_id"] == "lotus_performance.analytics_commentary.v1"
+    assert body["pack"]["quality_gate_domain_id"] == "analytics_commentary_pack"
+    assert body["pack"]["quality_evidence_state"] == "STAGED_ONLY"
+    assert body["approval_gate"]["domain_id"] == "analytics_commentary_pack"
+    assert any(
+        expectation["expectation_id"] == "grounded_to_caller_facts"
+        for expectation in body["quality_expectations"]
+    )
+    assert any(
+        behavior["behavior_id"] == "missing_metric_deltas"
+        for behavior in body["unsupported_input_behaviors"]
+    )
+
+
+def test_capability_pack_detail_route_for_decision_explanation(client: TestClient) -> None:
+    response = client.get("/platform/capability-packs/decision_explanation.pack.v1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pack"]["family_kind"] == "EXPLANATION"
+    assert body["pack"]["current_anchor_use_case_id"] is None
+    assert body["approval_gate"]["domain_id"] == "decision_explanation_pack"
+    assert any(
+        expectation["expectation_id"] == "grounded_to_deterministic_state"
+        for expectation in body["quality_expectations"]
+    )
+
+
+def test_capability_pack_detail_route_rejects_unknown_pack(client: TestClient) -> None:
+    response = client.get("/platform/capability-packs/unknown.pack")
+
+    assert response.status_code == 404
+    assert "Unknown capability pack" in response.json()["detail"]
+
+
+def test_capability_pack_governance_routes_for_analytics_commentary(client: TestClient) -> None:
+    adoption_template_response = client.get(
+        "/platform/capability-packs/analytics_commentary.pack.v1/adoption-template"
+    )
+    observability_response = client.get(
+        "/platform/capability-packs/analytics_commentary.pack.v1/observability-summary"
+    )
+    activation_response = client.get(
+        "/platform/capability-packs/analytics_commentary.pack.v1/activation-readiness"
+    )
+    runbook_response = client.get(
+        "/platform/capability-packs/analytics_commentary.pack.v1/runbook-readiness"
+    )
+    governance_response = client.get(
+        "/platform/capability-packs/analytics_commentary.pack.v1/governance-status"
+    )
+    catalog_governance_response = client.get("/platform/capability-packs/governance-status")
+
+    assert adoption_template_response.status_code == 200
+    assert observability_response.status_code == 200
+    assert activation_response.status_code == 200
+    assert runbook_response.status_code == 200
+    assert governance_response.status_code == 200
+    assert catalog_governance_response.status_code == 200
+    assert adoption_template_response.json()["pack_id"] == "analytics_commentary.pack.v1"
+    assert adoption_template_response.json()["current_reference_use_case_id"] == (
+        "lotus_performance.analytics_commentary.v1"
+    )
+    assert observability_response.json()["pack_id"] == "analytics_commentary.pack.v1"
+    assert activation_response.json()["pack_id"] == "analytics_commentary.pack.v1"
+    assert runbook_response.json()["pack_id"] == "analytics_commentary.pack.v1"
+    assert governance_response.json()["pack_id"] == "analytics_commentary.pack.v1"
+    assert "pack_summaries" in catalog_governance_response.json()
+
+
+def test_capability_pack_adoption_template_route_for_decision_explanation(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/platform/capability-packs/decision_explanation.pack.v1/adoption-template"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pack_id"] == "decision_explanation.pack.v1"
+    assert body["current_reference_use_case_id"] is None
+    assert any(
+        item["checklist_id"] == "deterministic_decision_owner_defined" for item in body["checklist"]
+    )

--- a/tests/integration/test_eval_api_contract.py
+++ b/tests/integration/test_eval_api_contract.py
@@ -51,6 +51,20 @@ def test_evaluation_catalog_route(client: TestClient) -> None:
         for fixture in body["fixture_families"]
     )
     assert any(
+        fixture["fixture_id"] == "capability_pack_analytics_commentary_examples"
+        and fixture["manifest_path"]
+        == "docs/evals/fixtures/capability-packs.analytics-commentary/basic_cases.json"
+        and fixture["case_count"] == 2
+        for fixture in body["fixture_families"]
+    )
+    assert any(
+        fixture["fixture_id"] == "capability_pack_decision_explanation_examples"
+        and fixture["manifest_path"]
+        == "docs/evals/fixtures/capability-packs.decision-explanation/basic_cases.json"
+        and fixture["case_count"] == 2
+        for fixture in body["fixture_families"]
+    )
+    assert any(
         fixture["fixture_id"] == "prompt_promotion_examples"
         and fixture["manifest_path"] == "docs/evals/fixtures/prompts.promotion/basic_cases.json"
         and fixture["case_count"] == 1
@@ -132,7 +146,7 @@ def test_evaluation_runtime_status_route(client: TestClient) -> None:
     assert body["service"] == "lotus-ai"
     assert body["manifest_version"] == "foundation.v1"
     assert body["evidence_category_count"] == 6
-    assert body["staged_case_count"] == 38
+    assert body["staged_case_count"] == 42
     assert [item["seam_id"] for item in body["seam_coverage"]] == [
         "async_execution",
         "task_execution",
@@ -143,8 +157,8 @@ def test_evaluation_runtime_status_route(client: TestClient) -> None:
     ]
     assert body["seam_coverage"][0]["staged_fixture_count"] == 1
     assert body["seam_coverage"][0]["staged_case_count"] == 3
-    assert body["seam_coverage"][1]["staged_fixture_count"] == 4
-    assert body["seam_coverage"][1]["staged_case_count"] == 8
+    assert body["seam_coverage"][1]["staged_fixture_count"] == 6
+    assert body["seam_coverage"][1]["staged_case_count"] == 12
     assert body["seam_coverage"][2]["staged_fixture_count"] == 2
     assert body["seam_coverage"][2]["staged_case_count"] == 2
     assert body["seam_coverage"][3]["staged_fixture_count"] == 2
@@ -167,6 +181,8 @@ def test_evaluation_runtime_status_route(client: TestClient) -> None:
     assert body["approval_gates"][2]["domain_id"] == "retrieval_execution"
     assert body["approval_gates"][3]["domain_id"] == "provider_execution"
     assert body["approval_gates"][4]["domain_id"] == "safety_enforcement"
+    assert body["approval_gates"][5]["domain_id"] == "analytics_commentary_pack"
+    assert body["approval_gates"][6]["domain_id"] == "decision_explanation_pack"
     assert body["approval_gates"][0]["evidence_state"] == "STAGED_ONLY"
 
 
@@ -231,7 +247,7 @@ def test_evaluation_run_catalog_route(client: TestClient) -> None:
     assert body["status_counts"]["RECORDED"] == 1
     assert body["status_counts"]["SUPERSEDED"] == 1
     assert body["runs"][0]["record_source"] == "STAGED_ARTIFACT"
-    assert body["runs"][0]["staged_case_count"] == 38
+    assert body["runs"][0]["staged_case_count"] == 42
     assert body["runs"][1]["status"] == "SUPERSEDED"
 
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -23,6 +23,21 @@ def test_platform_capabilities_contract(client: TestClient) -> None:
     assert any(task["task_id"] == "explain.v1" for task in body["tasks"])
 
 
+def test_platform_capability_pack_catalog_contract(client: TestClient) -> None:
+    response = client.get("/platform/capability-packs")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["service"] == "lotus-ai"
+    assert body["phase"] == "foundation"
+    assert body["pack_count"] == 2
+    assert body["reusable_pack_count"] == 1
+    assert body["approved_pack_count"] == 0
+    assert body["packs"][0]["pack_id"] == "analytics_commentary.pack.v1"
+    assert body["packs"][0]["maturity_stage"] == "REUSABLE"
+    assert body["packs"][1]["pack_id"] == "decision_explanation.pack.v1"
+
+
 def test_first_production_use_case_contract(client: TestClient) -> None:
     response = client.get("/platform/use-cases/first-production-use-case")
 
@@ -293,11 +308,11 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["prompt_governance"]["evidence_readiness"]["evidence_ready"] is False
     assert body["evaluation_runtime"]["manifest_version"] == "foundation.v1"
     assert body["evaluation_runtime"]["evidence_category_count"] == 6
-    assert body["evaluation_runtime"]["staged_case_count"] == 38
+    assert body["evaluation_runtime"]["staged_case_count"] == 42
     assert body["evaluation_runtime"]["seam_coverage"][0]["seam_id"] == "async_execution"
     assert body["evaluation_runtime"]["seam_coverage"][0]["staged_fixture_count"] == 1
-    assert body["evaluation_runtime"]["seam_coverage"][1]["staged_fixture_count"] == 4
-    assert body["evaluation_runtime"]["seam_coverage"][1]["staged_case_count"] == 8
+    assert body["evaluation_runtime"]["seam_coverage"][1]["staged_fixture_count"] == 6
+    assert body["evaluation_runtime"]["seam_coverage"][1]["staged_case_count"] == 12
     assert body["evaluation_runtime"]["seam_coverage"][2]["staged_fixture_count"] == 2
     assert body["evaluation_runtime"]["seam_coverage"][2]["staged_case_count"] == 2
     assert body["evaluation_runtime"]["seam_coverage"][3]["staged_fixture_count"] == 2
@@ -313,6 +328,12 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["evaluation_runtime"]["approval_gates"][2]["domain_id"] == "retrieval_execution"
     assert body["evaluation_runtime"]["approval_gates"][3]["domain_id"] == "provider_execution"
     assert body["evaluation_runtime"]["approval_gates"][4]["domain_id"] == "safety_enforcement"
+    assert (
+        body["evaluation_runtime"]["approval_gates"][5]["domain_id"] == "analytics_commentary_pack"
+    )
+    assert (
+        body["evaluation_runtime"]["approval_gates"][6]["domain_id"] == "decision_explanation_pack"
+    )
     assert body["evaluation_runtime"]["recorded_run_count"] == 2
     assert body["evaluation_runtime"]["latest_recorded_run_id"] == "foundation_eval_2026_03_22_001"
     assert body["evaluation_runtime"]["evaluation_runner_active"] is True
@@ -328,8 +349,22 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     )
     assert body["task_runtime"]["enabled_task_count"] >= 7
     assert body["task_runtime"]["retrieval_backed_task_count"] == 2
+    assert body["capability_pack_count"] == 2
+    assert body["capability_pack_catalog"]["pack_count"] == 2
+    assert body["capability_pack_catalog"]["reusable_pack_count"] == 1
+    assert body["capability_pack_catalog"]["packs"][0]["pack_id"] == "analytics_commentary.pack.v1"
+    assert body["capability_pack_catalog"]["packs"][0]["maturity_stage"] == "REUSABLE"
+    assert (
+        body["capability_pack_catalog"]["packs"][0]["quality_gate_domain_id"]
+        == "analytics_commentary_pack"
+    )
+    assert body["capability_pack_catalog"]["packs"][1]["pack_id"] == "decision_explanation.pack.v1"
+    assert body["capability_pack_governance"]["ready_pack_count"] == 0
+    assert body["capability_pack_governance"]["blocking_pack_count"] == 2
     assert body["first_use_case"]["use_case_id"] == "lotus_performance.analytics_commentary.v1"
     assert body["first_use_case"]["downstream_app"] == "lotus-performance"
+    assert body["first_use_case"]["capability_pack_id"] == "analytics_commentary.pack.v1"
+    assert body["first_use_case"]["capability_pack_family_id"] == "analytics_commentary"
     assert body["first_use_case"]["contract_hardened"] is True
     assert body["first_use_case_governance"]["rollout_stage"] == "PRE_PROD_VALIDATION"
     assert body["first_use_case_governance"]["operational_posture"] == "LIMITED_ROLLOUT_BLOCKED"

--- a/tests/integration/test_use_case_api_contract.py
+++ b/tests/integration/test_use_case_api_contract.py
@@ -9,6 +9,8 @@ def test_first_production_use_case_route(client: TestClient) -> None:
     assert body["service"] == "lotus-ai"
     assert body["use_case_id"] == "lotus_performance.analytics_commentary.v1"
     assert body["downstream_app"] == "lotus-performance"
+    assert body["capability_pack_id"] == "analytics_commentary.pack.v1"
+    assert body["capability_pack_family_id"] == "analytics_commentary"
     assert body["task_id"] == "explain.v1"
     assert body["output_label"] == "EXPLANATION_ONLY"
     assert body["contract_hardened"] is True
@@ -70,6 +72,7 @@ def test_use_case_onboarding_template_route(client: TestClient) -> None:
     assert body["service"] == "lotus-ai"
     assert body["template_id"] == "bounded_explanation_only_onboarding.v1"
     assert body["based_on_use_case_id"] == "lotus_performance.analytics_commentary.v1"
+    assert body["based_on_capability_pack_id"] == "analytics_commentary.pack.v1"
     assert any(item["checklist_id"] == "contract_boundary_defined" for item in body["checklist"])
     assert any(
         item["criterion_id"] == "approval_governance_summary" for item in body["approval_criteria"]

--- a/tests/unit/test_capability_pack_adoption_template.py
+++ b/tests/unit/test_capability_pack_adoption_template.py
@@ -1,0 +1,45 @@
+from app.services.capability_pack_adoption_template import (
+    build_capability_pack_adoption_template,
+)
+
+
+def test_build_capability_pack_adoption_template_for_analytics_commentary() -> None:
+    template = build_capability_pack_adoption_template("analytics_commentary.pack.v1")
+
+    assert template.template_id == "analytics_commentary.pack.v1.adoption-template.v1"
+    assert template.pack_id == "analytics_commentary.pack.v1"
+    assert template.current_reference_use_case_id == "lotus_performance.analytics_commentary.v1"
+    assert "lotus-performance" in template.recommended_caller_apps
+    assert any(
+        item.checklist_id == "pack_contract_adopted" and item.required
+        for item in template.checklist
+    )
+    assert any(
+        criterion.criterion_id == "pack_governance_ready"
+        and criterion.evaluation_surface
+        == "/platform/capability-packs/analytics_commentary.pack.v1/governance-status"
+        for criterion in template.approval_criteria
+    )
+
+
+def test_build_capability_pack_adoption_template_for_decision_explanation() -> None:
+    template = build_capability_pack_adoption_template("decision_explanation.pack.v1")
+
+    assert template.pack_id == "decision_explanation.pack.v1"
+    assert template.current_reference_use_case_id is None
+    assert "lotus-manage" in template.recommended_caller_apps
+    assert any(
+        item.checklist_id == "deterministic_decision_owner_defined" for item in template.checklist
+    )
+    assert any(
+        "lacks a concrete implemented downstream anchor" in line for line in template.status_summary
+    )
+
+
+def test_build_capability_pack_adoption_template_rejects_unknown_pack() -> None:
+    try:
+        build_capability_pack_adoption_template("unknown.pack")
+    except ValueError as exc:
+        assert "Unknown capability pack" in str(exc)
+    else:
+        raise AssertionError("Expected unknown capability pack lookup to fail")

--- a/tests/unit/test_capability_pack_catalog.py
+++ b/tests/unit/test_capability_pack_catalog.py
@@ -1,0 +1,115 @@
+from app.contracts.capability_packs import CapabilityPackMaturityStage
+from app.services.capability_pack_catalog import (
+    build_capability_pack_catalog,
+    build_capability_pack_detail,
+)
+
+
+def test_build_capability_pack_catalog_exposes_separate_product_layer() -> None:
+    catalog = build_capability_pack_catalog()
+
+    assert catalog.service == "lotus-ai"
+    assert catalog.phase == "foundation"
+    assert catalog.pack_count == 2
+    assert catalog.reusable_pack_count == 1
+    assert catalog.approved_pack_count == 0
+    assert catalog.packs[0].pack_id == "analytics_commentary.pack.v1"
+    assert catalog.packs[0].family_id == "analytics_commentary"
+    assert catalog.packs[0].maturity_stage == CapabilityPackMaturityStage.REUSABLE
+    assert catalog.packs[0].primary_task_id == "explain.v1"
+    assert (
+        catalog.packs[0].current_anchor_use_case_id == "lotus_performance.analytics_commentary.v1"
+    )
+    assert catalog.packs[0].reusable_across_apps is True
+    assert catalog.packs[0].quality_gate_domain_id == "analytics_commentary_pack"
+    assert catalog.packs[0].quality_gate_ready is False
+    assert catalog.packs[0].quality_evidence_state.value == "STAGED_ONLY"
+    assert (
+        catalog.packs[0].adoption_template_endpoint
+        == "/platform/capability-packs/analytics_commentary.pack.v1/adoption-template"
+    )
+    assert catalog.packs[1].pack_id == "decision_explanation.pack.v1"
+    assert catalog.packs[1].family_id == "decision_explanation"
+    assert catalog.packs[1].current_anchor_use_case_id is None
+    assert catalog.packs[1].quality_gate_domain_id == "decision_explanation_pack"
+
+
+def test_build_capability_pack_catalog_links_pack_governance_surfaces() -> None:
+    catalog = build_capability_pack_catalog()
+    pack = catalog.packs[0]
+
+    assert "/platform/capability-packs" in pack.governance_surface_ids
+    assert "/platform/capability-packs/analytics_commentary.pack.v1/adoption-template" in (
+        pack.governance_surface_ids
+    )
+    assert "/platform/use-cases/first-production-use-case" in pack.governance_surface_ids
+    assert (
+        "/platform/use-cases/first-production-use-case/governance-status"
+        in pack.governance_surface_ids
+    )
+    assert any("separate app-facing product layer" in line for line in catalog.status_summary)
+
+
+def test_build_capability_pack_detail_exposes_quality_and_input_boundaries() -> None:
+    detail = build_capability_pack_detail("analytics_commentary.pack.v1")
+
+    assert detail.pack.pack_id == "analytics_commentary.pack.v1"
+    assert detail.approval_gate.domain_id == "analytics_commentary_pack"
+    assert detail.approval_gate.evidence_state.value == "STAGED_ONLY"
+    assert len(detail.quality_expectations) == 3
+    assert any(
+        expectation.expectation_id == "grounded_to_caller_facts"
+        for expectation in detail.quality_expectations
+    )
+    assert any(
+        behavior.behavior_id == "missing_metric_deltas"
+        for behavior in detail.unsupported_input_behaviors
+    )
+    assert any("broader reusable product family" in line for line in detail.status_summary)
+
+
+def test_build_capability_pack_detail_supports_decision_explanation_family() -> None:
+    detail = build_capability_pack_detail("decision_explanation.pack.v1")
+
+    assert detail.pack.family_id == "decision_explanation"
+    assert detail.pack.current_anchor_use_case_id is None
+    assert detail.approval_gate.domain_id == "decision_explanation_pack"
+    assert any(
+        expectation.expectation_id == "grounded_to_deterministic_state"
+        for expectation in detail.quality_expectations
+    )
+    assert any(
+        behavior.behavior_id == "missing_decision_state"
+        for behavior in detail.unsupported_input_behaviors
+    )
+
+
+def test_build_capability_pack_detail_reports_runtime_quality_gate_pass() -> None:
+    from app.contracts.evals import EvaluationRunSubmissionRequest
+    from app.services.eval_async_execution import run_next_evaluation_execution_job
+    from app.services.eval_run_submission_service import submit_evaluation_run
+
+    submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="capability_pack_analytics_commentary_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-pack-quality-001",
+            triggered_by="operator-a",
+        )
+    )
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    detail = build_capability_pack_detail("analytics_commentary.pack.v1")
+
+    assert detail.approval_gate.approval_ready is True
+    assert detail.approval_gate.evidence_state.value == "RUNTIME_PASS"
+    assert detail.pack.quality_gate_ready is True
+
+
+def test_build_capability_pack_detail_rejects_unknown_pack() -> None:
+    try:
+        build_capability_pack_detail("unknown.pack")
+    except ValueError as exc:
+        assert "Unknown capability pack" in str(exc)
+    else:
+        raise AssertionError("Expected unknown capability pack lookup to fail")

--- a/tests/unit/test_capability_pack_governance.py
+++ b/tests/unit/test_capability_pack_governance.py
@@ -1,0 +1,98 @@
+from app.contracts.tasks import (
+    CallerMetadata,
+    TaskContextEnvelope,
+    TaskExecutionRequest,
+    TaskInputMode,
+)
+from app.services.capability_pack_activation_readiness import (
+    build_capability_pack_activation_readiness,
+)
+from app.services.capability_pack_governance import (
+    build_capability_pack_catalog_governance_status,
+    build_capability_pack_governance_status,
+)
+from app.services.capability_pack_observability import (
+    build_capability_pack_observability_summary,
+)
+from app.services.capability_pack_runbook_readiness import (
+    build_capability_pack_runbook_readiness,
+)
+from app.services.eval_async_execution import run_next_evaluation_execution_job
+from app.services.eval_run_submission_service import submit_evaluation_run
+from app.services.task_executor import execute_task
+from app.contracts.evals import EvaluationRunSubmissionRequest
+
+
+def test_analytics_commentary_pack_governance_reports_blocked_before_runtime_quality_pass() -> None:
+    activation = build_capability_pack_activation_readiness(pack_id="analytics_commentary.pack.v1")
+    runbook = build_capability_pack_runbook_readiness(pack_id="analytics_commentary.pack.v1")
+    governance = build_capability_pack_governance_status(pack_id="analytics_commentary.pack.v1")
+
+    assert activation.activation_ready is False
+    assert activation.items[0].item_id == "runtime_quality_gate"
+    assert runbook.runbook_ready is True
+    assert governance.governance_ready is False
+    assert governance.blocking_area_count == 1
+
+
+def test_decision_explanation_pack_governance_reports_missing_anchor_and_runbook() -> None:
+    observability = build_capability_pack_observability_summary(
+        pack_id="decision_explanation.pack.v1"
+    )
+    governance = build_capability_pack_governance_status(pack_id="decision_explanation.pack.v1")
+
+    assert observability.observability_ready is True
+    assert observability.sampled_audit_record_count == 0
+    assert governance.governance_ready is False
+    assert governance.blocking_area_count >= 2
+
+
+def test_analytics_commentary_pack_observability_summarizes_bounded_usage() -> None:
+    execute_task(
+        TaskExecutionRequest(
+            task_id="explain.v1",
+            input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+            caller=CallerMetadata(
+                caller_app="lotus-performance",
+                correlation_id="corr-pack-obs-001",
+                tenant_id="tenant-sg-001",
+            ),
+            context=TaskContextEnvelope(
+                summary="Analytics commentary pack observability coverage.",
+                payload={
+                    "analysis_scope": "monthly_contribution_change",
+                    "metric_deltas": [{"metric_id": "active_return_bps", "delta_bps": 33}],
+                    "material_findings": ["Allocation shifts drove the change."],
+                },
+                source_refs=[],
+            ),
+        )
+    )
+
+    summary = build_capability_pack_observability_summary(pack_id="analytics_commentary.pack.v1")
+
+    assert summary.observability_ready is True
+    assert summary.sampled_audit_record_count >= 1
+    assert "lotus-performance" in summary.observed_caller_apps
+
+
+def test_analytics_commentary_pack_governance_can_become_ready_after_runtime_quality_pass() -> None:
+    submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="capability_pack_analytics_commentary_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-pack-governance-001",
+            triggered_by="operator-a",
+        )
+    )
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    governance = build_capability_pack_governance_status(pack_id="analytics_commentary.pack.v1")
+    catalog_governance = build_capability_pack_catalog_governance_status()
+
+    assert governance.governance_ready is True
+    assert governance.activation_readiness.activation_ready is True
+    assert governance.runbook_readiness.runbook_ready is True
+    assert governance.observability.observability_ready is True
+    assert catalog_governance.ready_pack_count == 1
+    assert catalog_governance.blocking_pack_count == 1

--- a/tests/unit/test_eval_approval_gate_summary.py
+++ b/tests/unit/test_eval_approval_gate_summary.py
@@ -3,6 +3,8 @@ from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
 from app.services.eval_approval_gate_summary import (
     _build_domain_notes,
     _derive_domain_state,
+    build_analytics_commentary_pack_approval_gate_summary,
+    build_decision_explanation_pack_approval_gate_summary,
     build_first_use_case_approval_gate_summary,
     build_prompt_approval_gate_summary,
     build_provider_approval_gate_summary,
@@ -45,6 +47,19 @@ def test_first_use_case_approval_gate_reports_staged_only_without_runtime_runs()
     assert summary.required_fixture_count == 1
     assert summary.runtime_backed_fixture_count == 0
     assert summary.latest_historical_baseline_run_id == "foundation_eval_2026_03_22_001"
+
+
+def test_capability_pack_approval_gates_report_staged_only_without_runtime_runs() -> None:
+    analytics_summary = build_analytics_commentary_pack_approval_gate_summary()
+    decision_summary = build_decision_explanation_pack_approval_gate_summary()
+
+    assert analytics_summary.domain_id == "analytics_commentary_pack"
+    assert analytics_summary.evidence_state.value == "STAGED_ONLY"
+    assert analytics_summary.required_fixture_count == 1
+    assert analytics_summary.runtime_backed_fixture_count == 0
+    assert analytics_summary.latest_historical_baseline_run_id == "foundation_eval_2026_03_22_001"
+    assert decision_summary.domain_id == "decision_explanation_pack"
+    assert decision_summary.evidence_state.value == "STAGED_ONLY"
 
 
 def test_provider_approval_gate_reports_partial_runtime_coverage() -> None:
@@ -235,6 +250,26 @@ def test_first_use_case_approval_gate_reports_runtime_pass_when_required_fixture
     summary = build_first_use_case_approval_gate_summary()
 
     assert summary.domain_id == "first_use_case_onboarding"
+    assert summary.evidence_state.value == "RUNTIME_PASS"
+    assert summary.approval_ready is True
+    assert summary.required_fixture_count == 1
+    assert summary.runtime_backed_fixture_count == 1
+
+
+def test_capability_pack_approval_gate_reports_runtime_pass_when_fixture_passes() -> None:
+    submit_evaluation_run(
+        EvaluationRunSubmissionRequest(
+            fixture_id="capability_pack_analytics_commentary_examples",
+            caller_app="lotus-platform",
+            correlation_id="corr-pack-analytics",
+            triggered_by="operator-a",
+        )
+    )
+    run_next_evaluation_execution_job(worker_id="worker-a")
+
+    summary = build_analytics_commentary_pack_approval_gate_summary()
+
+    assert summary.domain_id == "analytics_commentary_pack"
     assert summary.evidence_state.value == "RUNTIME_PASS"
     assert summary.approval_ready is True
     assert summary.required_fixture_count == 1

--- a/tests/unit/test_eval_catalog.py
+++ b/tests/unit/test_eval_catalog.py
@@ -52,6 +52,28 @@ def test_evaluation_catalog_reports_evidence_categories_and_fixture_families() -
         == "docs/evals/fixtures/lotus-performance.first-use-case/basic_cases.json"
     )
     assert first_use_case_fixture.case_count == 2
+    analytics_pack_fixture = next(
+        fixture
+        for fixture in catalog.fixture_families
+        if fixture.fixture_id == "capability_pack_analytics_commentary_examples"
+    )
+    assert analytics_pack_fixture.status == "STAGED"
+    assert (
+        analytics_pack_fixture.manifest_path
+        == "docs/evals/fixtures/capability-packs.analytics-commentary/basic_cases.json"
+    )
+    assert analytics_pack_fixture.case_count == 2
+    decision_pack_fixture = next(
+        fixture
+        for fixture in catalog.fixture_families
+        if fixture.fixture_id == "capability_pack_decision_explanation_examples"
+    )
+    assert decision_pack_fixture.status == "STAGED"
+    assert (
+        decision_pack_fixture.manifest_path
+        == "docs/evals/fixtures/capability-packs.decision-explanation/basic_cases.json"
+    )
+    assert decision_pack_fixture.case_count == 2
     retrieval_fixture = next(
         fixture
         for fixture in catalog.fixture_families

--- a/tests/unit/test_eval_inventory_summary.py
+++ b/tests/unit/test_eval_inventory_summary.py
@@ -8,6 +8,6 @@ def test_summarize_evaluation_inventory_reports_fixture_and_case_counts() -> Non
     summary = summarize_evaluation_inventory(catalog)
 
     assert summary.evidence_category_count == 6
-    assert summary.staged_fixture_count >= 17
+    assert summary.staged_fixture_count >= 19
     assert summary.documented_fixture_count == 0
-    assert summary.staged_case_count == 38
+    assert summary.staged_case_count == 42

--- a/tests/unit/test_eval_run_registry.py
+++ b/tests/unit/test_eval_run_registry.py
@@ -59,7 +59,7 @@ def test_load_evaluation_run_artifacts_returns_seeded_run_inventory() -> None:
     runs = load_evaluation_run_artifacts()
 
     assert runs[0].run_id == "foundation_eval_2026_03_22_001"
-    assert runs[0].staged_case_count == 38
+    assert runs[0].staged_case_count == 42
     assert runs[1].status == "SUPERSEDED"
 
 

--- a/tests/unit/test_eval_run_service.py
+++ b/tests/unit/test_eval_run_service.py
@@ -17,7 +17,7 @@ def test_evaluation_run_catalog_reports_recorded_artifacts() -> None:
     assert catalog.status_counts[EvaluationRunStatus.RECORDED] == 1
     assert catalog.status_counts[EvaluationRunStatus.SUPERSEDED] == 1
     assert catalog.runs[0].manifest_version == "foundation.v1"
-    assert catalog.runs[0].staged_case_count == 38
+    assert catalog.runs[0].staged_case_count == 42
     assert catalog.runs[1].status == "SUPERSEDED"
     assert catalog.runs[0].record_source == EvaluationRunRecordSource.STAGED_ARTIFACT
 

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -337,6 +337,83 @@ def test_execute_fixture_case_reports_pass_for_lotus_performance_first_use_case(
     ]
 
 
+def test_execute_fixture_case_reports_pass_for_analytics_commentary_pack() -> None:
+    case = EvaluationFixtureRuntimeCase(
+        case_id="analytics_commentary_structured_facts_authorized",
+        summary="Analytics commentary should remain bounded and authorized.",
+        input_payload={
+            "task_id": "explain.v1",
+            "caller_app": "lotus-performance",
+            "tenant_id": "tenant-sg-001",
+            "analysis_scope": "monthly_contribution_change",
+            "metric_deltas": [{"metric_id": "active_return_bps", "delta_bps": 41}],
+            "material_findings": ["Industrials sector selection drove the change."],
+        },
+        expected_payload={
+            "output_label": "EXPLANATION_ONLY",
+            "authorization_outcome": "ALLOWED",
+            "caller_app": "lotus-performance",
+            "task_id": "explain.v1",
+            "safety_disposition": "DOCUMENTED_ONLY",
+            "caller_visible_in_payload": True,
+            "stubbed": True,
+        },
+    )
+
+    with _apply_case_configuration(case.input_payload):
+        summary, outcome, evidence_refs = _execute_fixture_case(
+            fixture_id="capability_pack_analytics_commentary_examples",
+            fixture_task_id="explain.v1",
+            case=case,
+        )
+
+    assert outcome == EvaluationCaseOutcome.PASS
+    assert "Analytics commentary pack execution preserved" in summary
+    assert evidence_refs == [
+        "service://platform/capability-packs/analytics_commentary.pack.v1",
+        "service://ai/tasks/execute",
+    ]
+
+
+def test_execute_fixture_case_reports_pass_for_decision_explanation_pack() -> None:
+    case = EvaluationFixtureRuntimeCase(
+        case_id="decision_explanation_blocker_state_authorized",
+        summary="Decision explanation should remain bounded and authorized.",
+        input_payload={
+            "task_id": "explain.v1",
+            "caller_app": "lotus-manage",
+            "tenant_id": "tenant-sg-001",
+            "decision_scope": "rebalance_submission",
+            "decision_state": "BLOCKED",
+            "blocker_reason": "Approval policy requires a missing compliance attestation.",
+            "required_next_step": "Upload the missing attestation before retry.",
+        },
+        expected_payload={
+            "output_label": "EXPLANATION_ONLY",
+            "authorization_outcome": "ALLOWED",
+            "caller_app": "lotus-manage",
+            "task_id": "explain.v1",
+            "safety_disposition": "DOCUMENTED_ONLY",
+            "caller_visible_in_payload": True,
+            "stubbed": True,
+        },
+    )
+
+    with _apply_case_configuration(case.input_payload):
+        summary, outcome, evidence_refs = _execute_fixture_case(
+            fixture_id="capability_pack_decision_explanation_examples",
+            fixture_task_id="explain.v1",
+            case=case,
+        )
+
+    assert outcome == EvaluationCaseOutcome.PASS
+    assert "Decision explanation pack execution preserved" in summary
+    assert evidence_refs == [
+        "service://platform/capability-packs/decision_explanation.pack.v1",
+        "service://ai/tasks/execute",
+    ]
+
+
 def test_execute_fixture_case_reports_unknown_runtime_semantics_for_unmapped_fixture() -> None:
     summary, outcome, evidence_refs = _execute_fixture_case(
         fixture_id="unknown_fixture_family",

--- a/tests/unit/test_eval_seam_summary.py
+++ b/tests/unit/test_eval_seam_summary.py
@@ -19,13 +19,15 @@ def test_evaluation_seam_coverage_reports_staged_fixtures_by_platform_boundary()
     assert async_execution.fixture_ids == ["async_runtime_examples"]
 
     task_execution = seam_coverage[1]
-    assert task_execution.staged_fixture_count == 4
-    assert task_execution.staged_case_count == 8
+    assert task_execution.staged_fixture_count == 6
+    assert task_execution.staged_case_count == 12
     assert task_execution.fixture_ids == [
         "task_capability_contracts",
         "explanation_task_examples",
         "summarization_task_examples",
         "lotus_performance_first_use_case_examples",
+        "capability_pack_analytics_commentary_examples",
+        "capability_pack_decision_explanation_examples",
     ]
 
     prompt_rollout = seam_coverage[2]

--- a/tests/unit/test_eval_status.py
+++ b/tests/unit/test_eval_status.py
@@ -8,9 +8,9 @@ def test_evaluation_runtime_status_reports_staged_assets() -> None:
     assert status.delivery_phase == "foundation"
     assert status.manifest_version == "foundation.v1"
     assert status.evidence_category_count == 6
-    assert status.staged_fixture_count >= 17
+    assert status.staged_fixture_count >= 19
     assert status.documented_fixture_count == 0
-    assert status.staged_case_count == 38
+    assert status.staged_case_count == 42
     assert [item.seam_id for item in status.seam_coverage] == [
         "async_execution",
         "task_execution",
@@ -21,8 +21,8 @@ def test_evaluation_runtime_status_reports_staged_assets() -> None:
     ]
     assert status.seam_coverage[0].staged_fixture_count == 1
     assert status.seam_coverage[0].staged_case_count == 3
-    assert status.seam_coverage[1].staged_fixture_count == 4
-    assert status.seam_coverage[1].staged_case_count == 8
+    assert status.seam_coverage[1].staged_fixture_count == 6
+    assert status.seam_coverage[1].staged_case_count == 12
     assert status.seam_coverage[2].staged_fixture_count == 2
     assert status.seam_coverage[2].staged_case_count == 2
     assert status.seam_coverage[3].staged_fixture_count == 2
@@ -37,12 +37,16 @@ def test_evaluation_runtime_status_reports_staged_assets() -> None:
         "retrieval_execution",
         "provider_execution",
         "safety_enforcement",
+        "analytics_commentary_pack",
+        "decision_explanation_pack",
     ]
     assert status.approval_gates[0].evidence_state.value == "STAGED_ONLY"
     assert status.approval_gates[1].evidence_state.value == "STAGED_ONLY"
     assert status.approval_gates[2].evidence_state.value == "STAGED_ONLY"
     assert status.approval_gates[3].evidence_state.value == "STAGED_ONLY"
     assert status.approval_gates[4].evidence_state.value == "STAGED_ONLY"
+    assert status.approval_gates[5].evidence_state.value == "STAGED_ONLY"
+    assert status.approval_gates[6].evidence_state.value == "STAGED_ONLY"
     assert status.recorded_run_count == 2
     assert status.runtime_backed_run_count == 0
     assert status.historical_run_count == 2

--- a/tests/unit/test_openapi_contract.py
+++ b/tests/unit/test_openapi_contract.py
@@ -145,6 +145,45 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     )
     assert spec["paths"]["/platform/async/jobs/submit"]["post"]["operationId"] == ("submitAsyncJob")
     assert spec["paths"]["/platform/capabilities"]["get"]["operationId"] == "getCapabilityCatalog"
+    assert spec["paths"]["/platform/capability-packs"]["get"]["operationId"] == (
+        "getCapabilityPackCatalog"
+    )
+    assert spec["paths"]["/platform/capability-packs/{pack_id}"]["get"]["operationId"] == (
+        "getCapabilityPackDetail"
+    )
+    assert (
+        spec["paths"]["/platform/capability-packs/{pack_id}/adoption-template"]["get"][
+            "operationId"
+        ]
+        == "getCapabilityPackAdoptionTemplate"
+    )
+    assert (
+        spec["paths"]["/platform/capability-packs/{pack_id}/observability-summary"]["get"][
+            "operationId"
+        ]
+        == "getCapabilityPackObservabilitySummary"
+    )
+    assert (
+        spec["paths"]["/platform/capability-packs/{pack_id}/activation-readiness"]["get"][
+            "operationId"
+        ]
+        == "getCapabilityPackActivationReadiness"
+    )
+    assert (
+        spec["paths"]["/platform/capability-packs/{pack_id}/runbook-readiness"]["get"][
+            "operationId"
+        ]
+        == "getCapabilityPackRunbookReadiness"
+    )
+    assert (
+        spec["paths"]["/platform/capability-packs/{pack_id}/governance-status"]["get"][
+            "operationId"
+        ]
+        == "getCapabilityPackGovernanceStatus"
+    )
+    assert spec["paths"]["/platform/capability-packs/governance-status"]["get"]["operationId"] == (
+        "getCapabilityPackCatalogGovernanceStatus"
+    )
     assert (
         spec["paths"]["/platform/use-cases/first-production-use-case"]["get"]["operationId"]
         == "getFirstProductionUseCaseStatus"
@@ -283,6 +322,27 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     assert "runtime_status" in artifact_governance_schema["properties"]
     assert "activation_readiness" in artifact_governance_schema["properties"]
     assert "runbook_readiness" in artifact_governance_schema["properties"]
+    capability_pack_catalog_schema = spec["components"]["schemas"]["CapabilityPackCatalogResponse"]
+    capability_pack_schema = spec["components"]["schemas"]["CapabilityPackDescriptor"]
+    capability_pack_detail_schema = spec["components"]["schemas"]["CapabilityPackDetailResponse"]
+    capability_pack_adoption_schema = spec["components"]["schemas"][
+        "CapabilityPackAdoptionTemplateResponse"
+    ]
+    capability_pack_observability_schema = spec["components"]["schemas"][
+        "CapabilityPackObservabilitySummaryResponse"
+    ]
+    capability_pack_activation_schema = spec["components"]["schemas"][
+        "CapabilityPackActivationReadinessResponse"
+    ]
+    capability_pack_runbook_schema = spec["components"]["schemas"][
+        "CapabilityPackRunbookReadinessResponse"
+    ]
+    capability_pack_governance_schema = spec["components"]["schemas"][
+        "CapabilityPackGovernanceStatusResponse"
+    ]
+    capability_pack_catalog_governance_schema = spec["components"]["schemas"][
+        "CapabilityPackCatalogGovernanceStatusResponse"
+    ]
     async_job_schema = spec["components"]["schemas"]["AsyncJobArtifactDescriptor"]
     assert "artifact_refs" in async_job_schema["properties"]
     evaluation_case_schema = spec["components"]["schemas"]["EvaluationCaseResultDescriptor"]
@@ -356,6 +416,9 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     assert "recovery_findings" in resilience_dependency_schema["properties"]
     assert "artifact_runtime" in platform_runtime_schema["properties"]
     assert "artifact_governance" in platform_runtime_schema["properties"]
+    assert "capability_pack_catalog" in platform_runtime_schema["properties"]
+    assert "capability_pack_governance" in platform_runtime_schema["properties"]
+    assert "capability_pack_count" in platform_runtime_schema["properties"]
     assert "resilience_runtime" in platform_runtime_schema["properties"]
     assert "resilience_governance" in platform_runtime_schema["properties"]
     assert "first_use_case" in platform_runtime_schema["properties"]
@@ -365,6 +428,8 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     assert "production_baseline" in platform_runtime_schema["properties"]
     assert "production_baseline_governance" in platform_runtime_schema["properties"]
     first_use_case_schema = spec["components"]["schemas"]["FirstUseCaseRuntimeStatusResponse"]
+    assert "capability_pack_id" in first_use_case_schema["properties"]
+    assert "capability_pack_family_id" in first_use_case_schema["properties"]
     assert "downstream_contract_fields" in first_use_case_schema["properties"]
     assert "ownership_boundaries" in first_use_case_schema["properties"]
     first_use_case_readiness_schema = spec["components"]["schemas"]["FirstUseCaseReadinessResponse"]
@@ -384,6 +449,27 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     onboarding_template_schema = spec["components"]["schemas"]["UseCaseOnboardingTemplateResponse"]
     assert "checklist" in onboarding_template_schema["properties"]
     assert "approval_criteria" in onboarding_template_schema["properties"]
+    assert "pack_count" in capability_pack_catalog_schema["properties"]
+    assert "packs" in capability_pack_catalog_schema["properties"]
+    assert "family_kind" in capability_pack_schema["properties"]
+    assert "maturity_stage" in capability_pack_schema["properties"]
+    assert "current_anchor_use_case_id" in capability_pack_schema["properties"]
+    assert "adoption_template_endpoint" in capability_pack_schema["properties"]
+    assert "quality_gate_domain_id" in capability_pack_schema["properties"]
+    assert "quality_gate_ready" in capability_pack_schema["properties"]
+    assert "quality_evidence_state" in capability_pack_schema["properties"]
+    assert "quality_expectations" in capability_pack_detail_schema["properties"]
+    assert "unsupported_input_behaviors" in capability_pack_detail_schema["properties"]
+    assert "approval_gate" in capability_pack_detail_schema["properties"]
+    assert "checklist" in capability_pack_adoption_schema["properties"]
+    assert "approval_criteria" in capability_pack_adoption_schema["properties"]
+    assert "observability_ready" in capability_pack_observability_schema["properties"]
+    assert "items" in capability_pack_activation_schema["properties"]
+    assert "items" in capability_pack_runbook_schema["properties"]
+    assert "activation_readiness" in capability_pack_governance_schema["properties"]
+    assert "observability" in capability_pack_governance_schema["properties"]
+    assert "pack_summaries" in capability_pack_catalog_governance_schema["properties"]
+    assert "based_on_capability_pack_id" in onboarding_template_schema["properties"]
     assert spec["paths"]["/platform/prompts"]["get"]["operationId"] == "listPromptDefinitions"
     assert spec["paths"]["/platform/prompts/runtime-status"]["get"]["operationId"] == (
         "getPromptRuntimeStatus"

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -106,10 +106,27 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.evaluation_runtime.approval_gates[2].domain_id == "retrieval_execution"
     assert status.evaluation_runtime.approval_gates[3].domain_id == "provider_execution"
     assert status.evaluation_runtime.approval_gates[4].domain_id == "safety_enforcement"
+    assert status.evaluation_runtime.approval_gates[5].domain_id == "analytics_commentary_pack"
+    assert status.evaluation_runtime.approval_gates[6].domain_id == "decision_explanation_pack"
     assert status.task_runtime.enabled_task_count >= 7
     assert status.task_runtime.retrieval_backed_task_count == 2
     assert status.task_runtime.tasks[0].task_id == "explain.v1"
+    assert status.capability_pack_count == 2
+    assert status.capability_pack_catalog.pack_count == 2
+    assert status.capability_pack_catalog.reusable_pack_count == 1
+    assert status.capability_pack_catalog.packs[0].pack_id == "analytics_commentary.pack.v1"
+    assert status.capability_pack_catalog.packs[0].maturity_stage.value == "REUSABLE"
+    assert status.capability_pack_catalog.packs[1].pack_id == "decision_explanation.pack.v1"
+    assert (
+        status.capability_pack_catalog.packs[0].quality_gate_domain_id
+        == "analytics_commentary_pack"
+    )
+    assert status.capability_pack_catalog.packs[0].quality_evidence_state.value == "STAGED_ONLY"
+    assert status.capability_pack_governance.ready_pack_count == 0
+    assert status.capability_pack_governance.blocking_pack_count == 2
     assert status.first_use_case.downstream_app == "lotus-performance"
+    assert status.first_use_case.capability_pack_id == "analytics_commentary.pack.v1"
+    assert status.first_use_case.capability_pack_family_id == "analytics_commentary"
     assert status.first_use_case.task_id == "explain.v1"
     assert status.first_use_case.contract_hardened is True
     assert status.first_use_case_governance.rollout_stage.value == "PRE_PROD_VALIDATION"


### PR DESCRIPTION
## Summary
- implement RFC-0021 capability packs as a product layer above generic task families
- add pack-native catalog, detail, quality-gate, observability, governance, and adoption-template surfaces
- mark RFC-0021 implemented and carry forward RFC-0022/RFC-0023 draft roadmap docs

## Validation
- `make ci`
- `python -m pytest tests/unit/test_capability_pack_catalog.py tests/unit/test_capability_pack_adoption_template.py tests/unit/test_platform_status.py tests/unit/test_openapi_contract.py tests/integration/test_capability_pack_api_contract.py tests/integration/test_health.py tests/integration/test_use_case_api_contract.py -q`
- `python scripts/openapi_quality_gate.py`
- `python scripts/run_security_audit.py`

## Notes
- security audit now carries one explicit temporary ignore for `CVE-2026-4539` in `pygments` because no patched upstream release is currently available on PyPI; the ignore is documented in `scripts/run_security_audit.py` and the operator docs so it can be removed as soon as a fix ships.
