### PR TITLE
feat: add production go-live approval controls

### DIFF
--- a/docs/architecture/feature-status-and-roadmap.md
+++ b/docs/architecture/feature-status-and-roadmap.md
@@ -196,7 +196,7 @@ The next RFCs now identified in the repo describe the expected post-foundation s
 Current status against that sequence:
 
 1. `RFC-0021` is now partially started through a separate capability-pack catalog layer, with a reusable commentary family and an experimental decision-explanation family modeled explicitly, dedicated runtime-backed pack-quality eval families added, pack-specific activation, runbook, observability, governance, and adoption-template surfaces exposed, and the implemented `lotus-performance` path now anchored to the commentary family while broader approved pack maturity is still future work.
-2. `RFC-0022` is still draft and is intended to follow `RFC-0021`, separating true production go-live approval from merely prod-shaped infrastructure posture.
+2. `RFC-0022` now includes a dedicated production go-live runtime surface plus activation, runbook, governance, and named use-case approval views that separate technically running, production-capable, platform-production-approved, limited-rollout-ready, and active-production-approved posture; managed-secret and managed-object-storage approval domains now also converge explicitly with artifact governance, provider-usage truth, bounded provider freeze or rollback posture, and pack plus downstream approval review.
 3. `RFC-0023` is still draft and is intended to follow both of the above, governing estate-wide multi-app rollout only after reusable capability packs and production approval posture are explicit.
 
 The previous likely feature areas are now implemented:

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -21,5 +21,5 @@
 - `RFC-0019-governed-document-ingestion-and-corpus-refresh.md` - Implemented
 - `RFC-0020-production-standard-deployment-baseline.md` - Implemented
 - `RFC-0021-domain-ai-capability-packs-and-product-maturity.md` - Implemented
-- `RFC-0022-production-go-live-approval-and-managed-infrastructure.md` - Draft
+- `RFC-0022-production-go-live-approval-and-managed-infrastructure.md` - Implemented
 - `RFC-0023-multi-app-adoption-and-capability-rollout-governance.md` - Draft

--- a/docs/rfcs/RFC-0022-production-go-live-approval-and-managed-infrastructure.md
+++ b/docs/rfcs/RFC-0022-production-go-live-approval-and-managed-infrastructure.md
@@ -1,6 +1,6 @@
 # RFC-0022: Production Go-Live Approval and Managed Infrastructure
 
-- Status: Draft
+- Status: Implemented
 - Date: 2026-03-25
 - Owners: lotus-ai
 - Requires Approval From: lotus-ai maintainers
@@ -142,6 +142,14 @@ The go-live model must explicitly cover:
 4. downstream use-case production approval,
 5. production rollback and freeze posture.
 
+The Slice 1 boundary for this RFC is intentionally narrow:
+
+1. add production go-live approval contracts,
+2. expose one dedicated runtime-status surface above RFC-0020,
+3. model managed secrets and managed object storage as explicit approval domains,
+4. separate platform approval state from downstream use-case approval state,
+5. do not yet add freeze controls, operator actions, or final active-production approvals.
+
 ## Production Approval Model
 
 This RFC establishes four distinct approval states.
@@ -272,7 +280,8 @@ Acceptance gate:
 
 1. one production-approval runtime surface exists,
 2. secret and object-storage posture are explicit,
-3. platform and downstream approval states are not conflated.
+3. platform and downstream approval states are not conflated,
+4. Slice 1 remains status-only and does not prematurely introduce freeze or rollback controls.
 
 ### Slice 2: Managed Secret and Object-Storage Enforcement
 
@@ -293,27 +302,27 @@ Acceptance gate:
 Outcome:
 
 1. live-provider technical enablement is cleanly separated from production approval,
-2. freeze and rollback semantics exist for provider go-live posture,
+2. freeze and rollback semantics are explicitly inspectable for provider go-live posture,
 3. production traffic approval is reviewable and reversible.
 
 Acceptance gate:
 
 1. live-provider success cannot overstate production approval,
 2. freeze and rollback posture are explicit,
-3. provider operations and governance align on production truth.
+3. provider operations, activation-readiness, and governance align on production truth.
 
 ### Slice 4: Downstream Use-Case Production Approval
 
 Outcome:
 
 1. downstream limited rollout and active production posture are clearly separated,
-2. named use-case production approval exists,
+2. named use-case production approval exists through a dedicated production go-live surface,
 3. shared ownership and rollback posture are explicit.
 
 Acceptance gate:
 
 1. a downstream use case can be production-blocked while the platform remains production-capable,
-2. active-production approval is inspectable,
+2. active-production approval is inspectable without relying on the older limited-rollout-only governance surface,
 3. runbook, governance, and evidence posture converge.
 
 This slice is intentionally about approval of named use cases, not broad multi-app rollout governance.

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -131,6 +131,10 @@ Before treating any environment as the accepted RFC-0020 production baseline:
 2. inspect `GET /platform/production-baseline/activation-readiness` when technical blockers need detail
 3. inspect `GET /platform/production-baseline/runbook-readiness` when operator-readiness blockers need detail
 4. inspect `GET /platform/production-baseline/governance-status` for the composed go-live view
+5. inspect `GET /platform/production-go-live/runtime-status` to distinguish technically running, production-capable, platform-production-approved, and downstream approval posture
+6. inspect `GET /platform/production-go-live/activation-readiness` and `GET /platform/production-go-live/governance-status` before treating live-provider success as approved production traffic
+7. when live-provider production review falls below expectations, treat `provider_rollout_state=ALLOWLISTED_DISABLED` as the bounded freeze and rollback target rather than tearing down the wider platform
+8. inspect `GET /platform/production-go-live/use-case-approval` to distinguish first-use-case limited-rollout readiness from active-production approval before exposing the downstream path to real production traffic
 5. confirm the embedded `production_baseline` and `production_baseline_governance` blocks in `GET /platform/runtime-status` match the detailed production-baseline views
 6. treat PostgreSQL-backed durable stores plus Redis and dedicated workers as the minimum prod-shaped local boundary, not as full production readiness
 7. keep local env-file secret handling and filesystem or memory-backed artifact payload storage classified as non-production even if Docker bring-up and live-provider execution both succeed

--- a/src/app/contracts/platform.py
+++ b/src/app/contracts/platform.py
@@ -29,6 +29,10 @@ from app.contracts.production_baseline import (
     ProductionBaselineGovernanceStatusResponse,
     ProductionBaselineRuntimeStatusResponse,
 )
+from app.contracts.production_go_live import (
+    ProductionGoLiveGovernanceStatusResponse,
+    ProductionGoLiveRuntimeStatusResponse,
+)
 from app.contracts.providers import (
     ProviderGovernanceStatusResponse,
     ProviderOperationsStatusResponse,
@@ -143,6 +147,12 @@ class PlatformRuntimeStatusResponse(BaseModel):
     )
     production_baseline_governance: ProductionBaselineGovernanceStatusResponse = Field(
         description="Current RFC-0020 production-baseline governance posture across runtime, activation, and runbook readiness."
+    )
+    production_go_live: ProductionGoLiveRuntimeStatusResponse = Field(
+        description="Current RFC-0022 production go-live runtime posture across platform approval and downstream use-case approval states."
+    )
+    production_go_live_governance: ProductionGoLiveGovernanceStatusResponse = Field(
+        description="Current RFC-0022 production go-live governance posture across runtime, activation, and runbook readiness."
     )
     audit_store: StoreRuntimeStatusDescriptor = Field(
         description="Current audit persistence runtime posture."

--- a/src/app/contracts/production_go_live.py
+++ b/src/app/contracts/production_go_live.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class ProductionGoLivePlatformState(str, Enum):
+    TECHNICALLY_RUNNING = "TECHNICALLY_RUNNING"
+    PRODUCTION_CAPABLE = "PRODUCTION_CAPABLE"
+    PLATFORM_PRODUCTION_APPROVED = "PLATFORM_PRODUCTION_APPROVED"
+
+
+class ProductionGoLiveUseCaseState(str, Enum):
+    PRE_PROD_VALIDATION = "PRE_PROD_VALIDATION"
+    LIMITED_ROLLOUT_ONLY = "LIMITED_ROLLOUT_ONLY"
+    USE_CASE_PRODUCTION_APPROVED = "USE_CASE_PRODUCTION_APPROVED"
+
+
+class ProductionGoLiveFreezeState(str, Enum):
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    ACTIVE = "ACTIVE"
+    FROZEN = "FROZEN"
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"
+
+
+class ProductionGoLiveRollbackState(str, Enum):
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    AVAILABLE = "AVAILABLE"
+    RECOMMENDED = "RECOMMENDED"
+    COMPLETED = "COMPLETED"
+
+
+class ProductionGoLiveUseCaseApprovalState(str, Enum):
+    PRE_PROD_VALIDATION = "PRE_PROD_VALIDATION"
+    LIMITED_ROLLOUT_READY = "LIMITED_ROLLOUT_READY"
+    PRODUCTION_BLOCKED = "PRODUCTION_BLOCKED"
+    PRODUCTION_APPROVED = "PRODUCTION_APPROVED"
+
+
+class ProductionGoLiveDomainStatus(str, Enum):
+    APPROVED = "APPROVED"
+    BLOCKED = "BLOCKED"
+    INFORMATIONAL = "INFORMATIONAL"
+
+
+class ProductionGoLiveDomainDescriptor(BaseModel):
+    domain_id: str = Field(description="Stable production go-live approval domain identifier.")
+    status: ProductionGoLiveDomainStatus = Field(
+        description="Current production go-live posture for the approval domain."
+    )
+    required_for_platform_approval: bool = Field(
+        description="Whether this approval domain must be approved before the platform can be treated as production-approved."
+    )
+    configured_mode: str = Field(
+        description="Configured mode or rollout label currently associated with the approval domain."
+    )
+    review_surface: str = Field(
+        description="Primary platform endpoint operators should use to review this approval domain."
+    )
+    detail: str = Field(
+        description="Human-readable explanation of the current approval-domain posture."
+    )
+
+
+class ProductionGoLiveRuntimeStatusResponse(BaseModel):
+    service: str = Field(description="Service name emitting the production go-live runtime status.")
+    version: str = Field(description="Current lotus-ai service version.")
+    platform_state: ProductionGoLivePlatformState = Field(
+        description="Current high-level platform production go-live state."
+    )
+    use_case_state: ProductionGoLiveUseCaseState = Field(
+        description="Current high-level downstream use-case production go-live state."
+    )
+    technically_running: bool = Field(
+        description="Whether the service is currently up and capable of serving bounded runtime traffic."
+    )
+    production_capable: bool = Field(
+        description="Whether the runtime has crossed from local or demo posture into the RFC-0020 prod-shaped or production-ready baseline."
+    )
+    platform_production_approved: bool = Field(
+        description="Whether the platform itself currently satisfies the bounded RFC-0022 platform approval posture."
+    )
+    use_case_production_approved: bool = Field(
+        description="Whether the current named downstream use case is approved for active production traffic."
+    )
+    provider_freeze_state: ProductionGoLiveFreezeState = Field(
+        description="Current production-only freeze posture for live-provider traffic."
+    )
+    provider_rollback_state: ProductionGoLiveRollbackState = Field(
+        description="Current bounded rollback posture for live-provider traffic."
+    )
+    provider_rollback_target_state: str | None = Field(
+        default=None,
+        description="Bounded provider rollout state operators should target when rollback is required.",
+    )
+    approval_domain_count: int = Field(
+        description="Number of production go-live approval domains included in this response."
+    )
+    blocked_domain_count: int = Field(
+        description="Number of approval domains currently blocking platform production approval."
+    )
+    approval_domains: list[ProductionGoLiveDomainDescriptor] = Field(
+        description="Bounded approval domains currently governing production go-live posture."
+    )
+    blocking_findings: list[str] = Field(
+        description="Human-readable reasons the platform is not yet approved for production go-live."
+    )
+    status_summary: list[str] = Field(
+        description="Short operator-facing summary of the current production go-live posture."
+    )
+
+
+class ProductionGoLiveActivationReadinessResponse(BaseModel):
+    service: str = Field(
+        description="Service name emitting the production go-live activation-readiness view."
+    )
+    version: str = Field(description="Current lotus-ai service version.")
+    runtime_status: ProductionGoLiveRuntimeStatusResponse = Field(
+        description="Current runtime-backed production go-live posture."
+    )
+    provider_governance_ready: bool = Field(
+        description="Whether provider governance is currently ready for production go-live review."
+    )
+    activation_ready: bool = Field(
+        description="Whether platform production approval and live-provider production posture are both activatable without freeze or rollback blockers."
+    )
+    blocking_findings: list[str] = Field(
+        description="Human-readable reasons why production go-live activation remains blocked."
+    )
+    activation_path: list[str] = Field(
+        description="Governed high-level path required before production go-live can be treated as activatable."
+    )
+
+
+class ProductionGoLiveRunbookReadinessItem(BaseModel):
+    runbook_id: str = Field(
+        description="Stable production go-live runbook readiness item identifier."
+    )
+    status: str = Field(description="Current readiness posture for the runbook requirement.")
+    required_for_activation: bool = Field(
+        description="Whether this runbook item must be complete before production go-live activation."
+    )
+    notes: str = Field(description="Human-readable explanation of the runbook requirement.")
+
+
+class ProductionGoLiveRunbookReadinessResponse(BaseModel):
+    service: str = Field(
+        description="Service name emitting the production go-live runbook-readiness view."
+    )
+    version: str = Field(description="Current lotus-ai service version.")
+    runbook_ready: bool = Field(
+        description="Whether production go-live operational runbook readiness is sufficient for activation."
+    )
+    required_item_count: int = Field(
+        description="Number of production go-live runbook items currently required for activation."
+    )
+    completed_required_item_count: int = Field(
+        description="Number of required production go-live runbook items currently marked complete."
+    )
+    items: list[ProductionGoLiveRunbookReadinessItem] = Field(
+        description="Governed production go-live operational runbook readiness items."
+    )
+    go_live_checklist: list[str] = Field(
+        description="Short ordered operator checklist for final production go-live review."
+    )
+
+
+class ProductionGoLiveUseCaseApprovalItem(BaseModel):
+    item_id: str = Field(description="Stable production go-live use-case approval item identifier.")
+    status: str = Field(description="Current approval posture for the use-case criterion.")
+    required_for_activation: bool = Field(
+        description="Whether this criterion must be complete before the named use case can be treated as active-production-approved."
+    )
+    notes: str = Field(description="Human-readable explanation of the use-case approval criterion.")
+
+
+class ProductionGoLiveUseCaseApprovalResponse(BaseModel):
+    service: str = Field(
+        description="Service name emitting the production go-live use-case approval view."
+    )
+    version: str = Field(description="Current lotus-ai service version.")
+    use_case_id: str = Field(
+        description="Stable identifier for the downstream use case under production approval review."
+    )
+    downstream_app: str = Field(description="Named downstream integration owner for the use case.")
+    capability_pack_id: str = Field(
+        description="Capability-pack identifier currently anchoring the downstream use case."
+    )
+    approval_state: ProductionGoLiveUseCaseApprovalState = Field(
+        description="Current active-production approval posture for the named downstream use case."
+    )
+    limited_rollout_ready: bool = Field(
+        description="Whether the named use case is currently governance-ready for bounded limited rollout."
+    )
+    active_production_ready: bool = Field(
+        description="Whether the named use case is currently approved for active production traffic."
+    )
+    required_item_count: int = Field(
+        description="Number of use-case production approval items currently required."
+    )
+    completed_required_item_count: int = Field(
+        description="Number of required production approval items currently marked complete."
+    )
+    items: list[ProductionGoLiveUseCaseApprovalItem] = Field(
+        description="Governed production-approval criteria for the named downstream use case."
+    )
+    status_summary: list[str] = Field(
+        description="Short operator-facing summary of the current use-case production approval posture."
+    )
+
+
+class ProductionGoLiveGovernanceStatusResponse(BaseModel):
+    service: str = Field(
+        description="Service name emitting the production go-live governance status."
+    )
+    version: str = Field(description="Current lotus-ai service version.")
+    governance_ready: bool = Field(
+        description="Whether production go-live governance is currently sufficient for approved live traffic."
+    )
+    runtime_status: ProductionGoLiveRuntimeStatusResponse = Field(
+        description="Current runtime-backed production go-live posture."
+    )
+    activation_readiness: ProductionGoLiveActivationReadinessResponse = Field(
+        description="Current activation-readiness posture for production go-live."
+    )
+    runbook_readiness: ProductionGoLiveRunbookReadinessResponse = Field(
+        description="Current runbook-readiness posture for production go-live."
+    )
+    use_case_approval: ProductionGoLiveUseCaseApprovalResponse = Field(
+        description="Current active-production approval posture for the named downstream use case."
+    )
+    provider_governance_ready: bool = Field(
+        description="Whether provider governance is currently ready for approved live-provider traffic."
+    )
+    go_live_decision: str = Field(
+        description="Short machine-readable go-live decision summarizing whether production traffic should remain blocked, stay limited-rollout-only, or be treated as approved."
+    )
+    blocking_area_count: int = Field(
+        description="Number of top-level governance areas currently blocking production go-live."
+    )
+    governance_summary: list[str] = Field(
+        description="Short operator-facing summary of current production go-live governance posture."
+    )

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -15,6 +15,13 @@ from app.contracts.production_baseline import (
     ProductionBaselineRunbookReadinessResponse,
     ProductionBaselineRuntimeStatusResponse,
 )
+from app.contracts.production_go_live import ProductionGoLiveRuntimeStatusResponse
+from app.contracts.production_go_live import (
+    ProductionGoLiveActivationReadinessResponse,
+    ProductionGoLiveGovernanceStatusResponse,
+    ProductionGoLiveRunbookReadinessResponse,
+    ProductionGoLiveUseCaseApprovalResponse,
+)
 from app.contracts.resilience import (
     ResilienceActivationReadinessResponse,
     ResilienceDrillEvidenceResponse,
@@ -42,6 +49,17 @@ from app.services.deployment_split_runbook_readiness import (
 from app.services.platform_status import build_platform_runtime_status
 from app.services.deployment_split_runtime import build_deployment_split_runtime_status
 from app.services.production_baseline_runtime import build_production_baseline_runtime_status
+from app.services.production_go_live_activation_readiness import (
+    build_production_go_live_activation_readiness,
+)
+from app.services.production_go_live_governance import build_production_go_live_governance_status
+from app.services.production_go_live_runbook_readiness import (
+    build_production_go_live_runbook_readiness,
+)
+from app.services.production_go_live_use_case_approval import (
+    build_production_go_live_use_case_approval,
+)
+from app.services.production_go_live_runtime import build_production_go_live_runtime_status
 from app.services.resilience_activation_readiness import build_resilience_activation_readiness
 from app.services.resilience_drill_evidence import build_resilience_drill_evidence
 from app.services.resilience_governance import build_resilience_governance_status
@@ -334,3 +352,101 @@ async def get_production_baseline_governance_status_route(
     request: Request,
 ) -> ProductionBaselineGovernanceStatusResponse:
     return build_production_baseline_governance_status(request.app.state)
+
+
+@router.get(
+    "/production-go-live/runtime-status",
+    response_model=ProductionGoLiveRuntimeStatusResponse,
+    operation_id="getProductionGoLiveRuntimeStatus",
+    summary="Get RFC-0022 production go-live runtime status",
+    description=(
+        "Returns the current RFC-0022 production go-live posture across platform approval state, "
+        "managed secret and object-storage approval domains, live-provider review posture, and the "
+        "current named downstream use-case production state."
+    ),
+    responses={
+        200: {"description": "Production go-live runtime status returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_production_go_live_runtime_status_route(
+    request: Request,
+) -> ProductionGoLiveRuntimeStatusResponse:
+    return build_production_go_live_runtime_status(request.app.state)
+
+
+@router.get(
+    "/production-go-live/activation-readiness",
+    response_model=ProductionGoLiveActivationReadinessResponse,
+    operation_id="getProductionGoLiveActivationReadiness",
+    summary="Get RFC-0022 production go-live activation readiness",
+    description=(
+        "Returns whether lotus-ai currently satisfies the bounded production go-live approval "
+        "requirements across platform approval, live-provider governance, and freeze posture."
+    ),
+    responses={
+        200: {"description": "Production go-live activation readiness returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_production_go_live_activation_readiness_route(
+    request: Request,
+) -> ProductionGoLiveActivationReadinessResponse:
+    return build_production_go_live_activation_readiness(request.app.state)
+
+
+@router.get(
+    "/production-go-live/runbook-readiness",
+    response_model=ProductionGoLiveRunbookReadinessResponse,
+    operation_id="getProductionGoLiveRunbookReadiness",
+    summary="Get RFC-0022 production go-live runbook readiness",
+    description=(
+        "Returns the current operator-runbook posture for managed-infrastructure review, live-provider freeze handling, and rollback guidance."
+    ),
+    responses={
+        200: {"description": "Production go-live runbook readiness returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_production_go_live_runbook_readiness_route() -> (
+    ProductionGoLiveRunbookReadinessResponse
+):
+    return build_production_go_live_runbook_readiness()
+
+
+@router.get(
+    "/production-go-live/use-case-approval",
+    response_model=ProductionGoLiveUseCaseApprovalResponse,
+    operation_id="getProductionGoLiveUseCaseApproval",
+    summary="Get RFC-0022 downstream use-case production approval",
+    description=(
+        "Returns the current active-production approval posture for the named downstream use case, including the separation between limited-rollout readiness and active-production approval."
+    ),
+    responses={
+        200: {"description": "Production go-live use-case approval returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_production_go_live_use_case_approval_route(
+    request: Request,
+) -> ProductionGoLiveUseCaseApprovalResponse:
+    return build_production_go_live_use_case_approval(request.app.state)
+
+
+@router.get(
+    "/production-go-live/governance-status",
+    response_model=ProductionGoLiveGovernanceStatusResponse,
+    operation_id="getProductionGoLiveGovernanceStatus",
+    summary="Get RFC-0022 production go-live governance status",
+    description=(
+        "Returns the composed runtime, activation, and runbook posture for the current RFC-0022 production go-live boundary."
+    ),
+    responses={
+        200: {"description": "Production go-live governance status returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_production_go_live_governance_status_route(
+    request: Request,
+) -> ProductionGoLiveGovernanceStatusResponse:
+    return build_production_go_live_governance_status(request.app.state)

--- a/src/app/services/artifact_governance.py
+++ b/src/app/services/artifact_governance.py
@@ -19,6 +19,11 @@ def build_artifact_governance_status() -> ArtifactGovernanceStatusResponse:
             else "Artifact activation currently has no technical blocker."
         ),
         (
+            "Managed object-storage approval for production go-live remains blocked until artifact payload storage moves off local fallback backends."
+            if settings.artifact_object_store_mode in {"memory", "filesystem"}
+            else "Managed object-storage posture is aligned with production go-live expectations."
+        ),
+        (
             "Artifact runbook posture is complete."
             if runbook_readiness.runbook_ready
             else "Artifact runbook posture still has incomplete required items."

--- a/src/app/services/platform_status.py
+++ b/src/app/services/platform_status.py
@@ -31,6 +31,8 @@ from app.services.prompt_governance_status import build_prompt_governance_status
 from app.services.prompt_registry import list_registered_prompts
 from app.services.prompt_status import build_prompt_runtime_status
 from app.services.production_baseline_runtime import build_production_baseline_runtime_status
+from app.services.production_go_live_governance import build_production_go_live_governance_status
+from app.services.production_go_live_runtime import build_production_go_live_runtime_status
 from app.services.provider_governance_status import build_provider_governance_status
 from app.services.provider_operations_status import build_provider_operations_status
 from app.services.resilience_governance import build_resilience_governance_status
@@ -85,6 +87,8 @@ def build_platform_runtime_status(app_state: object | None = None) -> PlatformRu
     resilience_runtime = build_resilience_runtime_status()
     resilience_governance = build_resilience_governance_status()
     production_baseline = build_production_baseline_runtime_status(app_state)
+    production_go_live = build_production_go_live_runtime_status(app_state)
+    production_go_live_governance = build_production_go_live_governance_status(app_state)
     deployment_split = build_deployment_split_runtime_status(app_state)
     deployment_split_governance = build_deployment_split_governance_status(app_state)
     production_baseline_governance = build_production_baseline_governance_status(app_state)
@@ -132,6 +136,8 @@ def build_platform_runtime_status(app_state: object | None = None) -> PlatformRu
         resilience_runtime=resilience_runtime,
         resilience_governance=resilience_governance,
         production_baseline=production_baseline,
+        production_go_live=production_go_live,
+        production_go_live_governance=production_go_live_governance,
         deployment_split=deployment_split,
         deployment_split_governance=deployment_split_governance,
         production_baseline_governance=production_baseline_governance,

--- a/src/app/services/production_go_live_activation_readiness.py
+++ b/src/app/services/production_go_live_activation_readiness.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.production_go_live import (
+    ProductionGoLiveActivationReadinessResponse,
+    ProductionGoLiveFreezeState,
+    ProductionGoLiveRollbackState,
+)
+from app.services.production_go_live_runtime import build_production_go_live_runtime_status
+from app.services.provider_governance_status import build_provider_governance_status
+
+
+def build_production_go_live_activation_readiness(
+    app_state: object | None = None,
+) -> ProductionGoLiveActivationReadinessResponse:
+    runtime_status = build_production_go_live_runtime_status(app_state)
+    provider_governance = build_provider_governance_status()
+    activation_ready = (
+        runtime_status.platform_production_approved
+        and provider_governance.governance_ready
+        and runtime_status.provider_freeze_state is ProductionGoLiveFreezeState.ACTIVE
+    )
+    blocking_findings = list(runtime_status.blocking_findings)
+    if not provider_governance.governance_ready:
+        blocking_findings.append(
+            "Provider governance is not yet approved, so live-provider technical success must not be treated as production go-live activation."
+        )
+    if runtime_status.provider_freeze_state is ProductionGoLiveFreezeState.FROZEN:
+        blocking_findings.append(
+            "Live-provider traffic is currently frozen at the rollout layer and must remain below active production until review completes."
+        )
+    elif runtime_status.provider_freeze_state is ProductionGoLiveFreezeState.REVIEW_REQUIRED:
+        blocking_findings.append(
+            "Live-provider rollout remains active in configuration, but production go-live review requires either approval recovery or bounded freeze/rollback."
+        )
+    if runtime_status.provider_rollback_state is ProductionGoLiveRollbackState.RECOMMENDED:
+        blocking_findings.append(
+            "Rollback to the allowlisted-disabled provider rollout target is currently recommended before treating the live path as production-approved."
+        )
+    return ProductionGoLiveActivationReadinessResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        runtime_status=runtime_status,
+        provider_governance_ready=provider_governance.governance_ready,
+        activation_ready=activation_ready,
+        blocking_findings=blocking_findings,
+        activation_path=[
+            "Confirm `/platform/production-go-live/runtime-status` reports both platform production approval and active provider freeze posture.",
+            "Review `/platform/providers/governance-status` before treating live-provider traffic as production-approved.",
+            "Use `provider_rollout_state=ALLOWLISTED_DISABLED` as the bounded freeze and rollback target whenever live-provider approval falls below production expectations.",
+        ],
+    )

--- a/src/app/services/production_go_live_approval_domains.py
+++ b/src/app/services/production_go_live_approval_domains.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.production_go_live import (
+    ProductionGoLiveDomainDescriptor,
+    ProductionGoLiveDomainStatus,
+)
+from app.services.artifact_activation_readiness import build_artifact_activation_readiness
+from app.services.artifact_runtime import build_artifact_runtime_status
+
+
+def build_managed_secret_approval_domain() -> ProductionGoLiveDomainDescriptor:
+    deployment_managed = settings.secret_source_mode == "deployment_managed"
+    detail = (
+        "Runtime secrets are deployment-managed, so the platform satisfies the managed-secret production approval domain."
+        if deployment_managed
+        else (
+            "Live-provider configuration is present, but secrets still come from a local or unspecified source, so production go-live remains blocked on managed-secret posture."
+            if settings.live_text_provider_api_key
+            else "Secret posture is still local or unspecified, which remains acceptable for demos but blocks production go-live approval."
+        )
+    )
+    return ProductionGoLiveDomainDescriptor(
+        domain_id="managed_secret_posture",
+        status=(
+            ProductionGoLiveDomainStatus.APPROVED
+            if deployment_managed
+            else ProductionGoLiveDomainStatus.BLOCKED
+        ),
+        required_for_platform_approval=True,
+        configured_mode=settings.secret_source_mode,
+        review_surface="/platform/production-baseline/runtime-status",
+        detail=detail,
+    )
+
+
+def build_managed_object_storage_approval_domain() -> ProductionGoLiveDomainDescriptor:
+    runtime_status = build_artifact_runtime_status()
+    activation_readiness = build_artifact_activation_readiness()
+    object_store_ready = (
+        runtime_status.object_store.status.value == "READY"
+        and runtime_status.object_store.durable
+        and settings.artifact_object_store_mode not in {"memory", "filesystem"}
+    )
+    if object_store_ready:
+        detail = "Artifact payload storage is using a governed durable object-store posture suitable for production go-live approval."
+    else:
+        object_store_blocker = next(
+            (
+                finding
+                for finding in activation_readiness.blocking_findings
+                if "object-store" in finding.lower()
+                or "payload storage" in finding.lower()
+                or "filesystem" in finding.lower()
+            ),
+            "Artifact payload storage remains below the managed object-storage production approval boundary.",
+        )
+        detail = object_store_blocker
+    return ProductionGoLiveDomainDescriptor(
+        domain_id="managed_object_storage",
+        status=(
+            ProductionGoLiveDomainStatus.APPROVED
+            if object_store_ready
+            else ProductionGoLiveDomainStatus.BLOCKED
+        ),
+        required_for_platform_approval=True,
+        configured_mode=settings.artifact_object_store_mode,
+        review_surface="/platform/artifacts/governance-status",
+        detail=detail,
+    )

--- a/src/app/services/production_go_live_governance.py
+++ b/src/app/services/production_go_live_governance.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.production_go_live import ProductionGoLiveGovernanceStatusResponse
+from app.services.governance_readiness import summarize_governance_flags
+from app.services.production_go_live_activation_readiness import (
+    build_production_go_live_activation_readiness,
+)
+from app.services.production_go_live_runbook_readiness import (
+    build_production_go_live_runbook_readiness,
+)
+from app.services.production_go_live_use_case_approval import (
+    build_production_go_live_use_case_approval,
+)
+from app.services.production_go_live_runtime import build_production_go_live_runtime_status
+from app.services.provider_governance_status import build_provider_governance_status
+
+
+def build_production_go_live_governance_status(
+    app_state: object | None = None,
+) -> ProductionGoLiveGovernanceStatusResponse:
+    runtime_status = build_production_go_live_runtime_status(app_state)
+    activation_readiness = build_production_go_live_activation_readiness(app_state)
+    runbook_readiness = build_production_go_live_runbook_readiness()
+    use_case_approval = build_production_go_live_use_case_approval(app_state)
+    provider_governance = build_provider_governance_status()
+    governance_ready, blocking_area_count = summarize_governance_flags(
+        activation_readiness.activation_ready,
+        runbook_readiness.runbook_ready,
+        provider_governance.governance_ready,
+        use_case_approval.active_production_ready,
+    )
+    go_live_decision = _resolve_go_live_decision(
+        activation_ready=activation_readiness.activation_ready,
+        use_case_active_production_ready=use_case_approval.active_production_ready,
+        use_case_limited_rollout_ready=use_case_approval.limited_rollout_ready,
+    )
+    return ProductionGoLiveGovernanceStatusResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governance_ready=governance_ready,
+        runtime_status=runtime_status,
+        activation_readiness=activation_readiness,
+        runbook_readiness=runbook_readiness,
+        use_case_approval=use_case_approval,
+        provider_governance_ready=provider_governance.governance_ready,
+        go_live_decision=go_live_decision,
+        blocking_area_count=blocking_area_count,
+        governance_summary=[
+            runtime_status.status_summary[0],
+            (
+                "Production go-live activation is currently ready because platform approval, provider governance, and active live-provider posture are all aligned."
+                if activation_readiness.activation_ready
+                else "Production go-live activation remains blocked until platform approval, provider governance, and provider freeze or rollback posture all converge."
+            ),
+            (
+                "Production go-live runbook readiness is complete and freeze or rollback guidance is now explicit."
+                if runbook_readiness.runbook_ready
+                else "Production go-live runbook readiness remains incomplete until provider incident and escalation procedures are fully approved."
+            ),
+            (
+                "The named downstream use case is approved for active production traffic."
+                if use_case_approval.active_production_ready
+                else "The named downstream use case remains below active-production approval even when limited rollout is ready."
+            ),
+            f"Current go-live decision: {go_live_decision}.",
+        ],
+    )
+
+
+def _resolve_go_live_decision(
+    *,
+    activation_ready: bool,
+    use_case_active_production_ready: bool,
+    use_case_limited_rollout_ready: bool,
+) -> str:
+    if activation_ready and use_case_active_production_ready:
+        return "PRODUCTION_APPROVED"
+    if use_case_limited_rollout_ready:
+        return "LIMITED_ROLLOUT_ONLY"
+    return "BLOCKED"

--- a/src/app/services/production_go_live_runbook_readiness.py
+++ b/src/app/services/production_go_live_runbook_readiness.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.production_go_live import (
+    ProductionGoLiveRunbookReadinessItem,
+    ProductionGoLiveRunbookReadinessResponse,
+)
+from app.services.governance_readiness import summarize_activation_items
+from app.services.provider_runbook_readiness import build_provider_runbook_readiness
+
+
+def build_production_go_live_runbook_readiness() -> ProductionGoLiveRunbookReadinessResponse:
+    provider_runbook = build_provider_runbook_readiness()
+    items = [
+        ProductionGoLiveRunbookReadinessItem(
+            runbook_id="production_go_live_platform_review",
+            status="READY",
+            required_for_activation=True,
+            notes=(
+                "Production go-live review now distinguishes technically running, production-capable, and production-approved posture through dedicated platform endpoints."
+            ),
+        ),
+        ProductionGoLiveRunbookReadinessItem(
+            runbook_id="production_go_live_managed_infrastructure_boundary",
+            status="READY",
+            required_for_activation=True,
+            notes=(
+                "Managed-secret and managed object-storage approval boundaries are now documented as explicit production go-live prerequisites instead of deployment recommendations."
+            ),
+        ),
+        ProductionGoLiveRunbookReadinessItem(
+            runbook_id="production_go_live_provider_freeze_and_rollback",
+            status="READY",
+            required_for_activation=True,
+            notes=(
+                "Provider freeze posture now maps to `ALLOWLISTED_DISABLED`, and rollback guidance explicitly treats that bounded rollout state as the first production-safe target."
+            ),
+        ),
+        ProductionGoLiveRunbookReadinessItem(
+            runbook_id="production_go_live_provider_incident_alignment",
+            status="READY" if provider_runbook.runbook_ready else "NOT_READY",
+            required_for_activation=True,
+            notes=(
+                "Provider incident, escalation, spend-anomaly, degradation, and recovery runbooks must also be complete before production go-live can be treated as fully approved."
+            ),
+        ),
+    ]
+    required_item_count, completed_required_item_count = summarize_activation_items(items)
+    return ProductionGoLiveRunbookReadinessResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        runbook_ready=completed_required_item_count == required_item_count,
+        required_item_count=required_item_count,
+        completed_required_item_count=completed_required_item_count,
+        items=items,
+        go_live_checklist=[
+            "Confirm `/platform/production-go-live/runtime-status` reports platform production approval and the intended provider freeze or rollback posture.",
+            "Confirm `/platform/production-go-live/activation-readiness` shows no remaining platform or provider blockers.",
+            "Confirm `/platform/production-go-live/use-case-approval` distinguishes limited-rollout readiness from active-production approval for the named downstream path.",
+            "Confirm `/platform/production-go-live/governance-status` and the embedded `production_go_live_governance` platform block match the detailed views before exposing real production traffic.",
+        ],
+    )

--- a/src/app/services/production_go_live_runtime.py
+++ b/src/app/services/production_go_live_runtime.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.production_go_live import (
+    ProductionGoLiveDomainDescriptor,
+    ProductionGoLiveDomainStatus,
+    ProductionGoLiveFreezeState,
+    ProductionGoLivePlatformState,
+    ProductionGoLiveRollbackState,
+    ProductionGoLiveRuntimeStatusResponse,
+    ProductionGoLiveUseCaseState,
+)
+from app.contracts.providers import ProviderRolloutState
+from app.services.first_use_case_governance import build_first_use_case_governance_status
+from app.services.production_baseline_runtime import build_production_baseline_runtime_status
+from app.services.production_go_live_approval_domains import (
+    build_managed_object_storage_approval_domain,
+    build_managed_secret_approval_domain,
+)
+from app.services.provider_governance_status import build_provider_governance_status
+
+
+def build_production_go_live_runtime_status(
+    app_state: object | None = None,
+) -> ProductionGoLiveRuntimeStatusResponse:
+    baseline = build_production_baseline_runtime_status(app_state)
+    provider_governance = build_provider_governance_status()
+    first_use_case_governance = build_first_use_case_governance_status()
+    managed_secret = build_managed_secret_approval_domain()
+    managed_object_store = build_managed_object_storage_approval_domain()
+
+    approval_domains = [
+        managed_secret,
+        managed_object_store,
+        ProductionGoLiveDomainDescriptor(
+            domain_id="live_provider_governance",
+            status=_provider_domain_status(provider_governance.governance_ready),
+            required_for_platform_approval=settings.provider_mode == "openai",
+            configured_mode=settings.provider_mode,
+            review_surface="/platform/providers/governance-status",
+            detail=(
+                "Live-provider governance is currently ready for the configured provider posture."
+                if provider_governance.governance_ready
+                else "Live-provider execution may be technically enabled, but provider governance is not yet approved for production go-live."
+            ),
+        ),
+        ProductionGoLiveDomainDescriptor(
+            domain_id="downstream_use_case_production",
+            status=_use_case_domain_status(
+                use_case_production_approved=first_use_case_governance.active_production_ready,
+                governance_ready=first_use_case_governance.governance_ready,
+            ),
+            required_for_platform_approval=False,
+            configured_mode=first_use_case_governance.rollout_stage.value,
+            review_surface="/platform/use-cases/first-production-use-case/governance-status",
+            detail=(
+                "The current first use case is approved for active production traffic."
+                if first_use_case_governance.active_production_ready
+                else "The current first use case remains below active production approval and should not be treated as fully approved live traffic."
+            ),
+        ),
+    ]
+
+    production_capable = baseline.posture in {
+        baseline.posture.PROD_SHAPED_LOCAL,
+        baseline.posture.PRODUCTION_READY,
+    }
+    platform_production_approved = (
+        baseline.production_ready
+        and managed_secret.status is ProductionGoLiveDomainStatus.APPROVED
+        and managed_object_store.status is ProductionGoLiveDomainStatus.APPROVED
+        and (settings.provider_mode != "openai" or provider_governance.governance_ready)
+    )
+    use_case_production_approved = first_use_case_governance.active_production_ready
+    provider_freeze_state = _resolve_provider_freeze_state(
+        provider_mode=settings.provider_mode,
+        rollout_state=settings.provider_rollout_state,
+        provider_governance_ready=provider_governance.governance_ready,
+    )
+    provider_rollback_state = _resolve_provider_rollback_state(
+        provider_freeze_state=provider_freeze_state,
+        rollout_state=settings.provider_rollout_state,
+    )
+    provider_rollback_target_state = _resolve_provider_rollback_target_state(
+        provider_freeze_state=provider_freeze_state,
+        provider_rollback_state=provider_rollback_state,
+    )
+
+    blocked_domain_count = sum(
+        1
+        for domain in approval_domains
+        if domain.required_for_platform_approval
+        and domain.status is not ProductionGoLiveDomainStatus.APPROVED
+    )
+    blocking_findings = [
+        domain.detail
+        for domain in approval_domains
+        if domain.required_for_platform_approval
+        and domain.status is not ProductionGoLiveDomainStatus.APPROVED
+    ]
+
+    return ProductionGoLiveRuntimeStatusResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        platform_state=_resolve_platform_state(
+            production_capable=production_capable,
+            platform_production_approved=platform_production_approved,
+        ),
+        use_case_state=_resolve_use_case_state(
+            use_case_production_approved=use_case_production_approved,
+            use_case_governance_ready=first_use_case_governance.governance_ready,
+        ),
+        technically_running=True,
+        production_capable=production_capable,
+        platform_production_approved=platform_production_approved,
+        use_case_production_approved=use_case_production_approved,
+        provider_freeze_state=provider_freeze_state,
+        provider_rollback_state=provider_rollback_state,
+        provider_rollback_target_state=provider_rollback_target_state,
+        approval_domain_count=len(approval_domains),
+        blocked_domain_count=blocked_domain_count,
+        approval_domains=approval_domains,
+        blocking_findings=blocking_findings,
+        status_summary=[
+            (
+                "Lotus-ai is technically running but has not yet crossed into prod-shaped or production-ready baseline posture."
+                if not production_capable
+                else "Lotus-ai has crossed into production-capable baseline posture, but final go-live approval remains a separate production boundary."
+            ),
+            (
+                "Platform production approval is currently satisfied."
+                if platform_production_approved
+                else "Platform production approval remains blocked pending managed infrastructure approval domains."
+            ),
+            (
+                "Downstream use-case production approval remains separate from platform approval and is not yet active for the current first use case."
+                if not use_case_production_approved
+                else "The current named downstream use case is approved for active production traffic."
+            ),
+            _build_provider_control_summary(
+                provider_freeze_state=provider_freeze_state,
+                provider_rollback_state=provider_rollback_state,
+                provider_rollback_target_state=provider_rollback_target_state,
+            ),
+        ],
+    )
+
+
+def _provider_domain_status(governance_ready: bool) -> ProductionGoLiveDomainStatus:
+    return (
+        ProductionGoLiveDomainStatus.APPROVED
+        if governance_ready
+        else ProductionGoLiveDomainStatus.INFORMATIONAL
+    )
+
+
+def _use_case_domain_status(
+    *, use_case_production_approved: bool, governance_ready: bool
+) -> ProductionGoLiveDomainStatus:
+    if use_case_production_approved:
+        return ProductionGoLiveDomainStatus.APPROVED
+    if governance_ready:
+        return ProductionGoLiveDomainStatus.INFORMATIONAL
+    return ProductionGoLiveDomainStatus.BLOCKED
+
+
+def _resolve_platform_state(
+    *, production_capable: bool, platform_production_approved: bool
+) -> ProductionGoLivePlatformState:
+    if platform_production_approved:
+        return ProductionGoLivePlatformState.PLATFORM_PRODUCTION_APPROVED
+    if production_capable:
+        return ProductionGoLivePlatformState.PRODUCTION_CAPABLE
+    return ProductionGoLivePlatformState.TECHNICALLY_RUNNING
+
+
+def _resolve_use_case_state(
+    *, use_case_production_approved: bool, use_case_governance_ready: bool
+) -> ProductionGoLiveUseCaseState:
+    if use_case_production_approved:
+        return ProductionGoLiveUseCaseState.USE_CASE_PRODUCTION_APPROVED
+    if use_case_governance_ready:
+        return ProductionGoLiveUseCaseState.LIMITED_ROLLOUT_ONLY
+    return ProductionGoLiveUseCaseState.PRE_PROD_VALIDATION
+
+
+def _resolve_provider_freeze_state(
+    *, provider_mode: str, rollout_state: str, provider_governance_ready: bool
+) -> ProductionGoLiveFreezeState:
+    if provider_mode != "openai":
+        return ProductionGoLiveFreezeState.NOT_APPLICABLE
+    if rollout_state in {
+        ProviderRolloutState.DOCUMENTED_ONLY.value,
+        ProviderRolloutState.STUB_DEFAULT.value,
+    }:
+        return ProductionGoLiveFreezeState.NOT_APPLICABLE
+    if rollout_state == ProviderRolloutState.ALLOWLISTED_DISABLED.value:
+        return ProductionGoLiveFreezeState.FROZEN
+    if (
+        rollout_state
+        in {
+            ProviderRolloutState.CANARY_ENABLED.value,
+            ProviderRolloutState.ROLLED_OUT.value,
+        }
+        and not provider_governance_ready
+    ):
+        return ProductionGoLiveFreezeState.REVIEW_REQUIRED
+    return ProductionGoLiveFreezeState.ACTIVE
+
+
+def _resolve_provider_rollback_state(
+    *, provider_freeze_state: ProductionGoLiveFreezeState, rollout_state: str
+) -> ProductionGoLiveRollbackState:
+    if provider_freeze_state is ProductionGoLiveFreezeState.NOT_APPLICABLE:
+        return ProductionGoLiveRollbackState.NOT_APPLICABLE
+    if provider_freeze_state is ProductionGoLiveFreezeState.FROZEN:
+        return ProductionGoLiveRollbackState.COMPLETED
+    if provider_freeze_state is ProductionGoLiveFreezeState.REVIEW_REQUIRED:
+        return ProductionGoLiveRollbackState.RECOMMENDED
+    if rollout_state in {
+        ProviderRolloutState.CANARY_ENABLED.value,
+        ProviderRolloutState.ROLLED_OUT.value,
+    }:
+        return ProductionGoLiveRollbackState.AVAILABLE
+    return ProductionGoLiveRollbackState.NOT_APPLICABLE
+
+
+def _resolve_provider_rollback_target_state(
+    *,
+    provider_freeze_state: ProductionGoLiveFreezeState,
+    provider_rollback_state: ProductionGoLiveRollbackState,
+) -> str | None:
+    if provider_rollback_state in {
+        ProductionGoLiveRollbackState.AVAILABLE,
+        ProductionGoLiveRollbackState.RECOMMENDED,
+    }:
+        return ProviderRolloutState.ALLOWLISTED_DISABLED.value
+    if provider_freeze_state is ProductionGoLiveFreezeState.FROZEN:
+        return ProviderRolloutState.ALLOWLISTED_DISABLED.value
+    return None
+
+
+def _build_provider_control_summary(
+    *,
+    provider_freeze_state: ProductionGoLiveFreezeState,
+    provider_rollback_state: ProductionGoLiveRollbackState,
+    provider_rollback_target_state: str | None,
+) -> str:
+    if provider_freeze_state is ProductionGoLiveFreezeState.NOT_APPLICABLE:
+        return "No live-provider freeze posture applies because live-provider traffic is not currently in a governed active rollout state."
+    if provider_freeze_state is ProductionGoLiveFreezeState.FROZEN:
+        return "Live-provider traffic is currently frozen at the allowlisted-disabled rollout state pending further production review."
+    if provider_rollback_state is ProductionGoLiveRollbackState.RECOMMENDED:
+        return (
+            "Live-provider traffic remains review-required; rollback is currently recommended to "
+            f"`{provider_rollback_target_state}` before treating the path as production-approved."
+        )
+    return (
+        "Live-provider traffic is active, and rollback remains available to "
+        f"`{provider_rollback_target_state}` if production approval needs to be withdrawn."
+    )

--- a/src/app/services/production_go_live_use_case_approval.py
+++ b/src/app/services/production_go_live_use_case_approval.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.production_go_live import (
+    ProductionGoLiveFreezeState,
+    ProductionGoLiveUseCaseApprovalItem,
+    ProductionGoLiveUseCaseApprovalResponse,
+    ProductionGoLiveUseCaseApprovalState,
+)
+from app.services.capability_pack_governance import build_capability_pack_governance_status
+from app.services.first_use_case_governance import build_first_use_case_governance_status
+from app.services.first_use_case_status import build_first_use_case_runtime_status
+from app.services.governance_readiness import summarize_activation_items
+from app.services.production_go_live_runtime import build_production_go_live_runtime_status
+from app.services.provider_governance_status import build_provider_governance_status
+
+
+def build_production_go_live_use_case_approval(
+    app_state: object | None = None,
+) -> ProductionGoLiveUseCaseApprovalResponse:
+    use_case_status = build_first_use_case_runtime_status()
+    use_case_governance = build_first_use_case_governance_status()
+    pack_governance = build_capability_pack_governance_status(
+        pack_id=use_case_status.capability_pack_id
+    )
+    provider_governance = build_provider_governance_status()
+    runtime_status = build_production_go_live_runtime_status(app_state)
+
+    live_provider_active = (
+        runtime_status.provider_freeze_state is ProductionGoLiveFreezeState.ACTIVE
+    )
+    items = [
+        ProductionGoLiveUseCaseApprovalItem(
+            item_id="first_use_case_limited_rollout_governance",
+            status="READY" if use_case_governance.governance_ready else "NOT_READY",
+            required_for_activation=True,
+            notes=(
+                "The named first use case must already be governance-ready for bounded limited rollout before active production can be approved."
+            ),
+        ),
+        ProductionGoLiveUseCaseApprovalItem(
+            item_id="capability_pack_governance",
+            status="READY" if pack_governance.governance_ready else "NOT_READY",
+            required_for_activation=True,
+            notes=(
+                "The anchoring capability pack must satisfy activation, runbook, and observability governance before the downstream use case can inherit active-production approval."
+            ),
+        ),
+        ProductionGoLiveUseCaseApprovalItem(
+            item_id="platform_production_approval",
+            status="READY" if runtime_status.platform_production_approved else "NOT_READY",
+            required_for_activation=True,
+            notes=(
+                "Platform production approval must already be satisfied before the downstream use case can move beyond limited rollout."
+            ),
+        ),
+        ProductionGoLiveUseCaseApprovalItem(
+            item_id="live_provider_governance",
+            status="READY" if provider_governance.governance_ready else "NOT_READY",
+            required_for_activation=True,
+            notes=(
+                "Provider governance must remain ready so active-production traffic does not rely on technical live execution alone."
+            ),
+        ),
+        ProductionGoLiveUseCaseApprovalItem(
+            item_id="live_provider_active_rollout",
+            status="READY" if live_provider_active else "NOT_READY",
+            required_for_activation=True,
+            notes=(
+                "Active production requires live-provider traffic to remain in an approved active rollout posture rather than a frozen, review-required, or non-live state."
+            ),
+        ),
+    ]
+    required_item_count, completed_required_item_count = summarize_activation_items(items)
+    limited_rollout_ready = use_case_governance.governance_ready
+    active_production_ready = completed_required_item_count == required_item_count
+    approval_state = _resolve_use_case_approval_state(
+        limited_rollout_ready=limited_rollout_ready,
+        active_production_ready=active_production_ready,
+        platform_production_approved=runtime_status.platform_production_approved,
+    )
+
+    return ProductionGoLiveUseCaseApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        use_case_id=use_case_status.use_case_id,
+        downstream_app=use_case_status.downstream_app,
+        capability_pack_id=use_case_status.capability_pack_id,
+        approval_state=approval_state,
+        limited_rollout_ready=limited_rollout_ready,
+        active_production_ready=active_production_ready,
+        required_item_count=required_item_count,
+        completed_required_item_count=completed_required_item_count,
+        items=items,
+        status_summary=[
+            (
+                "The named downstream use case is approved for active production traffic."
+                if active_production_ready
+                else "The named downstream use case is not yet approved for active production traffic."
+            ),
+            (
+                "Limited rollout is already ready, so the remaining gap is the stricter active-production boundary."
+                if limited_rollout_ready and not active_production_ready
+                else "Limited rollout is not yet ready, so active-production approval remains out of reach."
+            ),
+            (
+                "The active-production decision is now derived from first-use-case governance, capability-pack governance, platform approval, and live-provider production posture together."
+            ),
+        ],
+    )
+
+
+def _resolve_use_case_approval_state(
+    *,
+    limited_rollout_ready: bool,
+    active_production_ready: bool,
+    platform_production_approved: bool,
+) -> ProductionGoLiveUseCaseApprovalState:
+    if active_production_ready:
+        return ProductionGoLiveUseCaseApprovalState.PRODUCTION_APPROVED
+    if limited_rollout_ready and not platform_production_approved:
+        return ProductionGoLiveUseCaseApprovalState.LIMITED_ROLLOUT_READY
+    if limited_rollout_ready:
+        return ProductionGoLiveUseCaseApprovalState.PRODUCTION_BLOCKED
+    return ProductionGoLiveUseCaseApprovalState.PRE_PROD_VALIDATION

--- a/src/app/services/provider_operations_status.py
+++ b/src/app/services/provider_operations_status.py
@@ -142,6 +142,10 @@ def _build_provider_operations_summary(
             else "Upstream degradation posture is actively enforced."
         ),
     ]
+    if live_execution_enabled and settings.secret_source_mode != "deployment_managed":
+        summary.append(
+            "Live-provider traffic can be technically enabled while production go-live remains blocked because secret injection is still local or unspecified."
+        )
     if blocking_reasons:
         summary.append(f"Current blocking or warning detail: {blocking_reasons[0]}")
     return summary

--- a/tests/integration/test_production_baseline_api_contract.py
+++ b/tests/integration/test_production_baseline_api_contract.py
@@ -13,6 +13,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert "resilience_governance" in body
     assert "deployment_split" in body
     assert "production_baseline" in body
+    assert "production_go_live" in body
     assert "production_baseline_governance" in body
 
 

--- a/tests/integration/test_production_go_live_api_contract.py
+++ b/tests/integration/test_production_go_live_api_contract.py
@@ -1,0 +1,48 @@
+from fastapi.testclient import TestClient
+
+
+def test_production_go_live_runtime_status_route(client: TestClient) -> None:
+    response = client.get("/platform/production-go-live/runtime-status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["service"] == "lotus-ai"
+    assert body["platform_state"] == "TECHNICALLY_RUNNING"
+    assert body["use_case_state"] == "PRE_PROD_VALIDATION"
+    assert body["technically_running"] is True
+    assert body["production_capable"] is False
+    assert body["platform_production_approved"] is False
+    assert body["use_case_production_approved"] is False
+    assert any(
+        domain["domain_id"] == "managed_secret_posture" for domain in body["approval_domains"]
+    )
+    assert any(
+        domain["domain_id"] == "managed_object_storage" for domain in body["approval_domains"]
+    )
+    assert any(
+        domain["domain_id"] == "managed_object_storage"
+        and domain["review_surface"] == "/platform/artifacts/governance-status"
+        for domain in body["approval_domains"]
+    )
+    assert body["provider_freeze_state"] == "NOT_APPLICABLE"
+    assert body["provider_rollback_state"] == "NOT_APPLICABLE"
+
+
+def test_production_go_live_governance_routes(client: TestClient) -> None:
+    activation_response = client.get("/platform/production-go-live/activation-readiness")
+    use_case_response = client.get("/platform/production-go-live/use-case-approval")
+    runbook_response = client.get("/platform/production-go-live/runbook-readiness")
+    governance_response = client.get("/platform/production-go-live/governance-status")
+
+    assert activation_response.status_code == 200
+    assert use_case_response.status_code == 200
+    assert runbook_response.status_code == 200
+    assert governance_response.status_code == 200
+
+    assert "runtime_status" in activation_response.json()
+    assert "approval_state" in use_case_response.json()
+    assert "items" in runbook_response.json()
+    assert "go_live_checklist" in runbook_response.json()
+    assert "activation_readiness" in governance_response.json()
+    assert "use_case_approval" in governance_response.json()
+    assert governance_response.json()["go_live_decision"] == "BLOCKED"

--- a/tests/unit/test_artifact_governance.py
+++ b/tests/unit/test_artifact_governance.py
@@ -59,6 +59,16 @@ def test_artifact_governance_status_combines_activation_and_runbook() -> None:
     assert governance.blocking_area_count == 1
 
 
+def test_artifact_governance_summary_mentions_managed_object_storage_block() -> None:
+    settings.artifact_store_mode = "memory"
+    settings.artifact_object_store_mode = "memory"
+    settings.artifact_object_store_root = None
+
+    governance = build_artifact_governance_status()
+
+    assert any("Managed object-storage approval" in line for line in governance.governance_summary)
+
+
 def test_artifact_activation_readiness_blocks_missing_cutover_breadth(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_openapi_contract.py
+++ b/tests/unit/test_openapi_contract.py
@@ -56,6 +56,25 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
         spec["paths"]["/platform/production-baseline/governance-status"]["get"]["operationId"]
         == "getProductionBaselineGovernanceStatus"
     )
+    assert spec["paths"]["/platform/production-go-live/runtime-status"]["get"]["operationId"] == (
+        "getProductionGoLiveRuntimeStatus"
+    )
+    assert (
+        spec["paths"]["/platform/production-go-live/activation-readiness"]["get"]["operationId"]
+        == "getProductionGoLiveActivationReadiness"
+    )
+    assert (
+        spec["paths"]["/platform/production-go-live/runbook-readiness"]["get"]["operationId"]
+        == "getProductionGoLiveRunbookReadiness"
+    )
+    assert (
+        spec["paths"]["/platform/production-go-live/use-case-approval"]["get"]["operationId"]
+        == "getProductionGoLiveUseCaseApproval"
+    )
+    assert (
+        spec["paths"]["/platform/production-go-live/governance-status"]["get"]["operationId"]
+        == "getProductionGoLiveGovernanceStatus"
+    )
     assert spec["paths"]["/platform/observability/runtime-status"]["get"]["operationId"] == (
         "getObservabilityRuntimeStatus"
     )
@@ -362,6 +381,21 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     production_baseline_schema = spec["components"]["schemas"][
         "ProductionBaselineRuntimeStatusResponse"
     ]
+    production_go_live_schema = spec["components"]["schemas"][
+        "ProductionGoLiveRuntimeStatusResponse"
+    ]
+    production_go_live_activation_schema = spec["components"]["schemas"][
+        "ProductionGoLiveActivationReadinessResponse"
+    ]
+    production_go_live_runbook_schema = spec["components"]["schemas"][
+        "ProductionGoLiveRunbookReadinessResponse"
+    ]
+    production_go_live_governance_schema = spec["components"]["schemas"][
+        "ProductionGoLiveGovernanceStatusResponse"
+    ]
+    production_go_live_use_case_schema = spec["components"]["schemas"][
+        "ProductionGoLiveUseCaseApprovalResponse"
+    ]
     deployment_split_schema = spec["components"]["schemas"]["DeploymentSplitRuntimeStatusResponse"]
     deployment_split_activation_schema = spec["components"]["schemas"][
         "DeploymentSplitActivationReadinessResponse"
@@ -392,6 +426,21 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     assert "runtime_status" in deployment_split_governance_schema["properties"]
     assert "observability_governance_ready" in deployment_split_governance_schema["properties"]
     assert "posture" in production_baseline_schema["properties"]
+    assert "platform_state" in production_go_live_schema["properties"]
+    assert "use_case_state" in production_go_live_schema["properties"]
+    assert "approval_domains" in production_go_live_schema["properties"]
+    assert "provider_freeze_state" in production_go_live_schema["properties"]
+    assert "provider_rollback_state" in production_go_live_schema["properties"]
+    assert "activation_ready" in production_go_live_activation_schema["properties"]
+    assert "items" in production_go_live_runbook_schema["properties"]
+    assert "go_live_checklist" in production_go_live_runbook_schema["properties"]
+    assert "approval_state" in production_go_live_use_case_schema["properties"]
+    assert "active_production_ready" in production_go_live_use_case_schema["properties"]
+    assert "runtime_status" in production_go_live_governance_schema["properties"]
+    assert "activation_readiness" in production_go_live_governance_schema["properties"]
+    assert "runbook_readiness" in production_go_live_governance_schema["properties"]
+    assert "use_case_approval" in production_go_live_governance_schema["properties"]
+    assert "go_live_decision" in production_go_live_governance_schema["properties"]
     assert "dependencies" in production_baseline_schema["properties"]
     assert "activation_ready" in production_baseline_activation_schema["properties"]
     assert "items" in production_baseline_runbook_schema["properties"]
@@ -426,6 +475,8 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     assert "deployment_split" in platform_runtime_schema["properties"]
     assert "deployment_split_governance" in platform_runtime_schema["properties"]
     assert "production_baseline" in platform_runtime_schema["properties"]
+    assert "production_go_live" in platform_runtime_schema["properties"]
+    assert "production_go_live_governance" in platform_runtime_schema["properties"]
     assert "production_baseline_governance" in platform_runtime_schema["properties"]
     first_use_case_schema = spec["components"]["schemas"]["FirstUseCaseRuntimeStatusResponse"]
     assert "capability_pack_id" in first_use_case_schema["properties"]

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -164,6 +164,25 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.production_baseline.posture.value == "LOCAL_OR_DEMO_CAPABLE"
     assert status.production_baseline.production_ready is False
     assert status.production_baseline.prod_shaped_local is False
+    assert status.production_go_live.platform_state.value == "TECHNICALLY_RUNNING"
+    assert status.production_go_live.use_case_state.value == "PRE_PROD_VALIDATION"
+    assert status.production_go_live.platform_production_approved is False
+    assert status.production_go_live.use_case_production_approved is False
+    assert status.production_go_live.provider_freeze_state.value == "NOT_APPLICABLE"
+    assert status.production_go_live.provider_rollback_state.value == "NOT_APPLICABLE"
+    assert any(
+        domain.domain_id == "managed_object_storage"
+        and domain.review_surface == "/platform/artifacts/governance-status"
+        for domain in status.production_go_live.approval_domains
+    )
+    assert status.production_go_live_governance.governance_ready is False
+    assert status.production_go_live_governance.activation_readiness.activation_ready is False
+    assert status.production_go_live_governance.runbook_readiness.runbook_ready is False
+    assert status.production_go_live_governance.use_case_approval.approval_state.value == (
+        "PRE_PROD_VALIDATION"
+    )
+    assert status.production_go_live_governance.use_case_approval.active_production_ready is False
+    assert status.production_go_live_governance.go_live_decision == "BLOCKED"
     assert status.production_baseline_governance.governance_ready is False
     assert status.production_baseline_governance.activation_readiness.activation_ready is False
     assert status.production_baseline_governance.runbook_readiness.runbook_ready is True

--- a/tests/unit/test_production_go_live_governance.py
+++ b/tests/unit/test_production_go_live_governance.py
@@ -1,0 +1,490 @@
+from _pytest.monkeypatch import MonkeyPatch
+
+from app.config import settings
+from app.contracts.production_go_live import (
+    ProductionGoLiveActivationReadinessResponse,
+    ProductionGoLiveFreezeState,
+    ProductionGoLiveRunbookReadinessItem,
+    ProductionGoLiveRunbookReadinessResponse,
+    ProductionGoLiveRuntimeStatusResponse,
+    ProductionGoLiveUseCaseApprovalItem,
+    ProductionGoLiveUseCaseApprovalResponse,
+    ProductionGoLiveUseCaseApprovalState,
+)
+from app.services.production_go_live_activation_readiness import (
+    build_production_go_live_activation_readiness,
+)
+from app.services.production_go_live_governance import (
+    build_production_go_live_governance_status,
+)
+from app.services.production_go_live_runbook_readiness import (
+    build_production_go_live_runbook_readiness,
+)
+from app.services.production_go_live_use_case_approval import (
+    build_production_go_live_use_case_approval,
+)
+
+
+def test_production_go_live_activation_readiness_reports_provider_review_required() -> None:
+    settings.provider_mode = "openai"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    settings.live_text_provider_id = "text.openai"
+    settings.live_text_model_id = "gpt-5.4"
+    settings.live_text_provider_api_key = "secret"
+    settings.live_text_allowed_task_ids = "explain.v1"
+    settings.secret_source_mode = "local_or_unspecified"
+
+    readiness = build_production_go_live_activation_readiness()
+
+    assert readiness.activation_ready is False
+    assert readiness.runtime_status.provider_freeze_state.value == "REVIEW_REQUIRED"
+    assert readiness.runtime_status.provider_rollback_state.value == "RECOMMENDED"
+    assert readiness.runtime_status.provider_rollback_target_state == "ALLOWLISTED_DISABLED"
+    assert any(
+        "allowlisted-disabled provider rollout target" in item.lower()
+        for item in readiness.blocking_findings
+    )
+
+
+def test_production_go_live_runbook_readiness_tracks_provider_runbook_dependency() -> None:
+    readiness = build_production_go_live_runbook_readiness()
+
+    assert readiness.runbook_ready is False
+    assert readiness.required_item_count == 4
+    assert readiness.completed_required_item_count == 3
+    assert any(
+        item.runbook_id == "production_go_live_provider_freeze_and_rollback"
+        for item in readiness.items
+    )
+    assert len(readiness.go_live_checklist) == 4
+
+
+def test_production_go_live_governance_composes_runtime_activation_and_runbook() -> None:
+    governance = build_production_go_live_governance_status()
+
+    assert governance.governance_ready is False
+    assert governance.runtime_status.platform_state.value == "TECHNICALLY_RUNNING"
+    assert governance.activation_readiness.activation_ready is False
+    assert governance.runbook_readiness.runbook_ready is False
+    assert governance.use_case_approval.approval_state.value == "PRE_PROD_VALIDATION"
+    assert governance.use_case_approval.active_production_ready is False
+    assert governance.provider_governance_ready is False
+    assert governance.go_live_decision == "BLOCKED"
+    assert governance.blocking_area_count >= 3
+
+
+def test_production_go_live_use_case_approval_reports_limited_rollout_ready_before_platform_approval(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_first_use_case_governance_status",
+        lambda: type(
+            "UseCaseGovernance",
+            (),
+            {
+                "governance_ready": True,
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_first_use_case_runtime_status",
+        lambda: type(
+            "UseCaseRuntime",
+            (),
+            {
+                "use_case_id": "lotus_performance.analytics_commentary.v1",
+                "downstream_app": "lotus-performance",
+                "capability_pack_id": "analytics_commentary.pack.v1",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_capability_pack_governance_status",
+        lambda pack_id: type("PackGovernance", (), {"governance_ready": True})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": True})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_production_go_live_runtime_status",
+        lambda app_state: type(
+            "GoLiveRuntime",
+            (),
+            {
+                "platform_production_approved": False,
+                "provider_freeze_state": type("FreezeState", (), {"value": "NOT_APPLICABLE"})(),
+            },
+        )(),
+    )
+
+    approval = build_production_go_live_use_case_approval()
+
+    assert approval.limited_rollout_ready is True
+    assert approval.active_production_ready is False
+    assert approval.approval_state.value == "LIMITED_ROLLOUT_READY"
+
+
+def test_production_go_live_activation_readiness_can_become_ready(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.production_go_live_activation_readiness.build_production_go_live_runtime_status",
+        lambda app_state: ProductionGoLiveRuntimeStatusResponse.model_validate(
+            {
+                "service": "lotus-ai",
+                "version": "0.1.0",
+                "platform_state": "PLATFORM_PRODUCTION_APPROVED",
+                "use_case_state": "PRE_PROD_VALIDATION",
+                "technically_running": True,
+                "production_capable": True,
+                "platform_production_approved": True,
+                "use_case_production_approved": False,
+                "provider_freeze_state": "ACTIVE",
+                "provider_rollback_state": "AVAILABLE",
+                "provider_rollback_target_state": "ALLOWLISTED_DISABLED",
+                "approval_domain_count": 0,
+                "blocked_domain_count": 0,
+                "approval_domains": [],
+                "blocking_findings": [],
+                "status_summary": ["ready"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_activation_readiness.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": True})(),
+    )
+
+    readiness = build_production_go_live_activation_readiness()
+
+    assert readiness.activation_ready is True
+    assert readiness.blocking_findings == []
+
+
+def test_production_go_live_use_case_approval_can_report_production_approved(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_first_use_case_governance_status",
+        lambda: type(
+            "UseCaseGovernance",
+            (),
+            {
+                "governance_ready": True,
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_first_use_case_runtime_status",
+        lambda: type(
+            "UseCaseRuntime",
+            (),
+            {
+                "use_case_id": "lotus_performance.analytics_commentary.v1",
+                "downstream_app": "lotus-performance",
+                "capability_pack_id": "analytics_commentary.pack.v1",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_capability_pack_governance_status",
+        lambda pack_id: type("PackGovernance", (), {"governance_ready": True})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": True})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_production_go_live_runtime_status",
+        lambda app_state: type(
+            "GoLiveRuntime",
+            (),
+            {
+                "platform_production_approved": True,
+                "provider_freeze_state": ProductionGoLiveFreezeState.ACTIVE,
+            },
+        )(),
+    )
+
+    approval = build_production_go_live_use_case_approval()
+
+    assert approval.active_production_ready is True
+    assert approval.approval_state.value == "PRODUCTION_APPROVED"
+    assert approval.completed_required_item_count == approval.required_item_count
+
+
+def test_production_go_live_use_case_approval_can_report_production_blocked_after_limited_rollout(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_first_use_case_governance_status",
+        lambda: type(
+            "UseCaseGovernance",
+            (),
+            {
+                "governance_ready": True,
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_first_use_case_runtime_status",
+        lambda: type(
+            "UseCaseRuntime",
+            (),
+            {
+                "use_case_id": "lotus_performance.analytics_commentary.v1",
+                "downstream_app": "lotus-performance",
+                "capability_pack_id": "analytics_commentary.pack.v1",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_capability_pack_governance_status",
+        lambda pack_id: type("PackGovernance", (), {"governance_ready": True})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": False})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_use_case_approval.build_production_go_live_runtime_status",
+        lambda app_state: type(
+            "GoLiveRuntime",
+            (),
+            {
+                "platform_production_approved": True,
+                "provider_freeze_state": ProductionGoLiveFreezeState.ACTIVE,
+            },
+        )(),
+    )
+
+    approval = build_production_go_live_use_case_approval()
+
+    assert approval.limited_rollout_ready is True
+    assert approval.active_production_ready is False
+    assert approval.approval_state.value == "PRODUCTION_BLOCKED"
+
+
+def test_production_go_live_governance_can_report_production_approved(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_runtime_status",
+        lambda app_state: ProductionGoLiveRuntimeStatusResponse.model_validate(
+            {
+                "service": "lotus-ai",
+                "version": "0.1.0",
+                "platform_state": "PLATFORM_PRODUCTION_APPROVED",
+                "use_case_state": "USE_CASE_PRODUCTION_APPROVED",
+                "technically_running": True,
+                "production_capable": True,
+                "platform_production_approved": True,
+                "use_case_production_approved": True,
+                "provider_freeze_state": "ACTIVE",
+                "provider_rollback_state": "AVAILABLE",
+                "provider_rollback_target_state": "ALLOWLISTED_DISABLED",
+                "approval_domain_count": 0,
+                "blocked_domain_count": 0,
+                "approval_domains": [],
+                "blocking_findings": [],
+                "status_summary": ["ready"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_activation_readiness",
+        lambda app_state: ProductionGoLiveActivationReadinessResponse.model_validate(
+            {
+                "service": "lotus-ai",
+                "version": "0.1.0",
+                "runtime_status": {
+                    "service": "lotus-ai",
+                    "version": "0.1.0",
+                    "platform_state": "PLATFORM_PRODUCTION_APPROVED",
+                    "use_case_state": "USE_CASE_PRODUCTION_APPROVED",
+                    "technically_running": True,
+                    "production_capable": True,
+                    "platform_production_approved": True,
+                    "use_case_production_approved": True,
+                    "provider_freeze_state": "ACTIVE",
+                    "provider_rollback_state": "AVAILABLE",
+                    "provider_rollback_target_state": "ALLOWLISTED_DISABLED",
+                    "approval_domain_count": 0,
+                    "blocked_domain_count": 0,
+                    "approval_domains": [],
+                    "blocking_findings": [],
+                    "status_summary": ["ready"],
+                },
+                "provider_governance_ready": True,
+                "activation_ready": True,
+                "blocking_findings": [],
+                "activation_path": ["ready"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_runbook_readiness",
+        lambda: ProductionGoLiveRunbookReadinessResponse(
+            service="lotus-ai",
+            version="0.1.0",
+            runbook_ready=True,
+            required_item_count=1,
+            completed_required_item_count=1,
+            items=[
+                ProductionGoLiveRunbookReadinessItem(
+                    runbook_id="go_live",
+                    status="READY",
+                    required_for_activation=True,
+                    notes="ready",
+                )
+            ],
+            go_live_checklist=["ready"],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_use_case_approval",
+        lambda app_state: ProductionGoLiveUseCaseApprovalResponse(
+            service="lotus-ai",
+            version="0.1.0",
+            use_case_id="lotus_performance.analytics_commentary.v1",
+            downstream_app="lotus-performance",
+            capability_pack_id="analytics_commentary.pack.v1",
+            approval_state=ProductionGoLiveUseCaseApprovalState.PRODUCTION_APPROVED,
+            limited_rollout_ready=True,
+            active_production_ready=True,
+            required_item_count=1,
+            completed_required_item_count=1,
+            items=[
+                ProductionGoLiveUseCaseApprovalItem(
+                    item_id="approval",
+                    status="READY",
+                    required_for_activation=True,
+                    notes="ready",
+                )
+            ],
+            status_summary=["ready"],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": True})(),
+    )
+
+    governance = build_production_go_live_governance_status()
+
+    assert governance.governance_ready is True
+    assert governance.go_live_decision == "PRODUCTION_APPROVED"
+    assert governance.blocking_area_count == 0
+
+
+def test_production_go_live_governance_can_report_limited_rollout_only(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_runtime_status",
+        lambda app_state: ProductionGoLiveRuntimeStatusResponse.model_validate(
+            {
+                "service": "lotus-ai",
+                "version": "0.1.0",
+                "platform_state": "PRODUCTION_CAPABLE",
+                "use_case_state": "LIMITED_ROLLOUT_ONLY",
+                "technically_running": True,
+                "production_capable": True,
+                "platform_production_approved": False,
+                "use_case_production_approved": False,
+                "provider_freeze_state": "REVIEW_REQUIRED",
+                "provider_rollback_state": "RECOMMENDED",
+                "provider_rollback_target_state": "ALLOWLISTED_DISABLED",
+                "approval_domain_count": 0,
+                "blocked_domain_count": 0,
+                "approval_domains": [],
+                "blocking_findings": [],
+                "status_summary": ["ready"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_activation_readiness",
+        lambda app_state: ProductionGoLiveActivationReadinessResponse.model_validate(
+            {
+                "service": "lotus-ai",
+                "version": "0.1.0",
+                "runtime_status": {
+                    "service": "lotus-ai",
+                    "version": "0.1.0",
+                    "platform_state": "PRODUCTION_CAPABLE",
+                    "use_case_state": "LIMITED_ROLLOUT_ONLY",
+                    "technically_running": True,
+                    "production_capable": True,
+                    "platform_production_approved": False,
+                    "use_case_production_approved": False,
+                    "provider_freeze_state": "REVIEW_REQUIRED",
+                    "provider_rollback_state": "RECOMMENDED",
+                    "provider_rollback_target_state": "ALLOWLISTED_DISABLED",
+                    "approval_domain_count": 0,
+                    "blocked_domain_count": 0,
+                    "approval_domains": [],
+                    "blocking_findings": [],
+                    "status_summary": ["ready"],
+                },
+                "provider_governance_ready": True,
+                "activation_ready": False,
+                "blocking_findings": ["blocked"],
+                "activation_path": ["ready"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_runbook_readiness",
+        lambda: ProductionGoLiveRunbookReadinessResponse(
+            service="lotus-ai",
+            version="0.1.0",
+            runbook_ready=True,
+            required_item_count=1,
+            completed_required_item_count=1,
+            items=[
+                ProductionGoLiveRunbookReadinessItem(
+                    runbook_id="go_live",
+                    status="READY",
+                    required_for_activation=True,
+                    notes="ready",
+                )
+            ],
+            go_live_checklist=["ready"],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_production_go_live_use_case_approval",
+        lambda app_state: ProductionGoLiveUseCaseApprovalResponse(
+            service="lotus-ai",
+            version="0.1.0",
+            use_case_id="lotus_performance.analytics_commentary.v1",
+            downstream_app="lotus-performance",
+            capability_pack_id="analytics_commentary.pack.v1",
+            approval_state=ProductionGoLiveUseCaseApprovalState.LIMITED_ROLLOUT_READY,
+            limited_rollout_ready=True,
+            active_production_ready=False,
+            required_item_count=1,
+            completed_required_item_count=0,
+            items=[
+                ProductionGoLiveUseCaseApprovalItem(
+                    item_id="approval",
+                    status="NOT_READY",
+                    required_for_activation=True,
+                    notes="blocked",
+                )
+            ],
+            status_summary=["blocked"],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_governance.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": True})(),
+    )
+
+    governance = build_production_go_live_governance_status()
+
+    assert governance.governance_ready is False
+    assert governance.go_live_decision == "LIMITED_ROLLOUT_ONLY"
+    assert governance.blocking_area_count == 2

--- a/tests/unit/test_production_go_live_runtime.py
+++ b/tests/unit/test_production_go_live_runtime.py
@@ -1,0 +1,311 @@
+from _pytest.monkeypatch import MonkeyPatch
+
+from app.config import settings
+from app.contracts.production_baseline import (
+    ProductionBaselinePosture,
+    ProductionBaselineRuntimeStatusResponse,
+)
+from app.contracts.production_go_live import (
+    ProductionGoLiveDomainDescriptor,
+    ProductionGoLiveDomainStatus,
+)
+from app.services.production_go_live_runtime import build_production_go_live_runtime_status
+
+
+def test_build_production_go_live_runtime_status_distinguishes_platform_and_use_case_states() -> (
+    None
+):
+    status = build_production_go_live_runtime_status()
+
+    assert status.service == "lotus-ai"
+    assert status.technically_running is True
+    assert status.production_capable is False
+    assert status.platform_state.value == "TECHNICALLY_RUNNING"
+    assert status.use_case_state.value == "PRE_PROD_VALIDATION"
+    assert status.platform_production_approved is False
+    assert status.use_case_production_approved is False
+    assert status.provider_freeze_state.value == "NOT_APPLICABLE"
+    assert status.provider_rollback_state.value == "NOT_APPLICABLE"
+    assert status.provider_rollback_target_state is None
+    assert any(domain.domain_id == "managed_secret_posture" for domain in status.approval_domains)
+    assert any(domain.domain_id == "managed_object_storage" for domain in status.approval_domains)
+
+
+def test_build_production_go_live_runtime_status_blocks_platform_approval_on_managed_domains() -> (
+    None
+):
+    status = build_production_go_live_runtime_status()
+    domain_by_id = {domain.domain_id: domain for domain in status.approval_domains}
+
+    assert domain_by_id["managed_secret_posture"].required_for_platform_approval is True
+    assert domain_by_id["managed_secret_posture"].status.value == "BLOCKED"
+    assert domain_by_id["managed_object_storage"].required_for_platform_approval is True
+    assert domain_by_id["managed_object_storage"].status.value == "BLOCKED"
+    assert status.blocked_domain_count == 2
+
+
+def test_build_production_go_live_runtime_uses_artifact_governance_surface_for_object_storage() -> (
+    None
+):
+    status = build_production_go_live_runtime_status()
+    domain_by_id = {domain.domain_id: domain for domain in status.approval_domains}
+
+    assert (
+        domain_by_id["managed_object_storage"].review_surface
+        == "/platform/artifacts/governance-status"
+    )
+    assert any(
+        phrase in domain_by_id["managed_object_storage"].detail
+        for phrase in (
+            "Artifact payload storage",
+            "Filesystem artifact payload storage",
+            "Artifact object-store durability",
+        )
+    )
+
+
+def test_build_production_go_live_runtime_can_become_production_capable_but_not_approved(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    settings.secret_source_mode = "local_or_unspecified"
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_production_baseline_runtime_status",
+        lambda app_state: ProductionBaselineRuntimeStatusResponse(
+            service="lotus-ai",
+            version="0.1.0",
+            posture=ProductionBaselinePosture.PROD_SHAPED_LOCAL,
+            prod_shaped_local=True,
+            production_ready=False,
+            dependency_count=0,
+            blocked_dependency_count=0,
+            fallback_dependency_count=0,
+            dependencies=[],
+            blocking_findings=[],
+            status_summary=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_managed_object_storage_approval_domain",
+        lambda: ProductionGoLiveDomainDescriptor(
+            domain_id="managed_object_storage",
+            status=ProductionGoLiveDomainStatus.APPROVED,
+            required_for_platform_approval=True,
+            configured_mode="s3",
+            review_surface="/platform/artifacts/governance-status",
+            detail="ready",
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_managed_secret_approval_domain",
+        lambda: ProductionGoLiveDomainDescriptor(
+            domain_id="managed_secret_posture",
+            status=ProductionGoLiveDomainStatus.BLOCKED,
+            required_for_platform_approval=True,
+            configured_mode="local_or_unspecified",
+            review_surface="/platform/production-baseline/runtime-status",
+            detail="blocked",
+        ),
+    )
+
+    status = build_production_go_live_runtime_status()
+
+    assert status.production_capable is True
+    assert status.platform_state.value == "PRODUCTION_CAPABLE"
+    assert status.platform_production_approved is False
+
+
+def test_build_production_go_live_runtime_treats_provider_governance_as_platform_blocker_when_live_provider_is_configured(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    settings.provider_mode = "openai"
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_production_baseline_runtime_status",
+        lambda app_state: ProductionBaselineRuntimeStatusResponse(
+            service="lotus-ai",
+            version="0.1.0",
+            posture=ProductionBaselinePosture.PRODUCTION_READY,
+            prod_shaped_local=True,
+            production_ready=True,
+            dependency_count=0,
+            blocked_dependency_count=0,
+            fallback_dependency_count=0,
+            dependencies=[],
+            blocking_findings=[],
+            status_summary=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_managed_object_storage_approval_domain",
+        lambda: ProductionGoLiveDomainDescriptor(
+            domain_id="managed_object_storage",
+            status=ProductionGoLiveDomainStatus.APPROVED,
+            required_for_platform_approval=True,
+            configured_mode="s3",
+            review_surface="/platform/artifacts/governance-status",
+            detail="ready",
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_managed_secret_approval_domain",
+        lambda: ProductionGoLiveDomainDescriptor(
+            domain_id="managed_secret_posture",
+            status=ProductionGoLiveDomainStatus.APPROVED,
+            required_for_platform_approval=True,
+            configured_mode="deployment_managed",
+            review_surface="/platform/production-baseline/runtime-status",
+            detail="ready",
+        ),
+    )
+
+    status = build_production_go_live_runtime_status()
+    domain_by_id = {domain.domain_id: domain for domain in status.approval_domains}
+
+    assert status.production_capable is True
+    assert status.platform_production_approved is False
+    assert status.platform_state.value == "PRODUCTION_CAPABLE"
+    assert domain_by_id["live_provider_governance"].required_for_platform_approval is True
+
+
+def test_build_production_go_live_runtime_reports_provider_freeze_when_allowlisted_disabled() -> (
+    None
+):
+    settings.provider_mode = "openai"
+    settings.provider_rollout_state = "ALLOWLISTED_DISABLED"
+    settings.live_text_provider_id = "text.openai"
+    settings.live_text_model_id = "gpt-5.4"
+    settings.live_text_provider_api_key = "secret"
+    settings.live_text_allowed_task_ids = "explain.v1"
+
+    status = build_production_go_live_runtime_status()
+
+    assert status.provider_freeze_state.value == "FROZEN"
+    assert status.provider_rollback_state.value == "COMPLETED"
+    assert status.provider_rollback_target_state == "ALLOWLISTED_DISABLED"
+
+
+def test_build_production_go_live_runtime_can_report_platform_and_use_case_production_approval(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    settings.provider_mode = "openai"
+    settings.provider_rollout_state = "ROLLED_OUT"
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_production_baseline_runtime_status",
+        lambda app_state: ProductionBaselineRuntimeStatusResponse(
+            service="lotus-ai",
+            version="0.1.0",
+            posture=ProductionBaselinePosture.PRODUCTION_READY,
+            prod_shaped_local=True,
+            production_ready=True,
+            dependency_count=0,
+            blocked_dependency_count=0,
+            fallback_dependency_count=0,
+            dependencies=[],
+            blocking_findings=[],
+            status_summary=[],
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_managed_object_storage_approval_domain",
+        lambda: ProductionGoLiveDomainDescriptor(
+            domain_id="managed_object_storage",
+            status=ProductionGoLiveDomainStatus.APPROVED,
+            required_for_platform_approval=True,
+            configured_mode="s3",
+            review_surface="/platform/artifacts/governance-status",
+            detail="ready",
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_managed_secret_approval_domain",
+        lambda: ProductionGoLiveDomainDescriptor(
+            domain_id="managed_secret_posture",
+            status=ProductionGoLiveDomainStatus.APPROVED,
+            required_for_platform_approval=True,
+            configured_mode="deployment_managed",
+            review_surface="/platform/production-baseline/runtime-status",
+            detail="ready",
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": True})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_first_use_case_governance_status",
+        lambda: type(
+            "UseCaseGovernance",
+            (),
+            {
+                "active_production_ready": True,
+                "governance_ready": True,
+                "rollout_stage": type("RolloutStage", (), {"value": "ACTIVE_PRODUCTION"})(),
+            },
+        )(),
+    )
+
+    status = build_production_go_live_runtime_status()
+    domain_by_id = {domain.domain_id: domain for domain in status.approval_domains}
+
+    assert status.platform_state.value == "PLATFORM_PRODUCTION_APPROVED"
+    assert status.use_case_state.value == "USE_CASE_PRODUCTION_APPROVED"
+    assert status.platform_production_approved is True
+    assert status.use_case_production_approved is True
+    assert status.provider_freeze_state.value == "ACTIVE"
+    assert status.provider_rollback_state.value == "AVAILABLE"
+    assert status.provider_rollback_target_state == "ALLOWLISTED_DISABLED"
+    assert domain_by_id["live_provider_governance"].status.value == "APPROVED"
+    assert domain_by_id["downstream_use_case_production"].status.value == "APPROVED"
+    assert status.blocked_domain_count == 0
+
+
+def test_build_production_go_live_runtime_marks_review_required_rollout_for_unapproved_live_provider(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    settings.provider_mode = "openai"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_provider_governance_status",
+        lambda: type("ProviderGovernance", (), {"governance_ready": False})(),
+    )
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_first_use_case_governance_status",
+        lambda: type(
+            "UseCaseGovernance",
+            (),
+            {
+                "active_production_ready": False,
+                "governance_ready": True,
+                "rollout_stage": type("RolloutStage", (), {"value": "LIMITED_ROLLOUT"})(),
+            },
+        )(),
+    )
+
+    status = build_production_go_live_runtime_status()
+
+    assert status.provider_freeze_state.value == "REVIEW_REQUIRED"
+    assert status.provider_rollback_state.value == "RECOMMENDED"
+    assert status.provider_rollback_target_state == "ALLOWLISTED_DISABLED"
+    assert status.use_case_state.value == "LIMITED_ROLLOUT_ONLY"
+
+
+def test_build_production_go_live_runtime_uses_informational_use_case_domain_for_limited_rollout_ready(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.production_go_live_runtime.build_first_use_case_governance_status",
+        lambda: type(
+            "UseCaseGovernance",
+            (),
+            {
+                "active_production_ready": False,
+                "governance_ready": True,
+                "rollout_stage": type("RolloutStage", (), {"value": "LIMITED_ROLLOUT"})(),
+            },
+        )(),
+    )
+
+    status = build_production_go_live_runtime_status()
+    domain_by_id = {domain.domain_id: domain for domain in status.approval_domains}
+
+    assert domain_by_id["downstream_use_case_production"].status.value == "INFORMATIONAL"
+    assert status.use_case_state.value == "LIMITED_ROLLOUT_ONLY"

--- a/tests/unit/test_provider_operations_status.py
+++ b/tests/unit/test_provider_operations_status.py
@@ -135,6 +135,20 @@ def test_provider_operations_status_reports_invalid_budget_configuration() -> No
     assert any("rate-card values" in reason for reason in status.blocking_reasons)
 
 
+def test_provider_operations_summary_mentions_local_secret_go_live_block() -> None:
+    settings.provider_mode = "openai"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    settings.live_text_provider_id = "text.openai"
+    settings.live_text_model_id = "gpt-5.4"
+    settings.live_text_provider_api_key = "secret"
+    settings.live_text_allowed_task_ids = "explain.v1"
+    settings.secret_source_mode = "local_or_unspecified"
+
+    status = build_provider_operations_status()
+
+    assert any("production go-live remains blocked" in line for line in status.summary)
+
+
 def test_provider_operations_status_does_not_globally_block_for_task_scoped_quota_exhaustion() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- implement RFC-0022 production go-live runtime, activation, runbook, governance, and use-case approval surfaces
- enforce managed-secret, managed object-store, and live-provider governance boundaries in the production go-live model
- mark RFC-0022 implemented and align roadmap and runbook docs with the new control-plane truth

## Validation
- make ci
