### PR TITLE
Align AI first-use demo addressing with RFC-0071

### DIFF
--- a/demo/lotus-performance-first-use-case/README.md
+++ b/demo/lotus-performance-first-use-case/README.md
@@ -37,6 +37,12 @@ The next pass can reuse the same flow with `lotus-ai` brought up via Docker, and
 1. Docker Desktop is running.
 2. `lotus-performance` repo exists at `../lotus-performance`.
 3. Python dependencies for `lotus-ai` are installed locally.
+4. canonical local performance service identity is `http://performance.dev.lotus`.
+
+For the standalone source-run path in this demo:
+
+- `lotus-ai` defaults to the direct local process URL `http://127.0.0.1:8140`
+- override it with `LOTUS_AI_BASE_URL` if you are routing through a local ingress layer
 
 ## Run
 
@@ -68,8 +74,8 @@ powershell -ExecutionPolicy Bypass -File demo/lotus-performance-first-use-case/r
 
 After the script completes:
 
-1. `lotus-performance` should be healthy on `http://127.0.0.1:8002`
-2. `lotus-ai` should be healthy on `http://127.0.0.1:8140`
+1. `lotus-performance` should be healthy on `http://performance.dev.lotus`
+2. `lotus-ai` should be healthy on the configured `LOTUS_AI_BASE_URL` or the direct local default `http://127.0.0.1:8140`
 3. pre-eval first-use-case governance should show one blocker: runtime-backed eval evidence
 4. post-eval first-use-case governance should report `LIMITED_ROLLOUT_READY`
 5. the captured `explain.v1` response should show:

--- a/demo/lotus-performance-first-use-case/run-demo-docker.ps1
+++ b/demo/lotus-performance-first-use-case/run-demo-docker.ps1
@@ -20,8 +20,8 @@ $DockerEnvFile = if ($UseProjectEnvFile) {
     Join-Path $RuntimeRoot ".env.docker-demo"
 }
 $ComposeProject = "lotus-ai-first-use-case-demo"
-$LotusAiBaseUrl = "http://127.0.0.1:8140"
-$PerformanceBaseUrl = "http://127.0.0.1:8002"
+$LotusAiBaseUrl = if ($env:LOTUS_AI_BASE_URL) { $env:LOTUS_AI_BASE_URL } else { "http://127.0.0.1:8140" }
+$PerformanceBaseUrl = if ($env:LOTUS_PERFORMANCE_BASE_URL) { $env:LOTUS_PERFORMANCE_BASE_URL } else { "http://performance.dev.lotus" }
 
 function Ensure-Directory([string]$Path) {
     New-Item -ItemType Directory -Force -Path $Path | Out-Null

--- a/demo/lotus-performance-first-use-case/run-demo.ps1
+++ b/demo/lotus-performance-first-use-case/run-demo.ps1
@@ -11,6 +11,8 @@ $DatabasePath = Join-Path $RuntimeRoot "lotus-ai-demo.db"
 $StdoutLog = Join-Path $RuntimeRoot "lotus-ai.stdout.log"
 $StderrLog = Join-Path $RuntimeRoot "lotus-ai.stderr.log"
 $PidFile = Join-Path $RuntimeRoot "lotus-ai.pid"
+$LotusAiBaseUrl = if ($env:LOTUS_AI_BASE_URL) { $env:LOTUS_AI_BASE_URL } else { "http://127.0.0.1:8140" }
+$PerformanceBaseUrl = if ($env:LOTUS_PERFORMANCE_BASE_URL) { $env:LOTUS_PERFORMANCE_BASE_URL } else { "http://performance.dev.lotus" }
 
 function Ensure-Directory([string]$Path) {
     New-Item -ItemType Directory -Force -Path $Path | Out-Null
@@ -78,7 +80,7 @@ function Start-LotusAiDemo() {
     do {
         Start-Sleep -Seconds 1
         try {
-            $ready = Invoke-RestMethod -Uri "http://127.0.0.1:8140/health/ready" -Method Get
+            $ready = Invoke-RestMethod -Uri "$LotusAiBaseUrl/health/ready" -Method Get
             if ($ready.status -eq "ready") {
                 return
             }
@@ -101,7 +103,7 @@ function Ensure-LotusPerformanceReady() {
     do {
         Start-Sleep -Seconds 2
         try {
-            $ready = Invoke-RestMethod -Uri "http://127.0.0.1:8002/health/ready" -Method Get
+            $ready = Invoke-RestMethod -Uri "$PerformanceBaseUrl/health/ready" -Method Get
             if ($ready.status -eq "ready") {
                 return
             }
@@ -115,7 +117,7 @@ function Ensure-LotusPerformanceReady() {
 function Run-FirstUseCaseEval() {
     $submission = Invoke-CapturedPost `
         -Name "19-lotus-ai-first-use-case-eval-submit" `
-        -Uri "http://127.0.0.1:8140/platform/evals/runs/submit" `
+        -Uri "$LotusAiBaseUrl/platform/evals/runs/submit" `
         -RequestPath (Join-Path $RequestRoot "lotus-ai-first-use-case-eval.request.json")
 
     $env:PYTHONPATH = "src"
@@ -139,7 +141,7 @@ print(result)
 
     Invoke-CapturedGet `
         -Name "21-lotus-ai-first-use-case-eval-run-detail" `
-        -Uri ("http://127.0.0.1:8140/platform/evals/runs/" + $submission.run_id) | Out-Null
+        -Uri ("$LotusAiBaseUrl/platform/evals/runs/" + $submission.run_id) | Out-Null
 }
 
 Ensure-Directory $GeneratedRoot
@@ -151,33 +153,33 @@ Stop-LotusAiIfRunning
 Ensure-LotusPerformanceReady
 Start-LotusAiDemo
 
-Invoke-CapturedGet -Name "01-lotus-performance-health-ready" -Uri "http://127.0.0.1:8002/health/ready" | Out-Null
-Invoke-CapturedGet -Name "02-lotus-ai-health" -Uri "http://127.0.0.1:8140/health" | Out-Null
-Invoke-CapturedGet -Name "03-lotus-ai-health-ready" -Uri "http://127.0.0.1:8140/health/ready" | Out-Null
-Invoke-CapturedGet -Name "04-lotus-ai-root" -Uri "http://127.0.0.1:8140/" | Out-Null
-Invoke-CapturedGet -Name "05-lotus-ai-metadata" -Uri "http://127.0.0.1:8140/metadata" | Out-Null
-Invoke-CapturedGet -Name "06-lotus-ai-platform-runtime-status" -Uri "http://127.0.0.1:8140/platform/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "07-lotus-ai-capabilities" -Uri "http://127.0.0.1:8140/platform/capabilities" | Out-Null
-Invoke-CapturedGet -Name "08-lotus-ai-task-runtime-status" -Uri "http://127.0.0.1:8140/platform/tasks/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "09-lotus-ai-access-control-runtime-status" -Uri "http://127.0.0.1:8140/platform/access-control/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "10-lotus-ai-access-control-caller-policies" -Uri "http://127.0.0.1:8140/platform/access-control/caller-policies" | Out-Null
-Invoke-CapturedGet -Name "11-lotus-ai-provider-catalog" -Uri "http://127.0.0.1:8140/platform/providers" | Out-Null
-Invoke-CapturedGet -Name "12-lotus-ai-retrieval-sources" -Uri "http://127.0.0.1:8140/platform/retrieval/sources" | Out-Null
-Invoke-CapturedGet -Name "13-lotus-ai-safety-policy" -Uri "http://127.0.0.1:8140/platform/safety/policy" | Out-Null
-Invoke-CapturedGet -Name "14-lotus-ai-prompt-runtime-status" -Uri "http://127.0.0.1:8140/platform/prompts/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "15-lotus-ai-async-runtime-status" -Uri "http://127.0.0.1:8140/platform/async/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "16-lotus-ai-artifact-runtime-status" -Uri "http://127.0.0.1:8140/platform/artifacts/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "17-lotus-ai-observability-runtime-status" -Uri "http://127.0.0.1:8140/platform/observability/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "18-lotus-ai-evals-runtime-status" -Uri "http://127.0.0.1:8140/platform/evals/runtime-status" | Out-Null
-Invoke-CapturedGet -Name "22-lotus-ai-first-use-case-contract" -Uri "http://127.0.0.1:8140/platform/use-cases/first-production-use-case" | Out-Null
-Invoke-CapturedGet -Name "23-lotus-ai-first-use-case-readiness-before-eval" -Uri "http://127.0.0.1:8140/platform/use-cases/first-production-use-case/readiness" | Out-Null
-Invoke-CapturedGet -Name "24-lotus-ai-first-use-case-runbook-readiness" -Uri "http://127.0.0.1:8140/platform/use-cases/first-production-use-case/runbook-readiness" | Out-Null
-Invoke-CapturedGet -Name "25-lotus-ai-first-use-case-governance-before-eval" -Uri "http://127.0.0.1:8140/platform/use-cases/first-production-use-case/governance-status" | Out-Null
-Invoke-CapturedGet -Name "26-lotus-ai-onboarding-template" -Uri "http://127.0.0.1:8140/platform/use-cases/onboarding-template" | Out-Null
+Invoke-CapturedGet -Name "01-lotus-performance-health-ready" -Uri "$PerformanceBaseUrl/health/ready" | Out-Null
+Invoke-CapturedGet -Name "02-lotus-ai-health" -Uri "$LotusAiBaseUrl/health" | Out-Null
+Invoke-CapturedGet -Name "03-lotus-ai-health-ready" -Uri "$LotusAiBaseUrl/health/ready" | Out-Null
+Invoke-CapturedGet -Name "04-lotus-ai-root" -Uri "$LotusAiBaseUrl/" | Out-Null
+Invoke-CapturedGet -Name "05-lotus-ai-metadata" -Uri "$LotusAiBaseUrl/metadata" | Out-Null
+Invoke-CapturedGet -Name "06-lotus-ai-platform-runtime-status" -Uri "$LotusAiBaseUrl/platform/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "07-lotus-ai-capabilities" -Uri "$LotusAiBaseUrl/platform/capabilities" | Out-Null
+Invoke-CapturedGet -Name "08-lotus-ai-task-runtime-status" -Uri "$LotusAiBaseUrl/platform/tasks/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "09-lotus-ai-access-control-runtime-status" -Uri "$LotusAiBaseUrl/platform/access-control/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "10-lotus-ai-access-control-caller-policies" -Uri "$LotusAiBaseUrl/platform/access-control/caller-policies" | Out-Null
+Invoke-CapturedGet -Name "11-lotus-ai-provider-catalog" -Uri "$LotusAiBaseUrl/platform/providers" | Out-Null
+Invoke-CapturedGet -Name "12-lotus-ai-retrieval-sources" -Uri "$LotusAiBaseUrl/platform/retrieval/sources" | Out-Null
+Invoke-CapturedGet -Name "13-lotus-ai-safety-policy" -Uri "$LotusAiBaseUrl/platform/safety/policy" | Out-Null
+Invoke-CapturedGet -Name "14-lotus-ai-prompt-runtime-status" -Uri "$LotusAiBaseUrl/platform/prompts/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "15-lotus-ai-async-runtime-status" -Uri "$LotusAiBaseUrl/platform/async/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "16-lotus-ai-artifact-runtime-status" -Uri "$LotusAiBaseUrl/platform/artifacts/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "17-lotus-ai-observability-runtime-status" -Uri "$LotusAiBaseUrl/platform/observability/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "18-lotus-ai-evals-runtime-status" -Uri "$LotusAiBaseUrl/platform/evals/runtime-status" | Out-Null
+Invoke-CapturedGet -Name "22-lotus-ai-first-use-case-contract" -Uri "$LotusAiBaseUrl/platform/use-cases/first-production-use-case" | Out-Null
+Invoke-CapturedGet -Name "23-lotus-ai-first-use-case-readiness-before-eval" -Uri "$LotusAiBaseUrl/platform/use-cases/first-production-use-case/readiness" | Out-Null
+Invoke-CapturedGet -Name "24-lotus-ai-first-use-case-runbook-readiness" -Uri "$LotusAiBaseUrl/platform/use-cases/first-production-use-case/runbook-readiness" | Out-Null
+Invoke-CapturedGet -Name "25-lotus-ai-first-use-case-governance-before-eval" -Uri "$LotusAiBaseUrl/platform/use-cases/first-production-use-case/governance-status" | Out-Null
+Invoke-CapturedGet -Name "26-lotus-ai-onboarding-template" -Uri "$LotusAiBaseUrl/platform/use-cases/onboarding-template" | Out-Null
 
 $performanceResponse = Invoke-CapturedPost `
     -Name "27-lotus-performance-twr" `
-    -Uri "http://127.0.0.1:8002/performance/twr" `
+    -Uri "$PerformanceBaseUrl/performance/twr" `
     -RequestPath (Join-Path $RequestRoot "lotus-performance-twr.request.json")
 
 $explainTemplatePath = Join-Path $RequestRoot "lotus-ai-explain.request.json"
@@ -188,33 +190,33 @@ Write-JsonFile $explainRequestPath $explain
 
 $taskResponse = Invoke-CapturedPost `
     -Name "29-lotus-ai-explain" `
-    -Uri "http://127.0.0.1:8140/ai/tasks/execute" `
+    -Uri "$LotusAiBaseUrl/ai/tasks/execute" `
     -RequestPath $explainRequestPath
 
-Invoke-CapturedGet -Name "30-lotus-ai-audit-detail" -Uri ("http://127.0.0.1:8140/ai/audit/" + $taskResponse.audit.request_id) | Out-Null
-Invoke-CapturedGet -Name "31-lotus-ai-audit-catalog" -Uri "http://127.0.0.1:8140/ai/audit?caller_app=lotus-performance&limit=20" | Out-Null
-Invoke-CapturedGet -Name "32-lotus-ai-task-execution-summary" -Uri "http://127.0.0.1:8140/platform/tasks/execution-summary?limit=20" | Out-Null
-Invoke-CapturedGet -Name "33-lotus-ai-task-evidence-summary" -Uri "http://127.0.0.1:8140/platform/tasks/evidence-summary?limit=20" | Out-Null
-Invoke-CapturedGet -Name "34-lotus-ai-observability-incident-summary" -Uri "http://127.0.0.1:8140/platform/observability/incident-summary" | Out-Null
-Invoke-CapturedGet -Name "35-lotus-ai-observability-breakdowns" -Uri "http://127.0.0.1:8140/platform/observability/breakdowns?limit=20" | Out-Null
-Invoke-CapturedGet -Name "36-lotus-ai-access-control-governance" -Uri "http://127.0.0.1:8140/platform/access-control/governance-status" | Out-Null
-Invoke-CapturedGet -Name "37-lotus-ai-artifact-governance" -Uri "http://127.0.0.1:8140/platform/artifacts/governance-status" | Out-Null
-Invoke-CapturedGet -Name "38-lotus-ai-observability-governance" -Uri "http://127.0.0.1:8140/platform/observability/governance-status" | Out-Null
-Invoke-CapturedGet -Name "39-lotus-ai-provider-governance" -Uri "http://127.0.0.1:8140/platform/providers/governance-status" | Out-Null
-Invoke-CapturedGet -Name "40-lotus-ai-retrieval-governance" -Uri "http://127.0.0.1:8140/platform/retrieval/governance-status" | Out-Null
-Invoke-CapturedGet -Name "41-lotus-ai-safety-governance" -Uri "http://127.0.0.1:8140/platform/safety/governance-status" | Out-Null
-Invoke-CapturedGet -Name "42-lotus-ai-prompt-governance" -Uri "http://127.0.0.1:8140/platform/prompts/governance-status" | Out-Null
-Invoke-CapturedGet -Name "43-lotus-ai-async-governance" -Uri "http://127.0.0.1:8140/platform/async/governance-status" | Out-Null
+Invoke-CapturedGet -Name "30-lotus-ai-audit-detail" -Uri ("$LotusAiBaseUrl/ai/audit/" + $taskResponse.audit.request_id) | Out-Null
+Invoke-CapturedGet -Name "31-lotus-ai-audit-catalog" -Uri "$LotusAiBaseUrl/ai/audit?caller_app=lotus-performance&limit=20" | Out-Null
+Invoke-CapturedGet -Name "32-lotus-ai-task-execution-summary" -Uri "$LotusAiBaseUrl/platform/tasks/execution-summary?limit=20" | Out-Null
+Invoke-CapturedGet -Name "33-lotus-ai-task-evidence-summary" -Uri "$LotusAiBaseUrl/platform/tasks/evidence-summary?limit=20" | Out-Null
+Invoke-CapturedGet -Name "34-lotus-ai-observability-incident-summary" -Uri "$LotusAiBaseUrl/platform/observability/incident-summary" | Out-Null
+Invoke-CapturedGet -Name "35-lotus-ai-observability-breakdowns" -Uri "$LotusAiBaseUrl/platform/observability/breakdowns?limit=20" | Out-Null
+Invoke-CapturedGet -Name "36-lotus-ai-access-control-governance" -Uri "$LotusAiBaseUrl/platform/access-control/governance-status" | Out-Null
+Invoke-CapturedGet -Name "37-lotus-ai-artifact-governance" -Uri "$LotusAiBaseUrl/platform/artifacts/governance-status" | Out-Null
+Invoke-CapturedGet -Name "38-lotus-ai-observability-governance" -Uri "$LotusAiBaseUrl/platform/observability/governance-status" | Out-Null
+Invoke-CapturedGet -Name "39-lotus-ai-provider-governance" -Uri "$LotusAiBaseUrl/platform/providers/governance-status" | Out-Null
+Invoke-CapturedGet -Name "40-lotus-ai-retrieval-governance" -Uri "$LotusAiBaseUrl/platform/retrieval/governance-status" | Out-Null
+Invoke-CapturedGet -Name "41-lotus-ai-safety-governance" -Uri "$LotusAiBaseUrl/platform/safety/governance-status" | Out-Null
+Invoke-CapturedGet -Name "42-lotus-ai-prompt-governance" -Uri "$LotusAiBaseUrl/platform/prompts/governance-status" | Out-Null
+Invoke-CapturedGet -Name "43-lotus-ai-async-governance" -Uri "$LotusAiBaseUrl/platform/async/governance-status" | Out-Null
 
 Run-FirstUseCaseEval
 
-Invoke-CapturedGet -Name "44-lotus-ai-first-use-case-readiness-after-eval" -Uri "http://127.0.0.1:8140/platform/use-cases/first-production-use-case/readiness" | Out-Null
-Invoke-CapturedGet -Name "45-lotus-ai-first-use-case-governance-after-eval" -Uri "http://127.0.0.1:8140/platform/use-cases/first-production-use-case/governance-status" | Out-Null
-Invoke-CapturedGet -Name "46-lotus-ai-evals-run-catalog" -Uri "http://127.0.0.1:8140/platform/evals/runs" | Out-Null
+Invoke-CapturedGet -Name "44-lotus-ai-first-use-case-readiness-after-eval" -Uri "$LotusAiBaseUrl/platform/use-cases/first-production-use-case/readiness" | Out-Null
+Invoke-CapturedGet -Name "45-lotus-ai-first-use-case-governance-after-eval" -Uri "$LotusAiBaseUrl/platform/use-cases/first-production-use-case/governance-status" | Out-Null
+Invoke-CapturedGet -Name "46-lotus-ai-evals-run-catalog" -Uri "$LotusAiBaseUrl/platform/evals/runs" | Out-Null
 
 $summary = [pscustomobject]@{
-    performance_base_url = "http://127.0.0.1:8002"
-    lotus_ai_base_url = "http://127.0.0.1:8140"
+    performance_base_url = $PerformanceBaseUrl
+    lotus_ai_base_url = $LotusAiBaseUrl
     capture_root = $CaptureRoot
     runtime_root = $RuntimeRoot
     explanation_request_id = $taskResponse.audit.request_id

--- a/docs/architecture/feature-status-and-roadmap.md
+++ b/docs/architecture/feature-status-and-roadmap.md
@@ -192,12 +192,18 @@ The next RFCs now identified in the repo describe the expected post-foundation s
 1. `RFC-0021` domain AI capability packs and product maturity
 2. `RFC-0022` production go-live approval and managed infrastructure
 3. `RFC-0023` multi-app adoption and capability rollout governance
+4. `RFC-0024` portfolio narrative copilot for `lotus-performance`
+5. `RFC-0025` operational root-cause copilot for `lotus-core`
+6. `RFC-0026` operator control-plane dashboard and observability integration
 
 Current status against that sequence:
 
 1. `RFC-0021` is now partially started through a separate capability-pack catalog layer, with a reusable commentary family and an experimental decision-explanation family modeled explicitly, dedicated runtime-backed pack-quality eval families added, pack-specific activation, runbook, observability, governance, and adoption-template surfaces exposed, and the implemented `lotus-performance` path now anchored to the commentary family while broader approved pack maturity is still future work.
 2. `RFC-0022` now includes a dedicated production go-live runtime surface plus activation, runbook, governance, and named use-case approval views that separate technically running, production-capable, platform-production-approved, limited-rollout-ready, and active-production-approved posture; managed-secret and managed-object-storage approval domains now also converge explicitly with artifact governance, provider-usage truth, bounded provider freeze or rollback posture, and pack plus downstream approval review.
 3. `RFC-0023` now includes Slice 5 lifecycle discipline, so app-capability rollout records now have catalog, governance, onboarding-template, observability-summary, and lifecycle-status surfaces; retirement-ready versus blocked pairings are inspectable, stale not-onboarded or integration-stage pairings can be modeled as explicitly retired instead of lingering forever, historical traceability remains linked back to rollout, onboarding, and observability review surfaces, and retirement now states whether it is pairing-only or should trigger broader capability-pack follow-on review.
+4. `RFC-0024` is now drafted as the first genuinely product-defining `lotus-performance` feature, explicitly extending RFC-0016 rather than replacing it; the existing commentary seed becomes the narrow rollout anchor for a richer portfolio narrative copilot grounded in TWR, benchmark, contribution, attribution, returns-series, diagnostics, and lineage-backed evidence.
+5. `RFC-0025` is now drafted as the first high-value `lotus-core` operational AI feature, turning the existing support, lineage, reconciliation, replay, transaction-state, and snapshot control-plane surfaces into a bounded root-cause copilot rather than a generic support chatbot.
+6. `RFC-0026` is now drafted to add the missing operator UI layer over the already-shipped control planes, while explicitly keeping logs, metrics, traces, and alerting in external observability tooling rather than trying to recreate Grafana or Datadog inside `lotus-ai`.
 
 The previous likely feature areas are now implemented:
 
@@ -226,7 +232,10 @@ In practical feature terms, the roadmap is:
 
 1. turn the current platform backbone into reusable app-facing product capability packs,
 2. define a true final-mile production approval boundary above the existing prod-shaped baseline,
-3. expand from one proven downstream use case into governed multi-app adoption without fragmenting capability behavior.
+3. expand from one proven downstream use case into governed multi-app adoption without fragmenting capability behavior,
+4. convert the `lotus-performance` first-use-case seed into a genuinely reusable and high-value portfolio narrative capability,
+5. add an operational investigation copilot for `lotus-core` that explains likely causes from existing support and lineage truth,
+6. add an operator control-plane dashboard so the platform's many governance and rollout surfaces are operationally usable without replacing standard observability stacks.
 
 ## Recommended Reading Order
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -23,3 +23,6 @@
 - `RFC-0021-domain-ai-capability-packs-and-product-maturity.md` - Implemented
 - `RFC-0022-production-go-live-approval-and-managed-infrastructure.md` - Implemented
 - `RFC-0023-multi-app-adoption-and-capability-rollout-governance.md` - Implemented
+- `RFC-0024-portfolio-narrative-copilot-for-lotus-performance.md` - Draft
+- `RFC-0025-operational-root-cause-copilot-for-lotus-core.md` - Draft
+- `RFC-0026-operator-control-plane-dashboard-and-observability-integration.md` - Draft

--- a/docs/rfcs/RFC-0024-portfolio-narrative-copilot-for-lotus-performance.md
+++ b/docs/rfcs/RFC-0024-portfolio-narrative-copilot-for-lotus-performance.md
@@ -1,0 +1,418 @@
+# RFC-0024: Portfolio Narrative Copilot for lotus-performance
+
+- Status: Draft
+- Date: 2026-03-25
+- Owners: lotus-ai, lotus-performance
+- Requires Approval From: lotus-ai maintainers, lotus-performance maintainers
+
+## Summary
+
+`lotus-ai` now has:
+
+1. a governed platform backbone,
+2. a reusable capability-pack layer,
+3. production go-live approval posture,
+4. multi-app rollout governance,
+5. one bounded first-use-case anchor through `lotus-performance` commentary.
+
+What it still does not have is a truly high-value, product-defining AI feature that investment and
+client-facing teams would actively change behavior to use.
+
+This RFC defines that next step:
+
+1. a `Portfolio Narrative Copilot` built specifically for `lotus-performance`,
+2. grounded in `lotus-performance`'s actual analytics seams rather than generic summarization,
+3. designed to convert structured analytics truth into decision-useful and audience-aware
+   narratives,
+4. while preserving strict ownership boundaries so `lotus-performance` remains the source of
+   financial truth.
+
+This is not "chat over performance data."
+
+It is a bounded AI feature over:
+
+1. TWR and benchmark-relative performance,
+2. contribution and detractor/leader analysis,
+3. attribution and benchmark context,
+4. returns-series and period comparisons,
+5. diagnostics and materiality facts already owned by `lotus-performance`.
+
+## Why This RFC Exists
+
+The current first real downstream use case is valuable, but deliberately narrow.
+
+RFC-0016 proved that:
+
+1. `lotus-performance` can send structured analytics facts to `lotus-ai`,
+2. `lotus-ai` can return explanation-only commentary under governance,
+3. bounded rollout, audit, evidence, and support posture can be reviewed truthfully.
+
+That was the right first step.
+
+But RFC-0016 is still too narrow to become the flagship product capability for portfolio users.
+
+It is centered on:
+
+1. one explanation-oriented contract,
+2. one narrow commentary task shape,
+3. one first-use-case onboarding and rollout template.
+
+The next high-value feature must go further without abandoning those controls.
+
+`lotus-performance` is the strongest current candidate because it already owns:
+
+1. `POST /performance/twr`,
+2. `POST /performance/benchmark`,
+3. `POST /performance/mwr`,
+4. `POST /performance/contribution`,
+5. `POST /performance/attribution`,
+6. `POST /integration/returns/series`,
+7. durable execution state, async execution polling, and lineage capture.
+
+It also already surfaces:
+
+1. benchmark context,
+2. diagnostics and reset behavior,
+3. contribution and attribution evidence,
+4. canonical period-based analytics over structured inputs,
+5. reproducibility and execution lineage.
+
+That means the app now has enough real analytical depth for an AI layer to do something
+meaningfully useful:
+
+1. explain what happened,
+2. explain why it happened,
+3. prioritize what matters,
+4. tailor the explanation to a PM, reviewer, or client-facing audience,
+5. do all of that without inventing portfolio truth.
+
+## Relationship to RFC-0016
+
+RFC-0016 should be kept and explicitly evolved, not deprecated.
+
+Reason:
+
+1. RFC-0016 remains the correct first bounded governance anchor,
+2. its explanation-only contract is still the safest seed path,
+3. its readiness, runbook, and governance surfaces remain the right rollout gate for the first
+   `lotus-performance` integration,
+4. its onboarding template remains the correct reference path for later integrations.
+
+What changes now:
+
+1. RFC-0016 becomes the narrow seed and limited-rollout anchor,
+2. RFC-0024 expands that seed into a richer, reusable `lotus-performance` product capability,
+3. the current `analytics_commentary.pack.v1` should be enhanced rather than replaced,
+4. the existing RFC-0016 contract fields such as `analysis_scope`, `period_window`,
+   `metric_deltas`, and `material_findings` should be treated as the minimum bounded subset of the
+   broader narrative contract, not as the final product shape.
+
+So the correct posture is:
+
+1. keep RFC-0016,
+2. preserve its rollout discipline,
+3. extend its pack and contract model,
+4. do not fork a second disconnected commentary path.
+
+## Problem Statement
+
+Today, `lotus-performance` can compute high-value analytics truth, but users still have to perform
+too much manual interpretation and narrative assembly.
+
+Current workflow pain:
+
+1. users must inspect TWR, benchmark-relative, contribution, attribution, and returns-series
+   outputs separately,
+2. users must decide which facts are materially important,
+3. users must translate those facts into PM-ready, client-ready, or reviewer-ready narratives,
+4. users must manually reconcile diagnostics and benchmark context into the story,
+5. commentary often becomes repetitive, inconsistent, or dependent on individual analyst effort.
+
+Current `lotus-ai` limitation:
+
+1. the first-use-case commentary path can explain a bounded set of material changes,
+2. but it does not yet model a full portfolio narrative workflow,
+3. it does not yet express audience mode explicitly,
+4. it does not yet organize multiple analytics lenses into one governed explanation product,
+5. it does not yet treat explanation completeness and material prioritization as first-class product
+   quality requirements.
+
+Without this RFC:
+
+1. `lotus-ai` remains useful but not yet genuinely differentiated for portfolio teams,
+2. commentary remains a narrow wrapper instead of a core workflow accelerator,
+3. downstream teams may build ad hoc narrative layers outside the governed platform,
+4. the strongest current product opportunity remains under-realized.
+
+## Goals
+
+1. Deliver one genuinely high-value AI feature for `lotus-performance`.
+2. Turn multiple existing analytics surfaces into one bounded narrative capability.
+3. Keep `lotus-performance` as the owner of financial facts, materiality policy, and final
+   presentation semantics.
+4. Support multiple audience modes without creating open-ended free prompting.
+5. Make explanation quality depend on grounded completeness, prioritization, and evidence usage,
+   not only output fluency.
+6. Reuse and extend RFC-0016 and `analytics_commentary.pack.v1` rather than starting over.
+
+## Non-Goals
+
+1. Letting `lotus-ai` recompute TWR, contribution, attribution, or benchmark results.
+2. Giving investment recommendations or portfolio decisions.
+3. Replacing deterministic `lotus-performance` reporting surfaces.
+4. Building a generic "chat with all performance data" experience.
+5. Allowing raw portfolio dumps as the primary contract.
+6. Making `lotus-ai` the final renderer of reports or client materials.
+
+## Decision
+
+`lotus-ai` will add a new `Portfolio Narrative Copilot` capability for `lotus-performance`.
+
+This capability will:
+
+1. be implemented as an enhancement of the existing `analytics_commentary.pack.v1` family,
+2. remain explanation-oriented and evidence-backed,
+3. compose bounded facts from existing `lotus-performance` analytics surfaces,
+4. support explicit audience and narrative modes,
+5. be governed as a named product capability rather than a free-form prompt wrapper.
+
+The first implementation boundary is intentionally strict:
+
+1. `lotus-performance` selects and supplies the narrative fact bundle,
+2. `lotus-ai` transforms that bundle into a structured narrative response,
+3. `lotus-ai` may not infer missing analytics facts that are absent from the bundle,
+4. quality gates focus on materiality ordering, factual grounding, unsupported-input refusal, and
+   audience fit,
+5. rollout remains bounded by the existing first-use-case and capability-pack governance layers.
+
+## Proposed Capability Shape
+
+The copilot should produce one bounded response family with explicit audience mode.
+
+### Audience Modes
+
+The initial modes should be:
+
+1. `executive_summary`
+2. `pm_deep_dive`
+3. `client_commentary`
+4. `review_memo`
+
+These are not arbitrary stylistic variants.
+
+They represent different explanation constraints over the same portfolio truth.
+
+### Required Upstream Narrative Bundle
+
+The bundle should be assembled by `lotus-performance` from existing analytics APIs and execution
+artifacts.
+
+The initial contract should include:
+
+1. portfolio and reporting context
+2. period window and comparison basis
+3. headline performance facts
+4. benchmark-relative facts when available
+5. contribution winners and detractors
+6. attribution effects when available
+7. material change findings selected by `lotus-performance`
+8. diagnostics and caveat findings when relevant
+9. lineage and execution references for reproducibility
+
+Illustrative bundle sections:
+
+1. `performance_summary`
+2. `benchmark_context`
+3. `contribution_highlights`
+4. `attribution_highlights`
+5. `returns_series_changes`
+6. `diagnostic_findings`
+7. `material_findings`
+8. `evidence_refs`
+
+### Actual lotus-performance Sources This RFC Builds On
+
+The fact bundle should be derived from real `lotus-performance` surfaces, especially:
+
+1. `POST /performance/twr`
+2. `POST /performance/benchmark`
+3. `POST /performance/contribution`
+4. `POST /performance/attribution`
+5. `POST /integration/returns/series`
+6. `GET /performance/executions/{calculation_id}`
+7. endpoint-specific async result retrieval paths
+8. lineage and reproducibility artifacts already captured by `lotus-performance`
+
+This keeps the AI layer grounded in shipped analytics rather than speculative future functionality.
+
+## Architecture Direction
+
+### 1. Narrative Assembly Must Stay in lotus-performance
+
+`lotus-performance` should remain responsible for:
+
+1. which analytics runs are authoritative,
+2. how period comparisons are selected,
+3. which changes are materially important,
+4. what benchmark context applies,
+5. which diagnostics or caveats must be surfaced.
+
+`lotus-ai` should receive the narrative-ready fact bundle, not raw analytics sprawl.
+
+### 2. Copilot Output Must Be Structured, Not Just Text
+
+The response should include more than a single blob of prose.
+
+The initial response family should include:
+
+1. headline summary
+2. key drivers
+3. benchmark-relative interpretation
+4. watch-outs or caveats
+5. optional audience-tailored closing block
+6. evidence and confidence metadata
+
+This makes the feature reusable in UI, PM review, and reporting workflows.
+
+### 3. Product Quality Must Be Pack-Specific
+
+The quality bar should not be "text sounds good."
+
+The capability must be evaluated on:
+
+1. factual grounding against supplied metrics
+2. materiality ordering
+3. omission handling
+4. unsupported-input refusal behavior
+5. audience-mode correctness
+6. conservative treatment of diagnostics and caveats
+
+### 4. Diagnostics and Methodology Matter
+
+This RFC should explicitly build on `lotus-performance`'s richer diagnostic posture, especially the
+methodology and reset semantics hardening work reflected in RFC-043.
+
+That means:
+
+1. reset-heavy or caveated periods should not be narrated as ordinary periods,
+2. benchmark context should be surfaced when it materially changes interpretation,
+3. contribution and attribution statements should remain bounded by what the current runtime truly
+   computes,
+4. narrative mode must not flatten away methodological caveats.
+
+### 5. This RFC Should Not Recreate the Archived lotus-core Review Pattern
+
+The old "one giant assembled review endpoint" pattern was archived out of `lotus-core`.
+
+This RFC should therefore avoid:
+
+1. rebuilding a monolithic report assembly endpoint inside `lotus-ai`,
+2. blurring the boundaries between canonical data, analytics, and final reports.
+
+The right model is:
+
+1. `lotus-performance` assembles bounded analytics facts,
+2. `lotus-ai` generates governed narrative structure,
+3. downstream app or report layer still owns final report packaging.
+
+## Data and Operational Requirements
+
+1. The narrative copilot must use only caller-supplied structured analytics facts and approved
+   evidence refs.
+2. The capability must preserve RFC-0016 explanation-only discipline for its initial rollout.
+3. The capability must record audit, evidence, and audience mode in runtime state.
+4. The capability must support degraded or blocked behavior for incomplete bundles, conflicting
+   facts, or unsupported analytics mixes.
+5. The capability must carry enough lineage back to the underlying `lotus-performance` executions
+   to support supportability and review.
+6. The capability must not silently claim analytics relationships that `lotus-performance` did not
+   provide.
+
+## Delivery Slices
+
+### Slice 1: Contract and Pack Expansion
+
+Outcome:
+
+1. `analytics_commentary.pack.v1` is expanded into an explicit portfolio narrative pack,
+2. audience modes are formalized,
+3. the RFC-0016 commentary bundle becomes the minimum subset of the new contract.
+
+Acceptance gate:
+
+1. RFC-0016 compatibility is preserved,
+2. the pack contract remains bounded and typed,
+3. `lotus-performance` remains the owner of materiality selection and analytics truth.
+
+### Slice 2: Narrative Fact-Bundle Integration
+
+Outcome:
+
+1. `lotus-performance` can assemble a richer fact bundle from TWR, contribution, attribution,
+   returns-series, and benchmark context,
+2. `lotus-ai` can consume that bundle through one product capability seam.
+
+Acceptance gate:
+
+1. no raw analytics recomputation is delegated to `lotus-ai`,
+2. every narrative section traces back to actual `lotus-performance` surfaces,
+3. incomplete bundle behavior is explicit and testable.
+
+### Slice 3: Runtime-Backed Quality Gates
+
+Outcome:
+
+1. dedicated eval families exist for portfolio narrative quality,
+2. product-quality checks cover factual grounding, materiality ordering, and audience fit.
+
+Acceptance gate:
+
+1. runtime-backed evidence exists,
+2. unsupported-input and caveat-heavy periods are tested explicitly,
+3. approval-gate posture is pack-specific rather than generic commentary-only.
+
+### Slice 4: Governance, Runbook, and Operator Readiness
+
+Outcome:
+
+1. pack-specific observability, activation, runbook, and governance surfaces are complete,
+2. support teams can inspect why a narrative was generated, blocked, or caveated.
+
+Acceptance gate:
+
+1. operator review does not depend on reading raw prompts or logs only,
+2. lineage back to `lotus-performance` execution refs is inspectable,
+3. rollback remains compatible with first-use-case and pack-governance posture.
+
+### Slice 5: Product Maturity and Broader Reuse
+
+Outcome:
+
+1. the capability is promoted from a narrow first-use-case extension to a reusable
+   `lotus-performance` feature family,
+2. broader downstream consumers such as reporting or review layers can integrate through the pack.
+
+Acceptance gate:
+
+1. the commentary family is truthfully reusable, not only experimentally implemented,
+2. RFC-0016 remains the bounded seed but no longer the only narrative shape,
+3. product value is materially higher than the original first-use-case path.
+
+## Risks
+
+1. If the bundle is too thin, the feature becomes superficial commentary with little user value.
+2. If the bundle is too broad, the feature turns into unbounded data-dump prompting.
+3. If diagnostics and caveats are ignored, narratives may sound confident while hiding real
+   methodology limits.
+4. If audience modes are treated as pure style variants, product quality will drift.
+5. If this RFC forks away from RFC-0016, rollout and governance posture will fragment.
+
+## Success Criteria
+
+This RFC is successful when:
+
+1. `lotus-performance` users can request one bounded narrative capability that materially reduces
+   manual commentary work,
+2. the feature is clearly better than the current narrow commentary path,
+3. every narrative remains grounded in shipped `lotus-performance` analytics and diagnostics,
+4. RFC-0016 is enhanced into a stronger product seam rather than discarded.

--- a/docs/rfcs/RFC-0025-operational-root-cause-copilot-for-lotus-core.md
+++ b/docs/rfcs/RFC-0025-operational-root-cause-copilot-for-lotus-core.md
@@ -1,0 +1,389 @@
+# RFC-0025: Operational Root-Cause Copilot for lotus-core
+
+- Status: Draft
+- Date: 2026-03-25
+- Owners: lotus-ai, lotus-core
+- Requires Approval From: lotus-ai maintainers, lotus-core maintainers
+
+## Summary
+
+`lotus-core` is now a mature canonical system with:
+
+1. deterministic transaction, position, valuation, and cashflow processing,
+2. query and query-control-plane APIs,
+3. support and lineage diagnostics,
+4. reconciliation and replay visibility,
+5. snapshot and simulation contracts,
+6. strong operational and traceability posture.
+
+That maturity creates the opportunity for a second genuinely high-value AI feature:
+
+1. an `Operational Root-Cause Copilot`,
+2. designed for support, operations, and investigation workflows,
+3. grounded in `lotus-core`'s existing support, lineage, reconciliation, and transaction-state
+   APIs,
+4. capable of turning operational state into likely-cause explanations and next-check guidance.
+
+This is not a generic support chatbot.
+
+It is a bounded diagnostic explanation layer over real `lotus-core` surfaces such as:
+
+1. support overview,
+2. calculator SLOs,
+3. control stages,
+4. replay keys and replay jobs,
+5. valuation and aggregation jobs,
+6. reconciliation runs and findings,
+7. lineage key state,
+8. transaction, position, BUY-state, SELL-state, and snapshot contracts.
+
+## Why This RFC Exists
+
+`lotus-core` is feature-rich enough that much of the operational pain is no longer missing data.
+
+It is investigative effort.
+
+Operators and downstream teams still have to:
+
+1. inspect multiple support endpoints,
+2. correlate control-stage, replay, and lineage state manually,
+3. read transaction and position context alongside reconciliation findings,
+4. decide what is most likely wrong,
+5. determine what to check next.
+
+The platform already contains the right raw material.
+
+For example, `lotus-core` now exposes control-plane operational surfaces such as:
+
+1. `/support/portfolios/{portfolio_id}/overview`
+2. `/support/portfolios/{portfolio_id}/calculator-slos`
+3. `/support/portfolios/{portfolio_id}/control-stages`
+4. `/support/portfolios/{portfolio_id}/reprocessing-keys`
+5. `/support/portfolios/{portfolio_id}/reprocessing-jobs`
+6. `/support/portfolios/{portfolio_id}/valuation-jobs`
+7. `/support/portfolios/{portfolio_id}/aggregation-jobs`
+8. `/support/portfolios/{portfolio_id}/analytics-export-jobs`
+9. `/support/portfolios/{portfolio_id}/reconciliation-runs`
+10. `/support/portfolios/{portfolio_id}/reconciliation-runs/{run_id}/findings`
+11. `/lineage/portfolios/{portfolio_id}/securities/{security_id}`
+12. `/lineage/portfolios/{portfolio_id}/keys`
+
+And query-state surfaces such as:
+
+1. portfolio transaction timelines,
+2. position snapshots and as-of views,
+3. BUY-state linkage and cashflow details,
+4. SELL disposal and cash-linkage state,
+5. core snapshot contracts for governed downstream consumers.
+
+That means the next real value is not more raw APIs.
+
+It is faster human understanding of:
+
+1. what likely caused the issue,
+2. what evidence supports that interpretation,
+3. which next checks are most appropriate.
+
+## Relationship to Existing lotus-core RFCs
+
+This RFC should build on existing operational and support work, not replace it.
+
+Most importantly:
+
+1. RFC 033 in `lotus-core` established API-first support and lineage surfaces,
+2. the multi-model platform direction keeps `lotus-core` focused on deterministic core truth,
+3. the old in-core review/report orchestration idea in archived RFC 012 was explicitly moved out of
+   `lotus-core`.
+
+That has direct consequences for this RFC:
+
+1. do build on RFC 033 support and lineage APIs,
+2. do build on transaction, snapshot, and stateful query contracts,
+3. do not recreate a giant monolithic "review API" inside `lotus-core`,
+4. do not ask `lotus-ai` to replace deterministic support surfaces,
+5. do use `lotus-ai` as a bounded interpretation layer over those surfaces.
+
+## Problem Statement
+
+`lotus-core` exposes a large amount of operational truth, but root-cause analysis still requires too
+much manual synthesis.
+
+Common pain points include:
+
+1. missing or unexpected positions,
+2. unexplained cash or holding changes,
+3. blocked or failed reconciliation runs,
+4. stale replay keys or replay jobs,
+5. valuation or aggregation backlog issues,
+6. BUY or SELL linkage confusion,
+7. snapshot fallback or freshness confusion,
+8. portfolio-day control-stage failures that require multi-endpoint inspection.
+
+Current limitations:
+
+1. support and lineage APIs are strong but mostly descriptor-level,
+2. the system tells operators what exists, but not yet the most likely explanation,
+3. there is no reusable AI product seam for operational investigation,
+4. teams can still end up re-reading the same operational patterns incident after incident.
+
+Without this RFC:
+
+1. support resolution remains slower than it should be,
+2. operational knowledge remains concentrated in experienced individuals,
+3. downstream teams may build ad hoc diagnostic summarizers with weaker governance,
+4. the strongest operational AI opportunity in the Lotus estate remains unaddressed.
+
+## Goals
+
+1. Deliver a high-value AI investigation feature for `lotus-core`.
+2. Explain likely operational root causes using existing deterministic support APIs.
+3. Provide bounded next-check guidance without taking corrective action automatically.
+4. Preserve the authority of `lotus-core` support, lineage, transaction, and snapshot contracts.
+5. Make repeated investigation workflows faster and more consistent.
+6. Keep the feature reviewable, auditable, and support-safe.
+
+## Non-Goals
+
+1. Automatically mutating `lotus-core` state or replaying jobs.
+2. Replacing support, lineage, reconciliation, or query APIs.
+3. Letting `lotus-ai` invent operational facts not present in the supplied evidence bundle.
+4. Building a generic support chatbot over logs.
+5. Recreating the archived lotus-core report/review orchestration model.
+6. Turning `lotus-ai` into the owner of runbook or incident decisions.
+
+## Decision
+
+`lotus-ai` will add a new `Operational Root-Cause Copilot` capability for `lotus-core`.
+
+This capability will:
+
+1. consume a bounded investigation bundle composed from real `lotus-core` support and query
+   surfaces,
+2. produce a structured explanation of likely root cause candidates,
+3. surface supporting evidence and uncertainty explicitly,
+4. suggest bounded next checks rather than actions that mutate state,
+5. remain separate from automated replay, rollback, or remediation controls.
+
+The initial implementation boundary is strict:
+
+1. `lotus-core` or a trusted integration layer assembles the evidence bundle,
+2. `lotus-ai` explains the evidence bundle,
+3. `lotus-ai` does not fetch arbitrary logs or infer hidden system state,
+4. explanations must link back to named evidence sections,
+5. the output remains operator-assistive, not operator-authoritative.
+
+## Proposed Capability Shape
+
+The copilot should accept an investigation bundle and return a structured diagnosis response.
+
+### Investigation Types
+
+The initial supported investigation families should be:
+
+1. `reconciliation_failure`
+2. `stale_or_stuck_reprocessing`
+3. `unexpected_position_change`
+4. `unexpected_cash_change`
+5. `buy_sell_linkage_issue`
+6. `snapshot_or_freshness_issue`
+
+These should be explicit enumerations, not free-form support prompts.
+
+### Required Evidence Bundle
+
+The evidence bundle should be composed from deterministic `lotus-core` APIs.
+
+Initial evidence sections should include:
+
+1. support overview snapshot
+2. calculator SLO snapshot when relevant
+3. portfolio-day control stages
+4. replay keys or replay jobs when relevant
+5. reconciliation run and finding detail when relevant
+6. lineage key or single-key lineage detail
+7. transaction timeline excerpts
+8. position and snapshot context
+9. BUY-state or SELL-state linkage context when relevant
+10. core snapshot metadata when freshness or baseline confusion is part of the issue
+
+### Actual lotus-core Surfaces This RFC Builds On
+
+The bundle should be built from real shipped surfaces, especially:
+
+1. query-control-plane support and lineage APIs from RFC 033
+2. query-service transaction APIs
+3. query-service position APIs
+4. BUY-state and SELL-state APIs
+5. core snapshot APIs
+6. reconciliation support listings and findings
+
+This keeps the feature aligned with the current `lotus-core` architecture instead of inventing a
+parallel source of truth.
+
+## Architecture Direction
+
+### 1. Evidence Assembly Must Stay Outside lotus-ai
+
+`lotus-core` or a thin integration layer should decide:
+
+1. which evidence to fetch,
+2. which portfolio, security, run, or transaction scope is relevant,
+3. how much evidence is enough for a bounded investigation,
+4. which fields are safe and useful to include.
+
+`lotus-ai` should not become a dynamic multi-API orchestration engine in the first implementation.
+
+### 2. Output Must Be Diagnostic and Structured
+
+The response should include:
+
+1. issue summary
+2. likely root-cause candidates
+3. most likely candidate
+4. supporting evidence blocks
+5. contradictions or uncertainty notes
+6. next checks
+7. unsupported or missing evidence notes
+
+This is critical because support teams need inspectable reasoning, not just prose.
+
+### 3. Next Checks Must Be Bounded
+
+The feature may recommend checks such as:
+
+1. inspect a specific reconciliation finding,
+2. verify a replay-key state transition,
+3. compare BUY-state and linked cashflow details,
+4. confirm whether a snapshot fallback occurred,
+5. inspect a specific transaction group or lineage key.
+
+It must not:
+
+1. trigger replay,
+2. modify control stages,
+3. patch records,
+4. re-run ingestion automatically.
+
+### 4. Pairing With Existing Operational Contracts
+
+The feature should strengthen, not obscure, the current `lotus-core` support model.
+
+That means:
+
+1. explanations must cite named operational sections,
+2. `lotus-ai` should not flatten distinct support states into vague language,
+3. reconciliation blocking severity, replay staleness, and snapshot fallback should remain explicit,
+4. audit trails must preserve which evidence sections were used.
+
+### 5. No In-Core Review-Orchestration Regression
+
+RFC 012 in `lotus-core` was archived because review/report orchestration moved out of that repo.
+
+This RFC should therefore avoid:
+
+1. an all-purpose review endpoint in `lotus-core`,
+2. an AI-owned incident dashboard in `lotus-core`,
+3. bundling unrelated reporting concerns into operational diagnosis.
+
+The capability must stay focused on support and root cause.
+
+## Data and Operational Requirements
+
+1. Every investigation request must identify investigation type and bounded scope.
+2. Every diagnosis must reference named evidence sections.
+3. The capability must support explicit degraded behavior when evidence is incomplete or
+   contradictory.
+4. The capability must preserve audit and evidence traceability through the existing `lotus-ai`
+   runtime model.
+5. The capability must not claim certainty when the underlying evidence only supports multiple
+   plausible causes.
+6. The capability must remain read-only and support-oriented.
+
+## Delivery Slices
+
+### Slice 1: Contract and Pack Definition
+
+Outcome:
+
+1. a new bounded root-cause capability pack exists,
+2. investigation types and response shape are explicit,
+3. evidence bundle requirements are documented against real `lotus-core` APIs.
+
+Acceptance gate:
+
+1. the feature is clearly bounded,
+2. it builds on shipped `lotus-core` support surfaces,
+3. no implicit autonomous retrieval or mutation is introduced.
+
+### Slice 2: Evidence Bundle Integration
+
+Outcome:
+
+1. `lotus-core` can assemble investigation bundles from support, lineage, transaction, position,
+   and state contracts,
+2. `lotus-ai` can consume those bundles through one named capability seam.
+
+Acceptance gate:
+
+1. evidence section ownership is explicit,
+2. different investigation types use bounded evidence subsets,
+3. contradiction and insufficiency handling are testable.
+
+### Slice 3: Runtime-Backed Quality Gates
+
+Outcome:
+
+1. dedicated eval families exist for operational diagnosis quality,
+2. pack quality is measured on evidence usage, root-cause plausibility, and next-check quality.
+
+Acceptance gate:
+
+1. runtime-backed evals exist,
+2. uncertainty and ambiguity cases are included,
+3. the feature is not promoted on fluency alone.
+
+### Slice 4: Governance, Runbook, and Support Readiness
+
+Outcome:
+
+1. the capability has activation, runbook, observability, and governance surfaces,
+2. operators can inspect diagnosis outputs alongside their evidence refs.
+
+Acceptance gate:
+
+1. support review is practical,
+2. bounded rollback and disable posture exists,
+3. operational trust does not depend on hidden prompt behavior.
+
+### Slice 5: Reusable Operational Investigation Pattern
+
+Outcome:
+
+1. the feature is reusable across multiple operational investigation families,
+2. `lotus-core` support workflows gain one coherent AI investigation seam without weakening the
+   deterministic support model.
+
+Acceptance gate:
+
+1. the capability measurably reduces investigation ambiguity,
+2. evidence-linked diagnosis remains truthful,
+3. no support ownership boundaries are blurred.
+
+## Risks
+
+1. If evidence bundles are too broad, the feature becomes noisy and hard to trust.
+2. If evidence bundles are too thin, explanations become generic and low-value.
+3. If the feature overstates confidence, operators may follow weak hypotheses.
+4. If next checks drift into action suggestions, the system may blur support boundaries.
+5. If the feature bypasses existing support APIs, it will create a parallel and weaker ops model.
+
+## Success Criteria
+
+This RFC is successful when:
+
+1. `lotus-core` operators can get a useful, evidence-linked likely-cause explanation for bounded
+   incidents,
+2. the feature reduces manual synthesis across support endpoints,
+3. it clearly accelerates investigation without taking over deterministic support workflows,
+4. it strengthens the operational usefulness of `lotus-core`'s existing support and lineage
+   surfaces rather than competing with them.

--- a/docs/rfcs/RFC-0026-operator-control-plane-dashboard-and-observability-integration.md
+++ b/docs/rfcs/RFC-0026-operator-control-plane-dashboard-and-observability-integration.md
@@ -1,0 +1,327 @@
+# RFC-0026: Operator Control-Plane Dashboard and Observability Integration
+
+- Status: Draft
+- Date: 2026-03-25
+- Owners: lotus-ai
+- Requires Approval From: lotus-ai maintainers
+
+## Summary
+
+`lotus-ai` now exposes a large set of operator-facing APIs for:
+
+1. runtime,
+2. retrieval,
+3. evals,
+4. async execution,
+5. safety and governance,
+6. resilience,
+7. ingestion,
+8. embeddings and providers,
+9. deployment split,
+10. production go-live,
+11. capability packs,
+12. app-capability rollout.
+
+These control planes are strong, but they are still API-first and document-heavy.
+
+This RFC defines the next operational layer:
+
+1. a first-class `lotus-ai` operator control-plane dashboard,
+2. built on top of the existing platform APIs,
+3. explicitly separated from deep infrastructure observability tooling such as Grafana, Datadog,
+   OpenSearch, or cloud-native monitoring,
+4. focused on platform posture, rollout truth, governance state, and actionable operator review.
+
+## Why This RFC Exists
+
+The current platform is now mature enough that operators need more than endpoint literacy.
+
+Today, an operator may need to inspect:
+
+1. `/platform/runtime-status`
+2. `/platform/providers/*`
+3. `/platform/retrieval/*`
+4. `/platform/evals/*`
+5. `/platform/async/*`
+6. `/platform/observability/*`
+7. `/platform/production-baseline/*`
+8. `/platform/production-go-live/*`
+9. `/platform/capability-packs/*`
+10. `/platform/app-capability-rollouts/*`
+
+That is powerful, but not yet operationally ergonomic.
+
+Industry-standard practice is not to collapse all of this into one giant custom monitoring system.
+
+The usual model is:
+
+1. API-first control plane,
+2. thin operator dashboard for approval, rollout, and review workflows,
+3. separate observability tooling for logs, metrics, traces, and alerts.
+
+`lotus-ai` now has enough control-plane surface area that the absence of a dashboard is becoming an
+operator friction issue rather than a healthy sign of simplicity.
+
+## Problem Statement
+
+`lotus-ai` can already answer many important questions, but operators still have to reconstruct the
+answers manually from multiple APIs.
+
+Examples:
+
+1. is the platform technically healthy but still production-blocked?
+2. is retrieval degraded because of corpus posture, embedding posture, or ingestion review?
+3. is a capability pack reusable but not go-live approved?
+4. is a downstream app in limited rollout, production-approved, paused, or retired?
+5. is a first-use-case path blocked by resilience, provider governance, or use-case evidence?
+
+The current situation creates these problems:
+
+1. too much operator context-switching,
+2. slow incident or rollout review,
+3. duplicated mental stitching across control-plane APIs,
+4. risk that downstream teams over-rely on infrastructure dashboards and miss platform-governance
+   truth.
+
+Without this RFC:
+
+1. the platform remains harder to operate than it needs to be,
+2. governance truth is technically available but ergonomically weak,
+3. future multi-app adoption will increase operator friction.
+
+## Goals
+
+1. Add a dedicated operator control-plane dashboard for `lotus-ai`.
+2. Keep the dashboard API-first and derived from existing platform surfaces.
+3. Make rollout, governance, readiness, and production-approval truth easier to inspect quickly.
+4. Preserve separation between control-plane UI and full observability tooling.
+5. Give operators one clear entry point for platform posture, use-case posture, and app-rollout
+   posture.
+
+## Non-Goals
+
+1. Replacing Grafana, Datadog, Kibana, Sentry, or cloud monitoring stacks.
+2. Building a generic BI or analytics dashboard for end users.
+3. Creating a consumer-facing chat UI.
+4. Re-implementing every platform API as bespoke UI-only logic.
+5. Owning deep log search or arbitrary trace exploration in the custom dashboard.
+
+## Decision
+
+`lotus-ai` will add a dedicated operator control-plane dashboard.
+
+This dashboard will:
+
+1. read from existing platform APIs first,
+2. focus on governed operator questions rather than raw infrastructure telemetry,
+3. present clear platform, capability, use-case, and app-rollout posture,
+4. link out to external observability tooling for deep metrics, logs, and traces.
+
+The first implementation boundary is intentionally narrow:
+
+1. platform posture overview,
+2. domain control-plane pages,
+3. production go-live and rollout review pages,
+4. evidence and artifact drill-down links,
+5. no attempt yet to reproduce full observability-product functionality inside the app.
+
+## Operator Dashboard Model
+
+The dashboard should have a small number of clear operator views.
+
+### 1. Platform Overview
+
+This page should answer:
+
+1. is the platform running?
+2. is it production-capable?
+3. is it production-approved?
+4. what major domains are degraded or blocked?
+
+It should summarize:
+
+1. runtime
+2. provider posture
+3. retrieval posture
+4. async posture
+5. resilience posture
+6. production baseline
+7. production go-live decision
+
+### 2. Domain Control Pages
+
+The dashboard should expose focused pages for:
+
+1. providers and live execution
+2. retrieval, ingestion, and corpus posture
+3. evals and approval gates
+4. async jobs and worker posture
+5. safety and prompt governance
+6. resilience and restore posture
+
+These pages should surface control-plane truth, not all raw telemetry.
+
+### 3. Capability and Use-Case Pages
+
+The dashboard should expose:
+
+1. capability-pack catalog and maturity
+2. pack governance
+3. first-use-case readiness and governance
+4. named downstream production approval
+
+This keeps product maturity, rollout posture, and production approval visible in one operator UI.
+
+### 4. App-Rollout Pages
+
+The dashboard should expose:
+
+1. app-capability rollout catalog
+2. pairing governance
+3. onboarding templates
+4. observability summary
+5. lifecycle and retirement posture
+
+This is especially important now that `RFC-0023` is implemented.
+
+### 5. Evidence and Drill-Down Links
+
+The dashboard should link operators to:
+
+1. artifact descriptors
+2. audit or evidence drill-down
+3. incident bundles
+4. external observability systems
+
+The dashboard should be a review hub, not a data silo.
+
+## Architecture Direction
+
+### API-First UI
+
+The dashboard must remain a UI over existing APIs.
+
+Required behavior:
+
+1. existing platform APIs remain the source of truth,
+2. dashboard pages aggregate and visualize those APIs,
+3. UI-specific logic should stay thin and avoid duplicating backend policy logic.
+
+### Separation From Observability Tooling
+
+The dashboard must not try to replace industry-standard tooling.
+
+Required behavior:
+
+1. logs remain in the logging or search stack,
+2. metrics and alerts remain in observability systems,
+3. traces remain in tracing tools,
+4. the dashboard links to those systems when deep inspection is required.
+
+### Role Focus
+
+The first dashboard should be for:
+
+1. platform operators,
+2. AI-governance reviewers,
+3. downstream app owners during rollout,
+4. incident responders.
+
+It should not initially target end users.
+
+### Opinionated Navigation
+
+The dashboard should favor operator questions over API taxonomy.
+
+For example:
+
+1. `Can this go live?`
+2. `Why is this blocked?`
+3. `Which domain is degraded?`
+4. `Which app-capability pairings are active or paused?`
+5. `What evidence supports this decision?`
+
+This is more useful than simply mirroring the endpoint tree.
+
+## Data and Operational Requirements
+
+1. Every page must be backed by existing platform APIs or explicitly approved aggregations of them.
+2. Dashboard health must not become a hidden dependency for platform correctness.
+3. Operators must be able to navigate from dashboard summaries to evidence details.
+4. The dashboard must distinguish blocked, degraded, limited-rollout, and production-approved
+   states clearly.
+5. The dashboard must not hide uncertainty or collapse separate governance domains into vague
+   overall labels.
+
+## Delivery Slices
+
+### Slice 1: Overview and Navigation Foundation
+
+Outcome:
+
+1. one operator shell exists,
+2. platform overview is available,
+3. navigation reflects the current control-plane model.
+
+Acceptance gate:
+
+1. overview is powered by real platform APIs,
+2. platform, production-baseline, and production-go-live states are clearly separated,
+3. navigation is operator-oriented rather than endpoint-oriented.
+
+### Slice 2: Domain Control Pages
+
+Outcome:
+
+1. provider, retrieval, eval, async, and resilience pages exist,
+2. operators can inspect blocked and degraded posture by domain.
+
+Acceptance gate:
+
+1. domain pages use existing governance and runtime APIs,
+2. the UI does not duplicate backend policy logic,
+3. drill-down remains possible.
+
+### Slice 3: Capability, Use-Case, and App-Rollout Pages
+
+Outcome:
+
+1. capability-pack pages exist,
+2. first-use-case review is visible,
+3. app-capability rollout governance is visible.
+
+Acceptance gate:
+
+1. capability maturity, production approval, and app rollout are not conflated,
+2. app-specific blocked or paused posture is inspectable,
+3. adoption templates and lifecycle posture are reachable.
+
+### Slice 4: Evidence and External Observability Integration
+
+Outcome:
+
+1. dashboard links to artifacts and incident evidence,
+2. operators can jump from summary state to external logs, metrics, or traces.
+
+Acceptance gate:
+
+1. the dashboard remains a control-plane hub,
+2. deep infra inspection is delegated to the right external tools,
+3. evidence paths are practical in incidents and rollout review.
+
+## Risks
+
+1. If the dashboard tries to replace observability tooling, it will become bloated and weaker than
+   standard tools.
+2. If the dashboard merely mirrors APIs without operator focus, it will add little value.
+3. If UI aggregations drift from backend truth, operator trust will fall.
+4. If rollout and governance states are over-collapsed, real blocking details may be hidden.
+
+## Success Criteria
+
+This RFC is successful when:
+
+1. operators can answer the main platform-governance questions from one dashboard,
+2. the dashboard reduces API-by-API manual stitching,
+3. it complements rather than replaces standard observability practice,
+4. multi-app rollout becomes easier to operate because posture is visible in one place.


### PR DESCRIPTION
## Summary
- default the first-use-case demo to the canonical performance service identity
- make lotus-ai base URL an explicit seam instead of repeating direct-process URLs
- update the demo README to distinguish canonical cross-app URLs from local AI process defaults