### PR TITLE
test: keep lotus-ai local infra ports internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,12 @@ uvicorn app.main:app --reload --port 8140
 docker compose up --build
 ```
 
+Local Docker runtime does not publish internal infrastructure ports by default:
+
+1. PostgreSQL stays internal to the Compose network on `postgres:5432`
+2. Redis stays internal to the Compose network on `redis:6379`
+3. only the application port `8140` is published for local API access
+
 The checked-in Docker stack is now a prod-shaped local baseline, not a full production-ready posture:
 
 1. PostgreSQL backs the SQL store seams instead of SQLite,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       POSTGRES_DB: lotus_ai
       POSTGRES_USER: lotus
       POSTGRES_PASSWORD: lotus
-    ports:
-      - "5432:5432"
     volumes:
       - lotus-ai-postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -17,8 +15,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
 
   lotus-ai:
     build: .

--- a/tests/unit/test_deployment_baseline_files.py
+++ b/tests/unit/test_deployment_baseline_files.py
@@ -10,6 +10,9 @@ def test_docker_compose_represents_prod_shaped_local_baseline() -> None:
     assert "postgresql+psycopg://lotus:lotus@postgres:5432/lotus_ai" in compose_text
     assert "LOTUS_AI_ARTIFACT_OBJECT_STORE_MODE: filesystem" in compose_text
     assert "LOTUS_AI_SECRET_SOURCE_MODE: local_or_unspecified" in compose_text
+    assert '"8140:8140"' in compose_text
+    assert '"5432:5432"' not in compose_text
+    assert '"6379:6379"' not in compose_text
 
 
 def test_env_example_matches_prod_shaped_local_baseline() -> None:
@@ -22,3 +25,11 @@ def test_env_example_matches_prod_shaped_local_baseline() -> None:
     assert "LOTUS_AI_ARTIFACT_OBJECT_STORE_MODE=filesystem" in env_example_text
     assert "LOTUS_AI_SECRET_SOURCE_MODE=local_or_unspecified" in env_example_text
     assert "LOTUS_AI_ASYNC_CUTOVER_STATE=dedicated_workers_active" in env_example_text
+
+
+def test_readme_documents_internal_infra_ports_stay_unpublished() -> None:
+    readme_text = Path("README.md").read_text(encoding="utf-8")
+
+    assert "PostgreSQL stays internal to the Compose network on `postgres:5432`" in readme_text
+    assert "Redis stays internal to the Compose network on `redis:6379`" in readme_text
+    assert "only the application port `8140` is published" in readme_text


### PR DESCRIPTION
## Summary
- stop publishing postgres and redis ports from the local docker baseline
- document that only the application port remains exposed
- lock the deployment baseline with targeted tests

## Validation
- python -m pytest tests/unit/test_deployment_baseline_files.py -q