### PR TITLE
docs(mesh): document mesh wiki posture

### DIFF
--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -1,0 +1,17 @@
+# Mesh Data Products
+
+## Mesh role
+
+`lotus-ai` is not currently a first-wave mesh producer or consumer declaration participant.
+
+## Current posture
+
+RFC-0086 and RFC-0091 intentionally keep `lotus-ai` out of the maturity-wave product set until it owns a stable governed data product or a catalog-consuming AI capability with clear product authority, telemetry, access policy, and evidence boundaries.
+
+## Platform relationship
+
+When `lotus-ai` becomes a mesh participant, onboarding should start with the platform self-service product scaffold and must include repo-native declaration, trust telemetry, SLO policy, access policy, evidence policy, tests, and platform mesh certification.
+
+## Operating rule
+
+Do not describe AI outputs as certified mesh products until they have repo-native product declarations and pass platform certification. AI can consume certified mesh products only through governed gateway/platform contracts and explicit entitlement posture.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -11,3 +11,5 @@
 * [Security and Governance](Security-and-Governance)
 * [RFC Index](RFC-Index)
 * [Roadmap](Roadmap)
+
+- [Mesh Data Products](Mesh-Data-Products)


### PR DESCRIPTION
Updates the authored repo wiki with an explicit Mesh Data Products page and sidebar link so the repo's published wiki can reflect the implemented Lotus mesh RFC posture. This is documentation-only; no runtime or API behavior changes.