### PR TITLE
fix(workflow-packs): block review actions for failed runs

### DIFF
--- a/src/app/services/workflow_pack_run_ledger.py
+++ b/src/app/services/workflow_pack_run_ledger.py
@@ -338,6 +338,7 @@ def map_workflow_pack_run_record(
         allowed_review_actions=resolve_allowed_review_actions(
             review_required=record.review_required,
             review_state=WorkflowPackRunReviewState(record.review_state),
+            runtime_state=WorkflowPackRunRuntimeState(record.runtime_state),
         ),
         review_summary=review_summary,
         review_required=record.review_required,

--- a/src/app/services/workflow_pack_run_review.py
+++ b/src/app/services/workflow_pack_run_review.py
@@ -14,6 +14,7 @@ from app.contracts.workflow_pack_runs import (
     WorkflowPackRunReviewActionResponse,
     WorkflowPackRunReviewActionType,
     WorkflowPackRunReviewState,
+    WorkflowPackRunRuntimeState,
 )
 from app.repositories.workflow_pack_run_repository import (
     WorkflowPackRunEventRecord,
@@ -144,6 +145,7 @@ def _apply_review_transition(
     _validate_review_transition(
         review_required=run.review_required,
         current_state=current_state,
+        runtime_state=WorkflowPackRunRuntimeState(run.runtime_state),
         action_type=request.action_type,
     )
 
@@ -208,18 +210,20 @@ def _validate_review_transition(
     *,
     review_required: bool,
     current_state: WorkflowPackRunReviewState,
+    runtime_state: WorkflowPackRunRuntimeState,
     action_type: WorkflowPackRunReviewActionType,
 ) -> None:
     if action_type in resolve_allowed_review_actions(
         review_required=review_required,
         review_state=current_state,
+        runtime_state=runtime_state,
     ):
         return
     raise HTTPException(
         status_code=status.HTTP_409_CONFLICT,
         detail=(
             f"Workflow-pack run review action `{action_type.value}` is not allowed from "
-            f"review state `{current_state.value}`."
+            f"review state `{current_state.value}` and runtime state `{runtime_state.value}`."
         ),
     )
 

--- a/src/app/services/workflow_pack_run_review_policy.py
+++ b/src/app/services/workflow_pack_run_review_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.contracts.workflow_pack_runs import (
     WorkflowPackRunReviewActionType,
     WorkflowPackRunReviewState,
+    WorkflowPackRunRuntimeState,
 )
 
 
@@ -10,8 +11,11 @@ def resolve_allowed_review_actions(
     *,
     review_required: bool,
     review_state: WorkflowPackRunReviewState,
+    runtime_state: WorkflowPackRunRuntimeState,
 ) -> list[WorkflowPackRunReviewActionType]:
     if not review_required:
+        return []
+    if runtime_state is not WorkflowPackRunRuntimeState.COMPLETED:
         return []
     if review_state == WorkflowPackRunReviewState.AWAITING_REVIEW:
         return [

--- a/src/app/services/workflow_pack_run_review_summary.py
+++ b/src/app/services/workflow_pack_run_review_summary.py
@@ -5,6 +5,7 @@ from app.contracts.workflow_pack_runs import (
     WorkflowPackRunEventType,
     WorkflowPackRunReviewState,
     WorkflowPackRunReviewSummaryDescriptor,
+    WorkflowPackRunRuntimeState,
 )
 from app.repositories.workflow_pack_run_repository import (
     WorkflowPackRunEventRecord,
@@ -26,6 +27,7 @@ def build_workflow_pack_run_review_descriptor(
         allowed_actions=resolve_allowed_review_actions(
             review_required=record.review_required,
             review_state=review_state,
+            runtime_state=WorkflowPackRunRuntimeState(record.runtime_state),
         ),
         latest_review_event_at=review_summary.latest_review_event_at,
         latest_review_actor=review_summary.latest_review_actor,

--- a/tests/integration/test_workflow_pack_run_api_contract.py
+++ b/tests/integration/test_workflow_pack_run_api_contract.py
@@ -304,6 +304,7 @@ def test_workflow_pack_execute_route_records_failed_run_when_runtime_execution_i
     assert body["execution"]["result"]["message"].startswith("LIVE_EXECUTION_NOT_ENABLED:")
     assert body["execution"]["audit"]["workflow_pack_run_id"] == run_id
     assert body["workflow_pack_run"]["runtime_state"] == "FAILED"
+    assert body["workflow_pack_run"]["allowed_review_actions"] == []
     assert body["workflow_pack_run"]["supportability_status"] == "ACTION_REQUIRED"
     _assert_task_flow_recorded_for_run(
         client=client,
@@ -324,6 +325,25 @@ def test_workflow_pack_execute_route_records_failed_run_when_runtime_execution_i
     assert operator_body["runtime_state"] == "FAILED"
     assert operator_body["supportability_status"] == "ACTION_REQUIRED"
     assert any(finding["finding_id"] == "runtime_failed" for finding in operator_body["findings"])
+
+    review_response = client.post(
+        f"/platform/workflow-packs/runs/{run_id}/review-actions",
+        json={
+            "action_type": "ACCEPT",
+            "caller_app": "lotus-gateway",
+            "reviewed_by": "banker.sg.failed",
+            "reason": "Failed runtime output must not be accepted as workflow truth.",
+        },
+    )
+    assert review_response.status_code == 409
+    assert "runtime state `FAILED`" in review_response.json()["detail"]
+
+    unchanged_detail_response = client.get(f"/platform/workflow-packs/runs/{run_id}")
+    assert unchanged_detail_response.status_code == 200
+    unchanged_detail = unchanged_detail_response.json()
+    assert unchanged_detail["run"]["review_state"] == "AWAITING_REVIEW"
+    assert unchanged_detail["review"]["review_transition_count"] == 0
+    assert [event["event_type"] for event in unchanged_detail["events"]] == ["RUN_RECORDED"]
 
 
 def test_workflow_pack_execute_route_rejects_wrong_task_for_binding(client: TestClient) -> None:

--- a/tests/unit/test_workflow_pack_run_ledger.py
+++ b/tests/unit/test_workflow_pack_run_ledger.py
@@ -89,6 +89,7 @@ def test_record_workflow_pack_run_preserves_failed_runtime_posture() -> None:
     assert recorded is not None
     assert recorded.runtime_state.value == "FAILED"
     assert recorded.review_state.value == "AWAITING_REVIEW"
+    assert recorded.allowed_review_actions == []
     assert recorded.supportability_status.value == "ACTION_REQUIRED"
     assert recorded.output_preview.startswith("LIVE_EXECUTION_NOT_ENABLED:")
     assert "failure_category" in recorded.structured_output_keys
@@ -99,6 +100,27 @@ def test_record_workflow_pack_run_preserves_failed_runtime_posture() -> None:
     detail = build_workflow_pack_run_detail(run_id=recorded.run_id)
     assert detail.run.runtime_state.value == "FAILED"
     assert detail.supportability.partial_output_visible is True
+
+    try:
+        apply_workflow_pack_run_review_action(
+            run_id=recorded.run_id,
+            request=WorkflowPackRunReviewActionRequest(
+                action_type=WorkflowPackRunReviewActionType.ACCEPT,
+                caller_app="lotus-gateway",
+                reviewed_by="banker.sg.failed",
+                reason="Failed runtime output must not be accepted as workflow truth.",
+            ),
+        )
+    except HTTPException as exc:
+        assert exc.status_code == 409
+        assert "runtime state `FAILED`" in exc.detail
+    else:
+        raise AssertionError("Expected failed workflow-pack run to reject review action")
+
+    unchanged = build_workflow_pack_run_detail(run_id=recorded.run_id)
+    assert unchanged.run.review_state.value == "AWAITING_REVIEW"
+    assert unchanged.review.review_transition_count == 0
+    assert [event.event_type.value for event in unchanged.events] == ["RUN_RECORDED"]
 
 
 def test_record_workflow_pack_run_ignores_non_pack_task_execution() -> None:

--- a/tests/unit/test_workflow_pack_run_review_policy.py
+++ b/tests/unit/test_workflow_pack_run_review_policy.py
@@ -1,5 +1,6 @@
 from app.contracts.workflow_pack_runs import (
     WorkflowPackRunReviewState,
+    WorkflowPackRunRuntimeState,
 )
 from app.services.workflow_pack_run_review_policy import resolve_allowed_review_actions
 
@@ -8,6 +9,7 @@ def test_resolve_allowed_review_actions_for_awaiting_review() -> None:
     actions = resolve_allowed_review_actions(
         review_required=True,
         review_state=WorkflowPackRunReviewState.AWAITING_REVIEW,
+        runtime_state=WorkflowPackRunRuntimeState.COMPLETED,
     )
 
     assert [action.value for action in actions] == [
@@ -23,6 +25,7 @@ def test_resolve_allowed_review_actions_for_accepted_run() -> None:
     actions = resolve_allowed_review_actions(
         review_required=True,
         review_state=WorkflowPackRunReviewState.ACCEPTED,
+        runtime_state=WorkflowPackRunRuntimeState.COMPLETED,
     )
 
     assert [action.value for action in actions] == ["SUPERSEDE"]
@@ -33,6 +36,7 @@ def test_resolve_allowed_review_actions_returns_empty_for_non_reviewable_posture
         resolve_allowed_review_actions(
             review_required=False,
             review_state=WorkflowPackRunReviewState.NOT_REVIEW_REQUIRED,
+            runtime_state=WorkflowPackRunRuntimeState.COMPLETED,
         )
         == []
     )
@@ -40,6 +44,17 @@ def test_resolve_allowed_review_actions_returns_empty_for_non_reviewable_posture
         resolve_allowed_review_actions(
             review_required=True,
             review_state=WorkflowPackRunReviewState.SUPERSEDED,
+            runtime_state=WorkflowPackRunRuntimeState.COMPLETED,
         )
         == []
     )
+
+
+def test_resolve_allowed_review_actions_blocks_failed_runtime_posture() -> None:
+    actions = resolve_allowed_review_actions(
+        review_required=True,
+        review_state=WorkflowPackRunReviewState.AWAITING_REVIEW,
+        runtime_state=WorkflowPackRunRuntimeState.FAILED,
+    )
+
+    assert actions == []


### PR DESCRIPTION
## Summary
- block workflow-pack review actions when runtime posture is not COMPLETED
- keep failed runtime runs inspectable without allowing ACCEPT/REVISE/SUPERSEDE to mutate review truth
- add unit and integration regressions proving 409 response and no partial run-ledger mutation

## Proof
- python -m pytest tests\\unit\\test_workflow_pack_run_review_policy.py tests\\unit\\test_workflow_pack_run_ledger.py tests\\integration\\test_workflow_pack_run_api_contract.py -q
- python -m pytest tests\\unit\\test_workflow_pack_task_flow_service.py tests\\unit\\test_workflow_pack_task_flow_recording.py -q
- python -m ruff check touched files
- python -m mypy --config-file mypy.ini touched files
- git diff --check