### PR TITLE
Harden AI runtime status probes

### DIFF
--- a/src/app/repositories/memory_workflow_pack_run_repository.py
+++ b/src/app/repositories/memory_workflow_pack_run_repository.py
@@ -14,11 +14,15 @@ class InMemoryWorkflowPackRunRepository(WorkflowPackRunRepository):
         self._runs: dict[str, WorkflowPackRunRecord] = {}
         self._events: dict[str, list[WorkflowPackRunEventRecord]] = {}
 
-    def list_runs(self) -> list[WorkflowPackRunRecord]:
-        return [
-            deepcopy(self._runs[run_id])
-            for run_id in sorted(self._runs, key=lambda item: self._runs[item].created_at)
-        ]
+    def list_runs(self, *, limit: int | None = None) -> list[WorkflowPackRunRecord]:
+        run_ids = sorted(
+            self._runs,
+            key=lambda item: self._runs[item].created_at,
+            reverse=limit is not None,
+        )
+        if limit is not None:
+            run_ids = run_ids[: max(limit, 0)]
+        return [deepcopy(self._runs[run_id]) for run_id in run_ids]
 
     def get_run(self, *, run_id: str) -> WorkflowPackRunRecord | None:
         record = self._runs.get(run_id)

--- a/src/app/repositories/sqlalchemy_workflow_pack_run_repository.py
+++ b/src/app/repositories/sqlalchemy_workflow_pack_run_repository.py
@@ -21,11 +21,16 @@ class SqlAlchemyWorkflowPackRunRepository(SqlAlchemyRepositoryBase, WorkflowPack
         self._ensure_sqlite_parent_directory()
         self._configure_sqlalchemy(database_url)
 
-    def list_runs(self) -> list[WorkflowPackRunRecord]:
+    def list_runs(self, *, limit: int | None = None) -> list[WorkflowPackRunRecord]:
         with self._session_factory() as session:
-            models = session.scalars(
-                select(WorkflowPackRunModel).order_by(WorkflowPackRunModel.created_at)
-            ).all()
+            statement = select(WorkflowPackRunModel)
+            if limit is not None:
+                statement = statement.order_by(WorkflowPackRunModel.created_at.desc()).limit(
+                    max(limit, 0)
+                )
+            else:
+                statement = statement.order_by(WorkflowPackRunModel.created_at)
+            models = session.scalars(statement).all()
             return [self._to_run_record(model) for model in models]
 
     def get_run(self, *, run_id: str) -> WorkflowPackRunRecord | None:

--- a/src/app/repositories/workflow_pack_run_repository.py
+++ b/src/app/repositories/workflow_pack_run_repository.py
@@ -50,8 +50,8 @@ class WorkflowPackRunEventRecord:
 
 
 class WorkflowPackRunRepository(Protocol):
-    def list_runs(self) -> list[WorkflowPackRunRecord]:
-        """List all persisted workflow-pack run records."""
+    def list_runs(self, *, limit: int | None = None) -> list[WorkflowPackRunRecord]:
+        """List persisted workflow-pack run records, optionally bounded to newest records."""
 
     def get_run(self, *, run_id: str) -> WorkflowPackRunRecord | None:
         """Fetch one persisted workflow-pack run record."""

--- a/src/app/services/app_capability_rollout_catalog.py
+++ b/src/app/services/app_capability_rollout_catalog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from app.config import settings
 from app.contracts.app_capability_rollouts import (
     AppCapabilityRolloutCatalogResponse,
@@ -32,10 +34,36 @@ from app.services.production_go_live_use_case_approval import (
 from app.services.use_case_onboarding_template import build_use_case_onboarding_template
 
 
+@dataclass(frozen=True)
+class AppCapabilityRolloutBuildContext:
+    rollout_records: list[AppCapabilityRolloutDescriptor]
+
+
+def build_app_capability_rollout_context(
+    app_state: object | None = None,
+    *,
+    capability_catalog: object | None = None,
+    first_use_case: object | None = None,
+    first_use_case_governance: object | None = None,
+    production_go_live: object | None = None,
+) -> AppCapabilityRolloutBuildContext:
+    return AppCapabilityRolloutBuildContext(
+        rollout_records=_build_rollout_records(
+            app_state,
+            capability_catalog=capability_catalog,
+            first_use_case=first_use_case,
+            first_use_case_governance=first_use_case_governance,
+            production_go_live=production_go_live,
+        )
+    )
+
+
 def build_app_capability_rollout_catalog(
     app_state: object | None = None,
+    *,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutCatalogResponse:
-    rollout_records = _build_rollout_records(app_state)
+    rollout_records = _resolve_rollout_context(app_state, context).rollout_records
     onboarded_pairing_count = sum(1 for record in rollout_records if record.currently_onboarded)
     active_pairing_count = sum(
         1
@@ -139,13 +167,24 @@ def build_app_capability_onboarding_template(
 
 
 def build_app_capability_rollout_detail(
-    *, downstream_app: str, capability_pack_id: str, app_state: object | None = None
+    *,
+    downstream_app: str,
+    capability_pack_id: str,
+    app_state: object | None = None,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutDetailResponse:
     record = get_app_capability_rollout_record(
         downstream_app=downstream_app,
         capability_pack_id=capability_pack_id,
         app_state=app_state,
+        context=context,
     )
+    return _build_rollout_detail_response(record=record)
+
+
+def _build_rollout_detail_response(
+    *, record: AppCapabilityRolloutDescriptor
+) -> AppCapabilityRolloutDetailResponse:
     ownership_boundaries = _build_ownership_boundaries(record=record)
     escalation_paths = _build_escalation_paths(record=record)
     transition_targets = _build_transition_targets(record=record)
@@ -172,13 +211,24 @@ def build_app_capability_rollout_detail(
 
 
 def build_app_capability_rollout_governance_status(
-    *, downstream_app: str, capability_pack_id: str, app_state: object | None = None
+    *,
+    downstream_app: str,
+    capability_pack_id: str,
+    app_state: object | None = None,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutGovernanceStatusResponse:
     detail = build_app_capability_rollout_detail(
         downstream_app=downstream_app,
         capability_pack_id=capability_pack_id,
         app_state=app_state,
+        context=context,
     )
+    return _build_governance_status_response(detail=detail)
+
+
+def _build_governance_status_response(
+    *, detail: AppCapabilityRolloutDetailResponse
+) -> AppCapabilityRolloutGovernanceStatusResponse:
     items = _build_governance_items(detail=detail)
     blocking_area_count = sum(
         1 for item in items if item.required_for_rollout and item.status != "READY"
@@ -209,15 +259,15 @@ def build_app_capability_rollout_governance_status(
 
 def build_app_capability_rollout_catalog_governance_status(
     app_state: object | None = None,
+    *,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutCatalogGovernanceStatusResponse:
-    catalog = build_app_capability_rollout_catalog(app_state)
+    rollout_context = _resolve_rollout_context(app_state, context)
     summaries: list[AppCapabilityRolloutGovernanceSummaryItem] = []
     ready_pairing_count = 0
-    for record in catalog.rollout_records:
-        governance = build_app_capability_rollout_governance_status(
-            downstream_app=record.downstream_app,
-            capability_pack_id=record.capability_pack_id,
-            app_state=app_state,
+    for record in rollout_context.rollout_records:
+        governance = _build_governance_status_response(
+            detail=_build_rollout_detail_response(record=record)
         )
         if governance.governance_ready:
             ready_pairing_count += 1
@@ -249,9 +299,13 @@ def build_app_capability_rollout_catalog_governance_status(
 
 
 def get_app_capability_rollout_record(
-    *, downstream_app: str, capability_pack_id: str, app_state: object | None = None
+    *,
+    downstream_app: str,
+    capability_pack_id: str,
+    app_state: object | None = None,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutDescriptor:
-    for record in _build_rollout_records(app_state):
+    for record in _resolve_rollout_context(app_state, context).rollout_records:
         if (
             record.downstream_app == downstream_app
             and record.capability_pack_id == capability_pack_id
@@ -260,12 +314,38 @@ def get_app_capability_rollout_record(
     raise ValueError(f"Unknown app-capability rollout: {downstream_app} / {capability_pack_id}")
 
 
-def _build_rollout_records(app_state: object | None) -> list[AppCapabilityRolloutDescriptor]:
-    capability_catalog = build_capability_pack_catalog()
+def _resolve_rollout_context(
+    app_state: object | None,
+    context: AppCapabilityRolloutBuildContext | None,
+) -> AppCapabilityRolloutBuildContext:
+    return context if context is not None else build_app_capability_rollout_context(app_state)
+
+
+def _build_rollout_records(
+    app_state: object | None,
+    *,
+    capability_catalog: object | None = None,
+    first_use_case: object | None = None,
+    first_use_case_governance: object | None = None,
+    production_go_live: object | None = None,
+) -> list[AppCapabilityRolloutDescriptor]:
+    capability_catalog = (
+        capability_catalog if capability_catalog is not None else build_capability_pack_catalog()
+    )
     pack_by_id = {pack.pack_id: pack for pack in capability_catalog.packs}
-    first_use_case = build_first_use_case_runtime_status()
-    first_use_case_governance = build_first_use_case_governance_status()
-    production_go_live = build_production_go_live_use_case_approval(app_state)
+    first_use_case = (
+        first_use_case if first_use_case is not None else build_first_use_case_runtime_status()
+    )
+    first_use_case_governance = (
+        first_use_case_governance
+        if first_use_case_governance is not None
+        else build_first_use_case_governance_status()
+    )
+    production_go_live = (
+        production_go_live
+        if production_go_live is not None
+        else build_production_go_live_use_case_approval(app_state)
+    )
 
     analytics_pack = pack_by_id["analytics_commentary.pack.v1"]
     decision_pack = pack_by_id["decision_explanation.pack.v1"]

--- a/src/app/services/app_capability_rollout_catalog.py
+++ b/src/app/services/app_capability_rollout_catalog.py
@@ -20,6 +20,12 @@ from app.contracts.app_capability_rollouts import (
 from app.contracts.capability_packs import (
     CapabilityPackAdoptionChecklistItem,
     CapabilityPackAdoptionCriterion,
+    CapabilityPackCatalogResponse,
+)
+from app.contracts.production_go_live import ProductionGoLiveUseCaseApprovalResponse
+from app.contracts.use_cases import (
+    FirstUseCaseGovernanceStatusResponse,
+    FirstUseCaseRuntimeStatusResponse,
 )
 from app.services.capability_pack_catalog import (
     build_capability_pack_catalog,
@@ -42,10 +48,10 @@ class AppCapabilityRolloutBuildContext:
 def build_app_capability_rollout_context(
     app_state: object | None = None,
     *,
-    capability_catalog: object | None = None,
-    first_use_case: object | None = None,
-    first_use_case_governance: object | None = None,
-    production_go_live: object | None = None,
+    capability_catalog: CapabilityPackCatalogResponse | None = None,
+    first_use_case: FirstUseCaseRuntimeStatusResponse | None = None,
+    first_use_case_governance: FirstUseCaseGovernanceStatusResponse | None = None,
+    production_go_live: ProductionGoLiveUseCaseApprovalResponse | None = None,
 ) -> AppCapabilityRolloutBuildContext:
     return AppCapabilityRolloutBuildContext(
         rollout_records=_build_rollout_records(
@@ -324,10 +330,10 @@ def _resolve_rollout_context(
 def _build_rollout_records(
     app_state: object | None,
     *,
-    capability_catalog: object | None = None,
-    first_use_case: object | None = None,
-    first_use_case_governance: object | None = None,
-    production_go_live: object | None = None,
+    capability_catalog: CapabilityPackCatalogResponse | None = None,
+    first_use_case: FirstUseCaseRuntimeStatusResponse | None = None,
+    first_use_case_governance: FirstUseCaseGovernanceStatusResponse | None = None,
+    production_go_live: ProductionGoLiveUseCaseApprovalResponse | None = None,
 ) -> list[AppCapabilityRolloutDescriptor]:
     capability_catalog = (
         capability_catalog if capability_catalog is not None else build_capability_pack_catalog()

--- a/src/app/services/app_capability_rollout_lifecycle.py
+++ b/src/app/services/app_capability_rollout_lifecycle.py
@@ -14,7 +14,9 @@ from app.contracts.app_capability_rollouts import (
 from app.services.app_capability_rollout_catalog import (
     build_app_capability_rollout_catalog,
     build_app_capability_rollout_detail,
+    build_app_capability_rollout_context,
     build_app_capability_rollout_governance_status,
+    AppCapabilityRolloutBuildContext,
 )
 from app.services.app_capability_rollout_observability import (
     build_app_capability_rollout_observability_summary,
@@ -22,26 +24,49 @@ from app.services.app_capability_rollout_observability import (
 
 
 def build_app_capability_rollout_lifecycle_status(
-    *, downstream_app: str, capability_pack_id: str, app_state: object | None = None
+    *,
+    downstream_app: str,
+    capability_pack_id: str,
+    app_state: object | None = None,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutLifecycleStatusResponse:
+    rollout_context = (
+        context if context is not None else build_app_capability_rollout_context(app_state)
+    )
     detail = build_app_capability_rollout_detail(
         downstream_app=downstream_app,
         capability_pack_id=capability_pack_id,
         app_state=app_state,
+        context=rollout_context,
     )
     governance = build_app_capability_rollout_governance_status(
         downstream_app=downstream_app,
         capability_pack_id=capability_pack_id,
         app_state=app_state,
+        context=rollout_context,
     )
     observability = _get_pairing_observability_item(
         downstream_app=downstream_app,
         capability_pack_id=capability_pack_id,
         app_state=app_state,
+        context=rollout_context,
     )
-    items = _build_lifecycle_items(
+    return _build_lifecycle_status_response(
         detail=detail,
         governance_ready=governance.governance_ready,
+        observability=observability,
+    )
+
+
+def _build_lifecycle_status_response(
+    *,
+    detail: AppCapabilityRolloutDetailResponse,
+    governance_ready: bool,
+    observability: AppCapabilityRolloutObservabilityItem,
+) -> AppCapabilityRolloutLifecycleStatusResponse:
+    items = _build_lifecycle_items(
+        detail=detail,
+        governance_ready=governance_ready,
         historical_traceability_ready=observability.governance_ready
         or len(observability.linked_endpoints) >= 3,
         linked_endpoint_count=len(observability.linked_endpoints),
@@ -86,15 +111,39 @@ def build_app_capability_rollout_lifecycle_status(
 
 def build_app_capability_rollout_catalog_lifecycle_status(
     app_state: object | None = None,
+    *,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutCatalogLifecycleStatusResponse:
-    catalog = build_app_capability_rollout_catalog(app_state)
+    rollout_context = (
+        context if context is not None else build_app_capability_rollout_context(app_state)
+    )
+    catalog = build_app_capability_rollout_catalog(app_state, context=rollout_context)
+    observability_by_pairing = {
+        (item.downstream_app, item.capability_pack_id): item
+        for item in build_app_capability_rollout_observability_summary(
+            app_state, context=rollout_context
+        ).items
+    }
     summaries: list[AppCapabilityRolloutLifecycleSummaryItem] = []
     ready_pairing_count = 0
     for record in catalog.rollout_records:
-        lifecycle = build_app_capability_rollout_lifecycle_status(
+        governance = build_app_capability_rollout_governance_status(
             downstream_app=record.downstream_app,
             capability_pack_id=record.capability_pack_id,
             app_state=app_state,
+            context=rollout_context,
+        )
+        lifecycle = _build_lifecycle_status_response(
+            detail=build_app_capability_rollout_detail(
+                downstream_app=record.downstream_app,
+                capability_pack_id=record.capability_pack_id,
+                app_state=app_state,
+                context=rollout_context,
+            ),
+            governance_ready=governance.governance_ready,
+            observability=observability_by_pairing[
+                (record.downstream_app, record.capability_pack_id)
+            ],
         )
         if lifecycle.lifecycle_ready:
             ready_pairing_count += 1
@@ -173,9 +222,13 @@ def _build_lifecycle_items(
 
 
 def _get_pairing_observability_item(
-    *, downstream_app: str, capability_pack_id: str, app_state: object | None = None
+    *,
+    downstream_app: str,
+    capability_pack_id: str,
+    app_state: object | None = None,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutObservabilityItem:
-    summary = build_app_capability_rollout_observability_summary(app_state)
+    summary = build_app_capability_rollout_observability_summary(app_state, context=context)
     return next(
         item
         for item in summary.items

--- a/src/app/services/app_capability_rollout_observability.py
+++ b/src/app/services/app_capability_rollout_observability.py
@@ -11,7 +11,9 @@ from app.contracts.audit import AuditRecordResponse
 from app.contracts.async_runtime import AsyncJobArtifactDescriptor
 from app.services.app_capability_rollout_catalog import (
     build_app_capability_rollout_catalog,
+    build_app_capability_rollout_context,
     build_app_capability_rollout_governance_status,
+    AppCapabilityRolloutBuildContext,
 )
 from app.services.async_job_service import build_async_job_catalog
 from app.services.audit_store import get_audit_store
@@ -20,14 +22,24 @@ from app.services.runtime_readiness import get_audit_store_runtime_status
 
 def build_app_capability_rollout_observability_summary(
     app_state: object | None = None,
+    *,
+    context: AppCapabilityRolloutBuildContext | None = None,
 ) -> AppCapabilityRolloutObservabilitySummaryResponse:
-    catalog = build_app_capability_rollout_catalog(app_state)
+    rollout_context = (
+        context if context is not None else build_app_capability_rollout_context(app_state)
+    )
+    catalog = build_app_capability_rollout_catalog(app_state, context=rollout_context)
     audit_store_ready = get_audit_store_runtime_status().status in {"READY", "DEGRADED"}
+    audit_records = get_audit_store().list(limit=100)
+    async_jobs = build_async_job_catalog().jobs
     items = [
         _build_observability_item(
             downstream_app=record.downstream_app,
             capability_pack_id=record.capability_pack_id,
             app_state=app_state,
+            context=rollout_context,
+            audit_records=audit_records,
+            async_jobs=async_jobs,
         )
         for record in catalog.rollout_records
     ]
@@ -80,30 +92,41 @@ def build_app_capability_rollout_observability_summary(
 
 
 def _build_observability_item(
-    *, downstream_app: str, capability_pack_id: str, app_state: object | None = None
+    *,
+    downstream_app: str,
+    capability_pack_id: str,
+    app_state: object | None = None,
+    context: AppCapabilityRolloutBuildContext | None = None,
+    audit_records: list[AuditRecordResponse] | None = None,
+    async_jobs: list[AsyncJobArtifactDescriptor] | None = None,
 ) -> AppCapabilityRolloutObservabilityItem:
     governance = build_app_capability_rollout_governance_status(
         downstream_app=downstream_app,
         capability_pack_id=capability_pack_id,
         app_state=app_state,
+        context=context,
     )
-    audit_records = [
+    source_audit_records = (
+        audit_records if audit_records is not None else get_audit_store().list(limit=100)
+    )
+    source_async_jobs = async_jobs if async_jobs is not None else build_async_job_catalog().jobs
+    matching_audit_records = [
         record
-        for record in get_audit_store().list(limit=100)
+        for record in source_audit_records
         if _matches_pairing_record(
             record=record, downstream_app=downstream_app, capability_pack_id=capability_pack_id
         )
     ]
-    async_jobs = [
+    matching_async_jobs = [
         job
-        for job in build_async_job_catalog().jobs
+        for job in source_async_jobs
         if _matches_pairing_job(
             job=job, downstream_app=downstream_app, capability_pack_id=capability_pack_id
         )
     ]
     incident_signal_count = sum(
         1
-        for record in audit_records
+        for record in matching_audit_records
         if not record.authorization.allowed
         or record.safety_outcome.disposition.value != "DOCUMENTED_ONLY"
         or record.provider_mode not in {"disabled", "stub", "catalog_only"}
@@ -117,8 +140,8 @@ def _build_observability_item(
             governance_ready=governance.governance_ready,
         ),
         governance_ready=governance.governance_ready,
-        sampled_audit_record_count=len(audit_records),
-        sampled_async_job_count=len(async_jobs),
+        sampled_audit_record_count=len(matching_audit_records),
+        sampled_async_job_count=len(matching_async_jobs),
         incident_signal_count=incident_signal_count,
         linked_endpoints=_build_linked_endpoints(
             downstream_app=downstream_app, capability_pack_id=capability_pack_id

--- a/src/app/services/deployment_split_activation_readiness.py
+++ b/src/app/services/deployment_split_activation_readiness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.config import settings
 from app.contracts.deployment_split import (
     DeploymentSplitActivationReadinessResponse,
+    DeploymentSplitRuntimeStatusResponse,
     DeploymentSplitStage,
 )
 from app.services.deployment_split_runtime import build_deployment_split_runtime_status
@@ -11,7 +12,7 @@ from app.services.deployment_split_runtime import build_deployment_split_runtime
 def build_deployment_split_activation_readiness(
     app_state: object | None = None,
     *,
-    runtime_status: object | None = None,
+    runtime_status: DeploymentSplitRuntimeStatusResponse | None = None,
 ) -> DeploymentSplitActivationReadinessResponse:
     runtime_status = (
         runtime_status

--- a/src/app/services/deployment_split_activation_readiness.py
+++ b/src/app/services/deployment_split_activation_readiness.py
@@ -10,8 +10,14 @@ from app.services.deployment_split_runtime import build_deployment_split_runtime
 
 def build_deployment_split_activation_readiness(
     app_state: object | None = None,
+    *,
+    runtime_status: object | None = None,
 ) -> DeploymentSplitActivationReadinessResponse:
-    runtime_status = build_deployment_split_runtime_status(app_state)
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_deployment_split_runtime_status(app_state)
+    )
     split_active = runtime_status.effective_stage in {
         DeploymentSplitStage.RETRIEVAL_SPLIT_ACTIVE,
         DeploymentSplitStage.RETRIEVAL_AND_EVALS_SPLIT_ACTIVE,

--- a/src/app/services/deployment_split_governance.py
+++ b/src/app/services/deployment_split_governance.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from app.config import settings
-from app.contracts.deployment_split import DeploymentSplitGovernanceStatusResponse
+from app.contracts.deployment_split import (
+    DeploymentSplitActivationReadinessResponse,
+    DeploymentSplitGovernanceStatusResponse,
+    DeploymentSplitRuntimeStatusResponse,
+)
+from app.contracts.observability import ObservabilityGovernanceStatusResponse
 from app.services.deployment_split_activation_readiness import (
     build_deployment_split_activation_readiness,
 )
@@ -16,9 +21,9 @@ from app.services.observability_governance import build_observability_governance
 def build_deployment_split_governance_status(
     app_state: object | None = None,
     *,
-    runtime_status: object | None = None,
-    activation_readiness: object | None = None,
-    observability_governance: object | None = None,
+    runtime_status: DeploymentSplitRuntimeStatusResponse | None = None,
+    activation_readiness: DeploymentSplitActivationReadinessResponse | None = None,
+    observability_governance: ObservabilityGovernanceStatusResponse | None = None,
 ) -> DeploymentSplitGovernanceStatusResponse:
     runtime_status = (
         runtime_status

--- a/src/app/services/deployment_split_governance.py
+++ b/src/app/services/deployment_split_governance.py
@@ -15,11 +15,27 @@ from app.services.observability_governance import build_observability_governance
 
 def build_deployment_split_governance_status(
     app_state: object | None = None,
+    *,
+    runtime_status: object | None = None,
+    activation_readiness: object | None = None,
+    observability_governance: object | None = None,
 ) -> DeploymentSplitGovernanceStatusResponse:
-    runtime_status = build_deployment_split_runtime_status(app_state)
-    activation_readiness = build_deployment_split_activation_readiness(app_state)
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_deployment_split_runtime_status(app_state)
+    )
+    activation_readiness = (
+        activation_readiness
+        if activation_readiness is not None
+        else build_deployment_split_activation_readiness(app_state, runtime_status=runtime_status)
+    )
     runbook_readiness = build_deployment_split_runbook_readiness()
-    observability_governance = build_observability_governance_status()
+    observability_governance = (
+        observability_governance
+        if observability_governance is not None
+        else build_observability_governance_status()
+    )
     governance_ready, blocking_area_count = summarize_governance_flags(
         activation_readiness.activation_ready,
         runbook_readiness.runbook_ready,

--- a/src/app/services/first_use_case_governance.py
+++ b/src/app/services/first_use_case_governance.py
@@ -11,8 +11,24 @@ from app.services.first_use_case_runbook_readiness import build_first_use_case_r
 from app.services.governance_readiness import summarize_governance_flags
 
 
-def build_first_use_case_governance_status() -> FirstUseCaseGovernanceStatusResponse:
-    readiness = build_first_use_case_readiness()
+def build_first_use_case_governance_status(
+    *,
+    readiness: object | None = None,
+    access_control_governance: object | None = None,
+    artifact_runtime: object | None = None,
+    observability_governance: object | None = None,
+    resilience_governance: object | None = None,
+) -> FirstUseCaseGovernanceStatusResponse:
+    readiness = (
+        readiness
+        if readiness is not None
+        else build_first_use_case_readiness(
+            access_control_governance=access_control_governance,
+            artifact_runtime=artifact_runtime,
+            observability_governance=observability_governance,
+            resilience_governance=resilience_governance,
+        )
+    )
     runbook_readiness = build_first_use_case_runbook_readiness()
     governance_ready, blocking_area_count = summarize_governance_flags(
         readiness.readiness_ready,

--- a/src/app/services/first_use_case_governance.py
+++ b/src/app/services/first_use_case_governance.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.contracts.access_control import AccessControlGovernanceStatusResponse
+from app.contracts.artifacts import ArtifactRuntimeStatusResponse
+from app.contracts.observability import ObservabilityGovernanceStatusResponse
+from app.contracts.resilience import ResilienceGovernanceStatusResponse
 from app.contracts.use_cases import (
     FirstUseCaseGovernanceStatusResponse,
     FirstUseCaseOperationalPosture,
+    FirstUseCaseReadinessResponse,
     FirstUseCaseRolloutStage,
 )
 from app.services.first_use_case_readiness import build_first_use_case_readiness
@@ -13,11 +18,11 @@ from app.services.governance_readiness import summarize_governance_flags
 
 def build_first_use_case_governance_status(
     *,
-    readiness: object | None = None,
-    access_control_governance: object | None = None,
-    artifact_runtime: object | None = None,
-    observability_governance: object | None = None,
-    resilience_governance: object | None = None,
+    readiness: FirstUseCaseReadinessResponse | None = None,
+    access_control_governance: AccessControlGovernanceStatusResponse | None = None,
+    artifact_runtime: ArtifactRuntimeStatusResponse | None = None,
+    observability_governance: ObservabilityGovernanceStatusResponse | None = None,
+    resilience_governance: ResilienceGovernanceStatusResponse | None = None,
 ) -> FirstUseCaseGovernanceStatusResponse:
     readiness = (
         readiness

--- a/src/app/services/first_use_case_readiness.py
+++ b/src/app/services/first_use_case_readiness.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 from app.config import settings
-from app.contracts.access_control import CallerLifecycleStatus
+from app.contracts.access_control import (
+    AccessControlGovernanceStatusResponse,
+    CallerLifecycleStatus,
+)
+from app.contracts.artifacts import ArtifactRuntimeStatusResponse
 from app.contracts.evals import EvaluationApprovalEvidenceState
+from app.contracts.observability import ObservabilityGovernanceStatusResponse
+from app.contracts.resilience import ResilienceGovernanceStatusResponse
 from app.contracts.runtime_readiness import RuntimeReadinessStatus
 from app.contracts.tasks import OutputLabel
 from app.contracts.use_cases import FirstUseCaseReadinessItem, FirstUseCaseReadinessResponse
@@ -25,10 +31,10 @@ _FIRST_USE_CASE_FIXTURE_ID = "lotus_performance_first_use_case_examples"
 
 def build_first_use_case_readiness(
     *,
-    access_control_governance: object | None = None,
-    artifact_runtime: object | None = None,
-    observability_governance: object | None = None,
-    resilience_governance: object | None = None,
+    access_control_governance: AccessControlGovernanceStatusResponse | None = None,
+    artifact_runtime: ArtifactRuntimeStatusResponse | None = None,
+    observability_governance: ObservabilityGovernanceStatusResponse | None = None,
+    resilience_governance: ResilienceGovernanceStatusResponse | None = None,
 ) -> FirstUseCaseReadinessResponse:
     catalog = build_evaluation_catalog()
     approval_gate = build_first_use_case_approval_gate_summary()

--- a/src/app/services/first_use_case_readiness.py
+++ b/src/app/services/first_use_case_readiness.py
@@ -23,17 +23,37 @@ _FIRST_USE_CASE_TASK_ID = "explain.v1"
 _FIRST_USE_CASE_FIXTURE_ID = "lotus_performance_first_use_case_examples"
 
 
-def build_first_use_case_readiness() -> FirstUseCaseReadinessResponse:
+def build_first_use_case_readiness(
+    *,
+    access_control_governance: object | None = None,
+    artifact_runtime: object | None = None,
+    observability_governance: object | None = None,
+    resilience_governance: object | None = None,
+) -> FirstUseCaseReadinessResponse:
     catalog = build_evaluation_catalog()
     approval_gate = build_first_use_case_approval_gate_summary()
     staged_fixture_ids = {fixture.fixture_id for fixture in catalog.fixture_families}
     policy = get_caller_policy_repository().get_policy(_FIRST_USE_CASE_CALLER_APP)
     safety_outcome = build_safety_execution_outcome(OutputLabel.EXPLANATION_ONLY)
     audit_store = get_audit_store_runtime_status()
-    access_control_governance = build_access_control_governance_status()
-    artifact_runtime = build_artifact_runtime_status()
-    observability_governance = build_observability_governance_status()
-    resilience_governance = build_resilience_governance_status()
+    access_control_governance = (
+        access_control_governance
+        if access_control_governance is not None
+        else build_access_control_governance_status()
+    )
+    artifact_runtime = (
+        artifact_runtime if artifact_runtime is not None else build_artifact_runtime_status()
+    )
+    observability_governance = (
+        observability_governance
+        if observability_governance is not None
+        else build_observability_governance_status()
+    )
+    resilience_governance = (
+        resilience_governance
+        if resilience_governance is not None
+        else build_resilience_governance_status()
+    )
 
     caller_policy_ready = (
         policy is not None

--- a/src/app/services/observability_activation_readiness.py
+++ b/src/app/services/observability_activation_readiness.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from app.config import settings
-from app.contracts.observability import ObservabilityActivationReadinessResponse
+from app.contracts.observability import (
+    ObservabilityActivationReadinessResponse,
+    ObservabilityRuntimeStatusResponse,
+)
 from app.services.access_control_runtime import build_access_control_runtime_status
 from app.services.observability_runtime import build_observability_runtime_status
 from app.services.runtime_readiness import get_audit_store_runtime_status
 
 
 def build_observability_activation_readiness(
-    *, runtime_status: object | None = None
+    *, runtime_status: ObservabilityRuntimeStatusResponse | None = None
 ) -> ObservabilityActivationReadinessResponse:
     runtime_status = (
         runtime_status if runtime_status is not None else build_observability_runtime_status()

--- a/src/app/services/observability_activation_readiness.py
+++ b/src/app/services/observability_activation_readiness.py
@@ -7,8 +7,12 @@ from app.services.observability_runtime import build_observability_runtime_statu
 from app.services.runtime_readiness import get_audit_store_runtime_status
 
 
-def build_observability_activation_readiness() -> ObservabilityActivationReadinessResponse:
-    runtime_status = build_observability_runtime_status()
+def build_observability_activation_readiness(
+    *, runtime_status: object | None = None
+) -> ObservabilityActivationReadinessResponse:
+    runtime_status = (
+        runtime_status if runtime_status is not None else build_observability_runtime_status()
+    )
     audit_store = get_audit_store_runtime_status()
     access_control_runtime = build_access_control_runtime_status()
 

--- a/src/app/services/observability_governance.py
+++ b/src/app/services/observability_governance.py
@@ -9,10 +9,27 @@ from app.services.observability_runbook_readiness import build_observability_run
 from app.services.observability_runtime import build_observability_runtime_status
 
 
-def build_observability_governance_status() -> ObservabilityGovernanceStatusResponse:
-    deployment_split = build_deployment_split_runtime_status()
-    runtime_status = build_observability_runtime_status()
-    activation_readiness = build_observability_activation_readiness()
+def build_observability_governance_status(
+    *,
+    deployment_split: object | None = None,
+    runtime_status: object | None = None,
+    activation_readiness: object | None = None,
+) -> ObservabilityGovernanceStatusResponse:
+    deployment_split = (
+        deployment_split
+        if deployment_split is not None
+        else build_deployment_split_runtime_status()
+    )
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_observability_runtime_status(deployment_split=deployment_split)
+    )
+    activation_readiness = (
+        activation_readiness
+        if activation_readiness is not None
+        else build_observability_activation_readiness(runtime_status=runtime_status)
+    )
     runbook_readiness = build_observability_runbook_readiness()
     governance_ready, blocking_area_count = summarize_governance_flags(
         activation_readiness.activation_ready,

--- a/src/app/services/observability_governance.py
+++ b/src/app/services/observability_governance.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from app.config import settings
-from app.contracts.observability import ObservabilityGovernanceStatusResponse
+from app.contracts.deployment_split import DeploymentSplitRuntimeStatusResponse
+from app.contracts.observability import (
+    ObservabilityActivationReadinessResponse,
+    ObservabilityGovernanceStatusResponse,
+    ObservabilityRuntimeStatusResponse,
+)
 from app.services.governance_readiness import summarize_governance_flags
 from app.services.deployment_split_runtime import build_deployment_split_runtime_status
 from app.services.observability_activation_readiness import build_observability_activation_readiness
@@ -11,9 +16,9 @@ from app.services.observability_runtime import build_observability_runtime_statu
 
 def build_observability_governance_status(
     *,
-    deployment_split: object | None = None,
-    runtime_status: object | None = None,
-    activation_readiness: object | None = None,
+    deployment_split: DeploymentSplitRuntimeStatusResponse | None = None,
+    runtime_status: ObservabilityRuntimeStatusResponse | None = None,
+    activation_readiness: ObservabilityActivationReadinessResponse | None = None,
 ) -> ObservabilityGovernanceStatusResponse:
     deployment_split = (
         deployment_split

--- a/src/app/services/observability_runtime.py
+++ b/src/app/services/observability_runtime.py
@@ -14,11 +14,18 @@ from app.services.observability_domain_summaries import build_current_observabil
 from app.services.observability_shared import assess_observability_posture
 
 
-def build_observability_runtime_status() -> ObservabilityRuntimeStatusResponse:
-    deployment_split = build_deployment_split_runtime_status()
+def build_observability_runtime_status(
+    *, deployment_split: object | None = None
+) -> ObservabilityRuntimeStatusResponse:
+    deployment_split = (
+        deployment_split
+        if deployment_split is not None
+        else build_deployment_split_runtime_status()
+    )
     ai_surface_supportability = build_ai_surface_supportability_summary()
-    domains = _build_domain_summaries()
-    incident_items = _build_incident_items()
+    bundles = build_current_observability_bundles()
+    domains = _build_domain_summaries(bundles)
+    incident_items = _build_incident_items(bundles)
     postures = [domain.posture for domain in domains]
     freshness_states = [domain.freshness for domain in domains]
     healthy_domain_count = sum(1 for posture in postures if posture == ObservabilityPosture.HEALTHY)
@@ -61,16 +68,12 @@ def build_observability_runtime_status() -> ObservabilityRuntimeStatusResponse:
     )
 
 
-def _build_domain_summaries() -> list[DomainTelemetrySummary]:
-    return [bundle.summary.telemetry for bundle in build_current_observability_bundles()]
+def _build_domain_summaries(bundles: list[object]) -> list[DomainTelemetrySummary]:
+    return [bundle.summary.telemetry for bundle in bundles]
 
 
-def _build_incident_items() -> list[IncidentEvidenceSummaryItem]:
-    items = [
-        item
-        for bundle in build_current_observability_bundles()
-        for item in bundle.summary.incident_evidence_items
-    ]
+def _build_incident_items(bundles: list[object]) -> list[IncidentEvidenceSummaryItem]:
+    items = [item for bundle in bundles for item in bundle.summary.incident_evidence_items]
     return items
 
 

--- a/src/app/services/observability_runtime.py
+++ b/src/app/services/observability_runtime.py
@@ -8,14 +8,18 @@ from app.contracts.observability import (
     ObservabilityPosture,
     ObservabilityRuntimeStatusResponse,
 )
+from app.contracts.deployment_split import DeploymentSplitRuntimeStatusResponse
 from app.services.deployment_split_runtime import build_deployment_split_runtime_status
 from app.services.ai_surface_supportability import build_ai_surface_supportability_summary
-from app.services.observability_domain_summaries import build_current_observability_bundles
+from app.services.observability_domain_summaries import (
+    ObservabilityDomainBundle,
+    build_current_observability_bundles,
+)
 from app.services.observability_shared import assess_observability_posture
 
 
 def build_observability_runtime_status(
-    *, deployment_split: object | None = None
+    *, deployment_split: DeploymentSplitRuntimeStatusResponse | None = None
 ) -> ObservabilityRuntimeStatusResponse:
     deployment_split = (
         deployment_split
@@ -68,11 +72,15 @@ def build_observability_runtime_status(
     )
 
 
-def _build_domain_summaries(bundles: list[object]) -> list[DomainTelemetrySummary]:
+def _build_domain_summaries(
+    bundles: list[ObservabilityDomainBundle],
+) -> list[DomainTelemetrySummary]:
     return [bundle.summary.telemetry for bundle in bundles]
 
 
-def _build_incident_items(bundles: list[object]) -> list[IncidentEvidenceSummaryItem]:
+def _build_incident_items(
+    bundles: list[ObservabilityDomainBundle],
+) -> list[IncidentEvidenceSummaryItem]:
     items = [item for bundle in bundles for item in bundle.summary.incident_evidence_items]
     return items
 

--- a/src/app/services/platform_status.py
+++ b/src/app/services/platform_status.py
@@ -7,6 +7,7 @@ from app.config import settings
 from app.contracts.platform import PlatformRuntimeStatusResponse
 from app.services.app_capability_rollout_catalog import (
     build_app_capability_rollout_catalog,
+    build_app_capability_rollout_context,
     build_app_capability_rollout_catalog_governance_status,
 )
 from app.services.app_capability_rollout_lifecycle import (
@@ -43,6 +44,9 @@ from app.services.prompt_status import build_prompt_runtime_status
 from app.services.production_baseline_runtime import build_production_baseline_runtime_status
 from app.services.production_go_live_governance import build_production_go_live_governance_status
 from app.services.production_go_live_runtime import build_production_go_live_runtime_status
+from app.services.production_go_live_use_case_approval import (
+    build_production_go_live_use_case_approval,
+)
 from app.services.provider_governance_status import build_provider_governance_status
 from app.services.provider_operations_status import build_provider_operations_status
 from app.services.resilience_governance import build_resilience_governance_status
@@ -81,42 +85,85 @@ def build_platform_runtime_status(app_state: object | None = None) -> PlatformRu
     capabilities = build_capability_catalog()
     capability_packs = build_capability_pack_catalog()
     capability_pack_governance = build_capability_pack_catalog_governance_status()
-    app_capability_rollouts = build_app_capability_rollout_catalog(app_state)
-    app_capability_rollout_governance = build_app_capability_rollout_catalog_governance_status(
-        app_state
-    )
-    app_capability_rollout_lifecycle = build_app_capability_rollout_catalog_lifecycle_status(
-        app_state
-    )
-    app_capability_rollout_observability = build_app_capability_rollout_observability_summary(
-        app_state
-    )
-    prompts = list_registered_prompts()
+    first_use_case = build_first_use_case_runtime_status()
+    provider_governance = build_provider_governance_status()
+    deployment_split = build_deployment_split_runtime_status(app_state)
     access_control_runtime = build_access_control_runtime_status()
     access_control_governance = build_access_control_governance_status()
     artifact_runtime = build_artifact_runtime_status()
     artifact_governance = build_artifact_governance_status()
-    observability_runtime = build_observability_runtime_status()
-    observability_governance = build_observability_governance_status()
+    observability_runtime = build_observability_runtime_status(deployment_split=deployment_split)
+    observability_governance = build_observability_governance_status(
+        deployment_split=deployment_split,
+        runtime_status=observability_runtime,
+    )
+    resilience_runtime = build_resilience_runtime_status()
+    resilience_governance = build_resilience_governance_status()
+    first_use_case_governance = build_first_use_case_governance_status(
+        access_control_governance=access_control_governance,
+        artifact_runtime=artifact_runtime,
+        observability_governance=observability_governance,
+        resilience_governance=resilience_governance,
+    )
+    production_baseline = build_production_baseline_runtime_status(app_state)
+    production_go_live = build_production_go_live_runtime_status(
+        app_state,
+        baseline=production_baseline,
+        provider_governance=provider_governance,
+        first_use_case_governance=first_use_case_governance,
+    )
+    production_go_live_approval = build_production_go_live_use_case_approval(
+        app_state,
+        use_case_status=first_use_case,
+        use_case_governance=first_use_case_governance,
+        provider_governance=provider_governance,
+        runtime_status=production_go_live,
+    )
+    rollout_context = build_app_capability_rollout_context(
+        app_state,
+        capability_catalog=capability_packs,
+        first_use_case=first_use_case,
+        first_use_case_governance=first_use_case_governance,
+        production_go_live=production_go_live_approval,
+    )
+    app_capability_rollouts = build_app_capability_rollout_catalog(
+        app_state, context=rollout_context
+    )
+    app_capability_rollout_governance = build_app_capability_rollout_catalog_governance_status(
+        app_state, context=rollout_context
+    )
+    app_capability_rollout_lifecycle = build_app_capability_rollout_catalog_lifecycle_status(
+        app_state, context=rollout_context
+    )
+    app_capability_rollout_observability = build_app_capability_rollout_observability_summary(
+        app_state, context=rollout_context
+    )
+    prompts = list_registered_prompts()
     async_runtime = build_async_runtime_status()
     async_governance = build_async_governance_status()
-    provider_governance = build_provider_governance_status()
     provider_operations = build_provider_operations_status()
     retrieval_governance = build_retrieval_governance_status()
     prompt_governance = build_prompt_governance_status_summary()
     evaluation_runtime = build_evaluation_runtime_status()
     prompt_runtime = build_prompt_runtime_status()
     task_runtime = build_task_runtime_status()
-    first_use_case = build_first_use_case_runtime_status()
-    first_use_case_governance = build_first_use_case_governance_status()
-    resilience_runtime = build_resilience_runtime_status()
-    resilience_governance = build_resilience_governance_status()
-    production_baseline = build_production_baseline_runtime_status(app_state)
-    production_go_live = build_production_go_live_runtime_status(app_state)
-    production_go_live_governance = build_production_go_live_governance_status(app_state)
-    deployment_split = build_deployment_split_runtime_status(app_state)
-    deployment_split_governance = build_deployment_split_governance_status(app_state)
-    production_baseline_governance = build_production_baseline_governance_status(app_state)
+    production_go_live_governance = build_production_go_live_governance_status(
+        app_state,
+        runtime_status=production_go_live,
+        use_case_approval=production_go_live_approval,
+        provider_governance=provider_governance,
+    )
+    deployment_split_governance = build_deployment_split_governance_status(
+        app_state,
+        runtime_status=deployment_split,
+        observability_governance=observability_governance,
+    )
+    production_baseline_governance = build_production_baseline_governance_status(
+        app_state,
+        runtime_status=production_baseline,
+        provider_governance=provider_governance,
+        first_use_case_governance=first_use_case_governance,
+    )
     audit_store = get_audit_store_runtime_status()
     artifact_store = get_artifact_store_runtime_status()
     retrieval_store = get_retrieval_store_runtime_status()

--- a/src/app/services/production_baseline_activation_readiness.py
+++ b/src/app/services/production_baseline_activation_readiness.py
@@ -9,8 +9,14 @@ from app.services.production_baseline_runtime import build_production_baseline_r
 
 def build_production_baseline_activation_readiness(
     app_state: object | None = None,
+    *,
+    runtime_status: object | None = None,
 ) -> ProductionBaselineActivationReadinessResponse:
-    runtime_status = build_production_baseline_runtime_status(app_state)
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_production_baseline_runtime_status(app_state)
+    )
     activation_path = [
         "Use PostgreSQL-backed durable store seams for audit, prompts, retrieval metadata, access control, provider operations, async runtime, evaluation runtime, and artifact metadata.",
         "Keep Redis queue delivery and dedicated-worker execution active for allowlisted async job types before treating the runtime as production-shaped.",

--- a/src/app/services/production_baseline_activation_readiness.py
+++ b/src/app/services/production_baseline_activation_readiness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.config import settings
 from app.contracts.production_baseline import (
     ProductionBaselineActivationReadinessResponse,
+    ProductionBaselineRuntimeStatusResponse,
 )
 from app.services.production_baseline_runtime import build_production_baseline_runtime_status
 
@@ -10,7 +11,7 @@ from app.services.production_baseline_runtime import build_production_baseline_r
 def build_production_baseline_activation_readiness(
     app_state: object | None = None,
     *,
-    runtime_status: object | None = None,
+    runtime_status: ProductionBaselineRuntimeStatusResponse | None = None,
 ) -> ProductionBaselineActivationReadinessResponse:
     runtime_status = (
         runtime_status

--- a/src/app/services/production_baseline_governance.py
+++ b/src/app/services/production_baseline_governance.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from app.config import settings
 from app.contracts.production_baseline import (
+    ProductionBaselineActivationReadinessResponse,
     ProductionBaselineGovernanceStatusResponse,
+    ProductionBaselineRuntimeStatusResponse,
 )
+from app.contracts.providers import ProviderGovernanceStatusResponse
+from app.contracts.use_cases import FirstUseCaseGovernanceStatusResponse
 from app.services.first_use_case_governance import build_first_use_case_governance_status
 from app.services.governance_readiness import summarize_governance_flags
 from app.services.production_baseline_activation_readiness import (
@@ -19,10 +23,10 @@ from app.services.production_baseline_runtime import build_production_baseline_r
 def build_production_baseline_governance_status(
     app_state: object | None = None,
     *,
-    runtime_status: object | None = None,
-    activation_readiness: object | None = None,
-    provider_governance: object | None = None,
-    first_use_case_governance: object | None = None,
+    runtime_status: ProductionBaselineRuntimeStatusResponse | None = None,
+    activation_readiness: ProductionBaselineActivationReadinessResponse | None = None,
+    provider_governance: ProviderGovernanceStatusResponse | None = None,
+    first_use_case_governance: FirstUseCaseGovernanceStatusResponse | None = None,
 ) -> ProductionBaselineGovernanceStatusResponse:
     runtime_status = (
         runtime_status

--- a/src/app/services/production_baseline_governance.py
+++ b/src/app/services/production_baseline_governance.py
@@ -18,12 +18,35 @@ from app.services.production_baseline_runtime import build_production_baseline_r
 
 def build_production_baseline_governance_status(
     app_state: object | None = None,
+    *,
+    runtime_status: object | None = None,
+    activation_readiness: object | None = None,
+    provider_governance: object | None = None,
+    first_use_case_governance: object | None = None,
 ) -> ProductionBaselineGovernanceStatusResponse:
-    runtime_status = build_production_baseline_runtime_status(app_state)
-    activation_readiness = build_production_baseline_activation_readiness(app_state)
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_production_baseline_runtime_status(app_state)
+    )
+    activation_readiness = (
+        activation_readiness
+        if activation_readiness is not None
+        else build_production_baseline_activation_readiness(
+            app_state, runtime_status=runtime_status
+        )
+    )
     runbook_readiness = build_production_baseline_runbook_readiness()
-    provider_governance = build_provider_governance_status()
-    first_use_case_governance = build_first_use_case_governance_status()
+    provider_governance = (
+        provider_governance
+        if provider_governance is not None
+        else build_provider_governance_status()
+    )
+    first_use_case_governance = (
+        first_use_case_governance
+        if first_use_case_governance is not None
+        else build_first_use_case_governance_status()
+    )
     dependent_rollout_findings: list[str] = []
     if settings.provider_mode == "openai" and not provider_governance.governance_ready:
         dependent_rollout_findings.append(

--- a/src/app/services/production_go_live_activation_readiness.py
+++ b/src/app/services/production_go_live_activation_readiness.py
@@ -5,7 +5,9 @@ from app.contracts.production_go_live import (
     ProductionGoLiveActivationReadinessResponse,
     ProductionGoLiveFreezeState,
     ProductionGoLiveRollbackState,
+    ProductionGoLiveRuntimeStatusResponse,
 )
+from app.contracts.providers import ProviderGovernanceStatusResponse
 from app.services.production_go_live_runtime import build_production_go_live_runtime_status
 from app.services.provider_governance_status import build_provider_governance_status
 
@@ -13,8 +15,8 @@ from app.services.provider_governance_status import build_provider_governance_st
 def build_production_go_live_activation_readiness(
     app_state: object | None = None,
     *,
-    runtime_status: object | None = None,
-    provider_governance: object | None = None,
+    runtime_status: ProductionGoLiveRuntimeStatusResponse | None = None,
+    provider_governance: ProviderGovernanceStatusResponse | None = None,
 ) -> ProductionGoLiveActivationReadinessResponse:
     runtime_status = (
         runtime_status

--- a/src/app/services/production_go_live_activation_readiness.py
+++ b/src/app/services/production_go_live_activation_readiness.py
@@ -12,9 +12,20 @@ from app.services.provider_governance_status import build_provider_governance_st
 
 def build_production_go_live_activation_readiness(
     app_state: object | None = None,
+    *,
+    runtime_status: object | None = None,
+    provider_governance: object | None = None,
 ) -> ProductionGoLiveActivationReadinessResponse:
-    runtime_status = build_production_go_live_runtime_status(app_state)
-    provider_governance = build_provider_governance_status()
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_production_go_live_runtime_status(app_state)
+    )
+    provider_governance = (
+        provider_governance
+        if provider_governance is not None
+        else build_provider_governance_status()
+    )
     activation_ready = (
         runtime_status.platform_production_approved
         and provider_governance.governance_ready

--- a/src/app/services/production_go_live_governance.py
+++ b/src/app/services/production_go_live_governance.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from app.config import settings
-from app.contracts.production_go_live import ProductionGoLiveGovernanceStatusResponse
+from app.contracts.production_go_live import (
+    ProductionGoLiveActivationReadinessResponse,
+    ProductionGoLiveGovernanceStatusResponse,
+    ProductionGoLiveRuntimeStatusResponse,
+    ProductionGoLiveUseCaseApprovalResponse,
+)
+from app.contracts.providers import ProviderGovernanceStatusResponse
 from app.services.governance_readiness import summarize_governance_flags
 from app.services.production_go_live_activation_readiness import (
     build_production_go_live_activation_readiness,
@@ -19,10 +25,10 @@ from app.services.provider_governance_status import build_provider_governance_st
 def build_production_go_live_governance_status(
     app_state: object | None = None,
     *,
-    runtime_status: object | None = None,
-    activation_readiness: object | None = None,
-    use_case_approval: object | None = None,
-    provider_governance: object | None = None,
+    runtime_status: ProductionGoLiveRuntimeStatusResponse | None = None,
+    activation_readiness: ProductionGoLiveActivationReadinessResponse | None = None,
+    use_case_approval: ProductionGoLiveUseCaseApprovalResponse | None = None,
+    provider_governance: ProviderGovernanceStatusResponse | None = None,
 ) -> ProductionGoLiveGovernanceStatusResponse:
     runtime_status = (
         runtime_status

--- a/src/app/services/production_go_live_governance.py
+++ b/src/app/services/production_go_live_governance.py
@@ -18,12 +18,41 @@ from app.services.provider_governance_status import build_provider_governance_st
 
 def build_production_go_live_governance_status(
     app_state: object | None = None,
+    *,
+    runtime_status: object | None = None,
+    activation_readiness: object | None = None,
+    use_case_approval: object | None = None,
+    provider_governance: object | None = None,
 ) -> ProductionGoLiveGovernanceStatusResponse:
-    runtime_status = build_production_go_live_runtime_status(app_state)
-    activation_readiness = build_production_go_live_activation_readiness(app_state)
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_production_go_live_runtime_status(app_state)
+    )
+    provider_governance = (
+        provider_governance
+        if provider_governance is not None
+        else build_provider_governance_status()
+    )
+    activation_readiness = (
+        activation_readiness
+        if activation_readiness is not None
+        else build_production_go_live_activation_readiness(
+            app_state,
+            runtime_status=runtime_status,
+            provider_governance=provider_governance,
+        )
+    )
     runbook_readiness = build_production_go_live_runbook_readiness()
-    use_case_approval = build_production_go_live_use_case_approval(app_state)
-    provider_governance = build_provider_governance_status()
+    use_case_approval = (
+        use_case_approval
+        if use_case_approval is not None
+        else build_production_go_live_use_case_approval(
+            app_state,
+            provider_governance=provider_governance,
+            runtime_status=runtime_status,
+        )
+    )
     governance_ready, blocking_area_count = summarize_governance_flags(
         activation_readiness.activation_ready,
         runbook_readiness.runbook_ready,

--- a/src/app/services/production_go_live_runtime.py
+++ b/src/app/services/production_go_live_runtime.py
@@ -22,10 +22,24 @@ from app.services.provider_governance_status import build_provider_governance_st
 
 def build_production_go_live_runtime_status(
     app_state: object | None = None,
+    *,
+    baseline: object | None = None,
+    provider_governance: object | None = None,
+    first_use_case_governance: object | None = None,
 ) -> ProductionGoLiveRuntimeStatusResponse:
-    baseline = build_production_baseline_runtime_status(app_state)
-    provider_governance = build_provider_governance_status()
-    first_use_case_governance = build_first_use_case_governance_status()
+    baseline = (
+        baseline if baseline is not None else build_production_baseline_runtime_status(app_state)
+    )
+    provider_governance = (
+        provider_governance
+        if provider_governance is not None
+        else build_provider_governance_status()
+    )
+    first_use_case_governance = (
+        first_use_case_governance
+        if first_use_case_governance is not None
+        else build_first_use_case_governance_status()
+    )
     managed_secret = build_managed_secret_approval_domain()
     managed_object_store = build_managed_object_storage_approval_domain()
 

--- a/src/app/services/production_go_live_runtime.py
+++ b/src/app/services/production_go_live_runtime.py
@@ -10,7 +10,13 @@ from app.contracts.production_go_live import (
     ProductionGoLiveRuntimeStatusResponse,
     ProductionGoLiveUseCaseState,
 )
-from app.contracts.providers import ProviderExecutionMode, ProviderRolloutState
+from app.contracts.production_baseline import ProductionBaselineRuntimeStatusResponse
+from app.contracts.providers import (
+    ProviderExecutionMode,
+    ProviderGovernanceStatusResponse,
+    ProviderRolloutState,
+)
+from app.contracts.use_cases import FirstUseCaseGovernanceStatusResponse
 from app.services.first_use_case_governance import build_first_use_case_governance_status
 from app.services.production_baseline_runtime import build_production_baseline_runtime_status
 from app.services.production_go_live_approval_domains import (
@@ -23,9 +29,9 @@ from app.services.provider_governance_status import build_provider_governance_st
 def build_production_go_live_runtime_status(
     app_state: object | None = None,
     *,
-    baseline: object | None = None,
-    provider_governance: object | None = None,
-    first_use_case_governance: object | None = None,
+    baseline: ProductionBaselineRuntimeStatusResponse | None = None,
+    provider_governance: ProviderGovernanceStatusResponse | None = None,
+    first_use_case_governance: FirstUseCaseGovernanceStatusResponse | None = None,
 ) -> ProductionGoLiveRuntimeStatusResponse:
     baseline = (
         baseline if baseline is not None else build_production_baseline_runtime_status(app_state)

--- a/src/app/services/production_go_live_use_case_approval.py
+++ b/src/app/services/production_go_live_use_case_approval.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.contracts.capability_packs import CapabilityPackGovernanceStatusResponse
 from app.contracts.production_go_live import (
     ProductionGoLiveFreezeState,
+    ProductionGoLiveRuntimeStatusResponse,
     ProductionGoLiveUseCaseApprovalItem,
     ProductionGoLiveUseCaseApprovalResponse,
     ProductionGoLiveUseCaseApprovalState,
+)
+from app.contracts.providers import ProviderGovernanceStatusResponse
+from app.contracts.use_cases import (
+    FirstUseCaseGovernanceStatusResponse,
+    FirstUseCaseRuntimeStatusResponse,
 )
 from app.services.capability_pack_governance import build_capability_pack_governance_status
 from app.services.first_use_case_governance import build_first_use_case_governance_status
@@ -18,11 +25,11 @@ from app.services.provider_governance_status import build_provider_governance_st
 def build_production_go_live_use_case_approval(
     app_state: object | None = None,
     *,
-    use_case_status: object | None = None,
-    use_case_governance: object | None = None,
-    pack_governance: object | None = None,
-    provider_governance: object | None = None,
-    runtime_status: object | None = None,
+    use_case_status: FirstUseCaseRuntimeStatusResponse | None = None,
+    use_case_governance: FirstUseCaseGovernanceStatusResponse | None = None,
+    pack_governance: CapabilityPackGovernanceStatusResponse | None = None,
+    provider_governance: ProviderGovernanceStatusResponse | None = None,
+    runtime_status: ProductionGoLiveRuntimeStatusResponse | None = None,
 ) -> ProductionGoLiveUseCaseApprovalResponse:
     use_case_status = (
         use_case_status if use_case_status is not None else build_first_use_case_runtime_status()

--- a/src/app/services/production_go_live_use_case_approval.py
+++ b/src/app/services/production_go_live_use_case_approval.py
@@ -17,14 +17,36 @@ from app.services.provider_governance_status import build_provider_governance_st
 
 def build_production_go_live_use_case_approval(
     app_state: object | None = None,
+    *,
+    use_case_status: object | None = None,
+    use_case_governance: object | None = None,
+    pack_governance: object | None = None,
+    provider_governance: object | None = None,
+    runtime_status: object | None = None,
 ) -> ProductionGoLiveUseCaseApprovalResponse:
-    use_case_status = build_first_use_case_runtime_status()
-    use_case_governance = build_first_use_case_governance_status()
-    pack_governance = build_capability_pack_governance_status(
-        pack_id=use_case_status.capability_pack_id
+    use_case_status = (
+        use_case_status if use_case_status is not None else build_first_use_case_runtime_status()
     )
-    provider_governance = build_provider_governance_status()
-    runtime_status = build_production_go_live_runtime_status(app_state)
+    use_case_governance = (
+        use_case_governance
+        if use_case_governance is not None
+        else build_first_use_case_governance_status()
+    )
+    pack_governance = (
+        pack_governance
+        if pack_governance is not None
+        else build_capability_pack_governance_status(pack_id=use_case_status.capability_pack_id)
+    )
+    provider_governance = (
+        provider_governance
+        if provider_governance is not None
+        else build_provider_governance_status()
+    )
+    runtime_status = (
+        runtime_status
+        if runtime_status is not None
+        else build_production_go_live_runtime_status(app_state)
+    )
 
     live_provider_active = (
         runtime_status.provider_freeze_state is ProductionGoLiveFreezeState.ACTIVE

--- a/src/app/services/workflow_pack_run_ledger.py
+++ b/src/app/services/workflow_pack_run_ledger.py
@@ -90,7 +90,22 @@ def build_workflow_pack_run_catalog(
 ) -> WorkflowPackRunCatalogResponse:
     ensure_workflow_pack_run_store_ready()
     store = get_workflow_pack_run_store()
-    runs = [map_workflow_pack_run_record(record, store=store) for record in store.list_runs()]
+    bounded_at_source = all(
+        item is None
+        for item in (
+            registration_ref,
+            pack_id,
+            caller_app,
+            tenant_id,
+            workflow_surface,
+            runtime_state,
+            review_state,
+            supportability_status,
+            workflow_authority_owner,
+        )
+    )
+    source_records = store.list_runs(limit=limit if bounded_at_source else None)
+    runs = [map_workflow_pack_run_record(record, store=store) for record in source_records]
     filtered_runs = _filter_workflow_pack_runs(
         runs=runs,
         registration_ref=registration_ref,

--- a/src/app/services/workflow_pack_source_events.py
+++ b/src/app/services/workflow_pack_source_events.py
@@ -53,9 +53,19 @@ def build_workflow_pack_source_event_catalog(
 ) -> WorkflowPackSourceEventCatalogResponse:
     ensure_workflow_pack_run_store_ready()
     store = get_workflow_pack_run_store()
+    bounded_at_source = all(
+        item is None
+        for item in (
+            pack_id,
+            caller_app,
+            tenant_id,
+            workflow_surface,
+            supportability_status,
+        )
+    )
     runs = [
         record
-        for record in store.list_runs()
+        for record in store.list_runs(limit=limit if bounded_at_source else None)
         if _run_matches_filters(
             record=record,
             pack_id=pack_id,

--- a/tests/unit/test_deployment_split_governance.py
+++ b/tests/unit/test_deployment_split_governance.py
@@ -94,7 +94,7 @@ def test_deployment_split_governance_status_blocks_when_observability_is_not_rea
     )
     monkeypatch.setattr(
         "app.services.deployment_split_governance.build_deployment_split_activation_readiness",
-        lambda _app_state=None: DeploymentSplitActivationReadinessResponse(
+        lambda _app_state=None, **_kwargs: DeploymentSplitActivationReadinessResponse(
             service="lotus-ai",
             version="0.1.0",
             configured_stage=DeploymentSplitStage.RETRIEVAL_AND_EVALS_SPLIT_ACTIVE,
@@ -120,7 +120,7 @@ def test_deployment_split_governance_status_blocks_when_observability_is_not_rea
     )
     monkeypatch.setattr(
         "app.services.deployment_split_governance.build_observability_governance_status",
-        lambda: SimpleNamespace(governance_ready=False),
+        lambda **_kwargs: SimpleNamespace(governance_ready=False),
     )
 
     governance = build_deployment_split_governance_status(None)

--- a/tests/unit/test_observability_governance.py
+++ b/tests/unit/test_observability_governance.py
@@ -10,7 +10,7 @@ def test_observability_governance_mentions_split_degradation_when_present(
 ) -> None:
     monkeypatch.setattr(
         "app.services.observability_governance.build_deployment_split_runtime_status",
-        lambda: SimpleNamespace(degraded=True),
+        lambda: SimpleNamespace(degraded=True, status_summary=["split runtime degraded"]),
     )
 
     governance = build_observability_governance_status()

--- a/tests/unit/test_production_baseline_governance.py
+++ b/tests/unit/test_production_baseline_governance.py
@@ -100,7 +100,7 @@ def test_production_baseline_governance_status_composes_runtime_activation_and_r
     )
     monkeypatch.setattr(
         "app.services.production_baseline_governance.build_production_baseline_activation_readiness",
-        lambda _app_state=None: ProductionBaselineActivationReadinessResponse(
+        lambda _app_state=None, **_kwargs: ProductionBaselineActivationReadinessResponse(
             service="lotus-ai",
             version="0.1.0",
             posture=ProductionBaselinePosture.PROD_SHAPED_LOCAL,

--- a/tests/unit/test_production_go_live_governance.py
+++ b/tests/unit/test_production_go_live_governance.py
@@ -294,7 +294,7 @@ def test_production_go_live_governance_can_report_production_approved(
     )
     monkeypatch.setattr(
         "app.services.production_go_live_governance.build_production_go_live_activation_readiness",
-        lambda app_state: ProductionGoLiveActivationReadinessResponse.model_validate(
+        lambda app_state, **_kwargs: ProductionGoLiveActivationReadinessResponse.model_validate(
             {
                 "service": "lotus-ai",
                 "version": "0.1.0",
@@ -344,7 +344,7 @@ def test_production_go_live_governance_can_report_production_approved(
     )
     monkeypatch.setattr(
         "app.services.production_go_live_governance.build_production_go_live_use_case_approval",
-        lambda app_state: ProductionGoLiveUseCaseApprovalResponse(
+        lambda app_state, **_kwargs: ProductionGoLiveUseCaseApprovalResponse(
             service="lotus-ai",
             version="0.1.0",
             use_case_id="lotus_performance.analytics_commentary.v1",
@@ -406,7 +406,7 @@ def test_production_go_live_governance_can_report_limited_rollout_only(
     )
     monkeypatch.setattr(
         "app.services.production_go_live_governance.build_production_go_live_activation_readiness",
-        lambda app_state: ProductionGoLiveActivationReadinessResponse.model_validate(
+        lambda app_state, **_kwargs: ProductionGoLiveActivationReadinessResponse.model_validate(
             {
                 "service": "lotus-ai",
                 "version": "0.1.0",
@@ -456,7 +456,7 @@ def test_production_go_live_governance_can_report_limited_rollout_only(
     )
     monkeypatch.setattr(
         "app.services.production_go_live_governance.build_production_go_live_use_case_approval",
-        lambda app_state: ProductionGoLiveUseCaseApprovalResponse(
+        lambda app_state, **_kwargs: ProductionGoLiveUseCaseApprovalResponse(
             service="lotus-ai",
             version="0.1.0",
             use_case_id="lotus_performance.analytics_commentary.v1",


### PR DESCRIPTION
## Summary
- bound workflow-pack run/source-event catalog reads for unfiltered status surfaces
- reuse platform governance/status builders within one runtime-status request instead of recomputing nested rollout, observability, baseline, and go-live state
- preserve existing response contracts while preventing /platform/runtime-status from starving readiness in the live stack
- type the reused status objects with concrete contract response classes and align governance tests to assert the reused-status collaborator path

## Evidence
- python -m ruff check targeted changed service/repository files
- python -m ruff check tests/unit/test_deployment_split_governance.py tests/unit/test_observability_governance.py tests/unit/test_production_baseline_governance.py tests/unit/test_production_go_live_governance.py
- python -m mypy --config-file mypy.ini
- python -m pytest tests/unit/test_deployment_split_governance.py tests/unit/test_observability_governance.py tests/unit/test_production_baseline_governance.py tests/unit/test_production_go_live_governance.py -q
- python -m pytest tests/unit -q
- python -m pytest tests\\unit\\test_app_capability_rollout_catalog.py tests\\unit\\test_app_capability_rollout_governance.py tests\\unit\\test_app_capability_rollout_observability.py tests\\unit\\test_app_capability_rollout_lifecycle.py tests\\unit\\test_platform_status.py tests\\unit\\test_workflow_pack_run_ledger.py tests\\unit\\test_workflow_pack_runtime_status.py tests\\unit\\test_workflow_pack_run_store.py tests\\integration\\test_app_capability_rollout_api_contract.py tests\\integration\\test_health.py tests\\integration\\test_runtime_modes.py tests\\integration\\test_workflow_pack_run_api_contract.py -q
- python -m pytest tests\\unit\\test_platform_status.py tests\\unit\\test_production_go_live_runtime.py tests\\integration\\test_production_go_live_api_contract.py tests\\integration\\test_production_baseline_api_contract.py tests\\integration\\test_health.py tests\\integration\\test_runtime_modes.py -q
- python -m pytest tests\\unit\\test_platform_status.py tests\\unit\\test_production_go_live_runtime.py tests\\unit\\test_app_capability_rollout_catalog.py tests\\unit\\test_app_capability_rollout_governance.py tests\\unit\\test_app_capability_rollout_observability.py tests\\unit\\test_app_capability_rollout_lifecycle.py tests\\integration\\test_production_go_live_api_contract.py tests\\integration\\test_production_baseline_api_contract.py tests\\integration\\test_app_capability_rollout_api_contract.py tests\\integration\\test_health.py tests\\integration\\test_runtime_modes.py -q
- git diff --check
- docker compose up -d --build lotus-ai
- live HTTP probes: /health/ready, /platform/workflow-packs/registry, /platform/runtime-status twice; readiness remained healthy after runtime-status probes
- live Gateway DPM AI handoffs through lotus-ai returned 200 for proof-pack memo, wave memo, and outcome narrative