### PR TITLE
Implement DPM operations handoff summary pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,21 @@ Important posture limits:
 4. prompt bodies remain repository-managed even though runtime prompt selection is durable,
 5. workflow-pack registry records are control-plane metadata, not a second editable home for workflow logic,
 6. workflow-pack registrations must point to real owning-repository artifacts rather than placeholder definitions in `lotus-ai`,
-7. workflow-pack registry and control state can now run either in-memory or through a SQL-backed durable store, and the current executable workflow-pack set includes advisor brief, workspace rationale, TWR inspection support brief, the review-gated `dpm_pm_memo.pack@v1` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the review-gated `dpm_wave_pm_memo.pack@v1` contract for `lotus-manage` `DpmWaveReportInput`, and the review-gated `outcome_review_narrative.pack@v1` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`,
+7. workflow-pack registry and control state can now run either in-memory or through a SQL-backed durable store, and the current executable workflow-pack set includes advisor brief, workspace rationale, TWR inspection support brief, the review-gated `dpm_pm_memo.pack@v1` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the review-gated `dpm_wave_pm_memo.pack@v1` and `dpm_operations_handoff_summary.pack@v1` contracts for `lotus-manage` `DpmWaveReportInput`, and the review-gated `outcome_review_narrative.pack@v1` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`,
 8. the service should be treated as a governed capability layer, not a business-domain authority.
 
-For DPM PM memo support, `lotus-ai` owns workflow-pack execution, provider mode, safety, guardrail
-validation, run-ledger posture, queue policy, and deterministic stub behavior.
+For DPM PM memo and operations handoff summary support, `lotus-ai` owns workflow-pack execution,
+provider mode, safety, guardrail validation, run-ledger posture, queue policy, and deterministic
+stub behavior.
 `lotus-manage` remains the proof-pack and rebalance-wave evidence authority. The proof-pack pack
-consumes `DpmProofPackAiEvidenceInput`; the wave pack consumes `DpmWaveReportInput`. Both packs are
-pilot-scoped, support-only, and review-gated; they must not approve rebalances, place orders,
-produce client messages, score PMs, claim external execution, or invent missing proof-pack or wave
-evidence.
+consumes `DpmProofPackAiEvidenceInput`; the wave PM memo and operations handoff summary packs
+consume `DpmWaveReportInput`. These packs are pilot-scoped, support-only, and review-gated; they
+must not approve rebalances, place orders, produce client messages, score PMs, claim external
+execution, produce routing instructions, or invent missing proof-pack, wave, or handoff evidence.
 
-For DPM portfolio-memory support, the proof-pack PM memo, wave PM memo, and outcome-review
-narrative packs can consume optional `portfolio_memory_context` emitted by `lotus-manage`
-report-input handoffs. `lotus-ai` validates that the context is portfolio-matched,
+For DPM portfolio-memory support, the proof-pack PM memo, wave PM memo, operations handoff summary,
+and outcome-review narrative packs can consume optional `portfolio_memory_context` emitted by
+`lotus-manage` report-input handoffs. `lotus-ai` validates that the context is portfolio-matched,
 source-lineage-only, capped to the bounded event-ref limit, governed by `NO_RAW_PAYLOADS`, and
 explicitly marked as source-owned truth that consumers must not reconstruct. Generated outputs
 expose only a compact portfolio-memory lineage summary, content hash, event count, source systems,

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -37,8 +37,9 @@ Current repository posture:
 4. workflow-pack registry truth now exists as a separate control-plane seam above capability-pack maturity, with owner-artifact references that must resolve back to the real downstream repository and with one governed store-mode seam that can keep activation state and control history in memory or in a migration-backed SQL store,
 5. workflow-pack run-ledger foundations now exist as a separate runtime seam for the current
    executable workflow-pack families (`advisor_brief.pack`, `workspace_rationale.pack`,
-   `twr_inspection_support_brief.pack`, `dpm_pm_memo.pack`, `dpm_wave_pm_memo.pack`, and
-   `outcome_review_narrative.pack`), with runtime state kept separate from review state,
+   `twr_inspection_support_brief.pack`, `dpm_pm_memo.pack`, `dpm_wave_pm_memo.pack`,
+   `dpm_operations_handoff_summary.pack`, and `outcome_review_narrative.pack`), with runtime state
+   kept separate from review state,
    bounded actor-attributed review transitions available through the ledger API, bounded
    ledger-compatible `allowed_review_actions` emitted for consumers, governed workflow-pack
    artifact refs now attached for bounded output-summary review, deterministic proof-pack PM memo
@@ -47,8 +48,12 @@ Current repository posture:
    `portfolio_memory_context` before run/audit/task-flow side effects, deterministic wave PM memo
    guardrails that validate manage-owned `DpmWaveReportInput`, required forbidden actions,
    forbidden fields, forbidden requested outputs, source refs, proof-pack posture, no-external-execution
-   posture, `NO_RAW_PAYLOADS`, and optional source-lineage-only
-   `portfolio_memory_context` before run/audit/task-flow side effects, and deterministic
+   posture, `NO_RAW_PAYLOADS`, and optional source-lineage-only `portfolio_memory_context` before
+   run/audit/task-flow side effects, deterministic operations handoff summary guardrails that
+   validate manage-owned `DpmWaveReportInput`, non-empty bounded handoff refs, required forbidden
+   actions, forbidden fields, forbidden requested outputs, no-external-execution posture,
+   `NO_RAW_PAYLOADS`, and optional source-lineage-only `portfolio_memory_context` before
+   run/audit/task-flow side effects, and deterministic
    outcome-review narrative guardrails that validate manage-owned `DpmOutcomeAiEvidenceInput`,
    required forbidden actions, forbidden fields, forbidden requested outputs, and optional
    source-lineage-only `portfolio_memory_context` before run/audit/task-flow side effects. The

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -299,6 +299,12 @@ That sequence keeps downstream adoption pack-oriented first, while still preserv
    external execution claims, control override, or invented missing wave or proof-pack evidence
    are guardrail-blocked before execution and should be corrected in the caller contract rather
    than retried with prompt wording.
+7. Use `dpm_operations_handoff_summary.pack@v1` only with manage-owned `DpmWaveReportInput`,
+   non-empty bounded `handoff_refs`, a bounded `handoff_summary_request`, supportability posture,
+   and optional manage-owned `portfolio_memory_context`. Requests for order tickets, routing
+   instructions, execution instructions, trade recommendations, client messages, external execution
+   claims, control override, or invented missing handoff evidence are guardrail-blocked before
+   execution and should be corrected at the source evidence boundary.
 
 When supplied, `portfolio_memory_context` is lineage context, not a source-fact replacement. It must
 match the AI-evidence portfolio id, carry source-owned governance including `NO_RAW_PAYLOADS` and a
@@ -312,13 +318,17 @@ flowchart LR
     Wave["lotus-manage rebalance wave\nDpmWaveReportInput"] --> Gateway
     Manage --> AI["lotus-ai\ndpm_pm_memo.pack@v1"]
     Wave --> WaveAI["lotus-ai\ndpm_wave_pm_memo.pack@v1"]
+    Wave --> HandoffAI["lotus-ai\ndpm_operations_handoff_summary.pack@v1"]
     Gateway --> AI
     Gateway --> WaveAI
+    Gateway --> HandoffAI
     Manage --> Memory["portfolio_memory_context\nsource-lineage only"]
     Memory --> AI
     Memory --> WaveAI
+    Memory --> HandoffAI
     AI --> Guardrails["Forbidden action,\nfield, output,\nand memory guardrails"]
     WaveAI --> Guardrails
+    HandoffAI --> Guardrails
     Guardrails --> RunLedger["Workflow-pack run ledger\nreview required"]
     RunLedger --> Consumers["Gateway / Workbench\nfuture PM memo surface"]
 ```

--- a/src/app/providers/operations_handoff_summary_stub.py
+++ b/src/app/providers/operations_handoff_summary_stub.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.portfolio_memory_context_guardrails import portfolio_memory_context_summary
+
+
+def build_operations_handoff_summary_stub_result(
+    *,
+    context_payload: dict[str, object],
+) -> tuple[str, dict[str, object]] | None:
+    wave_report_input = context_payload.get("wave_report_input")
+    summary_request = context_payload.get("handoff_summary_request")
+    supportability = context_payload.get("supportability")
+    if not isinstance(wave_report_input, dict) or not isinstance(summary_request, dict):
+        return None
+
+    requested_outputs = summary_request.get("requested_outputs")
+    items = wave_report_input.get("items")
+    handoff_refs = wave_report_input.get("handoff_refs")
+    source_refs = wave_report_input.get("source_refs")
+    forbidden_actions = (
+        supportability.get("forbidden_actions") if isinstance(supportability, dict) else []
+    )
+
+    wave_id = _as_str(wave_report_input.get("wave_id"))
+    wave_state = _as_str(wave_report_input.get("wave_state"))
+    content_hash = _as_str(wave_report_input.get("content_hash"))
+    item_count = len(items) if isinstance(items, list) else 0
+    handoff_ref_count = len(handoff_refs) if isinstance(handoff_refs, list) else 0
+    source_ref_count = len(source_refs) if isinstance(source_refs, list) else 0
+    blocked_item_count = _blocked_item_count(items)
+    portfolio_memory_summary = portfolio_memory_context_summary(context_payload)
+
+    message = (
+        "Drafted a review-gated DPM operations handoff summary from bounded manage wave "
+        f"handoff evidence for wave {wave_id} in state {wave_state}."
+    )
+    structured_output: dict[str, object] = {
+        "workflow_pack_family": "dpm_operations_handoff_summary",
+        "narrative_type": "operations_handoff_summary",
+        "state": "REVIEW_REQUIRED",
+        "scope": "support_only",
+        "wave_id": wave_id,
+        "wave_state": wave_state,
+        "wave_report_content_hash": content_hash,
+        "requested_outputs": requested_outputs if isinstance(requested_outputs, list) else [],
+        "item_count": item_count,
+        "blocked_item_count": blocked_item_count,
+        "handoff_ref_count": handoff_ref_count,
+        "source_ref_count": source_ref_count,
+        "external_execution_claimed": bool(wave_report_input.get("external_execution_claimed")),
+        "forbidden_actions": forbidden_actions if isinstance(forbidden_actions, list) else [],
+        **portfolio_memory_summary,
+        "unsupported_claims": _unsupported_claims(supportability),
+        "review_guidance": [
+            "Review the handoff summary against the source wave report hash before operations use.",
+            "Do not treat this summary as order placement, routing instruction, or external execution acknowledgement.",
+            "Escalate missing handoff refs, proof-pack refs, or source evidence instead of inferring prerequisites.",
+            "Use portfolio memory only as bounded source lineage; do not reconstruct missing facts.",
+        ],
+    }
+    return message, structured_output
+
+
+def _blocked_item_count(items: object) -> int:
+    if not isinstance(items, list):
+        return 0
+    return sum(
+        1
+        for item in items
+        if isinstance(item, dict)
+        and isinstance(item.get("state"), str)
+        and item["state"] in {"BLOCKED", "EXCLUDED", "CANCELLED"}
+    )
+
+
+def _unsupported_claims(supportability: object) -> list[str]:
+    if not isinstance(supportability, dict):
+        return []
+    value = supportability.get("unsupported_claims")
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/src/app/providers/stub_text_provider.py
+++ b/src/app/providers/stub_text_provider.py
@@ -13,6 +13,9 @@ from app.providers.advisor_brief_stub import build_advisor_brief_stub_result
 from app.providers.outcome_review_narrative_stub import (
     build_outcome_review_narrative_stub_result,
 )
+from app.providers.operations_handoff_summary_stub import (
+    build_operations_handoff_summary_stub_result,
+)
 from app.providers.proof_pack_pm_memo_stub import build_proof_pack_pm_memo_stub_result
 from app.providers.wave_pm_memo_stub import build_wave_pm_memo_stub_result
 
@@ -33,6 +36,42 @@ class StubTextProvider:
     )
 
     def execute(self, request: ProviderExecutionRequest) -> ProviderExecutionResponse:
+        operations_handoff_summary_result = build_operations_handoff_summary_stub_result(
+            context_payload=request.context_payload,
+        )
+        if request.task_id == "explain.v1" and operations_handoff_summary_result:
+            message, structured_output = operations_handoff_summary_result
+            return ProviderExecutionResponse(
+                provider_id=self.descriptor.provider_id,
+                provider_mode=settings.provider_mode,
+                adapter_kind=self.descriptor.adapter_kind,
+                failure_category=None,
+                timeout_ms=request.timeout_ms,
+                retry_count=0,
+                max_output_tokens=request.max_output_tokens,
+                stubbed=True,
+                message=message,
+                structured_output={
+                    **structured_output,
+                    "phase": settings.delivery_phase,
+                    "provider_id": self.descriptor.provider_id,
+                    "provider_mode": settings.provider_mode,
+                    "adapter_kind": self.descriptor.adapter_kind.value,
+                    "timeout_ms": request.timeout_ms,
+                    "retry_count": 0,
+                    "max_output_tokens": request.max_output_tokens,
+                    "output_label": request.output_label,
+                    "safety_mode": request.safety_mode,
+                    "redaction_posture": request.redaction_posture,
+                    "context_summary": request.context_summary,
+                    "context_keys": sorted(request.context_payload.keys()),
+                    "source_refs": request.source_refs,
+                    "stub_reason": (
+                        "lotus-ai emits deterministic governed operations handoff summary posture "
+                        "before live provider rollout is enabled for this workflow pack."
+                    ),
+                },
+            )
         wave_pm_memo_result = build_wave_pm_memo_stub_result(
             context_payload=request.context_payload,
         )

--- a/src/app/services/ai_surface_supportability.py
+++ b/src/app/services/ai_surface_supportability.py
@@ -54,6 +54,11 @@ _WORKFLOW_PACK_SURFACE_OWNERS = {
         "lotus-manage",
         "lotus-manage",
     ),
+    "dpm_operations_handoff_summary.pack@v1": (
+        "dpm_operations_handoff_summary",
+        "lotus-manage",
+        "lotus-manage",
+    ),
 }
 
 _PROMETHEUS_POSTURES = (

--- a/src/app/services/operations_handoff_summary_guardrails.py
+++ b/src/app/services/operations_handoff_summary_guardrails.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import HTTPException, status
+
+from app.services.portfolio_memory_context_guardrails import (
+    validate_optional_portfolio_memory_context,
+)
+from app.services.wave_pm_memo_guardrails import (
+    FORBIDDEN_FIELD_NAMES,
+    REQUIRED_FORBIDDEN_ACTIONS,
+    REQUIRED_WAVE_REPORT_INPUT_KEYS,
+)
+
+FORBIDDEN_REQUESTED_OUTPUTS = frozenset(
+    {
+        "approval_decision",
+        "client_message",
+        "execution_instruction",
+        "order_ticket",
+        "place_orders",
+        "recommend_trade",
+        "rebalance_approval",
+        "routing_instruction",
+    }
+)
+
+ALLOWED_REQUESTED_OUTPUTS = frozenset(
+    {
+        "operations_summary",
+        "execution_prerequisites",
+        "blocking_conditions",
+        "support_references",
+        "evidence_gaps",
+    }
+)
+
+
+def validate_operations_handoff_summary_payload(payload: dict[str, object]) -> None:
+    if "memo_request" in payload:
+        _reject(
+            "Operations handoff summary payload must not include wave memo `memo_request`; "
+            "use `handoff_summary_request` only."
+        )
+    wave_report_input = _require_object_section(payload, "wave_report_input")
+    summary_request = _require_object_section(payload, "handoff_summary_request")
+    supportability = _require_object_section(payload, "supportability")
+
+    missing = sorted(REQUIRED_WAVE_REPORT_INPUT_KEYS.difference(wave_report_input.keys()))
+    if missing:
+        _reject("Missing DpmWaveReportInput fields: " + ", ".join(missing))
+
+    forbidden_fields = sorted(_find_forbidden_field_names(wave_report_input))
+    if forbidden_fields:
+        _reject("Forbidden wave report input fields present: " + ", ".join(forbidden_fields))
+
+    forbidden_actions = set(_require_string_list(supportability, "forbidden_actions"))
+    missing_actions = sorted(REQUIRED_FORBIDDEN_ACTIONS.difference(forbidden_actions))
+    if missing_actions:
+        _reject("Missing required forbidden-action guardrails: " + ", ".join(missing_actions))
+
+    requested_outputs = set(_require_string_list(summary_request, "requested_outputs"))
+    forbidden_outputs = sorted(FORBIDDEN_REQUESTED_OUTPUTS.intersection(requested_outputs))
+    if forbidden_outputs:
+        _reject("Forbidden operations handoff outputs requested: " + ", ".join(forbidden_outputs))
+    unsupported_outputs = sorted(requested_outputs.difference(ALLOWED_REQUESTED_OUTPUTS))
+    if unsupported_outputs:
+        _reject(
+            "Unsupported operations handoff outputs requested: " + ", ".join(unsupported_outputs)
+        )
+
+    if bool(wave_report_input.get("external_execution_claimed")):
+        _reject("Operations handoff summary cannot claim external execution authority.")
+    if wave_report_input.get("redaction_policy") != "NO_RAW_PAYLOADS":
+        _reject("DpmWaveReportInput must use NO_RAW_PAYLOADS redaction policy.")
+
+    items = wave_report_input.get("items")
+    if not isinstance(items, list) or not items:
+        _reject("Operations handoff summary requires at least one bounded wave item.")
+    bounded_items = cast(list[object], items)
+    if not _has_staged_or_ready_item(bounded_items):
+        _reject("Operations handoff summary requires staged or handoff-ready wave item evidence.")
+
+    handoff_refs = wave_report_input.get("handoff_refs")
+    if not isinstance(handoff_refs, list) or not handoff_refs:
+        _reject("Operations handoff summary requires non-empty handoff_refs.")
+    bounded_handoff_refs = cast(list[object], handoff_refs)
+    if not all(_is_bounded_handoff_ref(ref) for ref in bounded_handoff_refs):
+        _reject(
+            "Operations handoff refs must carry ref_type, ref_id, source_system, and content_hash."
+        )
+
+    source_refs = wave_report_input.get("source_refs")
+    if not isinstance(source_refs, list) or not source_refs:
+        _reject("DpmWaveReportInput source_refs must be a non-empty list.")
+
+    validate_optional_portfolio_memory_context(
+        payload=payload,
+        evidence_portfolio_id=_single_portfolio_id(bounded_items),
+        forbidden_field_names=FORBIDDEN_FIELD_NAMES,
+        reject=_reject,
+    )
+
+
+def _has_staged_or_ready_item(items: list[object]) -> bool:
+    eligible_states = {"STAGED", "HANDOFF_READY", "READY", "READY_FOR_HANDOFF"}
+    return any(
+        isinstance(item, dict)
+        and isinstance(item.get("state"), str)
+        and item["state"] in eligible_states
+        for item in items
+    )
+
+
+def _is_bounded_handoff_ref(ref: object) -> bool:
+    if not isinstance(ref, dict):
+        return False
+    return all(isinstance(ref.get(key), str) and ref[key] for key in _HANDOFF_REF_KEYS)
+
+
+_HANDOFF_REF_KEYS = ("ref_type", "ref_id", "source_system", "content_hash")
+
+
+def _single_portfolio_id(items: object) -> str | None:
+    if not isinstance(items, list):
+        return None
+    portfolio_ids = {
+        item.get("portfolio_id")
+        for item in items
+        if isinstance(item, dict) and isinstance(item.get("portfolio_id"), str)
+    }
+    if len(portfolio_ids) == 1:
+        return next(iter(portfolio_ids))
+    return None
+
+
+def _require_object_section(payload: dict[str, object], key: str) -> dict[str, Any]:
+    section = payload.get(key)
+    if not isinstance(section, dict):
+        _reject(f"Operations handoff summary payload requires object section `{key}`.")
+    return cast(dict[str, Any], section)
+
+
+def _require_string_list(section: dict[str, Any], key: str) -> list[str]:
+    value = section.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        _reject(f"Operations handoff summary payload requires string-list field `{key}`.")
+    return cast(list[str], value)
+
+
+def _find_forbidden_field_names(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized = key.lower()
+            if normalized in FORBIDDEN_FIELD_NAMES:
+                found.add(normalized)
+            found.update(_find_forbidden_field_names(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.update(_find_forbidden_field_names(item))
+    return found
+
+
+def _reject(detail: str) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=f"OPERATIONS_HANDOFF_SUMMARY_GUARDRAIL_BLOCKED: {detail}",
+    )

--- a/src/app/services/workflow_pack_bindings.py
+++ b/src/app/services/workflow_pack_bindings.py
@@ -8,6 +8,7 @@ from app.contracts.workflow_packs import (
 )
 from app.services.workflow_pack_phase1_specs import (
     ADVISOR_BRIEF_V1_SPEC,
+    DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
@@ -80,6 +81,7 @@ _WORKFLOW_PACK_EXECUTION_BINDINGS = (
     _build_execution_binding_from_spec(PROOF_PACK_PM_MEMO_V1_SPEC),
     _build_execution_binding_from_spec(OUTCOME_REVIEW_NARRATIVE_V1_SPEC),
     _build_execution_binding_from_spec(DPM_WAVE_PM_MEMO_V1_SPEC),
+    _build_execution_binding_from_spec(DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC),
 )
 
 

--- a/src/app/services/workflow_pack_execution.py
+++ b/src/app/services/workflow_pack_execution.py
@@ -37,6 +37,9 @@ from app.services.workflow_pack_queue_admission import workflow_pack_queue_admis
 from app.services.outcome_review_narrative_guardrails import (
     validate_outcome_review_narrative_payload,
 )
+from app.services.operations_handoff_summary_guardrails import (
+    validate_operations_handoff_summary_payload,
+)
 from app.services.proof_pack_pm_memo_guardrails import validate_proof_pack_pm_memo_payload
 from app.services.wave_pm_memo_guardrails import validate_wave_pm_memo_payload
 
@@ -155,6 +158,8 @@ def validate_workflow_pack_execution_binding(
         validate_proof_pack_pm_memo_payload(request.task_request.context.payload)
     if request.pack_id == "dpm_wave_pm_memo.pack" and request.version == "v1":
         validate_wave_pm_memo_payload(request.task_request.context.payload)
+    if request.pack_id == "dpm_operations_handoff_summary.pack" and request.version == "v1":
+        validate_operations_handoff_summary_payload(request.task_request.context.payload)
 
 
 def _attach_workflow_pack_run_id(

--- a/src/app/services/workflow_pack_phase1_specs.py
+++ b/src/app/services/workflow_pack_phase1_specs.py
@@ -138,3 +138,22 @@ DPM_WAVE_PM_MEMO_V1_SPEC = WorkflowPackPhase1VersionSpec(
     execution_task_id="explain.v1",
     required_payload_keys=frozenset({"wave_report_input", "memo_request", "supportability"}),
 )
+
+
+DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC = WorkflowPackPhase1VersionSpec(
+    pack_id="dpm_operations_handoff_summary.pack",
+    pack_family="dpm_operations_handoff_summary",
+    version="v1",
+    owner_repository="lotus-manage",
+    owner_service="lotus-manage",
+    truth_owner_services=("lotus-manage", "lotus-core", "lotus-risk", "lotus-performance"),
+    primary_use_case="dpm_operations_handoff_summary",
+    workflow_authority_owner="lotus-manage",
+    supported_callers=("lotus-manage", "lotus-gateway"),
+    surface_scope=("dpm-operations-handoff-ai-evidence",),
+    default_workflow_surface="dpm-operations-handoff-ai-evidence",
+    execution_task_id="explain.v1",
+    required_payload_keys=frozenset(
+        {"wave_report_input", "handoff_summary_request", "supportability"}
+    ),
+)

--- a/src/app/services/workflow_pack_queue_policy_catalog.py
+++ b/src/app/services/workflow_pack_queue_policy_catalog.py
@@ -24,6 +24,7 @@ from app.contracts.workflow_pack_queue_policies import (
 from app.config import settings
 from app.services.workflow_pack_phase1_specs import (
     ADVISOR_BRIEF_V1_SPEC,
+    DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
@@ -44,6 +45,7 @@ def list_workflow_pack_queue_policy_descriptors() -> list[WorkflowPackQueuePolic
         _review_support_proof_pack_pm_memo_policy(),
         _review_support_outcome_review_narrative_policy(),
         _review_support_wave_pm_memo_policy(),
+        _review_support_operations_handoff_summary_policy(),
     ]
     _validate_queue_policy_identity(policies)
     return [policy.model_copy(deep=True) for policy in policies]
@@ -317,6 +319,29 @@ def _review_support_wave_pm_memo_policy() -> WorkflowPackQueuePolicyDescriptor:
         status_summary=[
             "DPM wave PM memo work defaults to review-support capacity because generated narrative remains support-only and review-gated.",
             "Operator capacity is reserved for controlled investigation of guardrail-blocked, unavailable, or stale wave-evidence posture.",
+        ],
+    )
+
+
+def _review_support_operations_handoff_summary_policy() -> WorkflowPackQueuePolicyDescriptor:
+    return _build_queue_policy(
+        spec=DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
+        policy_id="queue-policy.dpm-operations-handoff-summary.v1",
+        allowed_lanes=[
+            WorkflowPackQueueLane.REVIEW_SUPPORT,
+            WorkflowPackQueueLane.OPERATOR,
+        ],
+        default_lane=WorkflowPackQueueLane.REVIEW_SUPPORT,
+        max_concurrent_runs_per_pack=2,
+        max_concurrent_runs_per_lane=1,
+        max_queued_runs_per_pack=25,
+        max_queued_runs_per_lane=10,
+        admission_timeout_seconds=20,
+        execution_timeout_seconds=300,
+        stale_queue_threshold_seconds=90,
+        status_summary=[
+            "DPM operations handoff summaries default to review-support capacity because generated text remains support-only and review-gated.",
+            "Operator capacity is reserved for controlled investigation of guardrail-blocked, unavailable, or stale handoff-evidence posture.",
         ],
     )
 

--- a/src/app/services/workflow_pack_registry_seed.py
+++ b/src/app/services/workflow_pack_registry_seed.py
@@ -14,6 +14,7 @@ from app.contracts.workflow_packs import (
 from app.services.workflow_pack_phase1_specs import (
     ADVISOR_BRIEF_V1_SPEC,
     ADVISOR_BRIEF_V2_SPEC,
+    DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
@@ -299,6 +300,50 @@ def build_seed_workflow_pack_registrations() -> list[WorkflowPackRegistrationDes
             status_summary=[
                 "The DPM wave PM memo workflow pack consumes lotus-manage DpmWaveReportInput only.",
                 "Activation remains pilot-scoped while Gateway and Workbench add product-surface invocation, unavailable posture, and canonical live proof without reconstructing wave or proof-pack evidence.",
+            ],
+        ),
+        WorkflowPackRegistrationDescriptor(
+            pack_id=DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.pack_id,
+            pack_family=DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.pack_family,
+            version=DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.version,
+            owner_repository=DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.owner_repository,
+            owner_service=DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.owner_service,
+            truth_owner_services=list(DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.truth_owner_services),
+            primary_use_case=DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.primary_use_case,
+            workflow_authority_owner=(
+                DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.workflow_authority_owner
+            ),
+            default_execution_mode=WorkflowPackExecutionMode.REVIEW_GATED,
+            definition_ref="repo://lotus-manage/src/core/waves/handoffs.py",
+            definition_refs=_dpm_operations_handoff_summary_v1_definition_refs(),
+            compatibility_contract_version="workflow-pack-contract.v1",
+            registration_status=WorkflowPackRegistrationStatus.REGISTERED,
+            activation_state=WorkflowPackActivationState.PILOT,
+            registered_definition_digest=(
+                "sha256:dpm-operations-handoff-summary-v1-registered-digest"
+            ),
+            supported_callers=list(DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.supported_callers),
+            supported_identity_classes=[
+                WorkflowPackCallerIdentityClass.INTERNAL_SERVICE,
+            ],
+            supported_environments=[
+                WorkflowPackEnvironment.DEVELOPMENT,
+                WorkflowPackEnvironment.QA,
+                WorkflowPackEnvironment.UAT,
+            ],
+            tenant_scope=[],
+            surface_scope=list(DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC.surface_scope),
+            default_rollout_stage="PILOT_SCOPED",
+            pause_state="NOT_PAUSED",
+            supersedes=None,
+            superseded_by=None,
+            registered_at="2026-05-11T08:00:00Z",
+            registered_by="lotus-ai.workflow-pack-registry.seed",
+            last_activated_at="2026-05-11T08:20:00Z",
+            last_changed_at="2026-05-11T08:20:00Z",
+            status_summary=[
+                "The DPM operations handoff summary workflow pack consumes lotus-manage DpmWaveReportInput handoff evidence only.",
+                "Activation remains pilot-scoped while Gateway and Workbench product surfaces add invocation, unavailable posture, and canonical live proof without reconstructing handoff or proof-pack evidence.",
             ],
         ),
     ]
@@ -649,6 +694,68 @@ def _dpm_wave_pm_memo_v1_definition_refs() -> list[WorkflowPackDefinitionReferen
             reference_type=WorkflowPackDefinitionReferenceType.RFC,
             required_for_registration=False,
             description="RFC-0041 defines rebalance-wave orchestration, CIO impact review, and no-autonomous-execution workflow boundaries.",
+        ),
+    ]
+
+
+def _dpm_operations_handoff_summary_v1_definition_refs() -> list[
+    WorkflowPackDefinitionReferenceDescriptor
+]:
+    return [
+        _definition_ref(
+            reference_id="primary_contract",
+            repository="lotus-manage",
+            path="src/core/waves/handoffs.py",
+            reference_type=WorkflowPackDefinitionReferenceType.CONTRACT,
+            required_for_registration=True,
+            description=(
+                "Manage-owned DpmWaveReportInput contract that bounds internal operations "
+                "handoff evidence for summary drafting."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_service",
+            repository="lotus-manage",
+            path="src/api/services/wave_service.py",
+            reference_type=WorkflowPackDefinitionReferenceType.SERVICE,
+            required_for_registration=True,
+            description=(
+                "Manage service that materializes governed rebalance waves, staged item posture, "
+                "and internal handoff refs without generating AI narrative locally."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_router",
+            repository="lotus-manage",
+            path="src/api/routers/waves.py",
+            reference_type=WorkflowPackDefinitionReferenceType.ROUTER,
+            required_for_registration=True,
+            description=(
+                "Manage API route exposing bounded rebalance-wave report input and internal "
+                "operations handoff evidence for downstream AI execution."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_tests",
+            repository="lotus-manage",
+            path="tests/unit/dpm/api/test_waves_api.py",
+            reference_type=WorkflowPackDefinitionReferenceType.TEST,
+            required_for_registration=True,
+            description=(
+                "Manage regression coverage proving wave report and handoff input remains "
+                "bounded, source-linked, and does not claim external execution."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_rfc",
+            repository="lotus-manage",
+            path="docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md",
+            reference_type=WorkflowPackDefinitionReferenceType.RFC,
+            required_for_registration=False,
+            description=(
+                "RFC-0043 defines governed operations handoff summary support, no-domain-decision "
+                "guardrails, review posture, and unavailable behavior."
+            ),
         ),
     ]
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -97,8 +97,8 @@ def test_platform_workflow_pack_registry_contract(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 7
-    assert body["registered_count"] == 6
+    assert body["registration_count"] == 8
+    assert body["registered_count"] == 7
     assert any(
         registration["pack_id"] == "advisor_brief.pack"
         and registration["activation_state"] == "PILOT"
@@ -123,6 +123,12 @@ def test_platform_workflow_pack_registry_contract(client: TestClient) -> None:
     )
     assert any(
         registration["pack_id"] == "dpm_wave_pm_memo.pack"
+        and registration["owner_repository"] == "lotus-manage"
+        and registration["activation_state"] == "PILOT"
+        for registration in body["registrations"]
+    )
+    assert any(
+        registration["pack_id"] == "dpm_operations_handoff_summary.pack"
         and registration["owner_repository"] == "lotus-manage"
         and registration["activation_state"] == "PILOT"
         for registration in body["registrations"]
@@ -403,15 +409,16 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["workflow_pack_task_flow_store"]["status"] == "READY"
     assert body["workflow_pack_queue_event_store"]["mode"] == "memory"
     assert body["workflow_pack_queue_event_store"]["status"] == "READY"
-    assert body["workflow_pack_runtime"]["registration_count"] == 7
-    assert body["workflow_pack_runtime"]["registered_count"] == 6
-    assert body["workflow_pack_runtime"]["execution_binding_count"] == 6
-    assert body["workflow_pack_runtime"]["executable_registration_count"] == 6
-    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 6
+    assert body["workflow_pack_runtime"]["registration_count"] == 8
+    assert body["workflow_pack_runtime"]["registered_count"] == 7
+    assert body["workflow_pack_runtime"]["execution_binding_count"] == 7
+    assert body["workflow_pack_runtime"]["executable_registration_count"] == 7
+    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 7
     assert body["workflow_pack_runtime"]["executable_without_review_count"] == 0
     assert body["workflow_pack_runtime"]["registered_without_execution_binding_count"] == 0
     assert body["workflow_pack_runtime"]["executable_registration_refs"] == [
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
@@ -420,6 +427,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     ]
     assert body["workflow_pack_runtime"]["executable_review_required_refs"] == [
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
@@ -453,25 +461,29 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
         is None
     )
     assert body["workflow_pack_runtime"]["executable_activity"][1]["registration_ref"] == (
-        "dpm_pm_memo.pack@v1"
+        "dpm_operations_handoff_summary.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][1]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][2]["registration_ref"] == (
-        "dpm_wave_pm_memo.pack@v1"
+        "dpm_pm_memo.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][2]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][3]["registration_ref"] == (
-        "outcome_review_narrative.pack@v1"
+        "dpm_wave_pm_memo.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][3]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][4]["registration_ref"] == (
-        "twr_inspection_support_brief.pack@v1"
+        "outcome_review_narrative.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][4]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][5]["registration_ref"] == (
-        "workspace_rationale.pack@v1"
+        "twr_inspection_support_brief.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][5]["run_count"] == 0
+    assert body["workflow_pack_runtime"]["executable_activity"][6]["registration_ref"] == (
+        "workspace_rationale.pack@v1"
+    )
+    assert body["workflow_pack_runtime"]["executable_activity"][6]["run_count"] == 0
     assert (
         body["workflow_pack_runtime"]["executable_activity"][0]["latest_ready_provenance"] is None
     )

--- a/tests/integration/test_observability_api_contract.py
+++ b/tests/integration/test_observability_api_contract.py
@@ -8,8 +8,8 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["domain_count"] == 6
-    assert body["ai_surface_supportability"]["supported_surface_count"] == 6
-    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 6
+    assert body["ai_surface_supportability"]["supported_surface_count"] == 7
+    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 7
     assert (
         body["ai_surface_supportability"]["metric_name"] == "lotus_ai_surface_supportability_state"
     )
@@ -18,12 +18,19 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
         surface["workflow_pack_ref"] for surface in body["ai_surface_supportability"]["surfaces"]
     } == {
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
+    assert any(
+        surface["surface_id"] == "dpm_operations_handoff_summary"
+        and surface["owning_service"] == "lotus-manage"
+        and surface["workflow_authority_owner"] == "lotus-manage"
+        for surface in body["ai_surface_supportability"]["surfaces"]
+    )
     assert any(
         surface["surface_id"] == "dpm_pm_memo"
         and surface["owning_service"] == "lotus-manage"

--- a/tests/integration/test_workflow_pack_queue_policy_api_contract.py
+++ b/tests/integration/test_workflow_pack_queue_policy_api_contract.py
@@ -28,7 +28,7 @@ def test_workflow_pack_queue_policy_catalog_route(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["service"] == "lotus-ai"
-    assert body["policy_count"] == 6
+    assert body["policy_count"] == 7
     advisor_policy = next(
         policy
         for policy in body["policies"]
@@ -69,6 +69,17 @@ def test_workflow_pack_queue_policy_catalog_route(client: TestClient) -> None:
     assert wave_policy["policy_id"] == "queue-policy.dpm-wave-pm-memo.v1"
     assert wave_policy["default_lane"] == "REVIEW_SUPPORT"
     assert wave_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
+    operations_handoff_policy = next(
+        policy
+        for policy in body["policies"]
+        if policy["workflow_pack_id"] == "dpm_operations_handoff_summary.pack"
+        and policy["workflow_pack_version"] == "v1"
+    )
+    assert operations_handoff_policy["policy_id"] == (
+        "queue-policy.dpm-operations-handoff-summary.v1"
+    )
+    assert operations_handoff_policy["default_lane"] == "REVIEW_SUPPORT"
+    assert operations_handoff_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
 
 
 def test_workflow_pack_queue_policy_detail_route(client: TestClient) -> None:

--- a/tests/integration/test_workflow_pack_registry_api_contract.py
+++ b/tests/integration/test_workflow_pack_registry_api_contract.py
@@ -13,8 +13,8 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 7
-    assert body["registered_count"] == 6
+    assert body["registration_count"] == 8
+    assert body["registered_count"] == 7
     assert body["production_eligible_count"] == 0
     advisor_brief_registration = next(
         registration
@@ -40,6 +40,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         registration
         for registration in body["registrations"]
         if registration["pack_id"] == "dpm_wave_pm_memo.pack"
+    )
+    operations_handoff_summary_registration = next(
+        registration
+        for registration in body["registrations"]
+        if registration["pack_id"] == "dpm_operations_handoff_summary.pack"
     )
     advisor_brief_binding = next(
         binding
@@ -71,6 +76,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         for binding in body["execution_bindings"]
         if binding["pack_id"] == "dpm_wave_pm_memo.pack"
     )
+    operations_handoff_summary_binding = next(
+        binding
+        for binding in body["execution_bindings"]
+        if binding["pack_id"] == "dpm_operations_handoff_summary.pack"
+    )
     advisor_brief_queue_policy = next(
         policy
         for policy in body["queue_policies"]
@@ -95,6 +105,12 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         if policy["workflow_pack_id"] == "dpm_wave_pm_memo.pack"
         and policy["workflow_pack_version"] == "v1"
     )
+    operations_handoff_summary_queue_policy = next(
+        policy
+        for policy in body["queue_policies"]
+        if policy["workflow_pack_id"] == "dpm_operations_handoff_summary.pack"
+        and policy["workflow_pack_version"] == "v1"
+    )
 
     assert advisor_brief_registration["registration_status"] == "REGISTERED"
     assert advisor_brief_registration["activation_state"] == "PILOT"
@@ -116,6 +132,13 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     assert wave_pm_memo_registration["owner_repository"] == "lotus-manage"
     assert wave_pm_memo_registration["workflow_authority_owner"] == "lotus-manage"
     assert wave_pm_memo_registration["supported_callers"] == [
+        "lotus-manage",
+        "lotus-gateway",
+    ]
+    assert operations_handoff_summary_registration["version"] == "v1"
+    assert operations_handoff_summary_registration["owner_repository"] == "lotus-manage"
+    assert operations_handoff_summary_registration["workflow_authority_owner"] == "lotus-manage"
+    assert operations_handoff_summary_registration["supported_callers"] == [
         "lotus-manage",
         "lotus-gateway",
     ]
@@ -171,6 +194,16 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         "supportability",
         "wave_report_input",
     ]
+    assert operations_handoff_summary_binding["version"] == "v1"
+    assert operations_handoff_summary_binding["task_id"] == "explain.v1"
+    assert operations_handoff_summary_binding["default_workflow_surface"] == (
+        "dpm-operations-handoff-ai-evidence"
+    )
+    assert operations_handoff_summary_binding["required_payload_keys"] == [
+        "handoff_summary_request",
+        "supportability",
+        "wave_report_input",
+    ]
     assert advisor_brief_queue_policy["default_lane"] == "LATENCY_SENSITIVE"
     assert advisor_brief_queue_policy["allowed_lanes"] == [
         "LATENCY_SENSITIVE",
@@ -187,6 +220,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     assert proof_pack_pm_memo_queue_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
     assert wave_pm_memo_queue_policy["default_lane"] == "REVIEW_SUPPORT"
     assert wave_pm_memo_queue_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
+    assert operations_handoff_summary_queue_policy["default_lane"] == "REVIEW_SUPPORT"
+    assert operations_handoff_summary_queue_policy["allowed_lanes"] == [
+        "REVIEW_SUPPORT",
+        "OPERATOR",
+    ]
 
 
 def test_workflow_pack_default_version_route_resolves_registered_executable_default(
@@ -224,6 +262,26 @@ def test_workflow_pack_default_version_route_resolves_dpm_pack_default(
     assert body["registration"]["workflow_authority_owner"] == "lotus-manage"
     assert body["execution_binding"]["required_payload_keys"] == [
         "memo_request",
+        "supportability",
+        "wave_report_input",
+    ]
+    assert body["queue_policy"]["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
+
+
+def test_workflow_pack_default_version_route_resolves_operations_handoff_pack_default(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/platform/workflow-packs/registry/dpm_operations_handoff_summary.pack/default"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["default_registration_ref"] == "dpm_operations_handoff_summary.pack@v1"
+    assert body["registration"]["owner_repository"] == "lotus-manage"
+    assert body["registration"]["workflow_authority_owner"] == "lotus-manage"
+    assert body["execution_binding"]["required_payload_keys"] == [
+        "handoff_summary_request",
         "supportability",
         "wave_report_input",
     ]

--- a/tests/support/workflow_pack_fixtures.py
+++ b/tests/support/workflow_pack_fixtures.py
@@ -782,3 +782,73 @@ def wave_pm_memo_workflow_pack_execution_request_json(
     if workflow_surface is not None:
         request["workflow_surface"] = workflow_surface
     return request
+
+
+def operations_handoff_summary_payload(
+    *,
+    requested_outputs: list[str] | None = None,
+    include_portfolio_memory_context: bool = False,
+) -> dict[str, object]:
+    payload = wave_pm_memo_payload(
+        requested_outputs=["operations_handoff"],
+        include_portfolio_memory_context=include_portfolio_memory_context,
+    )
+    payload.pop("memo_request")
+    payload["handoff_summary_request"] = {
+        "requested_outputs": requested_outputs
+        or [
+            "operations_summary",
+            "execution_prerequisites",
+            "blocking_conditions",
+            "support_references",
+            "evidence_gaps",
+        ],
+        "audience": ["operations", "portfolio_manager", "investment_control"],
+    }
+    return payload
+
+
+def operations_handoff_summary_workflow_pack_execution_request_json(
+    *,
+    correlation_id: str,
+    task_id: str = "explain.v1",
+    caller_app: str = "lotus-manage",
+    workflow_surface: str | None = "dpm-operations-handoff-ai-evidence",
+    environment: str = "DEVELOPMENT",
+    caller_identity_class: str = "INTERNAL_SERVICE",
+    requested_outputs: list[str] | None = None,
+    include_portfolio_memory_context: bool = False,
+) -> dict[str, object]:
+    request: dict[str, object] = {
+        "pack_id": "dpm_operations_handoff_summary.pack",
+        "version": "v1",
+        "environment": environment,
+        "caller_identity_class": caller_identity_class,
+        "task_request": {
+            "task_id": task_id,
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": caller_app,
+                "correlation_id": correlation_id,
+                "tenant_id": "tenant-sg-001",
+            },
+            "context": {
+                "summary": (
+                    "Generate review-gated operations handoff summary from bounded "
+                    "rebalance-wave handoff evidence."
+                ),
+                "payload": operations_handoff_summary_payload(
+                    requested_outputs=requested_outputs,
+                    include_portfolio_memory_context=include_portfolio_memory_context,
+                ),
+                "source_refs": [
+                    "lotus-manage:wave:wave_20260508_001",
+                    "lotus-manage:wave-report-input:wave_20260508_001",
+                ],
+            },
+            "expected_output_label": "EXPLANATION_ONLY",
+        },
+    }
+    if workflow_surface is not None:
+        request["workflow_surface"] = workflow_surface
+    return request

--- a/tests/unit/test_ai_surface_supportability.py
+++ b/tests/unit/test_ai_surface_supportability.py
@@ -33,15 +33,16 @@ def test_ai_surface_supportability_summary_is_source_backed_and_bounded() -> Non
     summary = build_ai_surface_supportability_summary()
 
     assert summary.posture == ObservabilityPosture.DEGRADED
-    assert summary.supported_surface_count == 6
-    assert summary.executable_workflow_pack_count == 6
-    assert summary.action_required_surface_count == 6
+    assert summary.supported_surface_count == 7
+    assert summary.executable_workflow_pack_count == 7
+    assert summary.action_required_surface_count == 7
     assert summary.unavailable_surface_count == 0
     assert summary.no_sensitive_content_telemetry is False
     assert summary.metric_name == "lotus_ai_surface_supportability_state"
     assert summary.metric_labels == list(AI_SURFACE_SUPPORTABILITY_METRIC_LABELS)
     assert {item.surface_id: item.owning_service for item in summary.surfaces} == {
         "advisor_brief": "lotus-advise",
+        "dpm_operations_handoff_summary": "lotus-manage",
         "dpm_pm_memo": "lotus-manage",
         "dpm_wave_pm_memo": "lotus-manage",
         "outcome_review_narrative": "lotus-manage",

--- a/tests/unit/test_observability_runtime.py
+++ b/tests/unit/test_observability_runtime.py
@@ -6,19 +6,26 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
 
     assert status.service == "lotus-ai"
     assert status.domain_count == 6
-    assert status.ai_surface_supportability.supported_surface_count == 6
-    assert status.ai_surface_supportability.executable_workflow_pack_count == 6
+    assert status.ai_surface_supportability.supported_surface_count == 7
+    assert status.ai_surface_supportability.executable_workflow_pack_count == 7
     assert status.ai_surface_supportability.no_sensitive_content_telemetry is False
     assert status.ai_surface_supportability.metric_name == "lotus_ai_surface_supportability_state"
     assert status.ai_surface_supportability.metric_labels == ["surface", "posture", "source"]
     assert {surface.workflow_pack_ref for surface in status.ai_surface_supportability.surfaces} == {
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
+    assert any(
+        surface.surface_id == "dpm_operations_handoff_summary"
+        and surface.owning_service == "lotus-manage"
+        and surface.workflow_authority_owner == "lotus-manage"
+        for surface in status.ai_surface_supportability.surfaces
+    )
     assert any(
         surface.surface_id == "dpm_pm_memo"
         and surface.owning_service == "lotus-manage"

--- a/tests/unit/test_operations_handoff_summary_guardrails.py
+++ b/tests/unit/test_operations_handoff_summary_guardrails.py
@@ -77,7 +77,9 @@ def test_operations_handoff_summary_guardrails_block_forbidden_requested_outputs
         requested_outputs=["operations_summary", "order_ticket"]
     )
 
-    _assert_guardrail_rejects(payload, "Forbidden operations handoff outputs requested: order_ticket")
+    _assert_guardrail_rejects(
+        payload, "Forbidden operations handoff outputs requested: order_ticket"
+    )
 
 
 def test_operations_handoff_summary_guardrails_block_unsupported_requested_outputs() -> None:

--- a/tests/unit/test_operations_handoff_summary_guardrails.py
+++ b/tests/unit/test_operations_handoff_summary_guardrails.py
@@ -1,14 +1,27 @@
 from typing import Any, cast
 
+import pytest
 from fastapi import HTTPException
 
+from app.providers.operations_handoff_summary_stub import (
+    build_operations_handoff_summary_stub_result,
+)
 from app.services.operations_handoff_summary_guardrails import (
+    _single_portfolio_id,
     validate_operations_handoff_summary_payload,
 )
 from tests.support.workflow_pack_fixtures import (
     operations_handoff_summary_payload,
     portfolio_memory_context_payload,
 )
+
+
+def _assert_guardrail_rejects(payload: dict[str, object], detail: str) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        validate_operations_handoff_summary_payload(payload)
+
+    assert exc_info.value.status_code == 422
+    assert detail in str(exc_info.value.detail)
 
 
 def test_operations_handoff_summary_guardrails_accept_bounded_handoff_evidence() -> None:
@@ -25,39 +38,21 @@ def test_operations_handoff_summary_guardrails_block_mixed_wave_memo_request() -
     payload = operations_handoff_summary_payload()
     payload["memo_request"] = {"requested_outputs": ["wave_pm_memo"]}
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "must not include wave memo `memo_request`" in str(exc.detail)
-    else:
-        raise AssertionError("expected mixed memo and handoff requests to block execution")
+    _assert_guardrail_rejects(payload, "must not include wave memo `memo_request`")
 
 
 def test_operations_handoff_summary_guardrails_block_unbounded_portfolio_memory_context() -> None:
     payload = cast(dict[str, Any], operations_handoff_summary_payload())
     payload["portfolio_memory_context"] = portfolio_memory_context_payload(event_ref_count=13)
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "event_refs exceeds bounded limit 12" in str(exc.detail)
-    else:
-        raise AssertionError("expected unbounded portfolio-memory context to block execution")
+    _assert_guardrail_rejects(payload, "event_refs exceeds bounded limit 12")
 
 
 def test_operations_handoff_summary_guardrails_block_missing_handoff_refs() -> None:
     payload = cast(dict[str, Any], operations_handoff_summary_payload())
     cast(dict[str, Any], payload["wave_report_input"])["handoff_refs"] = []
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "requires non-empty handoff_refs" in str(exc.detail)
-    else:
-        raise AssertionError("expected missing handoff refs to block execution")
+    _assert_guardrail_rejects(payload, "requires non-empty handoff_refs")
 
 
 def test_operations_handoff_summary_guardrails_block_malformed_handoff_refs() -> None:
@@ -67,26 +62,14 @@ def test_operations_handoff_summary_guardrails_block_malformed_handoff_refs() ->
     )
     handoff_refs[0].pop("content_hash")
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "ref_type, ref_id, source_system, and content_hash" in str(exc.detail)
-    else:
-        raise AssertionError("expected malformed handoff refs to block execution")
+    _assert_guardrail_rejects(payload, "ref_type, ref_id, source_system, and content_hash")
 
 
 def test_operations_handoff_summary_guardrails_block_external_execution_claim() -> None:
     payload = cast(dict[str, Any], operations_handoff_summary_payload())
     cast(dict[str, Any], payload["wave_report_input"])["external_execution_claimed"] = True
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "cannot claim external execution authority" in str(exc.detail)
-    else:
-        raise AssertionError("expected external execution claim to block execution")
+    _assert_guardrail_rejects(payload, "cannot claim external execution authority")
 
 
 def test_operations_handoff_summary_guardrails_block_forbidden_requested_outputs() -> None:
@@ -94,13 +77,7 @@ def test_operations_handoff_summary_guardrails_block_forbidden_requested_outputs
         requested_outputs=["operations_summary", "order_ticket"]
     )
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "Forbidden operations handoff outputs requested: order_ticket" in str(exc.detail)
-    else:
-        raise AssertionError("expected forbidden handoff output to block execution")
+    _assert_guardrail_rejects(payload, "Forbidden operations handoff outputs requested: order_ticket")
 
 
 def test_operations_handoff_summary_guardrails_block_unsupported_requested_outputs() -> None:
@@ -108,13 +85,10 @@ def test_operations_handoff_summary_guardrails_block_unsupported_requested_outpu
         requested_outputs=["operations_summary", "marketing_copy"]
     )
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "Unsupported operations handoff outputs requested: marketing_copy" in str(exc.detail)
-    else:
-        raise AssertionError("expected unsupported handoff output to block execution")
+    _assert_guardrail_rejects(
+        payload,
+        "Unsupported operations handoff outputs requested: marketing_copy",
+    )
 
 
 def test_operations_handoff_summary_guardrails_block_raw_payload_fields() -> None:
@@ -122,10 +96,113 @@ def test_operations_handoff_summary_guardrails_block_raw_payload_fields() -> Non
     items = cast(list[dict[str, Any]], cast(dict[str, Any], payload["wave_report_input"])["items"])
     items[0]["diagnostics"]["raw_payload"] = {"unsafe": True}
 
-    try:
-        validate_operations_handoff_summary_payload(payload)
-    except HTTPException as exc:
-        assert exc.status_code == 422
-        assert "Forbidden wave report input fields present: raw_payload" in str(exc.detail)
-    else:
-        raise AssertionError("expected forbidden raw payload field to block execution")
+    _assert_guardrail_rejects(payload, "Forbidden wave report input fields present: raw_payload")
+
+
+def test_operations_handoff_summary_guardrails_block_missing_wave_fields() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["wave_report_input"]).pop("contract_version")
+
+    _assert_guardrail_rejects(payload, "Missing DpmWaveReportInput fields: contract_version")
+
+
+def test_operations_handoff_summary_guardrails_block_missing_forbidden_actions() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["supportability"])["forbidden_actions"] = ["place_orders"]
+
+    _assert_guardrail_rejects(payload, "Missing required forbidden-action guardrails")
+
+
+def test_operations_handoff_summary_guardrails_block_invalid_redaction_policy() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["wave_report_input"])["redaction_policy"] = "RAW_ALLOWED"
+
+    _assert_guardrail_rejects(payload, "must use NO_RAW_PAYLOADS redaction policy")
+
+
+def test_operations_handoff_summary_guardrails_block_missing_items() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["wave_report_input"])["items"] = []
+
+    _assert_guardrail_rejects(payload, "requires at least one bounded wave item")
+
+
+def test_operations_handoff_summary_guardrails_block_items_without_ready_evidence() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    items = cast(list[dict[str, Any]], cast(dict[str, Any], payload["wave_report_input"])["items"])
+    items[0]["state"] = "DRAFT"
+
+    _assert_guardrail_rejects(payload, "requires staged or handoff-ready wave item evidence")
+
+
+def test_operations_handoff_summary_guardrails_block_missing_source_refs() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["wave_report_input"])["source_refs"] = []
+
+    _assert_guardrail_rejects(payload, "source_refs must be a non-empty list")
+
+
+def test_operations_handoff_summary_guardrails_block_non_object_sections() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    payload["handoff_summary_request"] = "not-an-object"
+
+    _assert_guardrail_rejects(payload, "requires object section `handoff_summary_request`")
+
+
+def test_operations_handoff_summary_guardrails_block_non_string_requested_outputs() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["handoff_summary_request"])["requested_outputs"] = [
+        "operations_summary",
+        42,
+    ]
+
+    _assert_guardrail_rejects(payload, "requires string-list field `requested_outputs`")
+
+
+def test_operations_handoff_summary_guardrails_block_non_object_handoff_ref() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["wave_report_input"])["handoff_refs"] = ["not-a-ref"]
+
+    _assert_guardrail_rejects(payload, "ref_type, ref_id, source_system, and content_hash")
+
+
+def test_operations_handoff_summary_portfolio_id_helper_handles_unbounded_shapes() -> None:
+    assert _single_portfolio_id("not-items") is None
+    assert (
+        _single_portfolio_id(
+            [
+                {"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+                {"portfolio_id": "PB_SG_GROWTH_001"},
+            ]
+        )
+        is None
+    )
+
+
+def test_operations_handoff_summary_stub_handles_unbounded_optional_shapes() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    wave_report_input = cast(dict[str, Any], payload["wave_report_input"])
+    wave_report_input["items"] = "not-a-list"
+    cast(dict[str, Any], payload["handoff_summary_request"])["requested_outputs"] = "not-a-list"
+    payload["supportability"] = "not-an-object"
+
+    result = build_operations_handoff_summary_stub_result(context_payload=payload)
+
+    assert result is not None
+    _, structured_output = result
+    assert structured_output["item_count"] == 0
+    assert structured_output["blocked_item_count"] == 0
+    assert structured_output["requested_outputs"] == []
+    assert structured_output["forbidden_actions"] == []
+    assert structured_output["unsupported_claims"] == []
+
+
+def test_operations_handoff_summary_stub_ignores_malformed_unsupported_claims() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["supportability"])["unsupported_claims"] = "not-a-list"
+
+    result = build_operations_handoff_summary_stub_result(context_payload=payload)
+
+    assert result is not None
+    _, structured_output = result
+    assert structured_output["unsupported_claims"] == []

--- a/tests/unit/test_operations_handoff_summary_guardrails.py
+++ b/tests/unit/test_operations_handoff_summary_guardrails.py
@@ -1,0 +1,131 @@
+from typing import Any, cast
+
+from fastapi import HTTPException
+
+from app.services.operations_handoff_summary_guardrails import (
+    validate_operations_handoff_summary_payload,
+)
+from tests.support.workflow_pack_fixtures import (
+    operations_handoff_summary_payload,
+    portfolio_memory_context_payload,
+)
+
+
+def test_operations_handoff_summary_guardrails_accept_bounded_handoff_evidence() -> None:
+    validate_operations_handoff_summary_payload(operations_handoff_summary_payload())
+
+
+def test_operations_handoff_summary_guardrails_accept_bounded_portfolio_memory_context() -> None:
+    validate_operations_handoff_summary_payload(
+        operations_handoff_summary_payload(include_portfolio_memory_context=True)
+    )
+
+
+def test_operations_handoff_summary_guardrails_block_mixed_wave_memo_request() -> None:
+    payload = operations_handoff_summary_payload()
+    payload["memo_request"] = {"requested_outputs": ["wave_pm_memo"]}
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "must not include wave memo `memo_request`" in str(exc.detail)
+    else:
+        raise AssertionError("expected mixed memo and handoff requests to block execution")
+
+
+def test_operations_handoff_summary_guardrails_block_unbounded_portfolio_memory_context() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    payload["portfolio_memory_context"] = portfolio_memory_context_payload(event_ref_count=13)
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "event_refs exceeds bounded limit 12" in str(exc.detail)
+    else:
+        raise AssertionError("expected unbounded portfolio-memory context to block execution")
+
+
+def test_operations_handoff_summary_guardrails_block_missing_handoff_refs() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["wave_report_input"])["handoff_refs"] = []
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "requires non-empty handoff_refs" in str(exc.detail)
+    else:
+        raise AssertionError("expected missing handoff refs to block execution")
+
+
+def test_operations_handoff_summary_guardrails_block_malformed_handoff_refs() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    handoff_refs = cast(
+        list[dict[str, Any]], cast(dict[str, Any], payload["wave_report_input"])["handoff_refs"]
+    )
+    handoff_refs[0].pop("content_hash")
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "ref_type, ref_id, source_system, and content_hash" in str(exc.detail)
+    else:
+        raise AssertionError("expected malformed handoff refs to block execution")
+
+
+def test_operations_handoff_summary_guardrails_block_external_execution_claim() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    cast(dict[str, Any], payload["wave_report_input"])["external_execution_claimed"] = True
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "cannot claim external execution authority" in str(exc.detail)
+    else:
+        raise AssertionError("expected external execution claim to block execution")
+
+
+def test_operations_handoff_summary_guardrails_block_forbidden_requested_outputs() -> None:
+    payload = operations_handoff_summary_payload(
+        requested_outputs=["operations_summary", "order_ticket"]
+    )
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden operations handoff outputs requested: order_ticket" in str(exc.detail)
+    else:
+        raise AssertionError("expected forbidden handoff output to block execution")
+
+
+def test_operations_handoff_summary_guardrails_block_unsupported_requested_outputs() -> None:
+    payload = operations_handoff_summary_payload(
+        requested_outputs=["operations_summary", "marketing_copy"]
+    )
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Unsupported operations handoff outputs requested: marketing_copy" in str(exc.detail)
+    else:
+        raise AssertionError("expected unsupported handoff output to block execution")
+
+
+def test_operations_handoff_summary_guardrails_block_raw_payload_fields() -> None:
+    payload = cast(dict[str, Any], operations_handoff_summary_payload())
+    items = cast(list[dict[str, Any]], cast(dict[str, Any], payload["wave_report_input"])["items"])
+    items[0]["diagnostics"]["raw_payload"] = {"unsafe": True}
+
+    try:
+        validate_operations_handoff_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden wave report input fields present: raw_payload" in str(exc.detail)
+    else:
+        raise AssertionError("expected forbidden raw payload field to block execution")

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -63,15 +63,16 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.access_control_store_mode == "memory"
     assert status.workflow_pack_registry_store_mode == "memory"
     assert status.workflow_pack_task_flow_store_mode == "memory"
-    assert status.workflow_pack_runtime.registration_count == 7
-    assert status.workflow_pack_runtime.registered_count == 6
-    assert status.workflow_pack_runtime.execution_binding_count == 6
-    assert status.workflow_pack_runtime.executable_registration_count == 6
-    assert status.workflow_pack_runtime.executable_review_required_count == 6
+    assert status.workflow_pack_runtime.registration_count == 8
+    assert status.workflow_pack_runtime.registered_count == 7
+    assert status.workflow_pack_runtime.execution_binding_count == 7
+    assert status.workflow_pack_runtime.executable_registration_count == 7
+    assert status.workflow_pack_runtime.executable_review_required_count == 7
     assert status.workflow_pack_runtime.executable_without_review_count == 0
     assert status.workflow_pack_runtime.registered_without_execution_binding_count == 0
     assert status.workflow_pack_runtime.executable_registration_refs == [
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
@@ -80,15 +81,17 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     ]
     assert status.workflow_pack_runtime.executable_review_required_refs == [
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
-    assert len(status.workflow_pack_runtime.executable_activity) == 6
+    assert len(status.workflow_pack_runtime.executable_activity) == 7
     assert [item.registration_ref for item in status.workflow_pack_runtime.executable_activity] == [
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
@@ -136,9 +139,9 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.observability_runtime.domain_count == 6
     assert status.observability_runtime.unavailable_domain_count == 0
     assert status.observability_runtime.incident_evidence_supported_domain_count >= 1
-    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 6
+    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 7
     assert (
-        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 6
+        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 7
     )
     assert (
         status.observability_runtime.ai_surface_supportability.no_sensitive_content_telemetry
@@ -148,6 +151,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         item.surface_id for item in status.observability_runtime.ai_surface_supportability.surfaces
     } == {
         "advisor_brief",
+        "dpm_operations_handoff_summary",
         "dpm_pm_memo",
         "dpm_wave_pm_memo",
         "outcome_review_narrative",

--- a/tests/unit/test_workflow_pack_bindings.py
+++ b/tests/unit/test_workflow_pack_bindings.py
@@ -21,6 +21,7 @@ from app.services.workflow_pack_bindings import (
 )
 from app.services.workflow_pack_phase1_specs import ADVISOR_BRIEF_V1_SPEC
 from tests.support.workflow_pack_fixtures import outcome_review_narrative_payload
+from tests.support.workflow_pack_fixtures import operations_handoff_summary_payload
 from tests.support.workflow_pack_fixtures import proof_pack_pm_memo_payload
 from tests.support.workflow_pack_fixtures import wave_pm_memo_payload
 
@@ -78,6 +79,18 @@ def test_get_workflow_pack_execution_binding_returns_wave_pm_memo_binding() -> N
     assert binding.task_id == "explain.v1"
     assert binding.default_workflow_surface == "dpm-wave-ai-evidence"
     assert binding.validate_task_request_payload(payload=wave_pm_memo_payload())
+
+
+def test_get_workflow_pack_execution_binding_returns_operations_handoff_summary_binding() -> None:
+    binding = get_workflow_pack_execution_binding(
+        pack_id="dpm_operations_handoff_summary.pack",
+        version="v1",
+    )
+
+    assert binding is not None
+    assert binding.task_id == "explain.v1"
+    assert binding.default_workflow_surface == "dpm-operations-handoff-ai-evidence"
+    assert binding.validate_task_request_payload(payload=operations_handoff_summary_payload())
 
 
 def test_workflow_pack_execution_binding_spec_requires_task_and_surface() -> None:

--- a/tests/unit/test_workflow_pack_execution.py
+++ b/tests/unit/test_workflow_pack_execution.py
@@ -7,6 +7,7 @@ from app.services.workflow_pack_execution import (
 )
 from app.services.workflow_pack_bindings import get_workflow_pack_execution_binding
 from tests.support.workflow_pack_fixtures import (
+    operations_handoff_summary_workflow_pack_execution_request_json,
     outcome_review_narrative_workflow_pack_execution_request_json,
     proof_pack_pm_memo_workflow_pack_execution_request_json,
     wave_pm_memo_workflow_pack_execution_request_json,
@@ -196,3 +197,45 @@ def test_execute_workflow_pack_records_wave_portfolio_memory_lineage() -> None:
         "sha256:portfolio-memory-context-001"
     )
     assert structured_output["portfolio_memory_event_ref_count"] == 2
+
+
+def test_execute_workflow_pack_records_review_gated_operations_handoff_summary() -> None:
+    request = WorkflowPackExecutionRequest.model_validate(
+        operations_handoff_summary_workflow_pack_execution_request_json(
+            correlation_id="corr-execution-operations-handoff-summary"
+        )
+    )
+
+    response = execute_workflow_pack(request)
+
+    structured_output = response.execution.result.structured_output
+    assert response.execution.status.value == "COMPLETED"
+    assert response.workflow_pack_run.pack_id == "dpm_operations_handoff_summary.pack"
+    assert response.workflow_pack_run.workflow_authority_owner == "lotus-manage"
+    assert structured_output["workflow_pack_family"] == "dpm_operations_handoff_summary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "support_only"
+    assert structured_output["wave_report_content_hash"] == "sha256:wave-report-input-001"
+    assert structured_output["handoff_ref_count"] == 1
+    assert structured_output["external_execution_claimed"] is False
+
+
+def test_validate_workflow_pack_execution_binding_runs_operations_handoff_guardrails() -> None:
+    request_payload = operations_handoff_summary_workflow_pack_execution_request_json(
+        correlation_id="corr-execution-operations-handoff-guardrail",
+        requested_outputs=["operations_summary", "order_ticket"],
+    )
+    request = WorkflowPackExecutionRequest.model_validate(request_payload)
+    binding = get_workflow_pack_execution_binding(
+        pack_id="dpm_operations_handoff_summary.pack",
+        version="v1",
+    )
+    assert binding is not None
+
+    try:
+        validate_workflow_pack_execution_binding(request=request, binding=binding)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden operations handoff outputs requested: order_ticket" in str(exc.detail)
+    else:
+        raise AssertionError("expected operations handoff guardrails to reject order-ticket output")

--- a/tests/unit/test_workflow_pack_queue_policy_catalog.py
+++ b/tests/unit/test_workflow_pack_queue_policy_catalog.py
@@ -18,6 +18,7 @@ def test_queue_policy_catalog_declares_policy_for_each_executable_phase1_pack() 
     }
     assert policy_refs == {
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",

--- a/tests/unit/test_workflow_pack_registry.py
+++ b/tests/unit/test_workflow_pack_registry.py
@@ -26,8 +26,8 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
 
     assert catalog.service == "lotus-ai"
     assert catalog.phase == "foundation"
-    assert catalog.registration_count == 7
-    assert catalog.registered_count == 6
+    assert catalog.registration_count == 8
+    assert catalog.registered_count == 7
     assert catalog.production_eligible_count == 0
     advisor_brief_registration = next(
         registration
@@ -58,6 +58,11 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         registration
         for registration in catalog.registrations
         if registration.pack_id == "dpm_wave_pm_memo.pack"
+    )
+    operations_handoff_summary_registration = next(
+        registration
+        for registration in catalog.registrations
+        if registration.pack_id == "dpm_operations_handoff_summary.pack"
     )
     assert (
         advisor_brief_registration.registration_status == WorkflowPackRegistrationStatus.REGISTERED
@@ -129,8 +134,23 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         and definition_ref.required_for_registration is True
         for definition_ref in wave_pm_memo_registration.definition_refs
     )
-    assert len(catalog.execution_bindings) == 6
-    assert len(catalog.queue_policies) == 6
+    assert operations_handoff_summary_registration.registration_status == (
+        WorkflowPackRegistrationStatus.REGISTERED
+    )
+    assert operations_handoff_summary_registration.owner_repository == "lotus-manage"
+    assert operations_handoff_summary_registration.workflow_authority_owner == "lotus-manage"
+    assert operations_handoff_summary_registration.supported_callers == [
+        "lotus-manage",
+        "lotus-gateway",
+    ]
+    assert any(
+        definition_ref.repository == "lotus-manage"
+        and definition_ref.path == "src/core/waves/handoffs.py"
+        and definition_ref.required_for_registration is True
+        for definition_ref in operations_handoff_summary_registration.definition_refs
+    )
+    assert len(catalog.execution_bindings) == 7
+    assert len(catalog.queue_policies) == 7
     assert any(
         binding.pack_id == "advisor_brief.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
@@ -159,6 +179,10 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
     )
     assert any(
         binding.pack_id == "dpm_wave_pm_memo.pack" and binding.task_id == "explain.v1"
+        for binding in catalog.execution_bindings
+    )
+    assert any(
+        binding.pack_id == "dpm_operations_handoff_summary.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
     )
 
@@ -273,6 +297,23 @@ def test_build_wave_pm_memo_registration_detail_exposes_manage_owned_binding() -
     assert detail.execution_binding is not None
     assert detail.execution_binding.task_id == "explain.v1"
     assert detail.execution_binding.default_workflow_surface == "dpm-wave-ai-evidence"
+
+
+def test_build_operations_handoff_summary_registration_detail_exposes_manage_owned_binding() -> (
+    None
+):
+    detail = build_workflow_pack_registration_detail(
+        pack_id="dpm_operations_handoff_summary.pack",
+        version="v1",
+    )
+
+    assert detail.registration.owner_repository == "lotus-manage"
+    assert detail.registration.workflow_authority_owner == "lotus-manage"
+    assert detail.execution_binding is not None
+    assert detail.execution_binding.task_id == "explain.v1"
+    assert detail.execution_binding.default_workflow_surface == (
+        "dpm-operations-handoff-ai-evidence"
+    )
 
 
 def test_build_workflow_pack_registration_detail_rejects_unknown_registration() -> None:

--- a/tests/unit/test_workflow_pack_registry_store.py
+++ b/tests/unit/test_workflow_pack_registry_store.py
@@ -70,6 +70,7 @@ def test_workflow_pack_registry_store_returns_sqlalchemy_repository(tmp_path: Pa
     assert [f"{registration.pack_id}@{registration.version}" for registration in registrations] == [
         "advisor_brief.pack@v1",
         "advisor_brief.pack@v2",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",

--- a/tests/unit/test_workflow_pack_runtime_status.py
+++ b/tests/unit/test_workflow_pack_runtime_status.py
@@ -248,14 +248,15 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
 ):
     summary = build_workflow_pack_runtime_status_summary()
 
-    assert summary.registration_count == 7
-    assert summary.registered_count == 6
-    assert summary.execution_binding_count == 6
-    assert summary.executable_registration_count == 6
-    assert summary.executable_review_required_count == 6
+    assert summary.registration_count == 8
+    assert summary.registered_count == 7
+    assert summary.execution_binding_count == 7
+    assert summary.executable_registration_count == 7
+    assert summary.executable_review_required_count == 7
     assert summary.registered_without_execution_binding_count == 0
     assert summary.executable_registration_refs == [
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
@@ -264,6 +265,7 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
     ]
     assert summary.executable_review_required_refs == [
         "advisor_brief.pack@v1",
+        "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -41,20 +41,24 @@ It does not own portfolio, performance, risk, advisory, management, or reporting
 
 ## Workflow-Pack Product Coverage
 
-Current executable workflow-pack coverage is implementation-backed for five pilot-scoped families:
+Current executable workflow-pack coverage is implementation-backed for seven pilot-scoped families:
 
 1. `advisor_brief.pack@v1`
 2. `workspace_rationale.pack@v1`
 3. `twr_inspection_support_brief.pack@v1`
 4. `dpm_pm_memo.pack@v1`
-5. `outcome_review_narrative.pack@v1`
+5. `dpm_wave_pm_memo.pack@v1`
+6. `dpm_operations_handoff_summary.pack@v1`
+7. `outcome_review_narrative.pack@v1`
 
 The DPM packs are deliberately support-only and review-gated. `dpm_pm_memo.pack@v1` consumes
-`lotus-manage` `DpmProofPackAiEvidenceInput`; `outcome_review_narrative.pack@v1` consumes
-`lotus-manage` `DpmOutcomeAiEvidenceInput`. Both can also consume optional manage-owned
-`portfolio_memory_context` as bounded source lineage. They validate forbidden actions, forbidden
-fields, requested output scope, portfolio-memory redaction/source-authority posture, run-ledger
-posture, and source evidence before generated narrative can be treated as usable support.
+`lotus-manage` `DpmProofPackAiEvidenceInput`; `dpm_wave_pm_memo.pack@v1` and
+`dpm_operations_handoff_summary.pack@v1` consume `lotus-manage` `DpmWaveReportInput`;
+`outcome_review_narrative.pack@v1` consumes `lotus-manage` `DpmOutcomeAiEvidenceInput`. These
+packs can also consume optional manage-owned `portfolio_memory_context` as bounded source lineage.
+They validate forbidden actions, forbidden fields, requested output scope, portfolio-memory
+redaction/source-authority posture, run-ledger posture, and source evidence before generated
+narrative can be treated as usable support.
 
 ## Supported Task Families
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -166,10 +166,11 @@ the owner-facing procedure and do one more truth check before treating a registr
 
 ## DPM PM Memo Integration
 
-`dpm_pm_memo.pack@v1` and `dpm_wave_pm_memo.pack@v1` are the current `lotus-ai` owner-side
-execution contracts for governed PM memo drafting from Manage evidence. The proof-pack pack is for
-single proof-pack evidence; the wave pack is for rebalance-wave evidence that may summarize multiple
-wave items and proof-pack refs.
+`dpm_pm_memo.pack@v1`, `dpm_wave_pm_memo.pack@v1`, and
+`dpm_operations_handoff_summary.pack@v1` are the current `lotus-ai` owner-side execution contracts
+for governed DPM support drafting from Manage evidence. The proof-pack pack is for single proof-pack
+evidence, the wave pack is for rebalance-wave PM memo evidence, and the operations pack is for
+bounded internal handoff evidence that may summarize staged wave items and handoff refs.
 
 Use it only when the caller supplies:
 
@@ -212,13 +213,27 @@ The wave pack additionally blocks external-execution claims and requires non-emp
 bounded wave items, proof-pack posture, and `NO_RAW_PAYLOADS` redaction before run, audit, or
 task-flow records are written.
 
+Use `dpm_operations_handoff_summary.pack@v1` only when the caller supplies:
+
+1. `wave_report_input` shaped as `lotus-manage` `DpmWaveReportInput`,
+2. non-empty bounded `handoff_refs` with ref type, ref id, source system, and content hash,
+3. `handoff_summary_request` with allowed requested outputs such as `operations_summary`,
+   `execution_prerequisites`, `blocking_conditions`, `support_references`, or `evidence_gaps`,
+4. `supportability` posture with required forbidden actions and unsupported claims,
+5. optional `portfolio_memory_context` only when `lotus-manage` supplies bounded source-lineage
+   context for the same portfolio.
+
+The operations handoff pack blocks order tickets, routing instructions, external-execution claims,
+trade recommendations, client messages, and inferred missing handoff evidence before run, audit, or
+task-flow records are written.
+
 ```mermaid
 sequenceDiagram
     participant Manage as lotus-manage
     participant AI as lotus-ai
     participant Ledger as workflow-pack ledger
     participant UI as Gateway / Workbench
-    Manage->>AI: dpm_pm_memo.pack@v1 or dpm_wave_pm_memo.pack@v1 with bounded evidence
+    Manage->>AI: DPM memo, wave memo, or operations handoff pack with bounded evidence
     AI->>AI: Validate forbidden actions, fields, requested outputs, and memory lineage
     AI->>Ledger: Record review-gated run after guardrails pass
     Ledger-->>AI: workflow_pack_run_id and provenance

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -178,7 +178,13 @@ For AI-backed product-surface support, also confirm:
    guardrail-blocked requests, not as prompt-tuning opportunities. Missing source refs, empty wave
    items, missing proof-pack posture, or non-`NO_RAW_PAYLOADS` redaction indicate caller contract
    defects that must be fixed at the source evidence boundary.
-8. `outcome_review_narrative` remains owned by `lotus-manage` evidence contracts; treat PM scoring,
+8. `dpm_operations_handoff_summary` remains owned by `lotus-manage` rebalance-wave handoff evidence
+   contracts; treat order tickets, routing instructions, execution instructions, client messages,
+   external execution claims, control overrides, and invented missing handoff evidence as
+   guardrail-blocked requests. Missing handoff refs, malformed handoff refs, empty wave items, or
+   non-`NO_RAW_PAYLOADS` redaction indicate caller contract defects that must be fixed at the
+   source evidence boundary.
+9. `outcome_review_narrative` remains owned by `lotus-manage` evidence contracts; treat PM scoring,
    client messages, trade approvals, control overrides, and invented missing evidence as
    guardrail-blocked requests, not as prompt-tuning opportunities. Optional portfolio-memory
    lineage can support review and demo provenance, but it must not be used to infer missing source

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -130,15 +130,18 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
 9. the current executable workflow-pack set includes `advisor_brief.pack`,
    `workspace_rationale.pack`, `twr_inspection_support_brief.pack`, the review-gated
    `dpm_pm_memo.pack` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the
-   review-gated `dpm_wave_pm_memo.pack` contract for `lotus-manage` `DpmWaveReportInput`, and the
-   review-gated `outcome_review_narrative.pack` contract for `lotus-manage`
+   review-gated `dpm_wave_pm_memo.pack` and `dpm_operations_handoff_summary.pack` contracts for
+   `lotus-manage` `DpmWaveReportInput`, and the review-gated `outcome_review_narrative.pack` contract for `lotus-manage`
    `DpmOutcomeAiEvidenceInput`. DPM proof-pack PM memo execution validates required proof-pack
    evidence, required forbidden actions, forbidden field names, forbidden requested outputs such as
    trade recommendations or client messages, and unsupported requested outputs before run, audit,
    or task-flow posture is recorded. DPM wave PM memo execution validates required wave report
    input fields, non-empty source refs, bounded wave items, proof-pack posture, `NO_RAW_PAYLOADS`,
    no-external-execution posture, forbidden actions, forbidden fields, and requested outputs before
-   side effects are recorded. Outcome-review narrative execution validates required forbidden
+   side effects are recorded. DPM operations handoff summary execution additionally requires
+   non-empty bounded handoff refs and blocks order tickets, routing instructions, execution
+   instructions, external-execution claims, and inferred missing handoff evidence. Outcome-review
+   narrative execution validates required forbidden
    actions, rejects forbidden field names, rejects forbidden requested outputs such as PM scoring or
    client messages, records run and task-flow posture only after those guardrails pass, and remains
    support-only until Gateway and Workbench surfaces consume the contract. The DPM packs can
@@ -150,12 +153,15 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
 flowchart LR
     ProofPack["lotus-manage\nDpmProofPackAiEvidenceInput"] --> MemoPack["dpm_pm_memo.pack@v1"]
     Wave["lotus-manage\nDpmWaveReportInput"] --> WavePack["dpm_wave_pm_memo.pack@v1"]
+    Wave --> HandoffPack["dpm_operations_handoff_summary.pack@v1"]
     Outcome["lotus-manage\nDpmOutcomeAiEvidenceInput"] --> OutcomePack["outcome_review_narrative.pack@v1"]
     Memory["lotus-manage\nportfolio_memory_context"] --> MemoPack
     Memory --> WavePack
+    Memory --> HandoffPack
     Memory --> OutcomePack
     MemoPack --> Guardrails["lotus-ai guardrails\nfields / actions / outputs / memory"]
     WavePack --> Guardrails
+    HandoffPack --> Guardrails
     OutcomePack --> Guardrails
     Guardrails --> Ledger["Run ledger\nreview required"]
     Ledger --> SourceEvents["AI source events\nno raw payloads"]


### PR DESCRIPTION
## Summary
- adds the lotus-manage-owned `dpm_operations_handoff_summary.pack@v1` workflow-pack registration, execution binding, queue policy, supportability mapping, and deterministic stub output
- enforces operations-handoff guardrails for bounded DPM wave handoff evidence, source refs, support-only output scope, no external execution claims, and no ambiguous wave memo payloads
- updates API/runtime tests plus README, integration guide, repository context, and wiki source for the new AI support surface

## Validation
- `python -m pytest tests/unit/test_operations_handoff_summary_guardrails.py tests/unit/test_workflow_pack_execution.py tests/unit/test_workflow_pack_bindings.py tests/unit/test_workflow_pack_registry.py tests/unit/test_workflow_pack_registry_store.py tests/unit/test_workflow_pack_queue_policy_catalog.py tests/unit/test_workflow_pack_runtime_status.py tests/unit/test_ai_surface_supportability.py tests/unit/test_observability_runtime.py tests/unit/test_platform_status.py tests/integration/test_workflow_pack_registry_api_contract.py tests/integration/test_observability_api_contract.py tests/integration/test_health.py -q` -> 123 passed
- `python -m pytest tests/unit/test_operations_handoff_summary_guardrails.py tests/unit/test_workflow_pack_execution.py tests/unit/test_workflow_pack_bindings.py -q` -> 34 passed
- `make check` -> ruff, mypy, OpenAPI gate, eval artifact checks, async artifact checks, migration contract check, runtime-mode smoke, and unit suite passed; final unit suite: 1139 passed, 3 warnings
- live API probe on `127.0.0.1:8011`: registry default 200 for `dpm_operations_handoff_summary.pack@v1`, execution 200/COMPLETED, review-required support-only output, `handoff_ref_count=1`, `external_execution_claimed=false`, mixed memo/handoff payload rejected with 422, and server log scan found no `ERROR|CRITICAL|Traceback|Exception|5xx`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai` -> expected pre-merge drift for repo-local wiki source changes (`Home.md`, `Integrations.md`, `Operations-Runbook.md`, `Platform-Surfaces.md`); publish after merge
- `git diff --check` -> passed, with CRLF normalization warnings for markdown/wiki files only

## Notes
- This is the owner-side AI workflow-pack slice for RFC-0043 operations handoff summary support. It does not claim gateway or Workbench product-surface completion.