### PR TITLE
Add DPM exception summary workflow pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ Important posture limits:
 4. prompt bodies remain repository-managed even though runtime prompt selection is durable,
 5. workflow-pack registry records are control-plane metadata, not a second editable home for workflow logic,
 6. workflow-pack registrations must point to real owning-repository artifacts rather than placeholder definitions in `lotus-ai`,
-7. workflow-pack registry and control state can now run either in-memory or through a SQL-backed durable store, and the current executable workflow-pack set includes advisor brief, workspace rationale, TWR inspection support brief, the review-gated `dpm_pm_memo.pack@v1` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the review-gated `dpm_wave_pm_memo.pack@v1` and `dpm_operations_handoff_summary.pack@v1` contracts for `lotus-manage` `DpmWaveReportInput`, and the review-gated `outcome_review_narrative.pack@v1` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`,
+7. workflow-pack registry and control state can now run either in-memory or through a SQL-backed durable store, and the current executable workflow-pack set includes advisor brief, workspace rationale, TWR inspection support brief, the review-gated `dpm_pm_memo.pack@v1` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the review-gated `dpm_wave_pm_memo.pack@v1` and `dpm_operations_handoff_summary.pack@v1` contracts for `lotus-manage` `DpmWaveReportInput`, the review-gated `dpm_exception_summary.pack@v1` contract for bounded `lotus-manage` monitoring exception evidence, and the review-gated `outcome_review_narrative.pack@v1` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`,
 8. the service should be treated as a governed capability layer, not a business-domain authority.
 
-For DPM PM memo and operations handoff summary support, `lotus-ai` owns workflow-pack execution,
-provider mode, safety, guardrail validation, run-ledger posture, queue policy, and deterministic
-stub behavior.
+For DPM PM memo, exception summary, and operations handoff summary support, `lotus-ai` owns
+workflow-pack execution, provider mode, safety, guardrail validation, run-ledger posture, queue
+policy, and deterministic stub behavior.
 `lotus-manage` remains the proof-pack and rebalance-wave evidence authority. The proof-pack pack
 consumes `DpmProofPackAiEvidenceInput`; the wave PM memo and operations handoff summary packs
-consume `DpmWaveReportInput`. These packs are pilot-scoped, support-only, and review-gated; they
-must not approve rebalances, place orders, produce client messages, score PMs, claim external
-execution, produce routing instructions, or invent missing proof-pack, wave, or handoff evidence.
+consume `DpmWaveReportInput`; the exception summary pack consumes bounded manage-owned monitoring
+exception evidence. These packs are pilot-scoped, support-only, and review-gated; they must not
+approve rebalances, place orders, produce client messages, score PMs, claim external execution,
+produce routing instructions, or invent missing proof-pack, wave, exception, or handoff evidence.
 
 For DPM portfolio-memory support, the proof-pack PM memo, wave PM memo, operations handoff summary,
 and outcome-review narrative packs can consume optional `portfolio_memory_context` emitted by

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -38,7 +38,8 @@ Current repository posture:
 5. workflow-pack run-ledger foundations now exist as a separate runtime seam for the current
    executable workflow-pack families (`advisor_brief.pack`, `workspace_rationale.pack`,
    `twr_inspection_support_brief.pack`, `dpm_pm_memo.pack`, `dpm_wave_pm_memo.pack`,
-   `dpm_operations_handoff_summary.pack`, and `outcome_review_narrative.pack`), with runtime state
+   `dpm_exception_summary.pack`, `dpm_operations_handoff_summary.pack`, and
+   `outcome_review_narrative.pack`), with runtime state
    kept separate from review state,
    bounded actor-attributed review transitions available through the ledger API, bounded
    ledger-compatible `allowed_review_actions` emitted for consumers, governed workflow-pack
@@ -53,7 +54,10 @@ Current repository posture:
    validate manage-owned `DpmWaveReportInput`, non-empty bounded handoff refs, required forbidden
    actions, forbidden fields, forbidden requested outputs, no-external-execution posture,
    `NO_RAW_PAYLOADS`, and optional source-lineage-only `portfolio_memory_context` before
-   run/audit/task-flow side effects, and deterministic
+   run/audit/task-flow side effects, deterministic exception summary guardrails that validate
+   manage-owned monitoring exception evidence, bounded source refs, required forbidden actions,
+   forbidden fields, forbidden requested outputs, `NO_RAW_PAYLOADS`, and support-only posture
+   before run/audit/task-flow side effects, and deterministic
    outcome-review narrative guardrails that validate manage-owned `DpmOutcomeAiEvidenceInput`,
    required forbidden actions, forbidden fields, forbidden requested outputs, and optional
    source-lineage-only `portfolio_memory_context` before run/audit/task-flow side effects. The

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -299,7 +299,14 @@ That sequence keeps downstream adoption pack-oriented first, while still preserv
    external execution claims, control override, or invented missing wave or proof-pack evidence
    are guardrail-blocked before execution and should be corrected in the caller contract rather
    than retried with prompt wording.
-7. Use `dpm_operations_handoff_summary.pack@v1` only with manage-owned `DpmWaveReportInput`,
+7. Use `dpm_exception_summary.pack@v1` only with bounded manage-owned monitoring exception
+   evidence, a bounded `exception_summary_request`, supportability posture, source refs,
+   `NO_RAW_PAYLOADS`, and requested outputs such as `exception_summary`, `severity_summary`,
+   `recommended_triage`, `support_references`, or `evidence_gaps`. Requests for rebalance
+   approval, order instructions, client messages, PM scoring, control override, or invented
+   exception evidence are guardrail-blocked before execution and should be corrected at the source
+   evidence boundary.
+8. Use `dpm_operations_handoff_summary.pack@v1` only with manage-owned `DpmWaveReportInput`,
    non-empty bounded `handoff_refs`, a bounded `handoff_summary_request`, supportability posture,
    and optional manage-owned `portfolio_memory_context`. Requests for order tickets, routing
    instructions, execution instructions, trade recommendations, client messages, external execution
@@ -318,9 +325,11 @@ flowchart LR
     Wave["lotus-manage rebalance wave\nDpmWaveReportInput"] --> Gateway
     Manage --> AI["lotus-ai\ndpm_pm_memo.pack@v1"]
     Wave --> WaveAI["lotus-ai\ndpm_wave_pm_memo.pack@v1"]
+    Exception["lotus-manage monitoring exceptions\nbounded exception evidence"] --> ExceptionAI["lotus-ai\ndpm_exception_summary.pack@v1"]
     Wave --> HandoffAI["lotus-ai\ndpm_operations_handoff_summary.pack@v1"]
     Gateway --> AI
     Gateway --> WaveAI
+    Gateway --> ExceptionAI
     Gateway --> HandoffAI
     Manage --> Memory["portfolio_memory_context\nsource-lineage only"]
     Memory --> AI
@@ -328,6 +337,7 @@ flowchart LR
     Memory --> HandoffAI
     AI --> Guardrails["Forbidden action,\nfield, output,\nand memory guardrails"]
     WaveAI --> Guardrails
+    ExceptionAI --> Guardrails
     HandoffAI --> Guardrails
     Guardrails --> RunLedger["Workflow-pack run ledger\nreview required"]
     RunLedger --> Consumers["Gateway / Workbench\nfuture PM memo surface"]

--- a/src/app/providers/dpm_exception_summary_stub.py
+++ b/src/app/providers/dpm_exception_summary_stub.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.portfolio_memory_context_guardrails import portfolio_memory_context_summary
+
+
+def build_dpm_exception_summary_stub_result(
+    *,
+    context_payload: dict[str, object],
+) -> tuple[str, dict[str, object]] | None:
+    exception_input = context_payload.get("exception_summary_input")
+    summary_request = context_payload.get("exception_summary_request")
+    supportability = context_payload.get("supportability")
+    if not isinstance(exception_input, dict) or not isinstance(summary_request, dict):
+        return None
+
+    exceptions = exception_input.get("exceptions")
+    requested_outputs = summary_request.get("requested_outputs")
+    portfolio_id = _as_str(exception_input.get("portfolio_id"))
+    mandate_id = _as_str(exception_input.get("mandate_id"))
+    content_hash = _as_str(exception_input.get("content_hash"))
+    exception_count = len(exceptions) if isinstance(exceptions, list) else 0
+    open_exception_count = _count_by_state(exceptions, "OPEN")
+    critical_exception_count = _count_by_severity(exceptions, "CRITICAL")
+    high_exception_count = _count_by_severity(exceptions, "HIGH")
+    portfolio_memory_summary = portfolio_memory_context_summary(context_payload)
+
+    message = (
+        "Drafted a review-gated DPM exception summary from bounded manage monitoring "
+        f"exception evidence for portfolio {portfolio_id}."
+    )
+    structured_output: dict[str, object] = {
+        "workflow_pack_family": "dpm_exception_summary",
+        "narrative_type": "dpm_exception_summary",
+        "state": "REVIEW_REQUIRED",
+        "scope": "support_only",
+        "portfolio_id": portfolio_id,
+        "mandate_id": mandate_id,
+        "exception_summary_content_hash": content_hash,
+        "requested_outputs": requested_outputs if isinstance(requested_outputs, list) else [],
+        "exception_count": exception_count,
+        "open_exception_count": open_exception_count,
+        "critical_exception_count": critical_exception_count,
+        "high_exception_count": high_exception_count,
+        **portfolio_memory_summary,
+        "unsupported_claims": _unsupported_claims(supportability),
+        "review_guidance": [
+            "Review the summary against the source exception evidence hash before operational use.",
+            "Do not treat this summary as PM scoring, approval, client communication, or order instruction.",
+            "Escalate missing source refs or stale exception posture instead of inferring status.",
+            "Use portfolio memory only as bounded lineage; do not reconstruct missing facts.",
+        ],
+    }
+    return message, structured_output
+
+
+def _count_by_state(exceptions: object, state: str) -> int:
+    if not isinstance(exceptions, list):
+        return 0
+    return sum(
+        1
+        for item in exceptions
+        if isinstance(item, dict) and isinstance(item.get("state"), str) and item["state"] == state
+    )
+
+
+def _count_by_severity(exceptions: object, severity: str) -> int:
+    if not isinstance(exceptions, list):
+        return 0
+    return sum(
+        1
+        for item in exceptions
+        if isinstance(item, dict)
+        and isinstance(item.get("severity"), str)
+        and item["severity"] == severity
+    )
+
+
+def _unsupported_claims(supportability: object) -> list[str]:
+    if not isinstance(supportability, dict):
+        return []
+    value = supportability.get("unsupported_claims")
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/src/app/providers/stub_text_provider.py
+++ b/src/app/providers/stub_text_provider.py
@@ -10,6 +10,7 @@ from app.contracts.providers import (
 )
 from app.providers.base import ProviderAdapterDescriptor
 from app.providers.advisor_brief_stub import build_advisor_brief_stub_result
+from app.providers.dpm_exception_summary_stub import build_dpm_exception_summary_stub_result
 from app.providers.outcome_review_narrative_stub import (
     build_outcome_review_narrative_stub_result,
 )
@@ -36,6 +37,42 @@ class StubTextProvider:
     )
 
     def execute(self, request: ProviderExecutionRequest) -> ProviderExecutionResponse:
+        dpm_exception_summary_result = build_dpm_exception_summary_stub_result(
+            context_payload=request.context_payload,
+        )
+        if request.task_id == "explain.v1" and dpm_exception_summary_result:
+            message, structured_output = dpm_exception_summary_result
+            return ProviderExecutionResponse(
+                provider_id=self.descriptor.provider_id,
+                provider_mode=settings.provider_mode,
+                adapter_kind=self.descriptor.adapter_kind,
+                failure_category=None,
+                timeout_ms=request.timeout_ms,
+                retry_count=0,
+                max_output_tokens=request.max_output_tokens,
+                stubbed=True,
+                message=message,
+                structured_output={
+                    **structured_output,
+                    "phase": settings.delivery_phase,
+                    "provider_id": self.descriptor.provider_id,
+                    "provider_mode": settings.provider_mode,
+                    "adapter_kind": self.descriptor.adapter_kind.value,
+                    "timeout_ms": request.timeout_ms,
+                    "retry_count": 0,
+                    "max_output_tokens": request.max_output_tokens,
+                    "output_label": request.output_label,
+                    "safety_mode": request.safety_mode,
+                    "redaction_posture": request.redaction_posture,
+                    "context_summary": request.context_summary,
+                    "context_keys": sorted(request.context_payload.keys()),
+                    "source_refs": request.source_refs,
+                    "stub_reason": (
+                        "lotus-ai emits deterministic governed DPM exception summary posture "
+                        "before live provider rollout is enabled for this workflow pack."
+                    ),
+                },
+            )
         operations_handoff_summary_result = build_operations_handoff_summary_stub_result(
             context_payload=request.context_payload,
         )

--- a/src/app/services/ai_surface_supportability.py
+++ b/src/app/services/ai_surface_supportability.py
@@ -59,6 +59,11 @@ _WORKFLOW_PACK_SURFACE_OWNERS = {
         "lotus-manage",
         "lotus-manage",
     ),
+    "dpm_exception_summary.pack@v1": (
+        "dpm_exception_summary",
+        "lotus-manage",
+        "lotus-manage",
+    ),
 }
 
 _PROMETHEUS_POSTURES = (

--- a/src/app/services/dpm_exception_summary_guardrails.py
+++ b/src/app/services/dpm_exception_summary_guardrails.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import HTTPException, status
+
+from app.services.portfolio_memory_context_guardrails import (
+    validate_optional_portfolio_memory_context,
+)
+from app.services.wave_pm_memo_guardrails import FORBIDDEN_FIELD_NAMES
+
+REQUIRED_EXCEPTION_SUMMARY_INPUT_KEYS = frozenset(
+    {
+        "contract_version",
+        "portfolio_id",
+        "mandate_id",
+        "as_of_date",
+        "generated_at",
+        "exception_count",
+        "exceptions",
+        "source_refs",
+        "redaction_policy",
+        "evidence_ref",
+        "content_hash",
+    }
+)
+
+REQUIRED_FORBIDDEN_ACTIONS = frozenset(
+    {
+        "approve_rebalance",
+        "contact_client",
+        "invent_missing_evidence",
+        "override_controls",
+        "place_orders",
+        "score_portfolio_manager",
+    }
+)
+
+FORBIDDEN_REQUESTED_OUTPUTS = frozenset(
+    {
+        "approval_decision",
+        "client_message",
+        "execution_instruction",
+        "order_ticket",
+        "place_orders",
+        "portfolio_manager_score",
+        "recommend_trade",
+        "rebalance_approval",
+        "routing_instruction",
+    }
+)
+
+ALLOWED_REQUESTED_OUTPUTS = frozenset(
+    {
+        "exception_summary",
+        "severity_summary",
+        "recommended_triage",
+        "support_references",
+        "evidence_gaps",
+    }
+)
+
+
+def validate_dpm_exception_summary_payload(payload: dict[str, object]) -> None:
+    exception_input = _require_object_section(payload, "exception_summary_input")
+    summary_request = _require_object_section(payload, "exception_summary_request")
+    supportability = _require_object_section(payload, "supportability")
+
+    missing = sorted(REQUIRED_EXCEPTION_SUMMARY_INPUT_KEYS.difference(exception_input.keys()))
+    if missing:
+        _reject("Missing exception summary input fields: " + ", ".join(missing))
+
+    forbidden_fields = sorted(_find_forbidden_field_names(exception_input))
+    if forbidden_fields:
+        _reject("Forbidden exception summary input fields present: " + ", ".join(forbidden_fields))
+
+    if exception_input.get("redaction_policy") != "NO_RAW_PAYLOADS":
+        _reject("Exception summary input must use NO_RAW_PAYLOADS redaction policy.")
+
+    exceptions = exception_input.get("exceptions")
+    if not isinstance(exceptions, list) or not exceptions:
+        _reject("Exception summary requires at least one bounded monitoring exception.")
+    bounded_exceptions = cast(list[object], exceptions)
+    if not all(_is_bounded_exception(item) for item in bounded_exceptions):
+        _reject(
+            "Each exception must carry exception_id, portfolio_id, severity, state, "
+            "reason_code, recommended_action, and source_refs."
+        )
+
+    declared_count = exception_input.get("exception_count")
+    if not isinstance(declared_count, int) or declared_count != len(bounded_exceptions):
+        _reject("exception_count must equal the number of supplied bounded exceptions.")
+
+    source_refs = exception_input.get("source_refs")
+    if not isinstance(source_refs, list) or not source_refs:
+        _reject("Exception summary input source_refs must be a non-empty list.")
+    bounded_source_refs = cast(list[object], source_refs)
+    if not all(
+        isinstance(ref, dict) and _has_required_ref_fields(ref) for ref in bounded_source_refs
+    ):
+        _reject("Exception summary input source_refs must be bounded and source-linked.")
+
+    evidence_ref = exception_input.get("evidence_ref")
+    if not isinstance(evidence_ref, dict) or not _has_required_ref_fields(evidence_ref):
+        _reject("Exception summary input evidence_ref must be bounded and source-linked.")
+
+    portfolio_id = exception_input.get("portfolio_id")
+    exception_portfolio_id = _single_portfolio_id(bounded_exceptions)
+    if not isinstance(portfolio_id, str) or portfolio_id != exception_portfolio_id:
+        _reject("Exception summary portfolio_id must match all supplied exceptions.")
+
+    requested_outputs = set(_require_string_list(summary_request, "requested_outputs"))
+    forbidden_outputs = sorted(FORBIDDEN_REQUESTED_OUTPUTS.intersection(requested_outputs))
+    if forbidden_outputs:
+        _reject("Forbidden exception summary outputs requested: " + ", ".join(forbidden_outputs))
+    unsupported_outputs = sorted(requested_outputs.difference(ALLOWED_REQUESTED_OUTPUTS))
+    if unsupported_outputs:
+        _reject(
+            "Unsupported exception summary outputs requested: " + ", ".join(unsupported_outputs)
+        )
+
+    forbidden_actions = set(_require_string_list(supportability, "forbidden_actions"))
+    missing_actions = sorted(REQUIRED_FORBIDDEN_ACTIONS.difference(forbidden_actions))
+    if missing_actions:
+        _reject("Missing required forbidden-action guardrails: " + ", ".join(missing_actions))
+
+    validate_optional_portfolio_memory_context(
+        payload=payload,
+        evidence_portfolio_id=exception_portfolio_id,
+        forbidden_field_names=FORBIDDEN_FIELD_NAMES,
+        reject=_reject,
+    )
+
+
+def _is_bounded_exception(item: object) -> bool:
+    if not isinstance(item, dict):
+        return False
+    required_string_keys = (
+        "exception_id",
+        "portfolio_id",
+        "severity",
+        "state",
+        "reason_code",
+        "recommended_action",
+    )
+    if not all(isinstance(item.get(key), str) and item[key] for key in required_string_keys):
+        return False
+    source_refs = item.get("source_refs")
+    return (
+        isinstance(source_refs, list)
+        and bool(source_refs)
+        and all(isinstance(ref, dict) and _has_required_ref_fields(ref) for ref in source_refs)
+    )
+
+
+def _has_required_ref_fields(ref: dict[str, object]) -> bool:
+    return all(
+        isinstance(ref.get(key), str) and ref[key]
+        for key in ("source_system", "source_type", "source_id", "content_hash")
+    )
+
+
+def _single_portfolio_id(items: list[object]) -> str | None:
+    portfolio_ids = {
+        item.get("portfolio_id")
+        for item in items
+        if isinstance(item, dict) and isinstance(item.get("portfolio_id"), str)
+    }
+    if len(portfolio_ids) == 1:
+        return next(iter(portfolio_ids))
+    return None
+
+
+def _require_object_section(payload: dict[str, object], key: str) -> dict[str, Any]:
+    section = payload.get(key)
+    if not isinstance(section, dict):
+        _reject(f"Exception summary payload requires object section `{key}`.")
+    return cast(dict[str, Any], section)
+
+
+def _require_string_list(section: dict[str, Any], key: str) -> list[str]:
+    value = section.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        _reject(f"Exception summary payload requires string-list field `{key}`.")
+    return cast(list[str], value)
+
+
+def _find_forbidden_field_names(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized = key.lower()
+            if normalized in FORBIDDEN_FIELD_NAMES:
+                found.add(normalized)
+            found.update(_find_forbidden_field_names(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.update(_find_forbidden_field_names(item))
+    return found
+
+
+def _reject(detail: str) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=f"DPM_EXCEPTION_SUMMARY_GUARDRAIL_BLOCKED: {detail}",
+    )

--- a/src/app/services/workflow_pack_bindings.py
+++ b/src/app/services/workflow_pack_bindings.py
@@ -8,6 +8,7 @@ from app.contracts.workflow_packs import (
 )
 from app.services.workflow_pack_phase1_specs import (
     ADVISOR_BRIEF_V1_SPEC,
+    DPM_EXCEPTION_SUMMARY_V1_SPEC,
     DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
@@ -82,6 +83,7 @@ _WORKFLOW_PACK_EXECUTION_BINDINGS = (
     _build_execution_binding_from_spec(OUTCOME_REVIEW_NARRATIVE_V1_SPEC),
     _build_execution_binding_from_spec(DPM_WAVE_PM_MEMO_V1_SPEC),
     _build_execution_binding_from_spec(DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC),
+    _build_execution_binding_from_spec(DPM_EXCEPTION_SUMMARY_V1_SPEC),
 )
 
 

--- a/src/app/services/workflow_pack_execution.py
+++ b/src/app/services/workflow_pack_execution.py
@@ -34,6 +34,9 @@ from app.services.workflow_pack_task_flow_service import (
     ensure_workflow_pack_task_flow_store_ready,
 )
 from app.services.workflow_pack_queue_admission import workflow_pack_queue_admission
+from app.services.dpm_exception_summary_guardrails import (
+    validate_dpm_exception_summary_payload,
+)
 from app.services.outcome_review_narrative_guardrails import (
     validate_outcome_review_narrative_payload,
 )
@@ -160,6 +163,8 @@ def validate_workflow_pack_execution_binding(
         validate_wave_pm_memo_payload(request.task_request.context.payload)
     if request.pack_id == "dpm_operations_handoff_summary.pack" and request.version == "v1":
         validate_operations_handoff_summary_payload(request.task_request.context.payload)
+    if request.pack_id == "dpm_exception_summary.pack" and request.version == "v1":
+        validate_dpm_exception_summary_payload(request.task_request.context.payload)
 
 
 def _attach_workflow_pack_run_id(

--- a/src/app/services/workflow_pack_phase1_specs.py
+++ b/src/app/services/workflow_pack_phase1_specs.py
@@ -157,3 +157,22 @@ DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC = WorkflowPackPhase1VersionSpec(
         {"wave_report_input", "handoff_summary_request", "supportability"}
     ),
 )
+
+
+DPM_EXCEPTION_SUMMARY_V1_SPEC = WorkflowPackPhase1VersionSpec(
+    pack_id="dpm_exception_summary.pack",
+    pack_family="dpm_exception_summary",
+    version="v1",
+    owner_repository="lotus-manage",
+    owner_service="lotus-manage",
+    truth_owner_services=("lotus-manage", "lotus-core", "lotus-risk", "lotus-performance"),
+    primary_use_case="dpm_exception_summary",
+    workflow_authority_owner="lotus-manage",
+    supported_callers=("lotus-manage", "lotus-gateway"),
+    surface_scope=("dpm-exception-summary-ai-evidence",),
+    default_workflow_surface="dpm-exception-summary-ai-evidence",
+    execution_task_id="explain.v1",
+    required_payload_keys=frozenset(
+        {"exception_summary_input", "exception_summary_request", "supportability"}
+    ),
+)

--- a/src/app/services/workflow_pack_queue_policy_catalog.py
+++ b/src/app/services/workflow_pack_queue_policy_catalog.py
@@ -24,6 +24,7 @@ from app.contracts.workflow_pack_queue_policies import (
 from app.config import settings
 from app.services.workflow_pack_phase1_specs import (
     ADVISOR_BRIEF_V1_SPEC,
+    DPM_EXCEPTION_SUMMARY_V1_SPEC,
     DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
@@ -46,6 +47,7 @@ def list_workflow_pack_queue_policy_descriptors() -> list[WorkflowPackQueuePolic
         _review_support_outcome_review_narrative_policy(),
         _review_support_wave_pm_memo_policy(),
         _review_support_operations_handoff_summary_policy(),
+        _review_support_dpm_exception_summary_policy(),
     ]
     _validate_queue_policy_identity(policies)
     return [policy.model_copy(deep=True) for policy in policies]
@@ -342,6 +344,29 @@ def _review_support_operations_handoff_summary_policy() -> WorkflowPackQueuePoli
         status_summary=[
             "DPM operations handoff summaries default to review-support capacity because generated text remains support-only and review-gated.",
             "Operator capacity is reserved for controlled investigation of guardrail-blocked, unavailable, or stale handoff-evidence posture.",
+        ],
+    )
+
+
+def _review_support_dpm_exception_summary_policy() -> WorkflowPackQueuePolicyDescriptor:
+    return _build_queue_policy(
+        spec=DPM_EXCEPTION_SUMMARY_V1_SPEC,
+        policy_id="queue-policy.dpm-exception-summary.v1",
+        allowed_lanes=[
+            WorkflowPackQueueLane.REVIEW_SUPPORT,
+            WorkflowPackQueueLane.OPERATOR,
+        ],
+        default_lane=WorkflowPackQueueLane.REVIEW_SUPPORT,
+        max_concurrent_runs_per_pack=2,
+        max_concurrent_runs_per_lane=1,
+        max_queued_runs_per_pack=25,
+        max_queued_runs_per_lane=10,
+        admission_timeout_seconds=20,
+        execution_timeout_seconds=300,
+        stale_queue_threshold_seconds=90,
+        status_summary=[
+            "DPM exception summaries default to review-support capacity because generated text remains support-only and review-gated.",
+            "Operator capacity is reserved for controlled investigation of guardrail-blocked, unavailable, or stale exception-evidence posture.",
         ],
     )
 

--- a/src/app/services/workflow_pack_registry_seed.py
+++ b/src/app/services/workflow_pack_registry_seed.py
@@ -14,6 +14,7 @@ from app.contracts.workflow_packs import (
 from app.services.workflow_pack_phase1_specs import (
     ADVISOR_BRIEF_V1_SPEC,
     ADVISOR_BRIEF_V2_SPEC,
+    DPM_EXCEPTION_SUMMARY_V1_SPEC,
     DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
@@ -300,6 +301,46 @@ def build_seed_workflow_pack_registrations() -> list[WorkflowPackRegistrationDes
             status_summary=[
                 "The DPM wave PM memo workflow pack consumes lotus-manage DpmWaveReportInput only.",
                 "Activation remains pilot-scoped while Gateway and Workbench add product-surface invocation, unavailable posture, and canonical live proof without reconstructing wave or proof-pack evidence.",
+            ],
+        ),
+        WorkflowPackRegistrationDescriptor(
+            pack_id=DPM_EXCEPTION_SUMMARY_V1_SPEC.pack_id,
+            pack_family=DPM_EXCEPTION_SUMMARY_V1_SPEC.pack_family,
+            version=DPM_EXCEPTION_SUMMARY_V1_SPEC.version,
+            owner_repository=DPM_EXCEPTION_SUMMARY_V1_SPEC.owner_repository,
+            owner_service=DPM_EXCEPTION_SUMMARY_V1_SPEC.owner_service,
+            truth_owner_services=list(DPM_EXCEPTION_SUMMARY_V1_SPEC.truth_owner_services),
+            primary_use_case=DPM_EXCEPTION_SUMMARY_V1_SPEC.primary_use_case,
+            workflow_authority_owner=DPM_EXCEPTION_SUMMARY_V1_SPEC.workflow_authority_owner,
+            default_execution_mode=WorkflowPackExecutionMode.REVIEW_GATED,
+            definition_ref="repo://lotus-manage/src/api/routers/monitoring.py",
+            definition_refs=_dpm_exception_summary_v1_definition_refs(),
+            compatibility_contract_version="workflow-pack-contract.v1",
+            registration_status=WorkflowPackRegistrationStatus.REGISTERED,
+            activation_state=WorkflowPackActivationState.PILOT,
+            registered_definition_digest="sha256:dpm-exception-summary-v1-registered-digest",
+            supported_callers=list(DPM_EXCEPTION_SUMMARY_V1_SPEC.supported_callers),
+            supported_identity_classes=[
+                WorkflowPackCallerIdentityClass.INTERNAL_SERVICE,
+            ],
+            supported_environments=[
+                WorkflowPackEnvironment.DEVELOPMENT,
+                WorkflowPackEnvironment.QA,
+                WorkflowPackEnvironment.UAT,
+            ],
+            tenant_scope=[],
+            surface_scope=list(DPM_EXCEPTION_SUMMARY_V1_SPEC.surface_scope),
+            default_rollout_stage="PILOT_SCOPED",
+            pause_state="NOT_PAUSED",
+            supersedes=None,
+            superseded_by=None,
+            registered_at="2026-05-12T08:00:00Z",
+            registered_by="lotus-ai.workflow-pack-registry.seed",
+            last_activated_at="2026-05-12T08:20:00Z",
+            last_changed_at="2026-05-12T08:20:00Z",
+            status_summary=[
+                "The DPM exception summary workflow pack consumes bounded lotus-manage monitoring exception evidence only.",
+                "Activation remains pilot-scoped while product invocation and any broader copilot workspace are implemented by their owners without reconstructing exception truth.",
             ],
         ),
         WorkflowPackRegistrationDescriptor(
@@ -754,6 +795,66 @@ def _dpm_operations_handoff_summary_v1_definition_refs() -> list[
             required_for_registration=False,
             description=(
                 "RFC-0043 defines governed operations handoff summary support, no-domain-decision "
+                "guardrails, review posture, and unavailable behavior."
+            ),
+        ),
+    ]
+
+
+def _dpm_exception_summary_v1_definition_refs() -> list[WorkflowPackDefinitionReferenceDescriptor]:
+    return [
+        _definition_ref(
+            reference_id="primary_contract",
+            repository="lotus-manage",
+            path="src/core/mandates.py",
+            reference_type=WorkflowPackDefinitionReferenceType.CONTRACT,
+            required_for_registration=True,
+            description=(
+                "Manage-owned monitoring exception models that bound exception identity, severity, "
+                "state, reason code, recommended action, and source lineage."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_service",
+            repository="lotus-manage",
+            path="src/api/services/monitoring_service.py",
+            reference_type=WorkflowPackDefinitionReferenceType.SERVICE,
+            required_for_registration=True,
+            description=(
+                "Manage service that materializes mandate monitoring runs and exception posture "
+                "without generating AI narrative locally."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_router",
+            repository="lotus-manage",
+            path="src/api/routers/monitoring.py",
+            reference_type=WorkflowPackDefinitionReferenceType.ROUTER,
+            required_for_registration=True,
+            description=(
+                "Manage API route exposing bounded mandate monitoring exception evidence for "
+                "downstream AI support summaries."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_tests",
+            repository="lotus-manage",
+            path="tests/unit/dpm/api/test_monitoring_api.py",
+            reference_type=WorkflowPackDefinitionReferenceType.TEST,
+            required_for_registration=True,
+            description=(
+                "Manage regression coverage proving monitoring exceptions remain source-linked, "
+                "bounded, and review-oriented."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_rfc",
+            repository="lotus-manage",
+            path="docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md",
+            reference_type=WorkflowPackDefinitionReferenceType.RFC,
+            required_for_registration=False,
+            description=(
+                "RFC-0043 defines governed exception-summary support, no-domain-decision "
                 "guardrails, review posture, and unavailable behavior."
             ),
         ),

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -97,8 +97,8 @@ def test_platform_workflow_pack_registry_contract(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 8
-    assert body["registered_count"] == 7
+    assert body["registration_count"] == 9
+    assert body["registered_count"] == 8
     assert any(
         registration["pack_id"] == "advisor_brief.pack"
         and registration["activation_state"] == "PILOT"
@@ -123,6 +123,12 @@ def test_platform_workflow_pack_registry_contract(client: TestClient) -> None:
     )
     assert any(
         registration["pack_id"] == "dpm_wave_pm_memo.pack"
+        and registration["owner_repository"] == "lotus-manage"
+        and registration["activation_state"] == "PILOT"
+        for registration in body["registrations"]
+    )
+    assert any(
+        registration["pack_id"] == "dpm_exception_summary.pack"
         and registration["owner_repository"] == "lotus-manage"
         and registration["activation_state"] == "PILOT"
         for registration in body["registrations"]
@@ -409,15 +415,16 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["workflow_pack_task_flow_store"]["status"] == "READY"
     assert body["workflow_pack_queue_event_store"]["mode"] == "memory"
     assert body["workflow_pack_queue_event_store"]["status"] == "READY"
-    assert body["workflow_pack_runtime"]["registration_count"] == 8
-    assert body["workflow_pack_runtime"]["registered_count"] == 7
-    assert body["workflow_pack_runtime"]["execution_binding_count"] == 7
-    assert body["workflow_pack_runtime"]["executable_registration_count"] == 7
-    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 7
+    assert body["workflow_pack_runtime"]["registration_count"] == 9
+    assert body["workflow_pack_runtime"]["registered_count"] == 8
+    assert body["workflow_pack_runtime"]["execution_binding_count"] == 8
+    assert body["workflow_pack_runtime"]["executable_registration_count"] == 8
+    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 8
     assert body["workflow_pack_runtime"]["executable_without_review_count"] == 0
     assert body["workflow_pack_runtime"]["registered_without_execution_binding_count"] == 0
     assert body["workflow_pack_runtime"]["executable_registration_refs"] == [
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -427,6 +434,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     ]
     assert body["workflow_pack_runtime"]["executable_review_required_refs"] == [
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -461,29 +469,33 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
         is None
     )
     assert body["workflow_pack_runtime"]["executable_activity"][1]["registration_ref"] == (
-        "dpm_operations_handoff_summary.pack@v1"
+        "dpm_exception_summary.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][1]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][2]["registration_ref"] == (
-        "dpm_pm_memo.pack@v1"
+        "dpm_operations_handoff_summary.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][2]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][3]["registration_ref"] == (
-        "dpm_wave_pm_memo.pack@v1"
+        "dpm_pm_memo.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][3]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][4]["registration_ref"] == (
-        "outcome_review_narrative.pack@v1"
+        "dpm_wave_pm_memo.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][4]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][5]["registration_ref"] == (
-        "twr_inspection_support_brief.pack@v1"
+        "outcome_review_narrative.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][5]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][6]["registration_ref"] == (
-        "workspace_rationale.pack@v1"
+        "twr_inspection_support_brief.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][6]["run_count"] == 0
+    assert body["workflow_pack_runtime"]["executable_activity"][7]["registration_ref"] == (
+        "workspace_rationale.pack@v1"
+    )
+    assert body["workflow_pack_runtime"]["executable_activity"][7]["run_count"] == 0
     assert (
         body["workflow_pack_runtime"]["executable_activity"][0]["latest_ready_provenance"] is None
     )

--- a/tests/integration/test_observability_api_contract.py
+++ b/tests/integration/test_observability_api_contract.py
@@ -8,8 +8,8 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["domain_count"] == 6
-    assert body["ai_surface_supportability"]["supported_surface_count"] == 7
-    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 7
+    assert body["ai_surface_supportability"]["supported_surface_count"] == 8
+    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 8
     assert (
         body["ai_surface_supportability"]["metric_name"] == "lotus_ai_surface_supportability_state"
     )
@@ -18,6 +18,7 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
         surface["workflow_pack_ref"] for surface in body["ai_surface_supportability"]["surfaces"]
     } == {
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -25,6 +26,12 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
+    assert any(
+        surface["surface_id"] == "dpm_exception_summary"
+        and surface["owning_service"] == "lotus-manage"
+        and surface["workflow_authority_owner"] == "lotus-manage"
+        for surface in body["ai_surface_supportability"]["surfaces"]
+    )
     assert any(
         surface["surface_id"] == "dpm_operations_handoff_summary"
         and surface["owning_service"] == "lotus-manage"

--- a/tests/integration/test_workflow_pack_queue_policy_api_contract.py
+++ b/tests/integration/test_workflow_pack_queue_policy_api_contract.py
@@ -28,7 +28,7 @@ def test_workflow_pack_queue_policy_catalog_route(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["service"] == "lotus-ai"
-    assert body["policy_count"] == 7
+    assert body["policy_count"] == 8
     advisor_policy = next(
         policy
         for policy in body["policies"]
@@ -80,6 +80,15 @@ def test_workflow_pack_queue_policy_catalog_route(client: TestClient) -> None:
     )
     assert operations_handoff_policy["default_lane"] == "REVIEW_SUPPORT"
     assert operations_handoff_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
+    exception_summary_policy = next(
+        policy
+        for policy in body["policies"]
+        if policy["workflow_pack_id"] == "dpm_exception_summary.pack"
+        and policy["workflow_pack_version"] == "v1"
+    )
+    assert exception_summary_policy["policy_id"] == "queue-policy.dpm-exception-summary.v1"
+    assert exception_summary_policy["default_lane"] == "REVIEW_SUPPORT"
+    assert exception_summary_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
 
 
 def test_workflow_pack_queue_policy_detail_route(client: TestClient) -> None:

--- a/tests/integration/test_workflow_pack_registry_api_contract.py
+++ b/tests/integration/test_workflow_pack_registry_api_contract.py
@@ -13,8 +13,8 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 8
-    assert body["registered_count"] == 7
+    assert body["registration_count"] == 9
+    assert body["registered_count"] == 8
     assert body["production_eligible_count"] == 0
     advisor_brief_registration = next(
         registration
@@ -45,6 +45,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         registration
         for registration in body["registrations"]
         if registration["pack_id"] == "dpm_operations_handoff_summary.pack"
+    )
+    dpm_exception_summary_registration = next(
+        registration
+        for registration in body["registrations"]
+        if registration["pack_id"] == "dpm_exception_summary.pack"
     )
     advisor_brief_binding = next(
         binding
@@ -81,6 +86,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         for binding in body["execution_bindings"]
         if binding["pack_id"] == "dpm_operations_handoff_summary.pack"
     )
+    dpm_exception_summary_binding = next(
+        binding
+        for binding in body["execution_bindings"]
+        if binding["pack_id"] == "dpm_exception_summary.pack"
+    )
     advisor_brief_queue_policy = next(
         policy
         for policy in body["queue_policies"]
@@ -111,6 +121,12 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         if policy["workflow_pack_id"] == "dpm_operations_handoff_summary.pack"
         and policy["workflow_pack_version"] == "v1"
     )
+    dpm_exception_summary_queue_policy = next(
+        policy
+        for policy in body["queue_policies"]
+        if policy["workflow_pack_id"] == "dpm_exception_summary.pack"
+        and policy["workflow_pack_version"] == "v1"
+    )
 
     assert advisor_brief_registration["registration_status"] == "REGISTERED"
     assert advisor_brief_registration["activation_state"] == "PILOT"
@@ -139,6 +155,13 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     assert operations_handoff_summary_registration["owner_repository"] == "lotus-manage"
     assert operations_handoff_summary_registration["workflow_authority_owner"] == "lotus-manage"
     assert operations_handoff_summary_registration["supported_callers"] == [
+        "lotus-manage",
+        "lotus-gateway",
+    ]
+    assert dpm_exception_summary_registration["version"] == "v1"
+    assert dpm_exception_summary_registration["owner_repository"] == "lotus-manage"
+    assert dpm_exception_summary_registration["workflow_authority_owner"] == "lotus-manage"
+    assert dpm_exception_summary_registration["supported_callers"] == [
         "lotus-manage",
         "lotus-gateway",
     ]
@@ -204,6 +227,16 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         "supportability",
         "wave_report_input",
     ]
+    assert dpm_exception_summary_binding["version"] == "v1"
+    assert dpm_exception_summary_binding["task_id"] == "explain.v1"
+    assert dpm_exception_summary_binding["default_workflow_surface"] == (
+        "dpm-exception-summary-ai-evidence"
+    )
+    assert dpm_exception_summary_binding["required_payload_keys"] == [
+        "exception_summary_input",
+        "exception_summary_request",
+        "supportability",
+    ]
     assert advisor_brief_queue_policy["default_lane"] == "LATENCY_SENSITIVE"
     assert advisor_brief_queue_policy["allowed_lanes"] == [
         "LATENCY_SENSITIVE",
@@ -222,6 +255,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     assert wave_pm_memo_queue_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
     assert operations_handoff_summary_queue_policy["default_lane"] == "REVIEW_SUPPORT"
     assert operations_handoff_summary_queue_policy["allowed_lanes"] == [
+        "REVIEW_SUPPORT",
+        "OPERATOR",
+    ]
+    assert dpm_exception_summary_queue_policy["default_lane"] == "REVIEW_SUPPORT"
+    assert dpm_exception_summary_queue_policy["allowed_lanes"] == [
         "REVIEW_SUPPORT",
         "OPERATOR",
     ]
@@ -284,6 +322,24 @@ def test_workflow_pack_default_version_route_resolves_operations_handoff_pack_de
         "handoff_summary_request",
         "supportability",
         "wave_report_input",
+    ]
+    assert body["queue_policy"]["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
+
+
+def test_workflow_pack_default_version_route_resolves_dpm_exception_pack_default(
+    client: TestClient,
+) -> None:
+    response = client.get("/platform/workflow-packs/registry/dpm_exception_summary.pack/default")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["default_registration_ref"] == "dpm_exception_summary.pack@v1"
+    assert body["registration"]["owner_repository"] == "lotus-manage"
+    assert body["registration"]["workflow_authority_owner"] == "lotus-manage"
+    assert body["execution_binding"]["required_payload_keys"] == [
+        "exception_summary_input",
+        "exception_summary_request",
+        "supportability",
     ]
     assert body["queue_policy"]["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
 

--- a/tests/integration/test_workflow_pack_run_api_contract.py
+++ b/tests/integration/test_workflow_pack_run_api_contract.py
@@ -18,6 +18,7 @@ from tests.support.runtime_settings import override_runtime_settings
 from tests.support.workflow_pack_fixtures import (
     advisor_brief_task_execution_request_json,
     advisor_brief_workflow_pack_execution_request_json,
+    dpm_exception_summary_workflow_pack_execution_request_json,
     outcome_review_narrative_workflow_pack_execution_request_json,
     proof_pack_pm_memo_workflow_pack_execution_request_json,
     twr_inspection_support_brief_workflow_pack_execution_request_json,
@@ -481,6 +482,54 @@ def test_workflow_pack_execute_route_records_wave_pm_memo_run(
     assert structured_output["wave_report_content_hash"] == "sha256:wave-report-input-001"
     assert structured_output["proof_pack_ref_count"] == 1
     _assert_task_flow_recorded_for_run(client=client, run_id=body["workflow_pack_run"]["run_id"])
+
+
+def test_workflow_pack_execute_route_records_dpm_exception_summary_run(
+    client: TestClient,
+) -> None:
+    execute_response = client.post(
+        "/platform/workflow-packs/execute",
+        json=dpm_exception_summary_workflow_pack_execution_request_json(
+            correlation_id="corr-dpm-exception-summary-pack-001"
+        ),
+    )
+
+    assert execute_response.status_code == 200
+    body = execute_response.json()
+    structured_output = body["execution"]["result"]["structured_output"]
+    assert body["eligibility"]["allowed"] is True
+    assert body["execution"]["status"] == "COMPLETED"
+    assert body["workflow_pack_run"]["pack_id"] == "dpm_exception_summary.pack"
+    assert body["workflow_pack_run"]["registration_ref"] == "dpm_exception_summary.pack@v1"
+    assert body["workflow_pack_run"]["caller_app"] == "lotus-manage"
+    assert body["workflow_pack_run"]["workflow_surface"] == "dpm-exception-summary-ai-evidence"
+    assert body["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert body["execution"]["audit"]["workflow_pack_run_id"] == body["workflow_pack_run"]["run_id"]
+    assert structured_output["workflow_pack_family"] == "dpm_exception_summary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "support_only"
+    assert structured_output["exception_count"] == 2
+    assert structured_output["open_exception_count"] == 2
+    _assert_task_flow_recorded_for_run(client=client, run_id=body["workflow_pack_run"]["run_id"])
+
+
+def test_workflow_pack_execute_route_blocks_dpm_exception_summary_forbidden_output(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/platform/workflow-packs/execute",
+        json=dpm_exception_summary_workflow_pack_execution_request_json(
+            correlation_id="corr-dpm-exception-summary-blocked-output-001",
+            requested_outputs=["exception_summary", "portfolio_manager_score"],
+        ),
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert "DPM_EXCEPTION_SUMMARY_GUARDRAIL_BLOCKED" in body["detail"]
+    assert (
+        "Forbidden exception summary outputs requested: portfolio_manager_score" in body["detail"]
+    )
 
 
 def test_workflow_pack_execute_route_blocks_wave_pm_memo_execution_claim(

--- a/tests/support/workflow_pack_fixtures.py
+++ b/tests/support/workflow_pack_fixtures.py
@@ -852,3 +852,155 @@ def operations_handoff_summary_workflow_pack_execution_request_json(
     if workflow_surface is not None:
         request["workflow_surface"] = workflow_surface
     return request
+
+
+def dpm_exception_summary_payload(
+    *,
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001",
+    content_hash: str = "sha256:dpm-exception-summary-input-001",
+    requested_outputs: list[str] | None = None,
+    include_portfolio_memory_context: bool = False,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "exception_summary_input": {
+            "contract_version": "1.0",
+            "portfolio_id": portfolio_id,
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "as_of_date": "2026-05-12",
+            "generated_at": "2026-05-12T08:00:00Z",
+            "exception_count": 2,
+            "exceptions": [
+                {
+                    "exception_id": "dpm_exception_001",
+                    "portfolio_id": portfolio_id,
+                    "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+                    "severity": "HIGH",
+                    "state": "OPEN",
+                    "reason_code": "CASH_LIQUIDITY_ATTENTION",
+                    "recommended_action": "REVIEW_WITH_PM",
+                    "detected_at": "2026-05-12T07:50:00Z",
+                    "source_refs": [
+                        {
+                            "source_system": "lotus-manage",
+                            "source_type": "DPM_MONITORING_EXCEPTION",
+                            "source_id": "dpm_exception_001",
+                            "content_hash": "sha256:dpm-exception-001",
+                        }
+                    ],
+                },
+                {
+                    "exception_id": "dpm_exception_002",
+                    "portfolio_id": portfolio_id,
+                    "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+                    "severity": "MEDIUM",
+                    "state": "OPEN",
+                    "reason_code": "BENCHMARK_DRIFT_REVIEW",
+                    "recommended_action": "CHECK_SOURCE_EVIDENCE",
+                    "detected_at": "2026-05-12T07:55:00Z",
+                    "source_refs": [
+                        {
+                            "source_system": "lotus-manage",
+                            "source_type": "DPM_MONITORING_EXCEPTION",
+                            "source_id": "dpm_exception_002",
+                            "content_hash": "sha256:dpm-exception-002",
+                        }
+                    ],
+                },
+            ],
+            "source_refs": [
+                {
+                    "source_system": "lotus-manage",
+                    "source_type": "DPM_EXCEPTION_SUMMARY_INPUT",
+                    "source_id": f"{portfolio_id}:dpm_exception_summary_input",
+                    "content_hash": content_hash,
+                }
+            ],
+            "redaction_policy": "NO_RAW_PAYLOADS",
+            "evidence_ref": {
+                "source_system": "lotus-manage",
+                "source_type": "DPM_EXCEPTION_SUMMARY_INPUT",
+                "source_id": f"{portfolio_id}:dpm_exception_summary_input",
+                "content_hash": content_hash,
+            },
+            "content_hash": content_hash,
+        },
+        "exception_summary_request": {
+            "requested_outputs": requested_outputs
+            or [
+                "exception_summary",
+                "severity_summary",
+                "recommended_triage",
+                "support_references",
+                "evidence_gaps",
+            ],
+            "audience": ["portfolio_manager", "investment_control", "operations"],
+        },
+        "supportability": {
+            "source_state": "READY",
+            "requires_human_review": True,
+            "forbidden_actions": [
+                "approve_rebalance",
+                "contact_client",
+                "invent_missing_evidence",
+                "override_controls",
+                "place_orders",
+                "score_portfolio_manager",
+            ],
+            "unsupported_claims": [
+                "trade_approval",
+                "order_instruction",
+                "client_message",
+                "portfolio_manager_scoring",
+            ],
+        },
+    }
+    if include_portfolio_memory_context:
+        payload["portfolio_memory_context"] = portfolio_memory_context_payload(
+            portfolio_id=portfolio_id
+        )
+    return payload
+
+
+def dpm_exception_summary_workflow_pack_execution_request_json(
+    *,
+    correlation_id: str,
+    task_id: str = "explain.v1",
+    caller_app: str = "lotus-manage",
+    workflow_surface: str | None = "dpm-exception-summary-ai-evidence",
+    environment: str = "DEVELOPMENT",
+    caller_identity_class: str = "INTERNAL_SERVICE",
+    requested_outputs: list[str] | None = None,
+    include_portfolio_memory_context: bool = False,
+) -> dict[str, object]:
+    request: dict[str, object] = {
+        "pack_id": "dpm_exception_summary.pack",
+        "version": "v1",
+        "environment": environment,
+        "caller_identity_class": caller_identity_class,
+        "task_request": {
+            "task_id": task_id,
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": caller_app,
+                "correlation_id": correlation_id,
+                "tenant_id": "tenant-sg-001",
+            },
+            "context": {
+                "summary": (
+                    "Generate review-gated DPM exception summary from bounded monitoring evidence."
+                ),
+                "payload": dpm_exception_summary_payload(
+                    requested_outputs=requested_outputs,
+                    include_portfolio_memory_context=include_portfolio_memory_context,
+                ),
+                "source_refs": [
+                    "lotus-manage:monitoring-exception:dpm_exception_001",
+                    "lotus-manage:monitoring-exception:dpm_exception_002",
+                ],
+            },
+            "expected_output_label": "EXPLANATION_ONLY",
+        },
+    }
+    if workflow_surface is not None:
+        request["workflow_surface"] = workflow_surface
+    return request

--- a/tests/unit/test_ai_surface_supportability.py
+++ b/tests/unit/test_ai_surface_supportability.py
@@ -33,15 +33,16 @@ def test_ai_surface_supportability_summary_is_source_backed_and_bounded() -> Non
     summary = build_ai_surface_supportability_summary()
 
     assert summary.posture == ObservabilityPosture.DEGRADED
-    assert summary.supported_surface_count == 7
-    assert summary.executable_workflow_pack_count == 7
-    assert summary.action_required_surface_count == 7
+    assert summary.supported_surface_count == 8
+    assert summary.executable_workflow_pack_count == 8
+    assert summary.action_required_surface_count == 8
     assert summary.unavailable_surface_count == 0
     assert summary.no_sensitive_content_telemetry is False
     assert summary.metric_name == "lotus_ai_surface_supportability_state"
     assert summary.metric_labels == list(AI_SURFACE_SUPPORTABILITY_METRIC_LABELS)
     assert {item.surface_id: item.owning_service for item in summary.surfaces} == {
         "advisor_brief": "lotus-advise",
+        "dpm_exception_summary": "lotus-manage",
         "dpm_operations_handoff_summary": "lotus-manage",
         "dpm_pm_memo": "lotus-manage",
         "dpm_wave_pm_memo": "lotus-manage",

--- a/tests/unit/test_dpm_exception_summary_guardrails.py
+++ b/tests/unit/test_dpm_exception_summary_guardrails.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import HTTPException
+
+from app.providers.dpm_exception_summary_stub import build_dpm_exception_summary_stub_result
+from app.services.dpm_exception_summary_guardrails import (
+    validate_dpm_exception_summary_payload,
+)
+from tests.support.workflow_pack_fixtures import dpm_exception_summary_payload
+
+
+def _assert_guardrail_blocks(payload: dict[str, object], expected_detail: str) -> None:
+    try:
+        validate_dpm_exception_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "DPM_EXCEPTION_SUMMARY_GUARDRAIL_BLOCKED" in str(exc.detail)
+        assert expected_detail in str(exc.detail)
+    else:
+        raise AssertionError("expected exception summary guardrail block")
+
+
+def test_dpm_exception_summary_guardrails_accept_bounded_exception_evidence() -> None:
+    validate_dpm_exception_summary_payload(dpm_exception_summary_payload())
+
+
+def test_dpm_exception_summary_guardrails_accept_bounded_portfolio_memory_context() -> None:
+    validate_dpm_exception_summary_payload(
+        dpm_exception_summary_payload(include_portfolio_memory_context=True)
+    )
+
+
+def test_dpm_exception_summary_guardrails_block_missing_required_input_section() -> None:
+    payload = dpm_exception_summary_payload()
+    payload.pop("exception_summary_input")
+
+    _assert_guardrail_blocks(payload, "requires object section `exception_summary_input`")
+
+
+def test_dpm_exception_summary_guardrails_block_unbounded_exception_rows() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["exceptions"][0].pop("source_refs")
+
+    _assert_guardrail_blocks(payload, "Each exception must carry")
+
+
+def test_dpm_exception_summary_guardrails_block_count_mismatch() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["exception_count"] = 99
+
+    _assert_guardrail_blocks(payload, "exception_count must equal")
+
+
+def test_dpm_exception_summary_guardrails_block_unbounded_top_level_source_refs() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["source_refs"] = [{"source_system": "lotus-manage"}]
+
+    _assert_guardrail_blocks(payload, "source_refs must be bounded and source-linked")
+
+
+def test_dpm_exception_summary_guardrails_block_portfolio_mismatch() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["exceptions"][0]["portfolio_id"] = "OTHER_PORTFOLIO"
+
+    _assert_guardrail_blocks(payload, "portfolio_id must match all supplied exceptions")
+
+
+def test_dpm_exception_summary_guardrails_block_forbidden_requested_outputs() -> None:
+    payload = dpm_exception_summary_payload(
+        requested_outputs=["exception_summary", "client_message"]
+    )
+
+    _assert_guardrail_blocks(payload, "Forbidden exception summary outputs requested")
+
+
+def test_dpm_exception_summary_guardrails_block_unsupported_requested_outputs() -> None:
+    payload = dpm_exception_summary_payload(
+        requested_outputs=["exception_summary", "marketing_copy"]
+    )
+
+    _assert_guardrail_blocks(payload, "Unsupported exception summary outputs requested")
+
+
+def test_dpm_exception_summary_guardrails_require_forbidden_actions() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["supportability"]["forbidden_actions"].remove("score_portfolio_manager")
+
+    _assert_guardrail_blocks(payload, "Missing required forbidden-action guardrails")
+
+
+def test_dpm_exception_summary_guardrails_block_raw_payload_policy() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["redaction_policy"] = "RAW_PAYLOADS_ALLOWED"
+
+    _assert_guardrail_blocks(payload, "NO_RAW_PAYLOADS")
+
+
+def test_dpm_exception_summary_guardrails_block_mismatched_portfolio_memory_context() -> None:
+    payload = cast(
+        dict[str, Any],
+        dpm_exception_summary_payload(include_portfolio_memory_context=True),
+    )
+    payload["portfolio_memory_context"]["portfolio_id"] = "OTHER_PORTFOLIO"
+
+    _assert_guardrail_blocks(payload, "portfolio_id must match")
+
+
+def test_dpm_exception_summary_stub_returns_review_gated_support_only_output() -> None:
+    result = build_dpm_exception_summary_stub_result(
+        context_payload=dpm_exception_summary_payload(include_portfolio_memory_context=True)
+    )
+
+    assert result is not None
+    message, structured_output = result
+    assert "review-gated DPM exception summary" in message
+    assert structured_output["workflow_pack_family"] == "dpm_exception_summary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "support_only"
+    assert structured_output["exception_count"] == 2
+    assert structured_output["open_exception_count"] == 2
+    assert structured_output["high_exception_count"] == 1
+    assert structured_output["portfolio_memory_event_count"] == 2
+    unsupported_claims = cast(list[str], structured_output["unsupported_claims"])
+    assert "portfolio_manager_scoring" in unsupported_claims

--- a/tests/unit/test_dpm_exception_summary_guardrails.py
+++ b/tests/unit/test_dpm_exception_summary_guardrails.py
@@ -46,6 +46,13 @@ def test_dpm_exception_summary_guardrails_block_unbounded_exception_rows() -> No
     _assert_guardrail_blocks(payload, "Each exception must carry")
 
 
+def test_dpm_exception_summary_guardrails_block_empty_exceptions() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["exceptions"] = []
+
+    _assert_guardrail_blocks(payload, "requires at least one bounded monitoring exception")
+
+
 def test_dpm_exception_summary_guardrails_block_count_mismatch() -> None:
     payload = cast(dict[str, Any], dpm_exception_summary_payload())
     payload["exception_summary_input"]["exception_count"] = 99
@@ -58,6 +65,20 @@ def test_dpm_exception_summary_guardrails_block_unbounded_top_level_source_refs(
     payload["exception_summary_input"]["source_refs"] = [{"source_system": "lotus-manage"}]
 
     _assert_guardrail_blocks(payload, "source_refs must be bounded and source-linked")
+
+
+def test_dpm_exception_summary_guardrails_block_empty_top_level_source_refs() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["source_refs"] = []
+
+    _assert_guardrail_blocks(payload, "source_refs must be a non-empty list")
+
+
+def test_dpm_exception_summary_guardrails_block_unbounded_evidence_ref() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["evidence_ref"] = {"source_system": "lotus-manage"}
+
+    _assert_guardrail_blocks(payload, "evidence_ref must be bounded and source-linked")
 
 
 def test_dpm_exception_summary_guardrails_block_portfolio_mismatch() -> None:
@@ -97,6 +118,27 @@ def test_dpm_exception_summary_guardrails_block_raw_payload_policy() -> None:
     _assert_guardrail_blocks(payload, "NO_RAW_PAYLOADS")
 
 
+def test_dpm_exception_summary_guardrails_block_nested_forbidden_fields() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_input"]["diagnostics"] = [{"raw_payload": {"unsafe": True}}]
+
+    _assert_guardrail_blocks(payload, "Forbidden exception summary input fields present")
+
+
+def test_dpm_exception_summary_guardrails_require_string_requested_outputs() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["exception_summary_request"]["requested_outputs"] = ["exception_summary", 7]
+
+    _assert_guardrail_blocks(payload, "requires string-list field `requested_outputs`")
+
+
+def test_dpm_exception_summary_guardrails_require_string_forbidden_actions() -> None:
+    payload = cast(dict[str, Any], dpm_exception_summary_payload())
+    payload["supportability"]["forbidden_actions"] = ["place_orders", 7]
+
+    _assert_guardrail_blocks(payload, "requires string-list field `forbidden_actions`")
+
+
 def test_dpm_exception_summary_guardrails_block_mismatched_portfolio_memory_context() -> None:
     payload = cast(
         dict[str, Any],
@@ -124,3 +166,32 @@ def test_dpm_exception_summary_stub_returns_review_gated_support_only_output() -
     assert structured_output["portfolio_memory_event_count"] == 2
     unsupported_claims = cast(list[str], structured_output["unsupported_claims"])
     assert "portfolio_manager_scoring" in unsupported_claims
+
+
+def test_dpm_exception_summary_stub_handles_malformed_optional_sections() -> None:
+    assert build_dpm_exception_summary_stub_result(context_payload={}) is None
+
+    result = build_dpm_exception_summary_stub_result(
+        context_payload={
+            "exception_summary_input": {
+                "portfolio_id": 101,
+                "mandate_id": None,
+                "content_hash": None,
+                "exceptions": "not-a-list",
+            },
+            "exception_summary_request": {"requested_outputs": "exception_summary"},
+            "supportability": {"unsupported_claims": "not-a-list"},
+        }
+    )
+
+    assert result is not None
+    _message, structured_output = result
+    assert structured_output["portfolio_id"] == ""
+    assert structured_output["mandate_id"] == ""
+    assert structured_output["exception_summary_content_hash"] == ""
+    assert structured_output["requested_outputs"] == []
+    assert structured_output["exception_count"] == 0
+    assert structured_output["open_exception_count"] == 0
+    assert structured_output["critical_exception_count"] == 0
+    assert structured_output["high_exception_count"] == 0
+    assert structured_output["unsupported_claims"] == []

--- a/tests/unit/test_observability_runtime.py
+++ b/tests/unit/test_observability_runtime.py
@@ -6,13 +6,14 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
 
     assert status.service == "lotus-ai"
     assert status.domain_count == 6
-    assert status.ai_surface_supportability.supported_surface_count == 7
-    assert status.ai_surface_supportability.executable_workflow_pack_count == 7
+    assert status.ai_surface_supportability.supported_surface_count == 8
+    assert status.ai_surface_supportability.executable_workflow_pack_count == 8
     assert status.ai_surface_supportability.no_sensitive_content_telemetry is False
     assert status.ai_surface_supportability.metric_name == "lotus_ai_surface_supportability_state"
     assert status.ai_surface_supportability.metric_labels == ["surface", "posture", "source"]
     assert {surface.workflow_pack_ref for surface in status.ai_surface_supportability.surfaces} == {
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -20,6 +21,12 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
+    assert any(
+        surface.surface_id == "dpm_exception_summary"
+        and surface.owning_service == "lotus-manage"
+        and surface.workflow_authority_owner == "lotus-manage"
+        for surface in status.ai_surface_supportability.surfaces
+    )
     assert any(
         surface.surface_id == "dpm_operations_handoff_summary"
         and surface.owning_service == "lotus-manage"

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -63,15 +63,16 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.access_control_store_mode == "memory"
     assert status.workflow_pack_registry_store_mode == "memory"
     assert status.workflow_pack_task_flow_store_mode == "memory"
-    assert status.workflow_pack_runtime.registration_count == 8
-    assert status.workflow_pack_runtime.registered_count == 7
-    assert status.workflow_pack_runtime.execution_binding_count == 7
-    assert status.workflow_pack_runtime.executable_registration_count == 7
-    assert status.workflow_pack_runtime.executable_review_required_count == 7
+    assert status.workflow_pack_runtime.registration_count == 9
+    assert status.workflow_pack_runtime.registered_count == 8
+    assert status.workflow_pack_runtime.execution_binding_count == 8
+    assert status.workflow_pack_runtime.executable_registration_count == 8
+    assert status.workflow_pack_runtime.executable_review_required_count == 8
     assert status.workflow_pack_runtime.executable_without_review_count == 0
     assert status.workflow_pack_runtime.registered_without_execution_binding_count == 0
     assert status.workflow_pack_runtime.executable_registration_refs == [
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -81,6 +82,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     ]
     assert status.workflow_pack_runtime.executable_review_required_refs == [
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -88,9 +90,10 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
-    assert len(status.workflow_pack_runtime.executable_activity) == 7
+    assert len(status.workflow_pack_runtime.executable_activity) == 8
     assert [item.registration_ref for item in status.workflow_pack_runtime.executable_activity] == [
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -139,9 +142,9 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.observability_runtime.domain_count == 6
     assert status.observability_runtime.unavailable_domain_count == 0
     assert status.observability_runtime.incident_evidence_supported_domain_count >= 1
-    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 7
+    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 8
     assert (
-        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 7
+        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 8
     )
     assert (
         status.observability_runtime.ai_surface_supportability.no_sensitive_content_telemetry
@@ -151,6 +154,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         item.surface_id for item in status.observability_runtime.ai_surface_supportability.surfaces
     } == {
         "advisor_brief",
+        "dpm_exception_summary",
         "dpm_operations_handoff_summary",
         "dpm_pm_memo",
         "dpm_wave_pm_memo",

--- a/tests/unit/test_portfolio_memory_context_guardrails.py
+++ b/tests/unit/test_portfolio_memory_context_guardrails.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+
+from app.services.portfolio_memory_context_guardrails import (
+    portfolio_memory_context_summary,
+    validate_optional_portfolio_memory_context,
+)
+from tests.support.workflow_pack_fixtures import portfolio_memory_context_payload
+
+
+class PortfolioMemoryRejected(Exception):
+    pass
+
+
+def _reject(detail: str) -> None:
+    raise PortfolioMemoryRejected(detail)
+
+
+def _payload_with_context(context: object) -> dict[str, object]:
+    return {"portfolio_memory_context": context}
+
+
+def _assert_rejected(context: object, expected_detail: str) -> None:
+    try:
+        validate_optional_portfolio_memory_context(
+            payload=_payload_with_context(context),
+            evidence_portfolio_id="PB_SG_GLOBAL_BAL_001",
+            forbidden_field_names=frozenset({"raw_payload", "client_id"}),
+            reject=_reject,
+        )
+    except PortfolioMemoryRejected as exc:
+        assert expected_detail in str(exc)
+    else:
+        raise AssertionError("expected portfolio-memory guardrail rejection")
+
+
+def test_portfolio_memory_context_guardrails_accept_absent_context() -> None:
+    assert (
+        validate_optional_portfolio_memory_context(
+            payload={},
+            evidence_portfolio_id="PB_SG_GLOBAL_BAL_001",
+            forbidden_field_names=frozenset(),
+            reject=_reject,
+        )
+        is None
+    )
+
+
+def test_portfolio_memory_context_guardrails_block_malformed_context_shapes() -> None:
+    _assert_rejected("not-an-object", "must be an object")
+
+    missing_context = portfolio_memory_context_payload()
+    missing_context.pop("content_hash")
+    _assert_rejected(missing_context, "Missing portfolio_memory_context fields")
+
+    forbidden_context = portfolio_memory_context_payload()
+    forbidden_context["nested"] = [{"raw_payload": {"unsafe": True}}]
+    _assert_rejected(forbidden_context, "Forbidden portfolio memory fields present")
+
+
+def test_portfolio_memory_context_guardrails_block_invalid_identity_and_counts() -> None:
+    wrong_portfolio = portfolio_memory_context_payload(portfolio_id="OTHER_PORTFOLIO")
+    _assert_rejected(wrong_portfolio, "portfolio_id must match")
+
+    missing_hash = portfolio_memory_context_payload()
+    missing_hash["content_hash"] = ""
+    _assert_rejected(missing_hash, "requires a source content_hash")
+
+    invalid_count = portfolio_memory_context_payload()
+    invalid_count["event_count"] = -1
+    _assert_rejected(invalid_count, "event_count must be a non-negative integer")
+
+
+def test_portfolio_memory_context_guardrails_block_invalid_governance() -> None:
+    invalid_sources = portfolio_memory_context_payload()
+    invalid_sources["source_systems"] = ["lotus-manage", 99]
+    _assert_rejected(invalid_sources, "requires string-list field `source_systems`")
+
+    invalid_reasons = portfolio_memory_context_payload()
+    invalid_reasons["reason_codes"] = "PORTFOLIO_MEMORY_READY"
+    _assert_rejected(invalid_reasons, "requires string-list field `reason_codes`")
+
+    missing_governance = portfolio_memory_context_payload()
+    missing_governance["governance_policy"] = {}
+    _assert_rejected(
+        missing_governance, "Missing portfolio_memory_context governance_policy fields"
+    )
+
+    invalid_governance = portfolio_memory_context_payload()
+    governance = invalid_governance["governance_policy"]
+    assert isinstance(governance, dict)
+    governance["redaction_policy"] = "RAW_PAYLOADS_ALLOWED"
+    _assert_rejected(invalid_governance, "must enforce NO_RAW_PAYLOADS")
+
+    missing_authority = portfolio_memory_context_payload()
+    governance = missing_authority["governance_policy"]
+    assert isinstance(governance, dict)
+    governance["source_authority_policy"] = "source owned"
+    _assert_rejected(missing_authority, "must carry source-authority")
+
+
+def test_portfolio_memory_context_guardrails_block_invalid_event_refs() -> None:
+    non_list_refs = portfolio_memory_context_payload()
+    non_list_refs["event_refs"] = "not-a-list"
+    _assert_rejected(non_list_refs, "event_refs must be a list")
+
+    non_object_ref = portfolio_memory_context_payload()
+    non_object_ref["event_refs"] = ["not-an-object"]
+    _assert_rejected(non_object_ref, "event_refs[0] must be an object")
+
+    missing_ref_fields = portfolio_memory_context_payload()
+    missing_ref_fields["event_refs"] = [{}]
+    _assert_rejected(missing_ref_fields, "Missing portfolio_memory_context event_refs[0] fields")
+
+    raw_ref = portfolio_memory_context_payload()
+    event_refs = raw_ref["event_refs"]
+    assert isinstance(event_refs, list)
+    first_ref = event_refs[0]
+    assert isinstance(first_ref, dict)
+    first_ref["redaction_policy"] = "RAW_PAYLOADS_ALLOWED"
+    _assert_rejected(raw_ref, "event_refs[0] must enforce NO_RAW_PAYLOADS")
+
+
+def test_portfolio_memory_context_summary_handles_unbounded_shapes() -> None:
+    assert portfolio_memory_context_summary({}) == {
+        "portfolio_memory_status": "not_supplied",
+        "portfolio_memory_content_hash": "",
+        "portfolio_memory_event_count": 0,
+        "portfolio_memory_event_ref_count": 0,
+        "portfolio_memory_source_systems": [],
+        "portfolio_memory_event_types": [],
+        "portfolio_memory_supportability_state": "",
+    }
+
+    summary = portfolio_memory_context_summary(
+        {
+            "portfolio_memory_context": {
+                "content_hash": "sha256:test",
+                "event_count": 1,
+                "source_systems": ["lotus-manage", 7],
+                "event_refs": [{"event_type": "DPM_EXCEPTION"}, {"event_type": 42}, "bad-ref"],
+                "supportability_state": "READY",
+            }
+        }
+    )
+
+    assert summary["portfolio_memory_status"] == "supplied"
+    assert summary["portfolio_memory_source_systems"] == ["lotus-manage"]
+    assert summary["portfolio_memory_event_types"] == ["DPM_EXCEPTION"]
+
+    malformed_summary = portfolio_memory_context_summary(
+        {
+            "portfolio_memory_context": {
+                "event_refs": "not-a-list",
+                "source_systems": "lotus-manage",
+            }
+        }
+    )
+    assert malformed_summary["portfolio_memory_event_ref_count"] == 0
+    assert malformed_summary["portfolio_memory_event_types"] == []
+    assert malformed_summary["portfolio_memory_source_systems"] == []

--- a/tests/unit/test_workflow_pack_execution.py
+++ b/tests/unit/test_workflow_pack_execution.py
@@ -7,6 +7,7 @@ from app.services.workflow_pack_execution import (
 )
 from app.services.workflow_pack_bindings import get_workflow_pack_execution_binding
 from tests.support.workflow_pack_fixtures import (
+    dpm_exception_summary_workflow_pack_execution_request_json,
     operations_handoff_summary_workflow_pack_execution_request_json,
     outcome_review_narrative_workflow_pack_execution_request_json,
     proof_pack_pm_memo_workflow_pack_execution_request_json,
@@ -218,6 +219,51 @@ def test_execute_workflow_pack_records_review_gated_operations_handoff_summary()
     assert structured_output["wave_report_content_hash"] == "sha256:wave-report-input-001"
     assert structured_output["handoff_ref_count"] == 1
     assert structured_output["external_execution_claimed"] is False
+
+
+def test_execute_workflow_pack_records_review_gated_dpm_exception_summary() -> None:
+    request = WorkflowPackExecutionRequest.model_validate(
+        dpm_exception_summary_workflow_pack_execution_request_json(
+            correlation_id="corr-execution-dpm-exception-summary"
+        )
+    )
+
+    response = execute_workflow_pack(request)
+
+    structured_output = response.execution.result.structured_output
+    assert response.execution.status.value == "COMPLETED"
+    assert response.workflow_pack_run.pack_id == "dpm_exception_summary.pack"
+    assert response.workflow_pack_run.workflow_authority_owner == "lotus-manage"
+    assert structured_output["workflow_pack_family"] == "dpm_exception_summary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "support_only"
+    assert structured_output["exception_summary_content_hash"] == (
+        "sha256:dpm-exception-summary-input-001"
+    )
+    assert structured_output["exception_count"] == 2
+
+
+def test_validate_workflow_pack_execution_binding_runs_dpm_exception_summary_guardrails() -> None:
+    request_payload = dpm_exception_summary_workflow_pack_execution_request_json(
+        correlation_id="corr-execution-dpm-exception-summary-guardrail",
+        requested_outputs=["exception_summary", "client_message"],
+    )
+    request = WorkflowPackExecutionRequest.model_validate(request_payload)
+    binding = get_workflow_pack_execution_binding(
+        pack_id="dpm_exception_summary.pack",
+        version="v1",
+    )
+    assert binding is not None
+
+    try:
+        validate_workflow_pack_execution_binding(request=request, binding=binding)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden exception summary outputs requested: client_message" in str(exc.detail)
+    else:
+        raise AssertionError(
+            "expected exception summary guardrails to reject client-message output"
+        )
 
 
 def test_validate_workflow_pack_execution_binding_runs_operations_handoff_guardrails() -> None:

--- a/tests/unit/test_workflow_pack_queue_policy_catalog.py
+++ b/tests/unit/test_workflow_pack_queue_policy_catalog.py
@@ -18,6 +18,7 @@ def test_queue_policy_catalog_declares_policy_for_each_executable_phase1_pack() 
     }
     assert policy_refs == {
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",

--- a/tests/unit/test_workflow_pack_registry.py
+++ b/tests/unit/test_workflow_pack_registry.py
@@ -26,8 +26,8 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
 
     assert catalog.service == "lotus-ai"
     assert catalog.phase == "foundation"
-    assert catalog.registration_count == 8
-    assert catalog.registered_count == 7
+    assert catalog.registration_count == 9
+    assert catalog.registered_count == 8
     assert catalog.production_eligible_count == 0
     advisor_brief_registration = next(
         registration
@@ -63,6 +63,11 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         registration
         for registration in catalog.registrations
         if registration.pack_id == "dpm_operations_handoff_summary.pack"
+    )
+    dpm_exception_summary_registration = next(
+        registration
+        for registration in catalog.registrations
+        if registration.pack_id == "dpm_exception_summary.pack"
     )
     assert (
         advisor_brief_registration.registration_status == WorkflowPackRegistrationStatus.REGISTERED
@@ -149,8 +154,23 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         and definition_ref.required_for_registration is True
         for definition_ref in operations_handoff_summary_registration.definition_refs
     )
-    assert len(catalog.execution_bindings) == 7
-    assert len(catalog.queue_policies) == 7
+    assert dpm_exception_summary_registration.registration_status == (
+        WorkflowPackRegistrationStatus.REGISTERED
+    )
+    assert dpm_exception_summary_registration.owner_repository == "lotus-manage"
+    assert dpm_exception_summary_registration.workflow_authority_owner == "lotus-manage"
+    assert dpm_exception_summary_registration.supported_callers == [
+        "lotus-manage",
+        "lotus-gateway",
+    ]
+    assert any(
+        definition_ref.repository == "lotus-manage"
+        and definition_ref.path == "src/core/mandates.py"
+        and definition_ref.required_for_registration is True
+        for definition_ref in dpm_exception_summary_registration.definition_refs
+    )
+    assert len(catalog.execution_bindings) == 8
+    assert len(catalog.queue_policies) == 8
     assert any(
         binding.pack_id == "advisor_brief.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
@@ -183,6 +203,10 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
     )
     assert any(
         binding.pack_id == "dpm_operations_handoff_summary.pack" and binding.task_id == "explain.v1"
+        for binding in catalog.execution_bindings
+    )
+    assert any(
+        binding.pack_id == "dpm_exception_summary.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
     )
 
@@ -314,6 +338,19 @@ def test_build_operations_handoff_summary_registration_detail_exposes_manage_own
     assert detail.execution_binding.default_workflow_surface == (
         "dpm-operations-handoff-ai-evidence"
     )
+
+
+def test_build_dpm_exception_summary_registration_detail_exposes_manage_owned_binding() -> None:
+    detail = build_workflow_pack_registration_detail(
+        pack_id="dpm_exception_summary.pack",
+        version="v1",
+    )
+
+    assert detail.registration.owner_repository == "lotus-manage"
+    assert detail.registration.workflow_authority_owner == "lotus-manage"
+    assert detail.execution_binding is not None
+    assert detail.execution_binding.task_id == "explain.v1"
+    assert detail.execution_binding.default_workflow_surface == "dpm-exception-summary-ai-evidence"
 
 
 def test_build_workflow_pack_registration_detail_rejects_unknown_registration() -> None:

--- a/tests/unit/test_workflow_pack_registry_store.py
+++ b/tests/unit/test_workflow_pack_registry_store.py
@@ -70,6 +70,7 @@ def test_workflow_pack_registry_store_returns_sqlalchemy_repository(tmp_path: Pa
     assert [f"{registration.pack_id}@{registration.version}" for registration in registrations] == [
         "advisor_brief.pack@v1",
         "advisor_brief.pack@v2",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",

--- a/tests/unit/test_workflow_pack_runtime_status.py
+++ b/tests/unit/test_workflow_pack_runtime_status.py
@@ -248,14 +248,15 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
 ):
     summary = build_workflow_pack_runtime_status_summary()
 
-    assert summary.registration_count == 8
-    assert summary.registered_count == 7
-    assert summary.execution_binding_count == 7
-    assert summary.executable_registration_count == 7
-    assert summary.executable_review_required_count == 7
+    assert summary.registration_count == 9
+    assert summary.registered_count == 8
+    assert summary.execution_binding_count == 8
+    assert summary.executable_registration_count == 8
+    assert summary.executable_review_required_count == 8
     assert summary.registered_without_execution_binding_count == 0
     assert summary.executable_registration_refs == [
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
@@ -265,6 +266,7 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
     ]
     assert summary.executable_review_required_refs == [
         "advisor_brief.pack@v1",
+        "dpm_exception_summary.pack@v1",
         "dpm_operations_handoff_summary.pack@v1",
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -41,24 +41,26 @@ It does not own portfolio, performance, risk, advisory, management, or reporting
 
 ## Workflow-Pack Product Coverage
 
-Current executable workflow-pack coverage is implementation-backed for seven pilot-scoped families:
+Current executable workflow-pack coverage is implementation-backed for eight pilot-scoped families:
 
 1. `advisor_brief.pack@v1`
 2. `workspace_rationale.pack@v1`
 3. `twr_inspection_support_brief.pack@v1`
 4. `dpm_pm_memo.pack@v1`
 5. `dpm_wave_pm_memo.pack@v1`
-6. `dpm_operations_handoff_summary.pack@v1`
-7. `outcome_review_narrative.pack@v1`
+6. `dpm_exception_summary.pack@v1`
+7. `dpm_operations_handoff_summary.pack@v1`
+8. `outcome_review_narrative.pack@v1`
 
 The DPM packs are deliberately support-only and review-gated. `dpm_pm_memo.pack@v1` consumes
 `lotus-manage` `DpmProofPackAiEvidenceInput`; `dpm_wave_pm_memo.pack@v1` and
 `dpm_operations_handoff_summary.pack@v1` consume `lotus-manage` `DpmWaveReportInput`;
-`outcome_review_narrative.pack@v1` consumes `lotus-manage` `DpmOutcomeAiEvidenceInput`. These
-packs can also consume optional manage-owned `portfolio_memory_context` as bounded source lineage.
-They validate forbidden actions, forbidden fields, requested output scope, portfolio-memory
-redaction/source-authority posture, run-ledger posture, and source evidence before generated
-narrative can be treated as usable support.
+`dpm_exception_summary.pack@v1` consumes bounded `lotus-manage` monitoring exception evidence; and
+`outcome_review_narrative.pack@v1` consumes `lotus-manage` `DpmOutcomeAiEvidenceInput`. The
+proof-pack, wave, handoff, and outcome packs can also consume optional manage-owned
+`portfolio_memory_context` as bounded source lineage. They validate forbidden actions, forbidden
+fields, requested output scope, portfolio-memory redaction/source-authority posture, run-ledger
+posture, and source evidence before generated narrative can be treated as usable support.
 
 ## Supported Task Families
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -166,11 +166,12 @@ the owner-facing procedure and do one more truth check before treating a registr
 
 ## DPM PM Memo Integration
 
-`dpm_pm_memo.pack@v1`, `dpm_wave_pm_memo.pack@v1`, and
+`dpm_pm_memo.pack@v1`, `dpm_wave_pm_memo.pack@v1`, `dpm_exception_summary.pack@v1`, and
 `dpm_operations_handoff_summary.pack@v1` are the current `lotus-ai` owner-side execution contracts
-for governed DPM support drafting from Manage evidence. The proof-pack pack is for single proof-pack
-evidence, the wave pack is for rebalance-wave PM memo evidence, and the operations pack is for
-bounded internal handoff evidence that may summarize staged wave items and handoff refs.
+for governed DPM support drafting from Manage evidence. The proof-pack pack is for single
+proof-pack evidence, the wave pack is for rebalance-wave PM memo evidence, the exception pack is
+for bounded monitoring exception evidence, and the operations pack is for bounded internal handoff
+evidence that may summarize staged wave items and handoff refs.
 
 Use it only when the caller supplies:
 
@@ -213,6 +214,18 @@ The wave pack additionally blocks external-execution claims and requires non-emp
 bounded wave items, proof-pack posture, and `NO_RAW_PAYLOADS` redaction before run, audit, or
 task-flow records are written.
 
+Use `dpm_exception_summary.pack@v1` only when the caller supplies:
+
+1. `exception_summary_input` from manage-owned monitoring exception evidence,
+2. bounded source refs with source system, content hash, and no raw payloads,
+3. `exception_summary_request` with allowed requested outputs such as `exception_summary`,
+   `severity_summary`, `recommended_triage`, `support_references`, or `evidence_gaps`,
+4. `supportability` posture with required forbidden actions and unsupported claims.
+
+The exception pack blocks rebalance approval, order instructions, client messages, PM scoring,
+control overrides, and invented missing exception evidence before run, audit, or task-flow records
+are written.
+
 Use `dpm_operations_handoff_summary.pack@v1` only when the caller supplies:
 
 1. `wave_report_input` shaped as `lotus-manage` `DpmWaveReportInput`,
@@ -233,7 +246,7 @@ sequenceDiagram
     participant AI as lotus-ai
     participant Ledger as workflow-pack ledger
     participant UI as Gateway / Workbench
-    Manage->>AI: DPM memo, wave memo, or operations handoff pack with bounded evidence
+    Manage->>AI: DPM memo, wave memo, exception summary, or operations handoff pack with bounded evidence
     AI->>AI: Validate forbidden actions, fields, requested outputs, and memory lineage
     AI->>Ledger: Record review-gated run after guardrails pass
     Ledger-->>AI: workflow_pack_run_id and provenance

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -184,7 +184,12 @@ For AI-backed product-surface support, also confirm:
    guardrail-blocked requests. Missing handoff refs, malformed handoff refs, empty wave items, or
    non-`NO_RAW_PAYLOADS` redaction indicate caller contract defects that must be fixed at the
    source evidence boundary.
-9. `outcome_review_narrative` remains owned by `lotus-manage` evidence contracts; treat PM scoring,
+9. `dpm_exception_summary` remains owned by `lotus-manage` monitoring exception evidence
+   contracts; treat rebalance approvals, order instructions, client messages, PM scoring, control
+   overrides, and invented missing exception evidence as guardrail-blocked requests. Missing source
+   refs, malformed source refs, empty exception sets, or non-`NO_RAW_PAYLOADS` redaction indicate
+   caller contract defects that must be fixed at the source evidence boundary.
+10. `outcome_review_narrative` remains owned by `lotus-manage` evidence contracts; treat PM scoring,
    client messages, trade approvals, control overrides, and invented missing evidence as
    guardrail-blocked requests, not as prompt-tuning opportunities. Optional portfolio-memory
    lineage can support review and demo provenance, but it must not be used to infer missing source

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -131,8 +131,10 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
    `workspace_rationale.pack`, `twr_inspection_support_brief.pack`, the review-gated
    `dpm_pm_memo.pack` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the
    review-gated `dpm_wave_pm_memo.pack` and `dpm_operations_handoff_summary.pack` contracts for
-   `lotus-manage` `DpmWaveReportInput`, and the review-gated `outcome_review_narrative.pack` contract for `lotus-manage`
-   `DpmOutcomeAiEvidenceInput`. DPM proof-pack PM memo execution validates required proof-pack
+   `lotus-manage` `DpmWaveReportInput`, the review-gated `dpm_exception_summary.pack` contract
+   for bounded `lotus-manage` monitoring exception evidence, and the review-gated
+   `outcome_review_narrative.pack` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`.
+   DPM proof-pack PM memo execution validates required proof-pack
    evidence, required forbidden actions, forbidden field names, forbidden requested outputs such as
    trade recommendations or client messages, and unsupported requested outputs before run, audit,
    or task-flow posture is recorded. DPM wave PM memo execution validates required wave report
@@ -140,8 +142,10 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
    no-external-execution posture, forbidden actions, forbidden fields, and requested outputs before
    side effects are recorded. DPM operations handoff summary execution additionally requires
    non-empty bounded handoff refs and blocks order tickets, routing instructions, execution
-   instructions, external-execution claims, and inferred missing handoff evidence. Outcome-review
-   narrative execution validates required forbidden
+   instructions, external-execution claims, and inferred missing handoff evidence. DPM exception
+   summary execution validates bounded exception evidence, source refs, `NO_RAW_PAYLOADS`, required
+   forbidden actions, forbidden fields, and requested outputs before side effects are recorded.
+   Outcome-review narrative execution validates required forbidden
    actions, rejects forbidden field names, rejects forbidden requested outputs such as PM scoring or
    client messages, records run and task-flow posture only after those guardrails pass, and remains
    support-only until Gateway and Workbench surfaces consume the contract. The DPM packs can
@@ -153,6 +157,7 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
 flowchart LR
     ProofPack["lotus-manage\nDpmProofPackAiEvidenceInput"] --> MemoPack["dpm_pm_memo.pack@v1"]
     Wave["lotus-manage\nDpmWaveReportInput"] --> WavePack["dpm_wave_pm_memo.pack@v1"]
+    Exception["lotus-manage\nmonitoring exception evidence"] --> ExceptionPack["dpm_exception_summary.pack@v1"]
     Wave --> HandoffPack["dpm_operations_handoff_summary.pack@v1"]
     Outcome["lotus-manage\nDpmOutcomeAiEvidenceInput"] --> OutcomePack["outcome_review_narrative.pack@v1"]
     Memory["lotus-manage\nportfolio_memory_context"] --> MemoPack
@@ -161,6 +166,7 @@ flowchart LR
     Memory --> OutcomePack
     MemoPack --> Guardrails["lotus-ai guardrails\nfields / actions / outputs / memory"]
     WavePack --> Guardrails
+    ExceptionPack --> Guardrails
     HandoffPack --> Guardrails
     OutcomePack --> Guardrails
     Guardrails --> Ledger["Run ledger\nreview required"]


### PR DESCRIPTION
## Summary
- Adds `dpm_exception_summary.pack@v1` as a review-gated, support-only workflow pack for bounded `lotus-manage` monitoring exception evidence.
- Wires registry seed/default resolution, execution binding, queue policy, deterministic stub output, guardrails, run-ledger behavior, observability supportability, and SQL registry-store expectations.
- Updates README, repository context, integration guide, and repo-local wiki source so operator/product documentation reflects the eighth executable workflow-pack surface.

## Validation
- `python -m pytest tests/unit/test_dpm_exception_summary_guardrails.py tests/unit/test_workflow_pack_execution.py tests/unit/test_workflow_pack_registry.py tests/unit/test_workflow_pack_registry_store.py tests/unit/test_workflow_pack_queue_policy_catalog.py tests/unit/test_ai_surface_supportability.py tests/unit/test_observability_runtime.py tests/unit/test_platform_status.py tests/unit/test_workflow_pack_runtime_status.py tests/integration/test_workflow_pack_registry_api_contract.py tests/integration/test_workflow_pack_run_api_contract.py tests/integration/test_workflow_pack_queue_policy_api_contract.py tests/integration/test_observability_api_contract.py tests/integration/test_health.py -q` -> `180 passed`
- `make check` -> ruff, format check, mypy, OpenAPI, eval/async artifact validation, migration SQL, runtime-mode smoke, and `1165 passed` unit tests
- Live API probe on `127.0.0.1:8011`:
  - default registry resolves `dpm_exception_summary.pack@v1`
  - valid execution returns `COMPLETED`, `AWAITING_REVIEW`, `exception_count=2`, `scope=support_only`
  - forbidden `client_message` requested output returns `422 DPM_EXCEPTION_SUMMARY_GUARDRAIL_BLOCKED`
  - observability runtime reports `supported_surface_count=8`, `executable_workflow_pack_count=8`, and includes `dpm_exception_summary`
- `git diff --check` -> no whitespace errors
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> no unmerged remote branch output at time of check

## Wiki
Repo-local wiki source changed. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai` reports expected drift for `Home.md`, `Integrations.md`, `Operations-Runbook.md`, and `Platform-Surfaces.md` until this PR is merged and published from main.
