### PR TITLE
fix(ai): return newest workflow task flows first

### DIFF
--- a/src/app/services/workflow_pack_task_flow_service.py
+++ b/src/app/services/workflow_pack_task_flow_service.py
@@ -148,14 +148,16 @@ def build_workflow_pack_task_flow_catalog(
     limit: int = 100,
 ) -> WorkflowPackTaskFlowCatalogResponse:
     task_flows = list_task_flows()
-    filtered = _filter_task_flows(
-        task_flows,
-        workflow_pack_id=workflow_pack_id,
-        caller=caller,
-        tenant_id=tenant_id,
-        workflow_surface=workflow_surface,
-        flow_status=flow_status,
-        supportability_status=supportability_status,
+    filtered = _sort_task_flows_newest_first(
+        _filter_task_flows(
+            task_flows,
+            workflow_pack_id=workflow_pack_id,
+            caller=caller,
+            tenant_id=tenant_id,
+            workflow_surface=workflow_surface,
+            flow_status=flow_status,
+            supportability_status=supportability_status,
+        )
     )[:limit]
     return WorkflowPackTaskFlowCatalogResponse(
         service=settings.service_name,
@@ -180,6 +182,41 @@ def build_workflow_pack_task_flow_catalog(
             limit=limit,
         ),
         task_flows=filtered,
+    )
+
+
+def _filter_task_flows(
+    task_flows: list[WorkflowPackTaskFlowDescriptor],
+    *,
+    workflow_pack_id: str | None,
+    caller: str | None,
+    tenant_id: str | None,
+    workflow_surface: str | None,
+    flow_status: WorkflowPackTaskFlowStatus | None,
+    supportability_status: WorkflowPackRunSupportabilityStatus | None,
+) -> list[WorkflowPackTaskFlowDescriptor]:
+    return [
+        task_flow
+        for task_flow in task_flows
+        if (workflow_pack_id is None or task_flow.workflow_pack_id == workflow_pack_id)
+        and (caller is None or task_flow.caller == caller)
+        and (tenant_id is None or task_flow.tenant_id == tenant_id)
+        and (workflow_surface is None or task_flow.workflow_surface == workflow_surface)
+        and (flow_status is None or task_flow.flow_status == flow_status)
+        and (
+            supportability_status is None
+            or task_flow.supportability_status == supportability_status
+        )
+    ]
+
+
+def _sort_task_flows_newest_first(
+    task_flows: list[WorkflowPackTaskFlowDescriptor],
+) -> list[WorkflowPackTaskFlowDescriptor]:
+    return sorted(
+        task_flows,
+        key=lambda task_flow: (task_flow.updated_at, task_flow.created_at, task_flow.task_flow_id),
+        reverse=True,
     )
 
 
@@ -257,31 +294,6 @@ def synchronize_task_flow_review_action(
         if replacement_run_id is not None and replacement_run_id in task_flow.run_refs:
             updated = _with_review_lineage(task_flow, lineage=lineage)
             task_flow_store.save_task_flow(WorkflowPackTaskFlowRecord(descriptor=updated))
-
-
-def _filter_task_flows(
-    task_flows: list[WorkflowPackTaskFlowDescriptor],
-    *,
-    workflow_pack_id: str | None,
-    caller: str | None,
-    tenant_id: str | None,
-    workflow_surface: str | None,
-    flow_status: WorkflowPackTaskFlowStatus | None,
-    supportability_status: WorkflowPackRunSupportabilityStatus | None,
-) -> list[WorkflowPackTaskFlowDescriptor]:
-    return [
-        task_flow
-        for task_flow in task_flows
-        if (workflow_pack_id is None or task_flow.workflow_pack_id == workflow_pack_id)
-        and (caller is None or task_flow.caller == caller)
-        and (tenant_id is None or task_flow.tenant_id == tenant_id)
-        and (workflow_surface is None or task_flow.workflow_surface == workflow_surface)
-        and (flow_status is None or task_flow.flow_status == flow_status)
-        and (
-            supportability_status is None
-            or task_flow.supportability_status == supportability_status
-        )
-    ]
 
 
 def _filters_applied(

--- a/tests/integration/test_workflow_pack_task_flow_api_contract.py
+++ b/tests/integration/test_workflow_pack_task_flow_api_contract.py
@@ -46,9 +46,7 @@ def test_workflow_pack_task_flow_catalog_limits_newest_flows_first(client: TestC
                     "created_at": timestamp,
                     "run_refs": [f"run-00{index}"],
                     "runtime_states": {f"run-00{index}": WorkflowPackRunRuntimeState.STAGED},
-                    "review_states": {
-                        f"run-00{index}": WorkflowPackRunReviewState.AWAITING_REVIEW
-                    },
+                    "review_states": {f"run-00{index}": WorkflowPackRunReviewState.AWAITING_REVIEW},
                 }
             )
         )

--- a/tests/integration/test_workflow_pack_task_flow_api_contract.py
+++ b/tests/integration/test_workflow_pack_task_flow_api_contract.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from app.contracts.workflow_pack_runs import WorkflowPackRunReviewState, WorkflowPackRunRuntimeState
 from app.contracts.workflow_pack_task_flows import WorkflowPackTaskFlowStatus
 from app.main import app
 from app.services.workflow_pack_task_flow_service import (
@@ -31,6 +32,36 @@ def test_workflow_pack_task_flow_catalog_starts_empty(client: TestClient) -> Non
     assert body["terminal_count"] == 0
     assert body["filters_applied"] == {"limit": 100}
     assert body["task_flows"] == []
+
+
+def test_workflow_pack_task_flow_catalog_limits_newest_flows_first(client: TestClient) -> None:
+    for index in range(3):
+        timestamp = f"2026-04-21T01:0{index}:00Z"
+        create_task_flow(
+            workflow_pack_task_flow_descriptor(
+                task_flow_id=f"task-flow-00{index}",
+                updated_at=timestamp,
+            ).model_copy(
+                update={
+                    "created_at": timestamp,
+                    "run_refs": [f"run-00{index}"],
+                    "runtime_states": {f"run-00{index}": WorkflowPackRunRuntimeState.STAGED},
+                    "review_states": {
+                        f"run-00{index}": WorkflowPackRunReviewState.AWAITING_REVIEW
+                    },
+                }
+            )
+        )
+
+    response = client.get("/platform/workflow-packs/task-flows", params={"limit": 2})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [flow["task_flow_id"] for flow in body["task_flows"]] == [
+        "task-flow-002",
+        "task-flow-001",
+    ]
+    assert "task-flow-000" not in {flow["task_flow_id"] for flow in body["task_flows"]}
 
 
 def test_workflow_pack_task_flow_catalog_detail_and_checkpoints(


### PR DESCRIPTION
## Summary
- Return workflow-pack task-flow catalog results newest-first before applying the limit.
- Preserve existing filtering semantics while making bounded Gateway lookups include newly-created replacement task flows in long-running runtimes.
- Add regression coverage for limit ordering.

## Evidence
- `python -m pytest tests/integration/test_workflow_pack_task_flow_api_contract.py tests/integration/test_workflow_pack_run_api_contract.py::test_workflow_pack_run_review_action_revise_links_replacement_lineage -q` -> 7 passed
- `python -m pytest tests/unit/test_advisor_brief_service.py tests/integration/test_workbench_router.py::test_workbench_performance_advisor_brief_router tests/integration/test_workbench_router.py::test_workbench_performance_advisor_brief_review_action_router -q` -> 19 passed from Gateway against the contract path
- Rebuilt/restarted local `lotus-ai`; Workbench live validation moved past the original Advisor Brief revise task-flow identity failure