### PR TITLE
Add PM quality summary workflow pack

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -39,7 +39,7 @@ Current repository posture:
    executable workflow-pack families (`advisor_brief.pack`, `workspace_rationale.pack`,
    `twr_inspection_support_brief.pack`, `dpm_pm_memo.pack`, `dpm_wave_pm_memo.pack`,
    `dpm_exception_summary.pack`, `dpm_operations_handoff_summary.pack`, and
-   `outcome_review_narrative.pack`), with runtime state
+   `outcome_review_narrative.pack`, and `pm_quality_summary.pack`), with runtime state
    kept separate from review state,
    bounded actor-attributed review transitions available through the ledger API, bounded
    ledger-compatible `allowed_review_actions` emitted for consumers, governed workflow-pack
@@ -60,7 +60,10 @@ Current repository posture:
    before run/audit/task-flow side effects, and deterministic
    outcome-review narrative guardrails that validate manage-owned `DpmOutcomeAiEvidenceInput`,
    required forbidden actions, forbidden fields, forbidden requested outputs, and optional
-   source-lineage-only `portfolio_memory_context` before run/audit/task-flow side effects. The
+   source-lineage-only `portfolio_memory_context`, and deterministic PM quality summary guardrails
+   that validate Manage-owned `PmOperatingQualityScoreRun` evidence, required non-use guardrails,
+   source refs, bounded requested outputs, and optional source-lineage-only
+   `portfolio_memory_context` before run/audit/task-flow side effects. The
    portfolio-memory context is consumed only as bounded lineage with matching portfolio identity,
    `NO_RAW_PAYLOADS` redaction, capped event refs, source content hash, and explicit
    no-reconstruction source-authority policy; generated outputs expose compact lineage summaries

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -312,6 +312,12 @@ That sequence keeps downstream adoption pack-oriented first, while still preserv
    instructions, execution instructions, trade recommendations, client messages, external execution
    claims, control override, or invented missing handoff evidence are guardrail-blocked before
    execution and should be corrected at the source evidence boundary.
+9. Use `pm_quality_summary.pack@v1` only with Manage-owned `PmOperatingQualityScoreRun` evidence,
+   a bounded `summary_request`, supportability posture, source refs, and optional manage-owned
+   `portfolio_memory_context`. Requests for PM ranking, HR ratings, compensation recommendations,
+   conduct actions, client messages, trade approvals, execution instructions, or invented missing
+   score-run evidence are guardrail-blocked before execution and should be corrected at the source
+   evidence boundary.
 
 When supplied, `portfolio_memory_context` is lineage context, not a source-fact replacement. It must
 match the AI-evidence portfolio id, carry source-owned governance including `NO_RAW_PAYLOADS` and a
@@ -327,6 +333,7 @@ flowchart LR
     Wave --> WaveAI["lotus-ai\ndpm_wave_pm_memo.pack@v1"]
     Exception["lotus-manage monitoring exceptions\nbounded exception evidence"] --> ExceptionAI["lotus-ai\ndpm_exception_summary.pack@v1"]
     Wave --> HandoffAI["lotus-ai\ndpm_operations_handoff_summary.pack@v1"]
+    PMQ["lotus-manage\nPmOperatingQualityScoreRun"] --> PMQAI["lotus-ai\npm_quality_summary.pack@v1"]
     Gateway --> AI
     Gateway --> WaveAI
     Gateway --> ExceptionAI

--- a/src/app/providers/pm_quality_summary_stub.py
+++ b/src/app/providers/pm_quality_summary_stub.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.portfolio_memory_context_guardrails import portfolio_memory_context_summary
+
+
+def build_pm_quality_summary_stub_result(
+    *,
+    context_payload: dict[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    score_run = context_payload.get("score_run")
+    summary_request = context_payload.get("summary_request")
+    supportability = context_payload.get("supportability")
+    if (
+        not isinstance(score_run, dict)
+        or not isinstance(summary_request, dict)
+        or not isinstance(supportability, dict)
+    ):
+        return None
+
+    score_run_id = str(score_run.get("score_run_id", "unknown"))
+    portfolio_manager_id = str(score_run.get("portfolio_manager_id", "unknown"))
+    indicator_results = score_run.get("indicator_results")
+    source_refs = score_run.get("source_refs")
+    requested_outputs = summary_request.get("requested_outputs")
+    output_sections = (
+        sorted(str(item) for item in requested_outputs)
+        if isinstance(requested_outputs, list)
+        else []
+    )
+    portfolio_memory_summary = portfolio_memory_context_summary(context_payload)
+
+    message = (
+        f"PM quality score run {score_run_id} for portfolio manager {portfolio_manager_id} "
+        "is ready for review-gated support-only summary from Manage-owned score-run evidence."
+    )
+    structured_output = {
+        "workflow_pack_family": "pm_quality_summary",
+        "narrative_type": "pm_quality_summary",
+        "state": "REVIEW_REQUIRED",
+        "scope": "support_only",
+        "score_run_id": score_run_id,
+        "policy_id": score_run.get("policy_id"),
+        "policy_version": score_run.get("policy_version"),
+        "portfolio_manager_id": portfolio_manager_id,
+        "portfolio_id": score_run.get("portfolio_id"),
+        "score_run_state": score_run.get("state"),
+        "score_run_content_hash": score_run.get("content_hash"),
+        "reason_codes": sorted(score_run.get("reason_codes", [])),
+        "indicator_result_count": (
+            len(indicator_results) if isinstance(indicator_results, list) else 0
+        ),
+        "source_ref_count": len(source_refs) if isinstance(source_refs, list) else 0,
+        "requested_outputs": output_sections,
+        "forbidden_actions_enforced": sorted(supportability.get("forbidden_actions", [])),
+        **portfolio_memory_summary,
+        "unsupported_claims": [
+            "pm_ranking",
+            "hr_decision",
+            "compensation_decision",
+            "conduct_enforcement",
+            "client_contact",
+            "trade_approval",
+            "execution_instruction",
+            "score_calculation",
+            "source_fact_invention",
+        ],
+        "review_guidance": (
+            "Use this generated posture as PM operating-quality support only. Manage owns the "
+            "score-run evidence; lotus-ai does not calculate scores, rank PMs, approve trades, "
+            "contact clients, or create HR, compensation, conduct, execution, or OMS decisions."
+        ),
+    }
+    return message, structured_output

--- a/src/app/providers/stub_text_provider.py
+++ b/src/app/providers/stub_text_provider.py
@@ -17,6 +17,7 @@ from app.providers.outcome_review_narrative_stub import (
 from app.providers.operations_handoff_summary_stub import (
     build_operations_handoff_summary_stub_result,
 )
+from app.providers.pm_quality_summary_stub import build_pm_quality_summary_stub_result
 from app.providers.proof_pack_pm_memo_stub import build_proof_pack_pm_memo_stub_result
 from app.providers.wave_pm_memo_stub import build_wave_pm_memo_stub_result
 
@@ -37,6 +38,42 @@ class StubTextProvider:
     )
 
     def execute(self, request: ProviderExecutionRequest) -> ProviderExecutionResponse:
+        pm_quality_summary_result = build_pm_quality_summary_stub_result(
+            context_payload=request.context_payload,
+        )
+        if request.task_id == "explain.v1" and pm_quality_summary_result:
+            message, structured_output = pm_quality_summary_result
+            return ProviderExecutionResponse(
+                provider_id=self.descriptor.provider_id,
+                provider_mode=settings.provider_mode,
+                adapter_kind=self.descriptor.adapter_kind,
+                failure_category=None,
+                timeout_ms=request.timeout_ms,
+                retry_count=0,
+                max_output_tokens=request.max_output_tokens,
+                stubbed=True,
+                message=message,
+                structured_output={
+                    **structured_output,
+                    "phase": settings.delivery_phase,
+                    "provider_id": self.descriptor.provider_id,
+                    "provider_mode": settings.provider_mode,
+                    "adapter_kind": self.descriptor.adapter_kind.value,
+                    "timeout_ms": request.timeout_ms,
+                    "retry_count": 0,
+                    "max_output_tokens": request.max_output_tokens,
+                    "output_label": request.output_label,
+                    "safety_mode": request.safety_mode,
+                    "redaction_posture": request.redaction_posture,
+                    "context_summary": request.context_summary,
+                    "context_keys": sorted(request.context_payload.keys()),
+                    "source_refs": request.source_refs,
+                    "stub_reason": (
+                        "lotus-ai emits deterministic governed PM quality summary posture "
+                        "before live provider rollout is enabled for this workflow pack."
+                    ),
+                },
+            )
         dpm_exception_summary_result = build_dpm_exception_summary_stub_result(
             context_payload=request.context_payload,
         )

--- a/src/app/services/ai_surface_supportability.py
+++ b/src/app/services/ai_surface_supportability.py
@@ -64,6 +64,11 @@ _WORKFLOW_PACK_SURFACE_OWNERS = {
         "lotus-manage",
         "lotus-manage",
     ),
+    "pm_quality_summary.pack@v1": (
+        "pm_quality_summary",
+        "lotus-manage",
+        "lotus-manage",
+    ),
 }
 
 _PROMETHEUS_POSTURES = (

--- a/src/app/services/pm_quality_summary_guardrails.py
+++ b/src/app/services/pm_quality_summary_guardrails.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import HTTPException, status
+
+from app.services.portfolio_memory_context_guardrails import (
+    validate_optional_portfolio_memory_context,
+)
+
+REQUIRED_SCORE_RUN_KEYS = frozenset(
+    {
+        "product_name",
+        "product_version",
+        "score_run_id",
+        "policy_id",
+        "policy_version",
+        "portfolio_manager_id",
+        "as_of_date",
+        "state",
+        "reason_codes",
+        "indicator_results",
+        "source_refs",
+        "content_hash",
+    }
+)
+REQUIRED_SUPPORTABILITY_KEYS = frozenset(
+    {
+        "source_state",
+        "requires_human_review",
+        "forbidden_actions",
+        "unsupported_claims",
+    }
+)
+REQUIRED_FORBIDDEN_ACTIONS = frozenset(
+    {
+        "rank_portfolio_managers",
+        "make_hr_decisions",
+        "make_compensation_decisions",
+        "enforce_conduct_action",
+        "approve_rebalance",
+        "contact_client",
+        "place_orders",
+        "invent_missing_evidence",
+    }
+)
+FORBIDDEN_FIELD_NAMES = frozenset(
+    {
+        "account_number",
+        "client_id",
+        "client_name",
+        "compensation_amount",
+        "email",
+        "hr_rating",
+        "phone",
+        "raw_payload",
+        "raw_request",
+        "raw_response",
+        "secret",
+        "ssn",
+        "token",
+    }
+)
+FORBIDDEN_REQUESTED_OUTPUTS = frozenset(
+    {
+        "client_message",
+        "compensation_recommendation",
+        "conduct_action",
+        "execution_instruction",
+        "hr_rating",
+        "pm_ranking",
+        "trade_approval",
+    }
+)
+ALLOWED_REQUESTED_OUTPUTS = frozenset(
+    {
+        "score_run_summary",
+        "governance_summary",
+        "evidence_gaps",
+        "fairness_review_posture",
+        "support_references",
+    }
+)
+
+
+def validate_pm_quality_summary_payload(payload: dict[str, object]) -> None:
+    score_run = _require_mapping(payload, "score_run")
+    missing_score_run = sorted(REQUIRED_SCORE_RUN_KEYS.difference(score_run.keys()))
+    if missing_score_run:
+        _reject(f"Missing PmOperatingQualityScoreRun fields: {', '.join(missing_score_run)}.")
+
+    if score_run.get("product_name") != "PmOperatingQualityScoreRun":
+        _reject("score_run.product_name must be PmOperatingQualityScoreRun.")
+
+    forbidden_fields = sorted(_find_forbidden_field_names(score_run))
+    if forbidden_fields:
+        _reject(f"Forbidden PM quality evidence fields present: {', '.join(forbidden_fields)}.")
+
+    if (
+        not isinstance(score_run.get("indicator_results"), list)
+        or not score_run["indicator_results"]
+    ):
+        _reject("PmOperatingQualityScoreRun must carry at least one bounded indicator result.")
+    if not isinstance(score_run.get("reason_codes"), list):
+        _reject("PmOperatingQualityScoreRun reason_codes must be a list.")
+    if not isinstance(score_run.get("source_refs"), list) or not score_run["source_refs"]:
+        _reject("PmOperatingQualityScoreRun source_refs must be a non-empty list.")
+    if "score" in score_run and not isinstance(
+        score_run.get("score"), (str, int, float, type(None))
+    ):
+        _reject("score_run.score must be numeric, string, or null when supplied.")
+
+    supportability = _require_mapping(payload, "supportability")
+    missing_supportability = sorted(REQUIRED_SUPPORTABILITY_KEYS.difference(supportability.keys()))
+    if missing_supportability:
+        _reject(f"Missing PM quality supportability fields: {', '.join(missing_supportability)}.")
+    forbidden_actions = _require_string_set(supportability, "forbidden_actions")
+    missing_actions = sorted(REQUIRED_FORBIDDEN_ACTIONS.difference(forbidden_actions))
+    if missing_actions:
+        _reject(f"Missing required forbidden-action guardrails: {', '.join(missing_actions)}.")
+
+    summary_request = _require_mapping(payload, "summary_request")
+    requested_outputs = _require_string_set(summary_request, "requested_outputs")
+    forbidden_outputs = sorted(requested_outputs.intersection(FORBIDDEN_REQUESTED_OUTPUTS))
+    unsupported_outputs = sorted(requested_outputs.difference(ALLOWED_REQUESTED_OUTPUTS))
+    if forbidden_outputs:
+        _reject(f"Forbidden PM quality summary outputs requested: {', '.join(forbidden_outputs)}.")
+    if unsupported_outputs:
+        _reject(
+            f"Unsupported PM quality summary outputs requested: {', '.join(unsupported_outputs)}."
+        )
+
+    validate_optional_portfolio_memory_context(
+        payload=payload,
+        evidence_portfolio_id=score_run.get("portfolio_id"),
+        forbidden_field_names=FORBIDDEN_FIELD_NAMES,
+        reject=_reject,
+    )
+
+
+def _require_mapping(payload: dict[str, object], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        _reject(f"PM quality summary payload requires object section `{key}`.")
+    return cast(dict[str, Any], value)
+
+
+def _require_string_set(payload: dict[str, Any], key: str) -> set[str]:
+    value = payload.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        _reject(f"PM quality summary payload requires string-list field `{key}`.")
+    return set(cast(list[str], value))
+
+
+def _find_forbidden_field_names(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized = key.lower()
+            if normalized in FORBIDDEN_FIELD_NAMES:
+                found.add(normalized)
+            found.update(_find_forbidden_field_names(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.update(_find_forbidden_field_names(item))
+    return found
+
+
+def _reject(detail: str) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=f"PM_QUALITY_SUMMARY_GUARDRAIL_BLOCKED: {detail}",
+    )

--- a/src/app/services/workflow_pack_bindings.py
+++ b/src/app/services/workflow_pack_bindings.py
@@ -12,6 +12,7 @@ from app.services.workflow_pack_phase1_specs import (
     DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
+    PM_QUALITY_SUMMARY_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
     TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC,
     WORKSPACE_RATIONALE_V1_SPEC,
@@ -84,6 +85,7 @@ _WORKFLOW_PACK_EXECUTION_BINDINGS = (
     _build_execution_binding_from_spec(DPM_WAVE_PM_MEMO_V1_SPEC),
     _build_execution_binding_from_spec(DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC),
     _build_execution_binding_from_spec(DPM_EXCEPTION_SUMMARY_V1_SPEC),
+    _build_execution_binding_from_spec(PM_QUALITY_SUMMARY_V1_SPEC),
 )
 
 

--- a/src/app/services/workflow_pack_execution.py
+++ b/src/app/services/workflow_pack_execution.py
@@ -43,6 +43,7 @@ from app.services.outcome_review_narrative_guardrails import (
 from app.services.operations_handoff_summary_guardrails import (
     validate_operations_handoff_summary_payload,
 )
+from app.services.pm_quality_summary_guardrails import validate_pm_quality_summary_payload
 from app.services.proof_pack_pm_memo_guardrails import validate_proof_pack_pm_memo_payload
 from app.services.wave_pm_memo_guardrails import validate_wave_pm_memo_payload
 
@@ -165,6 +166,8 @@ def validate_workflow_pack_execution_binding(
         validate_operations_handoff_summary_payload(request.task_request.context.payload)
     if request.pack_id == "dpm_exception_summary.pack" and request.version == "v1":
         validate_dpm_exception_summary_payload(request.task_request.context.payload)
+    if request.pack_id == "pm_quality_summary.pack" and request.version == "v1":
+        validate_pm_quality_summary_payload(request.task_request.context.payload)
 
 
 def _attach_workflow_pack_run_id(

--- a/src/app/services/workflow_pack_phase1_specs.py
+++ b/src/app/services/workflow_pack_phase1_specs.py
@@ -176,3 +176,20 @@ DPM_EXCEPTION_SUMMARY_V1_SPEC = WorkflowPackPhase1VersionSpec(
         {"exception_summary_input", "exception_summary_request", "supportability"}
     ),
 )
+
+
+PM_QUALITY_SUMMARY_V1_SPEC = WorkflowPackPhase1VersionSpec(
+    pack_id="pm_quality_summary.pack",
+    pack_family="pm_quality_summary",
+    version="v1",
+    owner_repository="lotus-manage",
+    owner_service="lotus-manage",
+    truth_owner_services=("lotus-manage", "lotus-core", "lotus-risk", "lotus-performance"),
+    primary_use_case="dpm_pm_operating_quality_summary",
+    workflow_authority_owner="lotus-manage",
+    supported_callers=("lotus-manage", "lotus-gateway"),
+    surface_scope=("dpm-pm-quality-ai-evidence",),
+    default_workflow_surface="dpm-pm-quality-ai-evidence",
+    execution_task_id="explain.v1",
+    required_payload_keys=frozenset({"score_run", "summary_request", "supportability"}),
+)

--- a/src/app/services/workflow_pack_queue_policy_catalog.py
+++ b/src/app/services/workflow_pack_queue_policy_catalog.py
@@ -28,6 +28,7 @@ from app.services.workflow_pack_phase1_specs import (
     DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
+    PM_QUALITY_SUMMARY_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
     TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC,
     WORKSPACE_RATIONALE_V1_SPEC,
@@ -48,6 +49,7 @@ def list_workflow_pack_queue_policy_descriptors() -> list[WorkflowPackQueuePolic
         _review_support_wave_pm_memo_policy(),
         _review_support_operations_handoff_summary_policy(),
         _review_support_dpm_exception_summary_policy(),
+        _review_support_pm_quality_summary_policy(),
     ]
     _validate_queue_policy_identity(policies)
     return [policy.model_copy(deep=True) for policy in policies]
@@ -367,6 +369,29 @@ def _review_support_dpm_exception_summary_policy() -> WorkflowPackQueuePolicyDes
         status_summary=[
             "DPM exception summaries default to review-support capacity because generated text remains support-only and review-gated.",
             "Operator capacity is reserved for controlled investigation of guardrail-blocked, unavailable, or stale exception-evidence posture.",
+        ],
+    )
+
+
+def _review_support_pm_quality_summary_policy() -> WorkflowPackQueuePolicyDescriptor:
+    return _build_queue_policy(
+        spec=PM_QUALITY_SUMMARY_V1_SPEC,
+        policy_id="queue-policy.pm-quality-summary.v1",
+        allowed_lanes=[
+            WorkflowPackQueueLane.REVIEW_SUPPORT,
+            WorkflowPackQueueLane.OPERATOR,
+        ],
+        default_lane=WorkflowPackQueueLane.REVIEW_SUPPORT,
+        max_concurrent_runs_per_pack=2,
+        max_concurrent_runs_per_lane=1,
+        max_queued_runs_per_pack=25,
+        max_queued_runs_per_lane=10,
+        admission_timeout_seconds=20,
+        execution_timeout_seconds=300,
+        stale_queue_threshold_seconds=90,
+        status_summary=[
+            "PM quality summaries default to review-support capacity because generated text remains support-only and review-gated.",
+            "Operator capacity is reserved for controlled investigation of guardrail-blocked, unavailable, or stale PM-quality evidence posture.",
         ],
     )
 

--- a/src/app/services/workflow_pack_registry_seed.py
+++ b/src/app/services/workflow_pack_registry_seed.py
@@ -18,6 +18,7 @@ from app.services.workflow_pack_phase1_specs import (
     DPM_OPERATIONS_HANDOFF_SUMMARY_V1_SPEC,
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
+    PM_QUALITY_SUMMARY_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
     TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC,
     WORKSPACE_RATIONALE_V1_SPEC,
@@ -385,6 +386,46 @@ def build_seed_workflow_pack_registrations() -> list[WorkflowPackRegistrationDes
             status_summary=[
                 "The DPM operations handoff summary workflow pack consumes lotus-manage DpmWaveReportInput handoff evidence only.",
                 "Activation remains pilot-scoped while Gateway and Workbench product surfaces add invocation, unavailable posture, and canonical live proof without reconstructing handoff or proof-pack evidence.",
+            ],
+        ),
+        WorkflowPackRegistrationDescriptor(
+            pack_id=PM_QUALITY_SUMMARY_V1_SPEC.pack_id,
+            pack_family=PM_QUALITY_SUMMARY_V1_SPEC.pack_family,
+            version=PM_QUALITY_SUMMARY_V1_SPEC.version,
+            owner_repository=PM_QUALITY_SUMMARY_V1_SPEC.owner_repository,
+            owner_service=PM_QUALITY_SUMMARY_V1_SPEC.owner_service,
+            truth_owner_services=list(PM_QUALITY_SUMMARY_V1_SPEC.truth_owner_services),
+            primary_use_case=PM_QUALITY_SUMMARY_V1_SPEC.primary_use_case,
+            workflow_authority_owner=PM_QUALITY_SUMMARY_V1_SPEC.workflow_authority_owner,
+            default_execution_mode=WorkflowPackExecutionMode.REVIEW_GATED,
+            definition_ref="repo://lotus-manage/src/core/pm_quality/models.py",
+            definition_refs=_pm_quality_summary_v1_definition_refs(),
+            compatibility_contract_version="workflow-pack-contract.v1",
+            registration_status=WorkflowPackRegistrationStatus.REGISTERED,
+            activation_state=WorkflowPackActivationState.PILOT,
+            registered_definition_digest="sha256:pm-quality-summary-v1-registered-digest",
+            supported_callers=list(PM_QUALITY_SUMMARY_V1_SPEC.supported_callers),
+            supported_identity_classes=[
+                WorkflowPackCallerIdentityClass.INTERNAL_SERVICE,
+            ],
+            supported_environments=[
+                WorkflowPackEnvironment.DEVELOPMENT,
+                WorkflowPackEnvironment.QA,
+                WorkflowPackEnvironment.UAT,
+            ],
+            tenant_scope=[],
+            surface_scope=list(PM_QUALITY_SUMMARY_V1_SPEC.surface_scope),
+            default_rollout_stage="PILOT_SCOPED",
+            pause_state="NOT_PAUSED",
+            supersedes=None,
+            superseded_by=None,
+            registered_at="2026-05-16T08:00:00Z",
+            registered_by="lotus-ai.workflow-pack-registry.seed",
+            last_activated_at="2026-05-16T08:20:00Z",
+            last_changed_at="2026-05-16T08:20:00Z",
+            status_summary=[
+                "The PM quality summary workflow pack consumes Manage-owned PmOperatingQualityScoreRun evidence only.",
+                "Activation remains pilot-scoped while Gateway and Workbench add PM-quality product surfaces without score calculation, PM ranking, HR, compensation, conduct, client-contact, execution, or OMS claims.",
             ],
         ),
     ]
@@ -856,6 +897,66 @@ def _dpm_exception_summary_v1_definition_refs() -> list[WorkflowPackDefinitionRe
             description=(
                 "RFC-0043 defines governed exception-summary support, no-domain-decision "
                 "guardrails, review posture, and unavailable behavior."
+            ),
+        ),
+    ]
+
+
+def _pm_quality_summary_v1_definition_refs() -> list[WorkflowPackDefinitionReferenceDescriptor]:
+    return [
+        _definition_ref(
+            reference_id="primary_contract",
+            repository="lotus-manage",
+            path="src/core/pm_quality/models.py",
+            reference_type=WorkflowPackDefinitionReferenceType.CONTRACT,
+            required_for_registration=True,
+            description=(
+                "Manage-owned PmOperatingQualityScoreRun model that bounds PM quality evidence, "
+                "governance evidence, source refs, non-use posture, and content hash."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_service",
+            repository="lotus-manage",
+            path="src/api/services/pm_operating_quality_service.py",
+            reference_type=WorkflowPackDefinitionReferenceType.SERVICE,
+            required_for_registration=True,
+            description=(
+                "Manage service that persists PM operating quality policy, score-run, and "
+                "fairness-analysis evidence without generating AI narrative locally."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_router",
+            repository="lotus-manage",
+            path="src/api/routers/pm_operating_quality.py",
+            reference_type=WorkflowPackDefinitionReferenceType.ROUTER,
+            required_for_registration=True,
+            description=(
+                "Manage API route exposing bounded PM operating quality policy, score-run, "
+                "and fairness-analysis lifecycle evidence."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_tests",
+            repository="lotus-manage",
+            path="tests/unit/dpm/pm_quality/test_pm_operating_quality.py",
+            reference_type=WorkflowPackDefinitionReferenceType.TEST,
+            required_for_registration=True,
+            description=(
+                "Manage regression coverage proving score-run evidence, governance controls, "
+                "peer/lookback scope, and non-use posture."
+            ),
+        ),
+        _definition_ref(
+            reference_id="owner_rfc",
+            repository="lotus-manage",
+            path="docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md",
+            reference_type=WorkflowPackDefinitionReferenceType.RFC,
+            required_for_registration=False,
+            description=(
+                "RFC-0042 defines bounded PM operating quality evidence and excludes PM ranking, "
+                "HR, compensation, conduct enforcement, client contact, execution, and OMS use."
             ),
         ),
     ]

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -97,8 +97,8 @@ def test_platform_workflow_pack_registry_contract(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 9
-    assert body["registered_count"] == 8
+    assert body["registration_count"] == 10
+    assert body["registered_count"] == 9
     assert any(
         registration["pack_id"] == "advisor_brief.pack"
         and registration["activation_state"] == "PILOT"
@@ -135,6 +135,12 @@ def test_platform_workflow_pack_registry_contract(client: TestClient) -> None:
     )
     assert any(
         registration["pack_id"] == "dpm_operations_handoff_summary.pack"
+        and registration["owner_repository"] == "lotus-manage"
+        and registration["activation_state"] == "PILOT"
+        for registration in body["registrations"]
+    )
+    assert any(
+        registration["pack_id"] == "pm_quality_summary.pack"
         and registration["owner_repository"] == "lotus-manage"
         and registration["activation_state"] == "PILOT"
         for registration in body["registrations"]
@@ -415,11 +421,11 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["workflow_pack_task_flow_store"]["status"] == "READY"
     assert body["workflow_pack_queue_event_store"]["mode"] == "memory"
     assert body["workflow_pack_queue_event_store"]["status"] == "READY"
-    assert body["workflow_pack_runtime"]["registration_count"] == 9
-    assert body["workflow_pack_runtime"]["registered_count"] == 8
-    assert body["workflow_pack_runtime"]["execution_binding_count"] == 8
-    assert body["workflow_pack_runtime"]["executable_registration_count"] == 8
-    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 8
+    assert body["workflow_pack_runtime"]["registration_count"] == 10
+    assert body["workflow_pack_runtime"]["registered_count"] == 9
+    assert body["workflow_pack_runtime"]["execution_binding_count"] == 9
+    assert body["workflow_pack_runtime"]["executable_registration_count"] == 9
+    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 9
     assert body["workflow_pack_runtime"]["executable_without_review_count"] == 0
     assert body["workflow_pack_runtime"]["registered_without_execution_binding_count"] == 0
     assert body["workflow_pack_runtime"]["executable_registration_refs"] == [
@@ -429,6 +435,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -439,6 +446,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -489,13 +497,17 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     )
     assert body["workflow_pack_runtime"]["executable_activity"][5]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][6]["registration_ref"] == (
-        "twr_inspection_support_brief.pack@v1"
+        "pm_quality_summary.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][6]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][7]["registration_ref"] == (
-        "workspace_rationale.pack@v1"
+        "twr_inspection_support_brief.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][7]["run_count"] == 0
+    assert body["workflow_pack_runtime"]["executable_activity"][8]["registration_ref"] == (
+        "workspace_rationale.pack@v1"
+    )
+    assert body["workflow_pack_runtime"]["executable_activity"][8]["run_count"] == 0
     assert (
         body["workflow_pack_runtime"]["executable_activity"][0]["latest_ready_provenance"] is None
     )

--- a/tests/integration/test_observability_api_contract.py
+++ b/tests/integration/test_observability_api_contract.py
@@ -8,8 +8,8 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["domain_count"] == 6
-    assert body["ai_surface_supportability"]["supported_surface_count"] == 8
-    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 8
+    assert body["ai_surface_supportability"]["supported_surface_count"] == 9
+    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 9
     assert (
         body["ai_surface_supportability"]["metric_name"] == "lotus_ai_surface_supportability_state"
     )
@@ -23,6 +23,7 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
@@ -52,6 +53,12 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
     )
     assert any(
         surface["surface_id"] == "outcome_review_narrative"
+        and surface["owning_service"] == "lotus-manage"
+        and surface["workflow_authority_owner"] == "lotus-manage"
+        for surface in body["ai_surface_supportability"]["surfaces"]
+    )
+    assert any(
+        surface["surface_id"] == "pm_quality_summary"
         and surface["owning_service"] == "lotus-manage"
         and surface["workflow_authority_owner"] == "lotus-manage"
         for surface in body["ai_surface_supportability"]["surfaces"]

--- a/tests/integration/test_workflow_pack_queue_policy_api_contract.py
+++ b/tests/integration/test_workflow_pack_queue_policy_api_contract.py
@@ -28,7 +28,7 @@ def test_workflow_pack_queue_policy_catalog_route(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["service"] == "lotus-ai"
-    assert body["policy_count"] == 8
+    assert body["policy_count"] == 9
     advisor_policy = next(
         policy
         for policy in body["policies"]

--- a/tests/integration/test_workflow_pack_registry_api_contract.py
+++ b/tests/integration/test_workflow_pack_registry_api_contract.py
@@ -13,8 +13,8 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 9
-    assert body["registered_count"] == 8
+    assert body["registration_count"] == 10
+    assert body["registered_count"] == 9
     assert body["production_eligible_count"] == 0
     advisor_brief_registration = next(
         registration
@@ -50,6 +50,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         registration
         for registration in body["registrations"]
         if registration["pack_id"] == "dpm_exception_summary.pack"
+    )
+    pm_quality_summary_registration = next(
+        registration
+        for registration in body["registrations"]
+        if registration["pack_id"] == "pm_quality_summary.pack"
     )
     advisor_brief_binding = next(
         binding
@@ -91,6 +96,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         for binding in body["execution_bindings"]
         if binding["pack_id"] == "dpm_exception_summary.pack"
     )
+    pm_quality_summary_binding = next(
+        binding
+        for binding in body["execution_bindings"]
+        if binding["pack_id"] == "pm_quality_summary.pack"
+    )
     advisor_brief_queue_policy = next(
         policy
         for policy in body["queue_policies"]
@@ -125,6 +135,12 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         policy
         for policy in body["queue_policies"]
         if policy["workflow_pack_id"] == "dpm_exception_summary.pack"
+        and policy["workflow_pack_version"] == "v1"
+    )
+    pm_quality_summary_queue_policy = next(
+        policy
+        for policy in body["queue_policies"]
+        if policy["workflow_pack_id"] == "pm_quality_summary.pack"
         and policy["workflow_pack_version"] == "v1"
     )
 
@@ -162,6 +178,13 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     assert dpm_exception_summary_registration["owner_repository"] == "lotus-manage"
     assert dpm_exception_summary_registration["workflow_authority_owner"] == "lotus-manage"
     assert dpm_exception_summary_registration["supported_callers"] == [
+        "lotus-manage",
+        "lotus-gateway",
+    ]
+    assert pm_quality_summary_registration["version"] == "v1"
+    assert pm_quality_summary_registration["owner_repository"] == "lotus-manage"
+    assert pm_quality_summary_registration["workflow_authority_owner"] == "lotus-manage"
+    assert pm_quality_summary_registration["supported_callers"] == [
         "lotus-manage",
         "lotus-gateway",
     ]
@@ -237,6 +260,14 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         "exception_summary_request",
         "supportability",
     ]
+    assert pm_quality_summary_binding["version"] == "v1"
+    assert pm_quality_summary_binding["task_id"] == "explain.v1"
+    assert pm_quality_summary_binding["default_workflow_surface"] == ("dpm-pm-quality-ai-evidence")
+    assert pm_quality_summary_binding["required_payload_keys"] == [
+        "score_run",
+        "summary_request",
+        "supportability",
+    ]
     assert advisor_brief_queue_policy["default_lane"] == "LATENCY_SENSITIVE"
     assert advisor_brief_queue_policy["allowed_lanes"] == [
         "LATENCY_SENSITIVE",
@@ -260,6 +291,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     ]
     assert dpm_exception_summary_queue_policy["default_lane"] == "REVIEW_SUPPORT"
     assert dpm_exception_summary_queue_policy["allowed_lanes"] == [
+        "REVIEW_SUPPORT",
+        "OPERATOR",
+    ]
+    assert pm_quality_summary_queue_policy["default_lane"] == "REVIEW_SUPPORT"
+    assert pm_quality_summary_queue_policy["allowed_lanes"] == [
         "REVIEW_SUPPORT",
         "OPERATOR",
     ]

--- a/tests/integration/test_workflow_pack_run_api_contract.py
+++ b/tests/integration/test_workflow_pack_run_api_contract.py
@@ -20,6 +20,7 @@ from tests.support.workflow_pack_fixtures import (
     advisor_brief_workflow_pack_execution_request_json,
     dpm_exception_summary_workflow_pack_execution_request_json,
     outcome_review_narrative_workflow_pack_execution_request_json,
+    pm_quality_summary_workflow_pack_execution_request_json,
     proof_pack_pm_memo_workflow_pack_execution_request_json,
     twr_inspection_support_brief_workflow_pack_execution_request_json,
     wave_pm_memo_workflow_pack_execution_request_json,
@@ -530,6 +531,52 @@ def test_workflow_pack_execute_route_blocks_dpm_exception_summary_forbidden_outp
     assert (
         "Forbidden exception summary outputs requested: portfolio_manager_score" in body["detail"]
     )
+
+
+def test_workflow_pack_execute_route_records_pm_quality_summary_run(
+    client: TestClient,
+) -> None:
+    execute_response = client.post(
+        "/platform/workflow-packs/execute",
+        json=pm_quality_summary_workflow_pack_execution_request_json(
+            correlation_id="corr-pm-quality-summary-pack-001"
+        ),
+    )
+
+    assert execute_response.status_code == 200
+    body = execute_response.json()
+    structured_output = body["execution"]["result"]["structured_output"]
+    assert body["eligibility"]["allowed"] is True
+    assert body["execution"]["status"] == "COMPLETED"
+    assert body["workflow_pack_run"]["pack_id"] == "pm_quality_summary.pack"
+    assert body["workflow_pack_run"]["registration_ref"] == "pm_quality_summary.pack@v1"
+    assert body["workflow_pack_run"]["caller_app"] == "lotus-manage"
+    assert body["workflow_pack_run"]["workflow_surface"] == "dpm-pm-quality-ai-evidence"
+    assert body["workflow_pack_run"]["workflow_authority_owner"] == "lotus-manage"
+    assert body["execution"]["audit"]["workflow_pack_run_id"] == body["workflow_pack_run"]["run_id"]
+    assert structured_output["workflow_pack_family"] == "pm_quality_summary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "support_only"
+    assert structured_output["score_run_content_hash"] == "sha256:pm-quality-score-run-001"
+    assert structured_output["indicator_result_count"] == 1
+    _assert_task_flow_recorded_for_run(client=client, run_id=body["workflow_pack_run"]["run_id"])
+
+
+def test_workflow_pack_execute_route_blocks_pm_quality_summary_pm_ranking(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/platform/workflow-packs/execute",
+        json=pm_quality_summary_workflow_pack_execution_request_json(
+            correlation_id="corr-pm-quality-summary-blocked-ranking-001",
+            requested_outputs=["score_run_summary", "pm_ranking"],
+        ),
+    )
+
+    assert response.status_code == 422
+    body = response.json()
+    assert "PM_QUALITY_SUMMARY_GUARDRAIL_BLOCKED" in body["detail"]
+    assert "Forbidden PM quality summary outputs requested: pm_ranking" in body["detail"]
 
 
 def test_workflow_pack_execute_route_blocks_wave_pm_memo_execution_claim(

--- a/tests/support/workflow_pack_fixtures.py
+++ b/tests/support/workflow_pack_fixtures.py
@@ -1004,3 +1004,145 @@ def dpm_exception_summary_workflow_pack_execution_request_json(
     if workflow_surface is not None:
         request["workflow_surface"] = workflow_surface
     return request
+
+
+def pm_quality_summary_payload(
+    *,
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001",
+    content_hash: str = "sha256:pm-quality-score-run-001",
+    requested_outputs: list[str] | None = None,
+    include_portfolio_memory_context: bool = False,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "score_run": {
+            "product_name": "PmOperatingQualityScoreRun",
+            "product_version": "1.0",
+            "score_run_id": "pmq_run_20260516_001",
+            "policy_id": "pmq_policy_operating_quality",
+            "policy_version": "2026.05",
+            "portfolio_manager_id": "pm_sg_001",
+            "portfolio_id": portfolio_id,
+            "as_of_date": "2026-05-16",
+            "state": "READY",
+            "score": "0.86",
+            "reason_codes": ["PM_QUALITY_WITHIN_POLICY"],
+            "indicator_results": [
+                {
+                    "indicator_id": "source_evidence_completeness",
+                    "state": "READY",
+                    "score": "0.92",
+                    "reason_codes": ["PM_QUALITY_SOURCE_EVIDENCE_COMPLETE"],
+                    "source_refs": [
+                        {
+                            "source_system": "lotus-manage",
+                            "source_type": "PmOperatingQualityScoreRun",
+                            "source_id": "pmq_run_20260516_001",
+                            "content_hash": content_hash,
+                        }
+                    ],
+                }
+            ],
+            "governance_evidence": {
+                "approval_ref": "PMQ-APPROVAL-2026-05",
+                "fairness_review_ref": "PMQ-FAIRNESS-2026-05",
+                "approved_by": "investment-control",
+                "fairness_reviewed_by": "fairness-committee",
+                "approved_at": "2026-05-15T09:00:00Z",
+                "fairness_reviewed_at": "2026-05-15T10:00:00Z",
+            },
+            "source_refs": [
+                {
+                    "source_system": "lotus-manage",
+                    "source_type": "PmOperatingQualityScoreRun",
+                    "source_id": "pmq_run_20260516_001",
+                    "content_hash": content_hash,
+                }
+            ],
+            "content_hash": content_hash,
+        },
+        "summary_request": {
+            "requested_outputs": requested_outputs
+            or [
+                "score_run_summary",
+                "governance_summary",
+                "fairness_review_posture",
+                "support_references",
+                "evidence_gaps",
+            ],
+            "audience": ["portfolio_manager", "investment_control", "cio_office"],
+        },
+        "supportability": {
+            "source_state": "READY",
+            "requires_human_review": True,
+            "forbidden_actions": [
+                "approve_rebalance",
+                "contact_client",
+                "enforce_conduct_action",
+                "invent_missing_evidence",
+                "make_compensation_decisions",
+                "make_hr_decisions",
+                "place_orders",
+                "rank_portfolio_managers",
+            ],
+            "unsupported_claims": [
+                "pm_ranking",
+                "hr_decision",
+                "compensation_decision",
+                "conduct_enforcement",
+                "client_message",
+                "trade_approval",
+                "execution_instruction",
+            ],
+        },
+    }
+    if include_portfolio_memory_context:
+        payload["portfolio_memory_context"] = portfolio_memory_context_payload(
+            portfolio_id=portfolio_id
+        )
+    return payload
+
+
+def pm_quality_summary_workflow_pack_execution_request_json(
+    *,
+    correlation_id: str,
+    task_id: str = "explain.v1",
+    caller_app: str = "lotus-manage",
+    workflow_surface: str | None = "dpm-pm-quality-ai-evidence",
+    environment: str = "DEVELOPMENT",
+    caller_identity_class: str = "INTERNAL_SERVICE",
+    requested_outputs: list[str] | None = None,
+    include_portfolio_memory_context: bool = False,
+) -> dict[str, object]:
+    request: dict[str, object] = {
+        "pack_id": "pm_quality_summary.pack",
+        "version": "v1",
+        "environment": environment,
+        "caller_identity_class": caller_identity_class,
+        "task_request": {
+            "task_id": task_id,
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": caller_app,
+                "correlation_id": correlation_id,
+                "tenant_id": "tenant-sg-001",
+            },
+            "context": {
+                "summary": (
+                    "Generate review-gated PM operating quality summary from bounded score-run "
+                    "evidence."
+                ),
+                "payload": pm_quality_summary_payload(
+                    requested_outputs=requested_outputs,
+                    include_portfolio_memory_context=include_portfolio_memory_context,
+                ),
+                "source_refs": [
+                    "lotus-manage:pm-quality-score-run:pmq_run_20260516_001",
+                    "lotus-manage:pm-quality-policy:pmq_policy_operating_quality:2026.05",
+                ],
+            },
+            "expected_output_label": "EXPLANATION_ONLY",
+        },
+    }
+    if workflow_surface is not None:
+        request["workflow_surface"] = workflow_surface
+    return request

--- a/tests/unit/test_ai_surface_supportability.py
+++ b/tests/unit/test_ai_surface_supportability.py
@@ -33,9 +33,9 @@ def test_ai_surface_supportability_summary_is_source_backed_and_bounded() -> Non
     summary = build_ai_surface_supportability_summary()
 
     assert summary.posture == ObservabilityPosture.DEGRADED
-    assert summary.supported_surface_count == 8
-    assert summary.executable_workflow_pack_count == 8
-    assert summary.action_required_surface_count == 8
+    assert summary.supported_surface_count == 9
+    assert summary.executable_workflow_pack_count == 9
+    assert summary.action_required_surface_count == 9
     assert summary.unavailable_surface_count == 0
     assert summary.no_sensitive_content_telemetry is False
     assert summary.metric_name == "lotus_ai_surface_supportability_state"
@@ -47,6 +47,7 @@ def test_ai_surface_supportability_summary_is_source_backed_and_bounded() -> Non
         "dpm_pm_memo": "lotus-manage",
         "dpm_wave_pm_memo": "lotus-manage",
         "outcome_review_narrative": "lotus-manage",
+        "pm_quality_summary": "lotus-manage",
         "twr_inspection_support_brief": "lotus-performance",
         "workspace_rationale": "lotus-workbench",
     }

--- a/tests/unit/test_observability_runtime.py
+++ b/tests/unit/test_observability_runtime.py
@@ -6,8 +6,8 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
 
     assert status.service == "lotus-ai"
     assert status.domain_count == 6
-    assert status.ai_surface_supportability.supported_surface_count == 8
-    assert status.ai_surface_supportability.executable_workflow_pack_count == 8
+    assert status.ai_surface_supportability.supported_surface_count == 9
+    assert status.ai_surface_supportability.executable_workflow_pack_count == 9
     assert status.ai_surface_supportability.no_sensitive_content_telemetry is False
     assert status.ai_surface_supportability.metric_name == "lotus_ai_surface_supportability_state"
     assert status.ai_surface_supportability.metric_labels == ["surface", "posture", "source"]
@@ -18,6 +18,7 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
@@ -47,6 +48,12 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
     )
     assert any(
         surface.surface_id == "outcome_review_narrative"
+        and surface.owning_service == "lotus-manage"
+        and surface.workflow_authority_owner == "lotus-manage"
+        for surface in status.ai_surface_supportability.surfaces
+    )
+    assert any(
+        surface.surface_id == "pm_quality_summary"
         and surface.owning_service == "lotus-manage"
         and surface.workflow_authority_owner == "lotus-manage"
         for surface in status.ai_surface_supportability.surfaces

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -63,11 +63,11 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.access_control_store_mode == "memory"
     assert status.workflow_pack_registry_store_mode == "memory"
     assert status.workflow_pack_task_flow_store_mode == "memory"
-    assert status.workflow_pack_runtime.registration_count == 9
-    assert status.workflow_pack_runtime.registered_count == 8
-    assert status.workflow_pack_runtime.execution_binding_count == 8
-    assert status.workflow_pack_runtime.executable_registration_count == 8
-    assert status.workflow_pack_runtime.executable_review_required_count == 8
+    assert status.workflow_pack_runtime.registration_count == 10
+    assert status.workflow_pack_runtime.registered_count == 9
+    assert status.workflow_pack_runtime.execution_binding_count == 9
+    assert status.workflow_pack_runtime.executable_registration_count == 9
+    assert status.workflow_pack_runtime.executable_review_required_count == 9
     assert status.workflow_pack_runtime.executable_without_review_count == 0
     assert status.workflow_pack_runtime.registered_without_execution_binding_count == 0
     assert status.workflow_pack_runtime.executable_registration_refs == [
@@ -77,6 +77,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -87,10 +88,11 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
-    assert len(status.workflow_pack_runtime.executable_activity) == 8
+    assert len(status.workflow_pack_runtime.executable_activity) == 9
     assert [item.registration_ref for item in status.workflow_pack_runtime.executable_activity] == [
         "advisor_brief.pack@v1",
         "dpm_exception_summary.pack@v1",
@@ -98,6 +100,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -142,9 +145,9 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.observability_runtime.domain_count == 6
     assert status.observability_runtime.unavailable_domain_count == 0
     assert status.observability_runtime.incident_evidence_supported_domain_count >= 1
-    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 8
+    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 9
     assert (
-        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 8
+        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 9
     )
     assert (
         status.observability_runtime.ai_surface_supportability.no_sensitive_content_telemetry
@@ -159,6 +162,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_pm_memo",
         "dpm_wave_pm_memo",
         "outcome_review_narrative",
+        "pm_quality_summary",
         "twr_inspection_support_brief",
         "workspace_rationale",
     }

--- a/tests/unit/test_pm_quality_summary_guardrails.py
+++ b/tests/unit/test_pm_quality_summary_guardrails.py
@@ -1,0 +1,103 @@
+from typing import Any, cast
+
+from fastapi import HTTPException
+
+from app.providers.pm_quality_summary_stub import build_pm_quality_summary_stub_result
+from app.services.pm_quality_summary_guardrails import validate_pm_quality_summary_payload
+from tests.support.workflow_pack_fixtures import (
+    pm_quality_summary_payload,
+    portfolio_memory_context_payload,
+)
+
+
+def test_pm_quality_summary_guardrails_accept_bounded_score_run_evidence() -> None:
+    validate_pm_quality_summary_payload(pm_quality_summary_payload())
+
+
+def test_pm_quality_summary_guardrails_accept_bounded_portfolio_memory_context() -> None:
+    validate_pm_quality_summary_payload(
+        pm_quality_summary_payload(include_portfolio_memory_context=True)
+    )
+
+
+def test_pm_quality_summary_guardrails_block_missing_required_score_run_field() -> None:
+    payload = cast(dict[str, Any], pm_quality_summary_payload())
+    cast(dict[str, Any], payload["score_run"]).pop("content_hash")
+
+    try:
+        validate_pm_quality_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Missing PmOperatingQualityScoreRun fields: content_hash" in str(exc.detail)
+    else:
+        raise AssertionError("expected missing score-run hash to block execution")
+
+
+def test_pm_quality_summary_guardrails_block_forbidden_requested_outputs() -> None:
+    payload = pm_quality_summary_payload(
+        requested_outputs=["score_run_summary", "compensation_recommendation"]
+    )
+
+    try:
+        validate_pm_quality_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden PM quality summary outputs requested" in str(exc.detail)
+        assert "compensation_recommendation" in str(exc.detail)
+    else:
+        raise AssertionError("expected compensation output to block execution")
+
+
+def test_pm_quality_summary_guardrails_block_missing_forbidden_actions() -> None:
+    payload = cast(dict[str, Any], pm_quality_summary_payload())
+    cast(dict[str, Any], payload["supportability"])["forbidden_actions"] = ["place_orders"]
+
+    try:
+        validate_pm_quality_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Missing required forbidden-action guardrails" in str(exc.detail)
+        assert "rank_portfolio_managers" in str(exc.detail)
+    else:
+        raise AssertionError("expected missing PM-quality guardrails to block execution")
+
+
+def test_pm_quality_summary_guardrails_block_raw_or_hr_fields() -> None:
+    payload = cast(dict[str, Any], pm_quality_summary_payload())
+    cast(dict[str, Any], payload["score_run"])["hr_rating"] = "high"
+
+    try:
+        validate_pm_quality_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden PM quality evidence fields present: hr_rating" in str(exc.detail)
+    else:
+        raise AssertionError("expected HR field to block execution")
+
+
+def test_pm_quality_summary_guardrails_block_unbounded_portfolio_memory_context() -> None:
+    payload = cast(dict[str, Any], pm_quality_summary_payload())
+    payload["portfolio_memory_context"] = portfolio_memory_context_payload(event_ref_count=13)
+
+    try:
+        validate_pm_quality_summary_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "event_refs exceeds bounded limit 12" in str(exc.detail)
+    else:
+        raise AssertionError("expected unbounded portfolio-memory context to block execution")
+
+
+def test_pm_quality_summary_stub_returns_review_gated_support_only_output() -> None:
+    result = build_pm_quality_summary_stub_result(
+        context_payload=pm_quality_summary_payload(include_portfolio_memory_context=True)
+    )
+
+    assert result is not None
+    _, structured_output = result
+    assert structured_output["workflow_pack_family"] == "pm_quality_summary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "support_only"
+    assert structured_output["score_run_content_hash"] == "sha256:pm-quality-score-run-001"
+    assert structured_output["indicator_result_count"] == 1
+    assert "pm_ranking" in structured_output["unsupported_claims"]

--- a/tests/unit/test_workflow_pack_execution.py
+++ b/tests/unit/test_workflow_pack_execution.py
@@ -10,6 +10,7 @@ from tests.support.workflow_pack_fixtures import (
     dpm_exception_summary_workflow_pack_execution_request_json,
     operations_handoff_summary_workflow_pack_execution_request_json,
     outcome_review_narrative_workflow_pack_execution_request_json,
+    pm_quality_summary_workflow_pack_execution_request_json,
     proof_pack_pm_memo_workflow_pack_execution_request_json,
     wave_pm_memo_workflow_pack_execution_request_json,
 )
@@ -285,3 +286,45 @@ def test_validate_workflow_pack_execution_binding_runs_operations_handoff_guardr
         assert "Forbidden operations handoff outputs requested: order_ticket" in str(exc.detail)
     else:
         raise AssertionError("expected operations handoff guardrails to reject order-ticket output")
+
+
+def test_execute_workflow_pack_records_review_gated_pm_quality_summary() -> None:
+    request = WorkflowPackExecutionRequest.model_validate(
+        pm_quality_summary_workflow_pack_execution_request_json(
+            correlation_id="corr-execution-pm-quality-summary"
+        )
+    )
+
+    response = execute_workflow_pack(request)
+
+    structured_output = response.execution.result.structured_output
+    assert response.execution.status.value == "COMPLETED"
+    assert response.workflow_pack_run.pack_id == "pm_quality_summary.pack"
+    assert response.workflow_pack_run.workflow_authority_owner == "lotus-manage"
+    assert structured_output["workflow_pack_family"] == "pm_quality_summary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "support_only"
+    assert structured_output["score_run_content_hash"] == "sha256:pm-quality-score-run-001"
+    assert structured_output["indicator_result_count"] == 1
+    assert "pm_ranking" in structured_output["unsupported_claims"]
+
+
+def test_validate_workflow_pack_execution_binding_runs_pm_quality_summary_guardrails() -> None:
+    request_payload = pm_quality_summary_workflow_pack_execution_request_json(
+        correlation_id="corr-execution-pm-quality-summary-guardrail",
+        requested_outputs=["score_run_summary", "pm_ranking"],
+    )
+    request = WorkflowPackExecutionRequest.model_validate(request_payload)
+    binding = get_workflow_pack_execution_binding(
+        pack_id="pm_quality_summary.pack",
+        version="v1",
+    )
+    assert binding is not None
+
+    try:
+        validate_workflow_pack_execution_binding(request=request, binding=binding)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden PM quality summary outputs requested: pm_ranking" in str(exc.detail)
+    else:
+        raise AssertionError("expected PM quality guardrails to reject PM-ranking output")

--- a/tests/unit/test_workflow_pack_queue_policy_catalog.py
+++ b/tests/unit/test_workflow_pack_queue_policy_catalog.py
@@ -23,6 +23,7 @@ def test_queue_policy_catalog_declares_policy_for_each_executable_phase1_pack() 
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "workspace_rationale.pack@v1",
         "twr_inspection_support_brief.pack@v1",
     }

--- a/tests/unit/test_workflow_pack_registry.py
+++ b/tests/unit/test_workflow_pack_registry.py
@@ -26,8 +26,8 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
 
     assert catalog.service == "lotus-ai"
     assert catalog.phase == "foundation"
-    assert catalog.registration_count == 9
-    assert catalog.registered_count == 8
+    assert catalog.registration_count == 10
+    assert catalog.registered_count == 9
     assert catalog.production_eligible_count == 0
     advisor_brief_registration = next(
         registration
@@ -68,6 +68,11 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         registration
         for registration in catalog.registrations
         if registration.pack_id == "dpm_exception_summary.pack"
+    )
+    pm_quality_summary_registration = next(
+        registration
+        for registration in catalog.registrations
+        if registration.pack_id == "pm_quality_summary.pack"
     )
     assert (
         advisor_brief_registration.registration_status == WorkflowPackRegistrationStatus.REGISTERED
@@ -169,8 +174,23 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         and definition_ref.required_for_registration is True
         for definition_ref in dpm_exception_summary_registration.definition_refs
     )
-    assert len(catalog.execution_bindings) == 8
-    assert len(catalog.queue_policies) == 8
+    assert pm_quality_summary_registration.registration_status == (
+        WorkflowPackRegistrationStatus.REGISTERED
+    )
+    assert pm_quality_summary_registration.owner_repository == "lotus-manage"
+    assert pm_quality_summary_registration.workflow_authority_owner == "lotus-manage"
+    assert pm_quality_summary_registration.supported_callers == [
+        "lotus-manage",
+        "lotus-gateway",
+    ]
+    assert any(
+        definition_ref.repository == "lotus-manage"
+        and definition_ref.path == "src/core/pm_quality/models.py"
+        and definition_ref.required_for_registration is True
+        for definition_ref in pm_quality_summary_registration.definition_refs
+    )
+    assert len(catalog.execution_bindings) == 9
+    assert len(catalog.queue_policies) == 9
     assert any(
         binding.pack_id == "advisor_brief.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
@@ -207,6 +227,10 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
     )
     assert any(
         binding.pack_id == "dpm_exception_summary.pack" and binding.task_id == "explain.v1"
+        for binding in catalog.execution_bindings
+    )
+    assert any(
+        binding.pack_id == "pm_quality_summary.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
     )
 

--- a/tests/unit/test_workflow_pack_registry_store.py
+++ b/tests/unit/test_workflow_pack_registry_store.py
@@ -75,6 +75,7 @@ def test_workflow_pack_registry_store_returns_sqlalchemy_repository(tmp_path: Pa
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]

--- a/tests/unit/test_workflow_pack_runtime_status.py
+++ b/tests/unit/test_workflow_pack_runtime_status.py
@@ -248,11 +248,11 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
 ):
     summary = build_workflow_pack_runtime_status_summary()
 
-    assert summary.registration_count == 9
-    assert summary.registered_count == 8
-    assert summary.execution_binding_count == 8
-    assert summary.executable_registration_count == 8
-    assert summary.executable_review_required_count == 8
+    assert summary.registration_count == 10
+    assert summary.registered_count == 9
+    assert summary.execution_binding_count == 9
+    assert summary.executable_registration_count == 9
+    assert summary.executable_review_required_count == 9
     assert summary.registered_without_execution_binding_count == 0
     assert summary.executable_registration_refs == [
         "advisor_brief.pack@v1",
@@ -261,6 +261,7 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -271,6 +272,7 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
         "dpm_pm_memo.pack@v1",
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
+        "pm_quality_summary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -41,7 +41,7 @@ It does not own portfolio, performance, risk, advisory, management, or reporting
 
 ## Workflow-Pack Product Coverage
 
-Current executable workflow-pack coverage is implementation-backed for eight pilot-scoped families:
+Current executable workflow-pack coverage is implementation-backed for nine pilot-scoped families:
 
 1. `advisor_brief.pack@v1`
 2. `workspace_rationale.pack@v1`
@@ -51,12 +51,16 @@ Current executable workflow-pack coverage is implementation-backed for eight pil
 6. `dpm_exception_summary.pack@v1`
 7. `dpm_operations_handoff_summary.pack@v1`
 8. `outcome_review_narrative.pack@v1`
+9. `pm_quality_summary.pack@v1`
 
 The DPM packs are deliberately support-only and review-gated. `dpm_pm_memo.pack@v1` consumes
 `lotus-manage` `DpmProofPackAiEvidenceInput`; `dpm_wave_pm_memo.pack@v1` and
 `dpm_operations_handoff_summary.pack@v1` consume `lotus-manage` `DpmWaveReportInput`;
 `dpm_exception_summary.pack@v1` consumes bounded `lotus-manage` monitoring exception evidence; and
-`outcome_review_narrative.pack@v1` consumes `lotus-manage` `DpmOutcomeAiEvidenceInput`. The
+`outcome_review_narrative.pack@v1` consumes `lotus-manage` `DpmOutcomeAiEvidenceInput`;
+`pm_quality_summary.pack@v1` consumes Manage-owned `PmOperatingQualityScoreRun` evidence without
+calculating scores, ranking PMs, or creating HR, compensation, conduct, client-contact, execution,
+or OMS decisions. The
 proof-pack, wave, handoff, and outcome packs can also consume optional manage-owned
 `portfolio_memory_context` as bounded source lineage. They validate forbidden actions, forbidden
 fields, requested output scope, portfolio-memory redaction/source-authority posture, run-ledger

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -166,12 +166,14 @@ the owner-facing procedure and do one more truth check before treating a registr
 
 ## DPM PM Memo Integration
 
-`dpm_pm_memo.pack@v1`, `dpm_wave_pm_memo.pack@v1`, `dpm_exception_summary.pack@v1`, and
-`dpm_operations_handoff_summary.pack@v1` are the current `lotus-ai` owner-side execution contracts
+`dpm_pm_memo.pack@v1`, `dpm_wave_pm_memo.pack@v1`, `dpm_exception_summary.pack@v1`,
+`dpm_operations_handoff_summary.pack@v1`, and `pm_quality_summary.pack@v1` are the current
+`lotus-ai` owner-side execution contracts
 for governed DPM support drafting from Manage evidence. The proof-pack pack is for single
 proof-pack evidence, the wave pack is for rebalance-wave PM memo evidence, the exception pack is
 for bounded monitoring exception evidence, and the operations pack is for bounded internal handoff
-evidence that may summarize staged wave items and handoff refs.
+evidence that may summarize staged wave items and handoff refs. The PM quality pack is for
+support-only summaries over Manage-owned `PmOperatingQualityScoreRun` evidence.
 
 Use it only when the caller supplies:
 
@@ -240,13 +242,27 @@ The operations handoff pack blocks order tickets, routing instructions, external
 trade recommendations, client messages, and inferred missing handoff evidence before run, audit, or
 task-flow records are written.
 
+Use `pm_quality_summary.pack@v1` only when the caller supplies:
+
+1. `score_run` shaped as Manage-owned `PmOperatingQualityScoreRun`,
+2. `summary_request` with allowed requested outputs such as `score_run_summary`,
+   `governance_summary`, `fairness_review_posture`, `support_references`, or `evidence_gaps`,
+3. `supportability` posture with required forbidden actions and unsupported claims,
+4. optional `portfolio_memory_context` only when `lotus-manage` supplies bounded source-lineage
+   context for the same portfolio.
+
+The PM quality pack blocks PM ranking, HR ratings, compensation recommendations, conduct actions,
+client messages, trade approvals, execution instructions, and inferred missing score-run evidence
+before run, audit, or task-flow records are written. It does not calculate PM scores or own
+fairness analysis.
+
 ```mermaid
 sequenceDiagram
     participant Manage as lotus-manage
     participant AI as lotus-ai
     participant Ledger as workflow-pack ledger
     participant UI as Gateway / Workbench
-    Manage->>AI: DPM memo, wave memo, exception summary, or operations handoff pack with bounded evidence
+    Manage->>AI: DPM memo, wave memo, exception summary, operations handoff, or PM quality pack with bounded evidence
     AI->>AI: Validate forbidden actions, fields, requested outputs, and memory lineage
     AI->>Ledger: Record review-gated run after guardrails pass
     Ledger-->>AI: workflow_pack_run_id and provenance

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -194,6 +194,11 @@ For AI-backed product-surface support, also confirm:
    guardrail-blocked requests, not as prompt-tuning opportunities. Optional portfolio-memory
    lineage can support review and demo provenance, but it must not be used to infer missing source
    facts.
+11. `pm_quality_summary` remains owned by `lotus-manage` PM operating quality score-run evidence;
+    treat PM ranking, HR ratings, compensation recommendations, conduct actions, client messages,
+    trade approvals, execution instructions, and invented missing score-run evidence as
+    guardrail-blocked requests. The pack is narrative support only and does not calculate PM scores
+    or own fairness analysis.
 
 The owner-facing source for that procedure is:
 

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -133,7 +133,8 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
    review-gated `dpm_wave_pm_memo.pack` and `dpm_operations_handoff_summary.pack` contracts for
    `lotus-manage` `DpmWaveReportInput`, the review-gated `dpm_exception_summary.pack` contract
    for bounded `lotus-manage` monitoring exception evidence, and the review-gated
-   `outcome_review_narrative.pack` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`.
+   `outcome_review_narrative.pack` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`, plus
+   `pm_quality_summary.pack` for Manage-owned `PmOperatingQualityScoreRun` evidence.
    DPM proof-pack PM memo execution validates required proof-pack
    evidence, required forbidden actions, forbidden field names, forbidden requested outputs such as
    trade recommendations or client messages, and unsupported requested outputs before run, audit,
@@ -148,7 +149,10 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
    Outcome-review narrative execution validates required forbidden
    actions, rejects forbidden field names, rejects forbidden requested outputs such as PM scoring or
    client messages, records run and task-flow posture only after those guardrails pass, and remains
-   support-only until Gateway and Workbench surfaces consume the contract. The DPM packs can
+   support-only until Gateway and Workbench surfaces consume the contract. PM quality summary
+   execution validates score-run source refs, non-use guardrails, forbidden fields, and requested
+   outputs before side effects are recorded; it does not calculate scores, rank PMs, or create HR,
+   compensation, conduct, client-contact, execution, or OMS decisions. The DPM packs can
    consume optional manage-owned `portfolio_memory_context` as bounded source lineage, validating
    portfolio identity, capped event refs, source content hash, `NO_RAW_PAYLOADS`, and
    no-reconstruction source-authority policy before any side effects are recorded.
@@ -160,6 +164,7 @@ flowchart LR
     Exception["lotus-manage\nmonitoring exception evidence"] --> ExceptionPack["dpm_exception_summary.pack@v1"]
     Wave --> HandoffPack["dpm_operations_handoff_summary.pack@v1"]
     Outcome["lotus-manage\nDpmOutcomeAiEvidenceInput"] --> OutcomePack["outcome_review_narrative.pack@v1"]
+    PMQ["lotus-manage\nPmOperatingQualityScoreRun"] --> PMQPack["pm_quality_summary.pack@v1"]
     Memory["lotus-manage\nportfolio_memory_context"] --> MemoPack
     Memory --> WavePack
     Memory --> HandoffPack
@@ -169,6 +174,7 @@ flowchart LR
     ExceptionPack --> Guardrails
     HandoffPack --> Guardrails
     OutcomePack --> Guardrails
+    PMQPack --> Guardrails
     Guardrails --> Ledger["Run ledger\nreview required"]
     Ledger --> SourceEvents["AI source events\nno raw payloads"]
     Ledger --> Operator["Operator profile\nconsumer view\nruntime status"]


### PR DESCRIPTION
## Summary
- Add `pm_quality_summary.pack@v1` as a review-gated workflow pack for Manage-owned `PmOperatingQualityScoreRun` evidence.
- Add fail-closed PM-quality summary guardrails and deterministic support-only stub output that forbids PM ranking, HR, compensation, conduct, client contact, trade approval, execution, OMS, and invented facts.
- Register runtime binding, queue policy, supportability surface ownership, tests, integration guidance, wiki source, and repository context.

## Validation
- `python -m pytest tests/unit/test_pm_quality_summary_guardrails.py tests/unit/test_workflow_pack_execution.py tests/unit/test_workflow_pack_registry.py tests/unit/test_workflow_pack_runtime_status.py tests/unit/test_ai_surface_supportability.py tests/unit/test_observability_runtime.py tests/integration/test_workflow_pack_registry_api_contract.py tests/integration/test_workflow_pack_run_api_contract.py tests/integration/test_observability_api_contract.py tests/integration/test_health.py -q` -> 143 passed
- `python -m ruff check src tests` -> passed
- `make check` -> passed
- `python -m pytest tests/integration/test_workflow_pack_queue_policy_api_contract.py -q` -> 16 passed
- `make ci` -> passed, including dependency health/security audit, lint, format, mypy, OpenAPI gate, eval/async artifact gates, migration smoke, runtime-mode smoke, unit/integration/e2e coverage with 99% threshold, and Docker build
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` -> passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai` -> expected pre-merge drift: `Home.md`, `Integrations.md`, `Operations-Runbook.md`, `Platform-Surfaces.md`

## Notes
- No Gateway or Workbench code changes. Downstream BFF/UI realization remains a separate slice.
- Stranded-truth check before PR: no unmerged `lotus-ai` remote branches.
