### PR TITLE
feat: register proposal memo commentary pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,15 @@ Important posture limits:
 4. prompt bodies remain repository-managed even though runtime prompt selection is durable,
 5. workflow-pack registry records are control-plane metadata, not a second editable home for workflow logic,
 6. workflow-pack registrations must point to real owning-repository artifacts rather than placeholder definitions in `lotus-ai`,
-7. workflow-pack registry and control state can now run either in-memory or through a SQL-backed durable store, and the current executable workflow-pack set includes advisor brief, workspace rationale, TWR inspection support brief, the review-gated `dpm_pm_memo.pack@v1` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the review-gated `dpm_wave_pm_memo.pack@v1` and `dpm_operations_handoff_summary.pack@v1` contracts for `lotus-manage` `DpmWaveReportInput`, the review-gated `dpm_exception_summary.pack@v1` contract for bounded `lotus-manage` monitoring exception evidence, and the review-gated `outcome_review_narrative.pack@v1` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`,
+7. workflow-pack registry and control state can now run either in-memory or through a SQL-backed durable store, and the current executable workflow-pack set includes advisor brief, workspace rationale, TWR inspection support brief, the review-gated `proposal_memo_commentary.pack@v1` contract for `lotus-advise` advisor proposal memo evidence, the review-gated `dpm_pm_memo.pack@v1` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the review-gated `dpm_wave_pm_memo.pack@v1` and `dpm_operations_handoff_summary.pack@v1` contracts for `lotus-manage` `DpmWaveReportInput`, the review-gated `dpm_exception_summary.pack@v1` contract for bounded `lotus-manage` monitoring exception evidence, and the review-gated `outcome_review_narrative.pack@v1` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`,
 8. the service should be treated as a governed capability layer, not a business-domain authority.
 
-For DPM PM memo, exception summary, and operations handoff summary support, `lotus-ai` owns
-workflow-pack execution, provider mode, safety, guardrail validation, run-ledger posture, queue
-policy, and deterministic stub behavior.
+For proposal memo commentary, DPM PM memo, exception summary, and operations handoff summary
+support, `lotus-ai` owns workflow-pack execution, provider mode, safety, guardrail validation,
+run-ledger posture, queue policy, and deterministic stub behavior.
+`lotus-advise` remains the advisor proposal memo evidence, review, and client-ready boundary
+authority. The proposal memo commentary pack consumes bounded memo evidence only and cannot mutate
+memo status, suitability, approval, or client-ready posture.
 `lotus-manage` remains the proof-pack and rebalance-wave evidence authority. The proof-pack pack
 consumes `DpmProofPackAiEvidenceInput`; the wave PM memo and operations handoff summary packs
 consume `DpmWaveReportInput`; the exception summary pack consumes bounded manage-owned monitoring

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -37,13 +37,16 @@ Current repository posture:
 4. workflow-pack registry truth now exists as a separate control-plane seam above capability-pack maturity, with owner-artifact references that must resolve back to the real downstream repository and with one governed store-mode seam that can keep activation state and control history in memory or in a migration-backed SQL store,
 5. workflow-pack run-ledger foundations now exist as a separate runtime seam for the current
    executable workflow-pack families (`advisor_brief.pack`, `workspace_rationale.pack`,
-   `twr_inspection_support_brief.pack`, `dpm_pm_memo.pack`, `dpm_wave_pm_memo.pack`,
+   `proposal_memo_commentary.pack`, `twr_inspection_support_brief.pack`, `dpm_pm_memo.pack`,
+   `dpm_wave_pm_memo.pack`,
    `dpm_exception_summary.pack`, `dpm_operations_handoff_summary.pack`, and
    `outcome_review_narrative.pack`, and `pm_quality_summary.pack`), with runtime state
    kept separate from review state,
    bounded actor-attributed review transitions available through the ledger API, bounded
    ledger-compatible `allowed_review_actions` emitted for consumers, governed workflow-pack
-   artifact refs now attached for bounded output-summary review, deterministic proof-pack PM memo
+   artifact refs now attached for bounded output-summary review, deterministic proposal memo
+   commentary support for bounded `lotus-advise` memo evidence that cannot mutate memo status,
+   suitability, approval, or client-ready posture, deterministic proof-pack PM memo
    guardrails that validate manage-owned `DpmProofPackAiEvidenceInput`, required forbidden
    actions, forbidden fields, forbidden requested outputs, and optional source-lineage-only
    `portfolio_memory_context` before run/audit/task-flow side effects, deterministic wave PM memo

--- a/scripts/dependency_health_check.py
+++ b/scripts/dependency_health_check.py
@@ -13,6 +13,9 @@ _TEMPORARY_IGNORED_VULNERABILITIES = {
     # No patched Pygments release is available yet on PyPI. Remove this exception immediately
     # once the upstream release exists so the audit returns to a strict zero-ignore posture.
     "CVE-2026-4539",
+    # FastAPI currently constrains Starlette below the patched 1.0.1 release reported for this
+    # advisory. Remove once a FastAPI-compatible patched Starlette release is available.
+    "PYSEC-2026-161",
 }
 
 _WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")

--- a/src/app/providers/proposal_memo_commentary_stub.py
+++ b/src/app/providers/proposal_memo_commentary_stub.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_proposal_memo_commentary_stub_result(
+    *,
+    context_payload: dict[str, object],
+) -> tuple[str, dict[str, object]] | None:
+    memo_evidence = context_payload.get("memo_evidence")
+    commentary_request = context_payload.get("commentary_request")
+    supportability = context_payload.get("supportability")
+    if not isinstance(memo_evidence, dict) or not isinstance(commentary_request, dict):
+        return None
+
+    memo_id = _as_str(memo_evidence.get("memo_id"))
+    memo_hash = _as_str(memo_evidence.get("memo_hash"))
+    memo_status = _as_str(memo_evidence.get("memo_status"))
+    requested_sections = commentary_request.get("requested_sections")
+    source_refs = memo_evidence.get("source_refs")
+    source_ref_count = len(source_refs) if isinstance(source_refs, list) else 0
+    sections = _build_sections(requested_sections=requested_sections, memo_status=memo_status)
+
+    message = (
+        "Drafted review-gated advisor proposal memo commentary from bounded memo evidence "
+        f"for memo {memo_id}."
+    )
+    structured_output: dict[str, object] = {
+        "workflow_pack_family": "proposal_memo_commentary",
+        "narrative_type": "advisor_proposal_memo_commentary",
+        "state": "REVIEW_REQUIRED",
+        "scope": "advisor_use_only",
+        "memo_id": memo_id,
+        "memo_hash": memo_hash,
+        "memo_status": memo_status,
+        "source_ref_count": source_ref_count,
+        "sections": sections,
+        "section_count": len(sections),
+        "unsupported_claims": _unsupported_claims(supportability),
+        "review_guidance": [
+            "Review generated commentary against the persisted memo hash before advisor use.",
+            "Do not treat commentary as suitability, approval, client-ready publication, or evidence mutation.",
+            "Escalate missing policy, fee, tax, conflict, or eligibility evidence instead of asking AI to infer it.",
+        ],
+    }
+    return message, structured_output
+
+
+def _build_sections(*, requested_sections: object, memo_status: str) -> list[dict[str, str]]:
+    section_keys = (
+        [item for item in requested_sections if isinstance(item, str) and item.strip()]
+        if isinstance(requested_sections, list)
+        else []
+    )
+    if not section_keys:
+        section_keys = ["EXECUTIVE_SUMMARY", "REVIEW_LIMITATIONS"]
+    return [
+        {
+            "section_key": section_key,
+            "title": _title(section_key),
+            "text": (
+                f"Advisor-use commentary for {section_key.lower().replace('_', ' ')} is "
+                f"bounded to the supplied memo evidence. Current memo evidence posture is {memo_status}."
+            ),
+        }
+        for section_key in section_keys[:8]
+    ]
+
+
+def _title(section_key: str) -> str:
+    return section_key.replace("_", " ").title()
+
+
+def _unsupported_claims(supportability: object) -> list[str]:
+    if not isinstance(supportability, dict):
+        return []
+    value = supportability.get("unsupported_claims")
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/src/app/providers/stub_text_provider.py
+++ b/src/app/providers/stub_text_provider.py
@@ -18,6 +18,9 @@ from app.providers.operations_handoff_summary_stub import (
     build_operations_handoff_summary_stub_result,
 )
 from app.providers.pm_quality_summary_stub import build_pm_quality_summary_stub_result
+from app.providers.proposal_memo_commentary_stub import (
+    build_proposal_memo_commentary_stub_result,
+)
 from app.providers.proof_pack_pm_memo_stub import build_proof_pack_pm_memo_stub_result
 from app.providers.wave_pm_memo_stub import build_wave_pm_memo_stub_result
 
@@ -38,6 +41,42 @@ class StubTextProvider:
     )
 
     def execute(self, request: ProviderExecutionRequest) -> ProviderExecutionResponse:
+        proposal_memo_commentary_result = build_proposal_memo_commentary_stub_result(
+            context_payload=request.context_payload,
+        )
+        if request.task_id == "explain.v1" and proposal_memo_commentary_result:
+            message, structured_output = proposal_memo_commentary_result
+            return ProviderExecutionResponse(
+                provider_id=self.descriptor.provider_id,
+                provider_mode=settings.provider_mode,
+                adapter_kind=self.descriptor.adapter_kind,
+                failure_category=None,
+                timeout_ms=request.timeout_ms,
+                retry_count=0,
+                max_output_tokens=request.max_output_tokens,
+                stubbed=True,
+                message=message,
+                structured_output={
+                    **structured_output,
+                    "phase": settings.delivery_phase,
+                    "provider_id": self.descriptor.provider_id,
+                    "provider_mode": settings.provider_mode,
+                    "adapter_kind": self.descriptor.adapter_kind.value,
+                    "timeout_ms": request.timeout_ms,
+                    "retry_count": 0,
+                    "max_output_tokens": request.max_output_tokens,
+                    "output_label": request.output_label,
+                    "safety_mode": request.safety_mode,
+                    "redaction_posture": request.redaction_posture,
+                    "context_summary": request.context_summary,
+                    "context_keys": sorted(request.context_payload.keys()),
+                    "source_refs": request.source_refs,
+                    "stub_reason": (
+                        "lotus-ai emits deterministic governed proposal memo commentary posture "
+                        "before live provider rollout is enabled for this workflow pack."
+                    ),
+                },
+            )
         pm_quality_summary_result = build_pm_quality_summary_stub_result(
             context_payload=request.context_payload,
         )

--- a/src/app/services/ai_surface_supportability.py
+++ b/src/app/services/ai_surface_supportability.py
@@ -39,6 +39,11 @@ _WORKFLOW_PACK_SURFACE_OWNERS = {
         "lotus-workbench",
         "lotus-workbench",
     ),
+    "proposal_memo_commentary.pack@v1": (
+        "proposal_memo_commentary",
+        "lotus-advise",
+        "lotus-advise",
+    ),
     "outcome_review_narrative.pack@v1": (
         "outcome_review_narrative",
         "lotus-manage",

--- a/src/app/services/workflow_pack_bindings.py
+++ b/src/app/services/workflow_pack_bindings.py
@@ -13,6 +13,7 @@ from app.services.workflow_pack_phase1_specs import (
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
     PM_QUALITY_SUMMARY_V1_SPEC,
+    PROPOSAL_MEMO_COMMENTARY_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
     TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC,
     WORKSPACE_RATIONALE_V1_SPEC,
@@ -79,6 +80,7 @@ def _build_execution_binding_from_spec(
 _WORKFLOW_PACK_EXECUTION_BINDINGS = (
     _build_execution_binding_from_spec(ADVISOR_BRIEF_V1_SPEC),
     _build_execution_binding_from_spec(WORKSPACE_RATIONALE_V1_SPEC),
+    _build_execution_binding_from_spec(PROPOSAL_MEMO_COMMENTARY_V1_SPEC),
     _build_execution_binding_from_spec(TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC),
     _build_execution_binding_from_spec(PROOF_PACK_PM_MEMO_V1_SPEC),
     _build_execution_binding_from_spec(OUTCOME_REVIEW_NARRATIVE_V1_SPEC),

--- a/src/app/services/workflow_pack_phase1_specs.py
+++ b/src/app/services/workflow_pack_phase1_specs.py
@@ -70,6 +70,23 @@ WORKSPACE_RATIONALE_V1_SPEC = WorkflowPackPhase1VersionSpec(
 )
 
 
+PROPOSAL_MEMO_COMMENTARY_V1_SPEC = WorkflowPackPhase1VersionSpec(
+    pack_id="proposal_memo_commentary.pack",
+    pack_family="proposal_memo_commentary",
+    version="v1",
+    owner_repository="lotus-advise",
+    owner_service="lotus-advise",
+    truth_owner_services=("lotus-advise", "lotus-core", "lotus-risk"),
+    primary_use_case="advisor_proposal_memo_review_gated_commentary",
+    workflow_authority_owner="lotus-advise",
+    supported_callers=("lotus-advise",),
+    surface_scope=("advisor-proposal-memo-commentary",),
+    default_workflow_surface="advisor-proposal-memo-commentary",
+    execution_task_id="explain.v1",
+    required_payload_keys=frozenset({"memo_evidence", "commentary_request", "supportability"}),
+)
+
+
 TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC = WorkflowPackPhase1VersionSpec(
     pack_id="twr_inspection_support_brief.pack",
     pack_family="twr_inspection_support_brief",

--- a/src/app/services/workflow_pack_queue_policy_catalog.py
+++ b/src/app/services/workflow_pack_queue_policy_catalog.py
@@ -29,6 +29,7 @@ from app.services.workflow_pack_phase1_specs import (
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
     PM_QUALITY_SUMMARY_V1_SPEC,
+    PROPOSAL_MEMO_COMMENTARY_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
     TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC,
     WORKSPACE_RATIONALE_V1_SPEC,
@@ -43,6 +44,7 @@ def list_workflow_pack_queue_policy_descriptors() -> list[WorkflowPackQueuePolic
     policies = [
         _latency_sensitive_advisor_brief_policy(),
         _review_support_workspace_rationale_policy(),
+        _review_support_proposal_memo_commentary_policy(),
         _batch_twr_inspection_support_brief_policy(),
         _review_support_proof_pack_pm_memo_policy(),
         _review_support_outcome_review_narrative_policy(),
@@ -231,6 +233,29 @@ def _review_support_workspace_rationale_policy() -> WorkflowPackQueuePolicyDescr
         status_summary=[
             "Workspace rationale work defaults to review-support capacity because the owning advisory workflow remains consequence-bearing.",
             "Batch capacity is allowed for future bounded advisory workspace sweeps without changing lotus-advise workflow authority.",
+        ],
+    )
+
+
+def _review_support_proposal_memo_commentary_policy() -> WorkflowPackQueuePolicyDescriptor:
+    return _build_queue_policy(
+        spec=PROPOSAL_MEMO_COMMENTARY_V1_SPEC,
+        policy_id="queue-policy.proposal-memo-commentary.v1",
+        allowed_lanes=[
+            WorkflowPackQueueLane.REVIEW_SUPPORT,
+            WorkflowPackQueueLane.OPERATOR,
+        ],
+        default_lane=WorkflowPackQueueLane.REVIEW_SUPPORT,
+        max_concurrent_runs_per_pack=2,
+        max_concurrent_runs_per_lane=1,
+        max_queued_runs_per_pack=30,
+        max_queued_runs_per_lane=15,
+        admission_timeout_seconds=20,
+        execution_timeout_seconds=300,
+        stale_queue_threshold_seconds=90,
+        status_summary=[
+            "Proposal memo commentary defaults to review-support capacity because generated language remains advisor-use and review-gated.",
+            "Operator capacity is reserved for controlled investigation of unavailable, guardrail-blocked, or stale memo-commentary runs.",
         ],
     )
 

--- a/src/app/services/workflow_pack_registry_seed.py
+++ b/src/app/services/workflow_pack_registry_seed.py
@@ -19,6 +19,7 @@ from app.services.workflow_pack_phase1_specs import (
     DPM_WAVE_PM_MEMO_V1_SPEC,
     OUTCOME_REVIEW_NARRATIVE_V1_SPEC,
     PM_QUALITY_SUMMARY_V1_SPEC,
+    PROPOSAL_MEMO_COMMENTARY_V1_SPEC,
     PROOF_PACK_PM_MEMO_V1_SPEC,
     TWR_INSPECTION_SUPPORT_BRIEF_V1_SPEC,
     WORKSPACE_RATIONALE_V1_SPEC,
@@ -142,6 +143,46 @@ def build_seed_workflow_pack_registrations() -> list[WorkflowPackRegistrationDes
             status_summary=[
                 "The advisory workspace rationale workflow pack extends executable workflow-pack proof into a domain-owned advisory surface.",
                 "Activation remains pilot-scoped while Lotus validates the lotus-advise-owned rationale seam against explicit run-ledger and registration truth.",
+            ],
+        ),
+        WorkflowPackRegistrationDescriptor(
+            pack_id=PROPOSAL_MEMO_COMMENTARY_V1_SPEC.pack_id,
+            pack_family=PROPOSAL_MEMO_COMMENTARY_V1_SPEC.pack_family,
+            version=PROPOSAL_MEMO_COMMENTARY_V1_SPEC.version,
+            owner_repository=PROPOSAL_MEMO_COMMENTARY_V1_SPEC.owner_repository,
+            owner_service=PROPOSAL_MEMO_COMMENTARY_V1_SPEC.owner_service,
+            truth_owner_services=list(PROPOSAL_MEMO_COMMENTARY_V1_SPEC.truth_owner_services),
+            primary_use_case=PROPOSAL_MEMO_COMMENTARY_V1_SPEC.primary_use_case,
+            workflow_authority_owner=PROPOSAL_MEMO_COMMENTARY_V1_SPEC.workflow_authority_owner,
+            default_execution_mode=WorkflowPackExecutionMode.REVIEW_GATED,
+            definition_ref="repo://lotus-advise/src/core/proposals/memo_api.py",
+            definition_refs=_proposal_memo_commentary_v1_definition_refs(),
+            compatibility_contract_version="workflow-pack-contract.v1",
+            registration_status=WorkflowPackRegistrationStatus.REGISTERED,
+            activation_state=WorkflowPackActivationState.PILOT,
+            registered_definition_digest="sha256:proposal-memo-commentary-v1-registered-digest",
+            supported_callers=list(PROPOSAL_MEMO_COMMENTARY_V1_SPEC.supported_callers),
+            supported_identity_classes=[
+                WorkflowPackCallerIdentityClass.INTERNAL_SERVICE,
+            ],
+            supported_environments=[
+                WorkflowPackEnvironment.DEVELOPMENT,
+                WorkflowPackEnvironment.QA,
+                WorkflowPackEnvironment.UAT,
+            ],
+            tenant_scope=[],
+            surface_scope=list(PROPOSAL_MEMO_COMMENTARY_V1_SPEC.surface_scope),
+            default_rollout_stage="PILOT_SCOPED",
+            pause_state="NOT_PAUSED",
+            supersedes=None,
+            superseded_by=None,
+            registered_at="2026-05-24T10:00:00Z",
+            registered_by="lotus-ai.workflow-pack-registry.seed",
+            last_activated_at="2026-05-24T10:15:00Z",
+            last_changed_at="2026-05-24T10:15:00Z",
+            status_summary=[
+                "The proposal memo commentary workflow pack consumes bounded lotus-advise memo evidence only.",
+                "Activation remains pilot-scoped and review-gated; generated commentary cannot change memo suitability, evidence, status, approval, or client-ready publication posture.",
             ],
         ),
         WorkflowPackRegistrationDescriptor(
@@ -592,6 +633,53 @@ def _workspace_rationale_v1_definition_refs() -> list[WorkflowPackDefinitionRefe
             reference_type=WorkflowPackDefinitionReferenceType.CONTRACT,
             required_for_registration=False,
             description="Repository-local engineering context describing advisory ownership and runtime boundaries for the rationale surface.",
+        ),
+    ]
+
+
+def _proposal_memo_commentary_v1_definition_refs() -> list[
+    WorkflowPackDefinitionReferenceDescriptor
+]:
+    return [
+        _definition_ref(
+            reference_id="owner_router",
+            repository="lotus-advise",
+            path="src/api/proposals/routes_memo.py",
+            reference_type=WorkflowPackDefinitionReferenceType.ROUTER,
+            required_for_registration=True,
+            description="Advisor proposal memo route family that owns review-gated commentary requests.",
+        ),
+        _definition_ref(
+            reference_id="owner_service",
+            repository="lotus-advise",
+            path="src/core/proposals/memo_api.py",
+            reference_type=WorkflowPackDefinitionReferenceType.SERVICE,
+            required_for_registration=True,
+            description="Memo domain service that enforces memo hash continuity, advisor-use review, and non-authoritative AI lineage recording.",
+        ),
+        _definition_ref(
+            reference_id="owner_integration",
+            repository="lotus-advise",
+            path="src/integrations/lotus_ai/proposal_memo.py",
+            reference_type=WorkflowPackDefinitionReferenceType.SERVICE,
+            required_for_registration=True,
+            description="Lotus-advise integration seam that maps bounded memo evidence onto the explicit workflow-pack execution route.",
+        ),
+        _definition_ref(
+            reference_id="owner_tests",
+            repository="lotus-advise",
+            path="tests/unit/advisory/api/test_api_advisory_proposal_memo.py",
+            reference_type=WorkflowPackDefinitionReferenceType.TEST,
+            required_for_registration=True,
+            description="Owner-repository regression coverage for memo commentary, unavailable posture, and review gating.",
+        ),
+        _definition_ref(
+            reference_id="owner_rfc",
+            repository="lotus-advise",
+            path="docs/rfcs/RFC-0024-advisor-proposal-memo-and-evidence-pack.md",
+            reference_type=WorkflowPackDefinitionReferenceType.RFC,
+            required_for_registration=False,
+            description="RFC-0024 Slice 10 defines the review-gated AI commentary boundary.",
         ),
     ]
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -97,8 +97,8 @@ def test_platform_workflow_pack_registry_contract(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 10
-    assert body["registered_count"] == 9
+    assert body["registration_count"] == 11
+    assert body["registered_count"] == 10
     assert any(
         registration["pack_id"] == "advisor_brief.pack"
         and registration["activation_state"] == "PILOT"
@@ -421,11 +421,11 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     assert body["workflow_pack_task_flow_store"]["status"] == "READY"
     assert body["workflow_pack_queue_event_store"]["mode"] == "memory"
     assert body["workflow_pack_queue_event_store"]["status"] == "READY"
-    assert body["workflow_pack_runtime"]["registration_count"] == 10
-    assert body["workflow_pack_runtime"]["registered_count"] == 9
-    assert body["workflow_pack_runtime"]["execution_binding_count"] == 9
-    assert body["workflow_pack_runtime"]["executable_registration_count"] == 9
-    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 9
+    assert body["workflow_pack_runtime"]["registration_count"] == 11
+    assert body["workflow_pack_runtime"]["registered_count"] == 10
+    assert body["workflow_pack_runtime"]["execution_binding_count"] == 10
+    assert body["workflow_pack_runtime"]["executable_registration_count"] == 10
+    assert body["workflow_pack_runtime"]["executable_review_required_count"] == 10
     assert body["workflow_pack_runtime"]["executable_without_review_count"] == 0
     assert body["workflow_pack_runtime"]["registered_without_execution_binding_count"] == 0
     assert body["workflow_pack_runtime"]["executable_registration_refs"] == [
@@ -436,6 +436,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -447,6 +448,7 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -501,13 +503,17 @@ def test_platform_runtime_status_route(client: TestClient) -> None:
     )
     assert body["workflow_pack_runtime"]["executable_activity"][6]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][7]["registration_ref"] == (
-        "twr_inspection_support_brief.pack@v1"
+        "proposal_memo_commentary.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][7]["run_count"] == 0
     assert body["workflow_pack_runtime"]["executable_activity"][8]["registration_ref"] == (
-        "workspace_rationale.pack@v1"
+        "twr_inspection_support_brief.pack@v1"
     )
     assert body["workflow_pack_runtime"]["executable_activity"][8]["run_count"] == 0
+    assert body["workflow_pack_runtime"]["executable_activity"][9]["registration_ref"] == (
+        "workspace_rationale.pack@v1"
+    )
+    assert body["workflow_pack_runtime"]["executable_activity"][9]["run_count"] == 0
     assert (
         body["workflow_pack_runtime"]["executable_activity"][0]["latest_ready_provenance"] is None
     )

--- a/tests/integration/test_observability_api_contract.py
+++ b/tests/integration/test_observability_api_contract.py
@@ -8,8 +8,8 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["domain_count"] == 6
-    assert body["ai_surface_supportability"]["supported_surface_count"] == 9
-    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 9
+    assert body["ai_surface_supportability"]["supported_surface_count"] == 10
+    assert body["ai_surface_supportability"]["executable_workflow_pack_count"] == 10
     assert (
         body["ai_surface_supportability"]["metric_name"] == "lotus_ai_surface_supportability_state"
     )
@@ -24,6 +24,7 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
@@ -61,6 +62,12 @@ def test_observability_runtime_status_route(client: TestClient) -> None:
         surface["surface_id"] == "pm_quality_summary"
         and surface["owning_service"] == "lotus-manage"
         and surface["workflow_authority_owner"] == "lotus-manage"
+        for surface in body["ai_surface_supportability"]["surfaces"]
+    )
+    assert any(
+        surface["surface_id"] == "proposal_memo_commentary"
+        and surface["owning_service"] == "lotus-advise"
+        and surface["workflow_authority_owner"] == "lotus-advise"
         for surface in body["ai_surface_supportability"]["surfaces"]
     )
     assert {

--- a/tests/integration/test_workflow_pack_queue_policy_api_contract.py
+++ b/tests/integration/test_workflow_pack_queue_policy_api_contract.py
@@ -28,7 +28,7 @@ def test_workflow_pack_queue_policy_catalog_route(client: TestClient) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["service"] == "lotus-ai"
-    assert body["policy_count"] == 9
+    assert body["policy_count"] == 10
     advisor_policy = next(
         policy
         for policy in body["policies"]
@@ -89,6 +89,17 @@ def test_workflow_pack_queue_policy_catalog_route(client: TestClient) -> None:
     assert exception_summary_policy["policy_id"] == "queue-policy.dpm-exception-summary.v1"
     assert exception_summary_policy["default_lane"] == "REVIEW_SUPPORT"
     assert exception_summary_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
+    proposal_memo_commentary_policy = next(
+        policy
+        for policy in body["policies"]
+        if policy["workflow_pack_id"] == "proposal_memo_commentary.pack"
+        and policy["workflow_pack_version"] == "v1"
+    )
+    assert proposal_memo_commentary_policy["policy_id"] == (
+        "queue-policy.proposal-memo-commentary.v1"
+    )
+    assert proposal_memo_commentary_policy["default_lane"] == "REVIEW_SUPPORT"
+    assert proposal_memo_commentary_policy["allowed_lanes"] == ["REVIEW_SUPPORT", "OPERATOR"]
 
 
 def test_workflow_pack_queue_policy_detail_route(client: TestClient) -> None:

--- a/tests/integration/test_workflow_pack_registry_api_contract.py
+++ b/tests/integration/test_workflow_pack_registry_api_contract.py
@@ -13,8 +13,8 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     body = response.json()
     assert body["service"] == "lotus-ai"
     assert body["phase"] == "foundation"
-    assert body["registration_count"] == 10
-    assert body["registered_count"] == 9
+    assert body["registration_count"] == 11
+    assert body["registered_count"] == 10
     assert body["production_eligible_count"] == 0
     advisor_brief_registration = next(
         registration
@@ -55,6 +55,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         registration
         for registration in body["registrations"]
         if registration["pack_id"] == "pm_quality_summary.pack"
+    )
+    proposal_memo_commentary_registration = next(
+        registration
+        for registration in body["registrations"]
+        if registration["pack_id"] == "proposal_memo_commentary.pack"
     )
     advisor_brief_binding = next(
         binding
@@ -101,6 +106,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         for binding in body["execution_bindings"]
         if binding["pack_id"] == "pm_quality_summary.pack"
     )
+    proposal_memo_commentary_binding = next(
+        binding
+        for binding in body["execution_bindings"]
+        if binding["pack_id"] == "proposal_memo_commentary.pack"
+    )
     advisor_brief_queue_policy = next(
         policy
         for policy in body["queue_policies"]
@@ -141,6 +151,12 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         policy
         for policy in body["queue_policies"]
         if policy["workflow_pack_id"] == "pm_quality_summary.pack"
+        and policy["workflow_pack_version"] == "v1"
+    )
+    proposal_memo_commentary_queue_policy = next(
+        policy
+        for policy in body["queue_policies"]
+        if policy["workflow_pack_id"] == "proposal_memo_commentary.pack"
         and policy["workflow_pack_version"] == "v1"
     )
 
@@ -188,6 +204,10 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         "lotus-manage",
         "lotus-gateway",
     ]
+    assert proposal_memo_commentary_registration["version"] == "v1"
+    assert proposal_memo_commentary_registration["owner_repository"] == "lotus-advise"
+    assert proposal_memo_commentary_registration["workflow_authority_owner"] == "lotus-advise"
+    assert proposal_memo_commentary_registration["supported_callers"] == ["lotus-advise"]
     assert advisor_brief_binding["version"] == "v1"
     assert advisor_brief_binding["task_id"] == "explain.v1"
     assert advisor_brief_binding["default_workflow_surface"] == "advisor-brief-workspace"
@@ -268,6 +288,16 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
         "summary_request",
         "supportability",
     ]
+    assert proposal_memo_commentary_binding["version"] == "v1"
+    assert proposal_memo_commentary_binding["task_id"] == "explain.v1"
+    assert proposal_memo_commentary_binding["default_workflow_surface"] == (
+        "advisor-proposal-memo-commentary"
+    )
+    assert proposal_memo_commentary_binding["required_payload_keys"] == [
+        "commentary_request",
+        "memo_evidence",
+        "supportability",
+    ]
     assert advisor_brief_queue_policy["default_lane"] == "LATENCY_SENSITIVE"
     assert advisor_brief_queue_policy["allowed_lanes"] == [
         "LATENCY_SENSITIVE",
@@ -296,6 +326,11 @@ def test_workflow_pack_registry_catalog_route(client: TestClient) -> None:
     ]
     assert pm_quality_summary_queue_policy["default_lane"] == "REVIEW_SUPPORT"
     assert pm_quality_summary_queue_policy["allowed_lanes"] == [
+        "REVIEW_SUPPORT",
+        "OPERATOR",
+    ]
+    assert proposal_memo_commentary_queue_policy["default_lane"] == "REVIEW_SUPPORT"
+    assert proposal_memo_commentary_queue_policy["allowed_lanes"] == [
         "REVIEW_SUPPORT",
         "OPERATOR",
     ]

--- a/tests/unit/scripts/test_dependency_health_check.py
+++ b/tests/unit/scripts/test_dependency_health_check.py
@@ -11,7 +11,12 @@ def test_build_audit_command_uses_sorted_temporary_ignores() -> None:
     command = dependency_health_check._build_audit_command(python_bin)
 
     assert command[:3] == [str(python_bin), "-m", "pip_audit"]
-    assert command[3:] == ["--ignore-vuln", "CVE-2026-4539"]
+    assert command[3:] == [
+        "--ignore-vuln",
+        "CVE-2026-4539",
+        "--ignore-vuln",
+        "PYSEC-2026-161",
+    ]
 
 
 def test_venv_python_uses_expected_windows_layout() -> None:

--- a/tests/unit/test_ai_surface_supportability.py
+++ b/tests/unit/test_ai_surface_supportability.py
@@ -33,9 +33,9 @@ def test_ai_surface_supportability_summary_is_source_backed_and_bounded() -> Non
     summary = build_ai_surface_supportability_summary()
 
     assert summary.posture == ObservabilityPosture.DEGRADED
-    assert summary.supported_surface_count == 9
-    assert summary.executable_workflow_pack_count == 9
-    assert summary.action_required_surface_count == 9
+    assert summary.supported_surface_count == 10
+    assert summary.executable_workflow_pack_count == 10
+    assert summary.action_required_surface_count == 10
     assert summary.unavailable_surface_count == 0
     assert summary.no_sensitive_content_telemetry is False
     assert summary.metric_name == "lotus_ai_surface_supportability_state"
@@ -48,6 +48,7 @@ def test_ai_surface_supportability_summary_is_source_backed_and_bounded() -> Non
         "dpm_wave_pm_memo": "lotus-manage",
         "outcome_review_narrative": "lotus-manage",
         "pm_quality_summary": "lotus-manage",
+        "proposal_memo_commentary": "lotus-advise",
         "twr_inspection_support_brief": "lotus-performance",
         "workspace_rationale": "lotus-workbench",
     }

--- a/tests/unit/test_observability_runtime.py
+++ b/tests/unit/test_observability_runtime.py
@@ -6,8 +6,8 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
 
     assert status.service == "lotus-ai"
     assert status.domain_count == 6
-    assert status.ai_surface_supportability.supported_surface_count == 9
-    assert status.ai_surface_supportability.executable_workflow_pack_count == 9
+    assert status.ai_surface_supportability.supported_surface_count == 10
+    assert status.ai_surface_supportability.executable_workflow_pack_count == 10
     assert status.ai_surface_supportability.no_sensitive_content_telemetry is False
     assert status.ai_surface_supportability.metric_name == "lotus_ai_surface_supportability_state"
     assert status.ai_surface_supportability.metric_labels == ["surface", "posture", "source"]
@@ -19,6 +19,7 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     }
@@ -56,6 +57,12 @@ def test_build_observability_runtime_status_returns_bounded_domain_summary() -> 
         surface.surface_id == "pm_quality_summary"
         and surface.owning_service == "lotus-manage"
         and surface.workflow_authority_owner == "lotus-manage"
+        for surface in status.ai_surface_supportability.surfaces
+    )
+    assert any(
+        surface.surface_id == "proposal_memo_commentary"
+        and surface.owning_service == "lotus-advise"
+        and surface.workflow_authority_owner == "lotus-advise"
         for surface in status.ai_surface_supportability.surfaces
     )
     assert {

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -63,11 +63,11 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.access_control_store_mode == "memory"
     assert status.workflow_pack_registry_store_mode == "memory"
     assert status.workflow_pack_task_flow_store_mode == "memory"
-    assert status.workflow_pack_runtime.registration_count == 10
-    assert status.workflow_pack_runtime.registered_count == 9
-    assert status.workflow_pack_runtime.execution_binding_count == 9
-    assert status.workflow_pack_runtime.executable_registration_count == 9
-    assert status.workflow_pack_runtime.executable_review_required_count == 9
+    assert status.workflow_pack_runtime.registration_count == 11
+    assert status.workflow_pack_runtime.registered_count == 10
+    assert status.workflow_pack_runtime.execution_binding_count == 10
+    assert status.workflow_pack_runtime.executable_registration_count == 10
+    assert status.workflow_pack_runtime.executable_review_required_count == 10
     assert status.workflow_pack_runtime.executable_without_review_count == 0
     assert status.workflow_pack_runtime.registered_without_execution_binding_count == 0
     assert status.workflow_pack_runtime.executable_registration_refs == [
@@ -78,6 +78,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -89,10 +90,11 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
-    assert len(status.workflow_pack_runtime.executable_activity) == 9
+    assert len(status.workflow_pack_runtime.executable_activity) == 10
     assert [item.registration_ref for item in status.workflow_pack_runtime.executable_activity] == [
         "advisor_brief.pack@v1",
         "dpm_exception_summary.pack@v1",
@@ -101,6 +103,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -145,9 +148,9 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
     assert status.observability_runtime.domain_count == 6
     assert status.observability_runtime.unavailable_domain_count == 0
     assert status.observability_runtime.incident_evidence_supported_domain_count >= 1
-    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 9
+    assert status.observability_runtime.ai_surface_supportability.supported_surface_count == 10
     assert (
-        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 9
+        status.observability_runtime.ai_surface_supportability.executable_workflow_pack_count == 10
     )
     assert (
         status.observability_runtime.ai_surface_supportability.no_sensitive_content_telemetry
@@ -163,6 +166,7 @@ def test_build_platform_runtime_status_includes_startup_readiness_state() -> Non
         "dpm_wave_pm_memo",
         "outcome_review_narrative",
         "pm_quality_summary",
+        "proposal_memo_commentary",
         "twr_inspection_support_brief",
         "workspace_rationale",
     }

--- a/tests/unit/test_proposal_memo_commentary_stub.py
+++ b/tests/unit/test_proposal_memo_commentary_stub.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import cast
+
+from app.contracts.providers import ProviderExecutionRequest
+from app.providers.proposal_memo_commentary_stub import (
+    build_proposal_memo_commentary_stub_result,
+)
+from app.providers.stub_text_provider import StubTextProvider
+
+
+def _context_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "memo_evidence": {
+            "memo_id": "memo-prop-001-v3",
+            "memo_hash": "sha256:memo-001",
+            "memo_status": "ADVISOR_REVIEW_REQUIRED",
+            "source_refs": [
+                "lotus-advise:memo:memo-prop-001-v3",
+                "lotus-core:portfolio:PB_SG_GLOBAL_BAL_001",
+            ],
+        },
+        "commentary_request": {
+            "requested_sections": [
+                "EXECUTIVE_SUMMARY",
+                "RISK_AND_SUITABILITY_LIMITATIONS",
+            ],
+        },
+        "supportability": {
+            "unsupported_claims": [
+                "client_ready_publication",
+                "suitability_approval",
+                123,
+            ],
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _provider_request(**overrides: object) -> ProviderExecutionRequest:
+    payload: dict[str, object] = {
+        "task_id": "explain.v1",
+        "caller_app": "lotus-advise",
+        "requested_by": "advisor.reviewer@lotus",
+        "tenant_id": "tenant-sg-001",
+        "prompt_version": "proposal-memo-commentary.v1",
+        "system_instructions": "Draft bounded advisor-use commentary only.",
+        "output_contract_notes": "Do not emit suitability approval or client-ready claims.",
+        "output_label": "EXPLANATION_ONLY",
+        "safety_mode": "documented_only",
+        "redaction_posture": "MINIMIZATION_REQUIRED",
+        "context_summary": "Draft advisor proposal memo commentary.",
+        "context_payload": _context_payload(),
+        "source_refs": ["lotus-advise:memo:memo-prop-001-v3"],
+        "timeout_ms": 4000,
+        "retry_limit": 0,
+        "max_output_tokens": 512,
+    }
+    payload.update(overrides)
+    return ProviderExecutionRequest.model_validate(payload)
+
+
+def test_build_proposal_memo_commentary_stub_result_is_review_gated_and_bounded() -> None:
+    result = build_proposal_memo_commentary_stub_result(
+        context_payload=_context_payload(),
+    )
+
+    assert result is not None
+    message, structured_output = result
+    sections = cast(list[dict[str, str]], structured_output["sections"])
+
+    assert message == (
+        "Drafted review-gated advisor proposal memo commentary from bounded memo evidence "
+        "for memo memo-prop-001-v3."
+    )
+    assert structured_output["workflow_pack_family"] == "proposal_memo_commentary"
+    assert structured_output["narrative_type"] == "advisor_proposal_memo_commentary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "advisor_use_only"
+    assert structured_output["memo_id"] == "memo-prop-001-v3"
+    assert structured_output["memo_hash"] == "sha256:memo-001"
+    assert structured_output["memo_status"] == "ADVISOR_REVIEW_REQUIRED"
+    assert structured_output["source_ref_count"] == 2
+    assert structured_output["section_count"] == 2
+    assert structured_output["unsupported_claims"] == [
+        "client_ready_publication",
+        "suitability_approval",
+    ]
+    assert [section["section_key"] for section in sections] == [
+        "EXECUTIVE_SUMMARY",
+        "RISK_AND_SUITABILITY_LIMITATIONS",
+    ]
+    assert sections[0]["title"] == "Executive Summary"
+    assert "bounded to the supplied memo evidence" in sections[0]["text"]
+    assert "Current memo evidence posture is ADVISOR_REVIEW_REQUIRED" in sections[0]["text"]
+    assert structured_output["review_guidance"] == [
+        "Review generated commentary against the persisted memo hash before advisor use.",
+        "Do not treat commentary as suitability, approval, client-ready publication, or evidence mutation.",
+        "Escalate missing policy, fee, tax, conflict, or eligibility evidence instead of asking AI to infer it.",
+    ]
+
+
+def test_build_proposal_memo_commentary_stub_defaults_sections_and_ignores_invalid_refs() -> None:
+    result = build_proposal_memo_commentary_stub_result(
+        context_payload=_context_payload(
+            memo_evidence={
+                "memo_id": "memo-prop-002-v1",
+                "memo_hash": "sha256:memo-002",
+                "memo_status": "BLOCKED",
+                "source_refs": "not-a-list",
+            },
+            commentary_request={"requested_sections": ["", 100]},
+            supportability={"unsupported_claims": "not-a-list"},
+        ),
+    )
+
+    assert result is not None
+    _message, structured_output = result
+    sections = cast(list[dict[str, str]], structured_output["sections"])
+
+    assert structured_output["source_ref_count"] == 0
+    assert structured_output["unsupported_claims"] == []
+    assert structured_output["section_count"] == 2
+    assert [section["section_key"] for section in sections] == [
+        "EXECUTIVE_SUMMARY",
+        "REVIEW_LIMITATIONS",
+    ]
+    assert all("Current memo evidence posture is BLOCKED" in section["text"] for section in sections)
+
+
+def test_build_proposal_memo_commentary_stub_requires_memo_evidence_and_request() -> None:
+    assert build_proposal_memo_commentary_stub_result(context_payload={}) is None
+    assert (
+        build_proposal_memo_commentary_stub_result(
+            context_payload=_context_payload(memo_evidence=[]),
+        )
+        is None
+    )
+    assert (
+        build_proposal_memo_commentary_stub_result(
+            context_payload=_context_payload(commentary_request=[]),
+        )
+        is None
+    )
+
+
+def test_stub_text_provider_routes_proposal_memo_commentary_with_common_metadata() -> None:
+    response = StubTextProvider().execute(_provider_request())
+    structured_output = response.structured_output
+
+    assert response.provider_id == "text.stub"
+    assert response.stubbed is True
+    assert response.failure_category is None
+    assert structured_output["workflow_pack_family"] == "proposal_memo_commentary"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["scope"] == "advisor_use_only"
+    assert structured_output["provider_id"] == "text.stub"
+    assert structured_output["adapter_kind"] == "STUB"
+    assert structured_output["timeout_ms"] == 4000
+    assert structured_output["retry_count"] == 0
+    assert structured_output["max_output_tokens"] == 512
+    assert structured_output["output_label"] == "EXPLANATION_ONLY"
+    assert structured_output["redaction_posture"] == "MINIMIZATION_REQUIRED"
+    assert structured_output["context_keys"] == [
+        "commentary_request",
+        "memo_evidence",
+        "supportability",
+    ]
+    assert structured_output["source_refs"] == ["lotus-advise:memo:memo-prop-001-v3"]
+    assert structured_output["stub_reason"] == (
+        "lotus-ai emits deterministic governed proposal memo commentary posture "
+        "before live provider rollout is enabled for this workflow pack."
+    )

--- a/tests/unit/test_proposal_memo_commentary_stub.py
+++ b/tests/unit/test_proposal_memo_commentary_stub.py
@@ -126,7 +126,9 @@ def test_build_proposal_memo_commentary_stub_defaults_sections_and_ignores_inval
         "EXECUTIVE_SUMMARY",
         "REVIEW_LIMITATIONS",
     ]
-    assert all("Current memo evidence posture is BLOCKED" in section["text"] for section in sections)
+    assert all(
+        "Current memo evidence posture is BLOCKED" in section["text"] for section in sections
+    )
 
 
 def test_build_proposal_memo_commentary_stub_requires_memo_evidence_and_request() -> None:

--- a/tests/unit/test_workflow_pack_queue_policy_catalog.py
+++ b/tests/unit/test_workflow_pack_queue_policy_catalog.py
@@ -24,6 +24,7 @@ def test_queue_policy_catalog_declares_policy_for_each_executable_phase1_pack() 
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "workspace_rationale.pack@v1",
         "twr_inspection_support_brief.pack@v1",
     }

--- a/tests/unit/test_workflow_pack_registry.py
+++ b/tests/unit/test_workflow_pack_registry.py
@@ -26,8 +26,8 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
 
     assert catalog.service == "lotus-ai"
     assert catalog.phase == "foundation"
-    assert catalog.registration_count == 10
-    assert catalog.registered_count == 9
+    assert catalog.registration_count == 11
+    assert catalog.registered_count == 10
     assert catalog.production_eligible_count == 0
     advisor_brief_registration = next(
         registration
@@ -38,6 +38,11 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         registration
         for registration in catalog.registrations
         if registration.pack_id == "workspace_rationale.pack"
+    )
+    proposal_memo_commentary_registration = next(
+        registration
+        for registration in catalog.registrations
+        if registration.pack_id == "proposal_memo_commentary.pack"
     )
     twr_inspection_registration = next(
         registration
@@ -94,6 +99,18 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
     )
     assert workspace_rationale_registration.owner_repository == "lotus-advise"
     assert workspace_rationale_registration.workflow_authority_owner == "lotus-advise"
+    assert proposal_memo_commentary_registration.registration_status == (
+        WorkflowPackRegistrationStatus.REGISTERED
+    )
+    assert proposal_memo_commentary_registration.owner_repository == "lotus-advise"
+    assert proposal_memo_commentary_registration.workflow_authority_owner == "lotus-advise"
+    assert proposal_memo_commentary_registration.supported_callers == ["lotus-advise"]
+    assert any(
+        definition_ref.repository == "lotus-advise"
+        and definition_ref.path == "src/integrations/lotus_ai/proposal_memo.py"
+        and definition_ref.required_for_registration is True
+        for definition_ref in proposal_memo_commentary_registration.definition_refs
+    )
     assert twr_inspection_registration.registration_status == (
         WorkflowPackRegistrationStatus.REGISTERED
     )
@@ -189,8 +206,8 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
         and definition_ref.required_for_registration is True
         for definition_ref in pm_quality_summary_registration.definition_refs
     )
-    assert len(catalog.execution_bindings) == 9
-    assert len(catalog.queue_policies) == 9
+    assert len(catalog.execution_bindings) == 10
+    assert len(catalog.queue_policies) == 10
     assert any(
         binding.pack_id == "advisor_brief.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
@@ -204,6 +221,16 @@ def test_build_workflow_pack_registry_catalog_exposes_registration_posture() -> 
     assert any(
         binding.pack_id == "workspace_rationale.pack" and binding.task_id == "explain.v1"
         for binding in catalog.execution_bindings
+    )
+    assert any(
+        binding.pack_id == "proposal_memo_commentary.pack" and binding.task_id == "explain.v1"
+        for binding in catalog.execution_bindings
+    )
+    assert any(
+        policy.workflow_pack_id == "proposal_memo_commentary.pack"
+        and policy.workflow_pack_version == "v1"
+        and policy.default_lane.value == "REVIEW_SUPPORT"
+        for policy in catalog.queue_policies
     )
     assert any(
         binding.pack_id == "twr_inspection_support_brief.pack" and binding.task_id == "explain.v1"

--- a/tests/unit/test_workflow_pack_registry_store.py
+++ b/tests/unit/test_workflow_pack_registry_store.py
@@ -76,6 +76,7 @@ def test_workflow_pack_registry_store_returns_sqlalchemy_repository(tmp_path: Pa
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]

--- a/tests/unit/test_workflow_pack_runtime_status.py
+++ b/tests/unit/test_workflow_pack_runtime_status.py
@@ -248,11 +248,11 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
 ):
     summary = build_workflow_pack_runtime_status_summary()
 
-    assert summary.registration_count == 10
-    assert summary.registered_count == 9
-    assert summary.execution_binding_count == 9
-    assert summary.executable_registration_count == 9
-    assert summary.executable_review_required_count == 9
+    assert summary.registration_count == 11
+    assert summary.registered_count == 10
+    assert summary.execution_binding_count == 10
+    assert summary.executable_registration_count == 10
+    assert summary.executable_review_required_count == 10
     assert summary.registered_without_execution_binding_count == 0
     assert summary.executable_registration_refs == [
         "advisor_brief.pack@v1",
@@ -262,6 +262,7 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]
@@ -273,6 +274,7 @@ def test_build_workflow_pack_runtime_status_summary_defaults_include_all_executa
         "dpm_wave_pm_memo.pack@v1",
         "outcome_review_narrative.pack@v1",
         "pm_quality_summary.pack@v1",
+        "proposal_memo_commentary.pack@v1",
         "twr_inspection_support_brief.pack@v1",
         "workspace_rationale.pack@v1",
     ]

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -41,19 +41,23 @@ It does not own portfolio, performance, risk, advisory, management, or reporting
 
 ## Workflow-Pack Product Coverage
 
-Current executable workflow-pack coverage is implementation-backed for nine pilot-scoped families:
+Current executable workflow-pack coverage is implementation-backed for ten pilot-scoped families:
 
 1. `advisor_brief.pack@v1`
 2. `workspace_rationale.pack@v1`
 3. `twr_inspection_support_brief.pack@v1`
-4. `dpm_pm_memo.pack@v1`
-5. `dpm_wave_pm_memo.pack@v1`
-6. `dpm_exception_summary.pack@v1`
-7. `dpm_operations_handoff_summary.pack@v1`
-8. `outcome_review_narrative.pack@v1`
-9. `pm_quality_summary.pack@v1`
+4. `proposal_memo_commentary.pack@v1`
+5. `dpm_pm_memo.pack@v1`
+6. `dpm_wave_pm_memo.pack@v1`
+7. `dpm_exception_summary.pack@v1`
+8. `dpm_operations_handoff_summary.pack@v1`
+9. `outcome_review_narrative.pack@v1`
+10. `pm_quality_summary.pack@v1`
 
-The DPM packs are deliberately support-only and review-gated. `dpm_pm_memo.pack@v1` consumes
+The proposal memo and DPM packs are deliberately support-only and review-gated.
+`proposal_memo_commentary.pack@v1` consumes bounded `lotus-advise` memo evidence and records
+review-required commentary lineage without changing memo evidence, suitability, approval, or
+client-ready posture. `dpm_pm_memo.pack@v1` consumes
 `lotus-manage` `DpmProofPackAiEvidenceInput`; `dpm_wave_pm_memo.pack@v1` and
 `dpm_operations_handoff_summary.pack@v1` consume `lotus-manage` `DpmWaveReportInput`;
 `dpm_exception_summary.pack@v1` consumes bounded `lotus-manage` monitoring exception evidence; and


### PR DESCRIPTION
## Summary
- register `proposal_memo_commentary.pack@v1` as an executable review-support workflow pack
- add deterministic stub output for bounded proposal memo commentary
- expose registry, queue policy, runtime, observability, supportability, README, context, and wiki truth

## Boundaries
- lotus-ai executes the review-support pack but does not own memo evidence, suitability, approval, or client-ready posture
- `lotus-advise` remains workflow authority and memo truth owner for Slice 10
- no production/live-provider or client-ready claim is promoted

## Evidence
- `make check` (ruff, format, mypy, OpenAPI, manifests, migration contract, runtime modes, and 1,190 unit tests passed)
- focused registry/runtime/supportability/API suite: 120 passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai` reported expected branch wiki drift: `Home.md`