### PR TITLE
feat: execute idea workflow pack with guardrails

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   queue-auto-merge:
@@ -18,13 +18,17 @@ jobs:
       github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge queue (merge commit)
+      - name: Enable auto-merge queue (rebase)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LOTUS_AUTOMERGE_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "LOTUS_AUTOMERGE_TOKEN is not configured; skipping automatic rebase merge."
+            exit 0
+          fi
           set +e
-          output=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --merge --delete-branch 2>&1)
+          output=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --rebase --delete-branch 2>&1)
           code=$?
           set -e
           if [ "$code" -eq 0 ]; then

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ produce routing instructions, or invent missing proof-pack, wave, exception, or 
 `lotus-idea` remains the opportunity-intelligence and idea-evidence authority. The idea explanation
 pack consumes only redacted evidence packets, bounded explanation requests, and supportability
 posture from `lotus-idea`; it cannot create suitability approval, proposal authority, rebalance
-authority, client-ready publication, supported-feature promotion, or missing source evidence.
+authority, client-ready publication, supported-feature promotion, or missing source evidence. The
+caller policy recognizes `lotus-idea` only for restricted-tenant, review-gated `explain.v1`
+execution and does not grant live-provider, prompt-control, provider-control, or async-control
+privilege.
 
 For DPM portfolio-memory support, the proof-pack PM memo, wave PM memo, operations handoff summary,
 and outcome-review narrative packs can consume optional `portfolio_memory_context` emitted by

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -74,10 +74,11 @@ Current repository posture:
    that validate Manage-owned `PmOperatingQualityScoreRun` evidence, required non-use guardrails,
    source refs, bounded requested outputs, and optional source-lineage-only
    `portfolio_memory_context` before run/audit/task-flow side effects. The
-   deterministic idea explanation registration validates `lotus-idea` ownership, required
-   redacted evidence packet, bounded explanation request, supportability posture, review-required
-   posture, and forbidden suitability/proposal/rebalance/client-publication authority before
-   downstream product claims can consume the contract.
+   deterministic idea explanation execution validates `lotus-idea` caller authorization,
+   required redacted evidence packet, bounded explanation request, supportability posture,
+   review-required posture, unsupported claims, forbidden actions, and forbidden
+   suitability/proposal/rebalance/client-publication authority before run/audit/task-flow side
+   effects.
    The
    portfolio-memory context is consumed only as bounded lineage with matching portfolio identity,
    `NO_RAW_PAYLOADS` redaction, capped event refs, source content hash, and explicit

--- a/alembic/versions/0034_seed_lotus_idea_caller_policy.py
+++ b/alembic/versions/0034_seed_lotus_idea_caller_policy.py
@@ -1,0 +1,54 @@
+"""seed lotus-idea caller policy
+
+Revision ID: 0034_seed_lotus_idea_caller_policy
+Revises: 0033_allow_lotus_advise_sg_tenant
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0034_seed_lotus_idea_caller_policy"
+down_revision = "0033_allow_lotus_advise_sg_tenant"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO caller_policies (
+            caller_app,
+            lifecycle_status,
+            description,
+            allowed_task_ids,
+            allowed_retrieval_source_ids,
+            allow_live_provider,
+            allow_async_control,
+            allow_prompt_control,
+            allow_provider_control,
+            tenant_policy_mode,
+            restricted_tenant_ids,
+            updated_at
+        ) VALUES (
+            'lotus-idea',
+            'ACTIVE',
+            'Idea service caller for review-gated explanation generation over redacted opportunity evidence packets.',
+            '["explain.v1"]',
+            '[]',
+            FALSE,
+            FALSE,
+            FALSE,
+            FALSE,
+            'RESTRICTED',
+            '["tenant-sg-001"]',
+            '2026-06-26T00:00:00Z'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM caller_policies WHERE caller_app = 'lotus-idea'")

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -365,6 +365,8 @@ rebalance authority, client-ready publication, supported-feature promotion, raw 
 exposure, raw prompt or generated-output exposure, and invented missing evidence. `lotus-idea`
 remains the opportunity-intelligence, idea lifecycle, and idea-evidence authority; `lotus-ai`
 provides the governed workflow-pack runtime, review posture, queue policy, and safety guardrails.
+The `lotus-idea` caller policy is restricted to `explain.v1` for the governed tenant scope and does
+not grant live-provider or control-plane privilege.
 
 ```mermaid
 flowchart LR

--- a/src/app/providers/idea_explanation_stub.py
+++ b/src/app/providers/idea_explanation_stub.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_idea_explanation_stub_result(
+    *,
+    context_payload: dict[str, object],
+) -> tuple[str, dict[str, object]] | None:
+    redacted_evidence = context_payload.get("redacted_evidence_packet")
+    explanation_request = context_payload.get("explanation_request")
+    supportability = context_payload.get("supportability")
+    if not (
+        isinstance(redacted_evidence, dict)
+        and isinstance(explanation_request, dict)
+        and isinstance(supportability, dict)
+    ):
+        return None
+
+    candidate_id = _as_str(redacted_evidence.get("candidate_id"))
+    evidence_packet_id = _as_str(redacted_evidence.get("evidence_packet_id"))
+    source_refs = redacted_evidence.get("source_refs")
+    reason_codes = _string_list(redacted_evidence.get("reason_codes"))
+    requested_outputs = _string_list(explanation_request.get("requested_outputs"))
+
+    message = (
+        "Drafted a review-gated Lotus Idea explanation from redacted evidence packet "
+        f"{evidence_packet_id} for candidate {candidate_id}."
+    )
+    structured_output: dict[str, object] = {
+        "workflow_pack_family": "idea_explanation",
+        "state": "REVIEW_REQUIRED",
+        "scope": "advisor_and_reviewer_use_only",
+        "candidate_id": candidate_id,
+        "evidence_packet_id": evidence_packet_id,
+        "evidence_content_hash": _as_str(redacted_evidence.get("evidence_content_hash")),
+        "family": _as_str(redacted_evidence.get("family")),
+        "lifecycle_status": _as_str(redacted_evidence.get("lifecycle_status")),
+        "review_posture": _as_str(redacted_evidence.get("review_posture")),
+        "source_ref_count": len(source_refs) if isinstance(source_refs, list) else 0,
+        "source_signal_count": _int_or_zero(redacted_evidence.get("source_signal_count")),
+        "reason_codes": reason_codes,
+        "requested_outputs": requested_outputs,
+        "purpose": _as_str(explanation_request.get("purpose")),
+        "evaluation_ref": _as_str(explanation_request.get("evaluation_ref")),
+        "human_review_required": True,
+        "client_ready_publication": "BLOCKED",
+        "downstream_authority": "BLOCKED",
+        "unsupported_claims": _string_list(supportability.get("unsupported_claims")),
+        "forbidden_actions": _string_list(supportability.get("forbidden_actions")),
+        "review_guidance": [
+            "Review the generated explanation against the redacted evidence packet before advisor use.",
+            "Do not treat the explanation as suitability approval, final advice, rebalance authority, or client-ready communication.",
+            "Escalate missing or unsupported evidence back to the source-owning Lotus service.",
+        ],
+    }
+    return message, structured_output
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _as_str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _int_or_zero(value: object) -> int:
+    return value if isinstance(value, int) else 0

--- a/src/app/providers/stub_text_provider.py
+++ b/src/app/providers/stub_text_provider.py
@@ -12,6 +12,7 @@ from app.providers.base import ProviderAdapterDescriptor
 from app.providers.advisory_copilot_stub import build_advisory_copilot_stub_result
 from app.providers.advisor_brief_stub import build_advisor_brief_stub_result
 from app.providers.dpm_exception_summary_stub import build_dpm_exception_summary_stub_result
+from app.providers.idea_explanation_stub import build_idea_explanation_stub_result
 from app.providers.outcome_review_narrative_stub import (
     build_outcome_review_narrative_stub_result,
 )
@@ -42,6 +43,42 @@ class StubTextProvider:
     )
 
     def execute(self, request: ProviderExecutionRequest) -> ProviderExecutionResponse:
+        idea_explanation_result = build_idea_explanation_stub_result(
+            context_payload=request.context_payload,
+        )
+        if request.task_id == "explain.v1" and idea_explanation_result:
+            message, structured_output = idea_explanation_result
+            return ProviderExecutionResponse(
+                provider_id=self.descriptor.provider_id,
+                provider_mode=settings.provider_mode,
+                adapter_kind=self.descriptor.adapter_kind,
+                failure_category=None,
+                timeout_ms=request.timeout_ms,
+                retry_count=0,
+                max_output_tokens=request.max_output_tokens,
+                stubbed=True,
+                message=message,
+                structured_output={
+                    **structured_output,
+                    "phase": settings.delivery_phase,
+                    "provider_id": self.descriptor.provider_id,
+                    "provider_mode": settings.provider_mode,
+                    "adapter_kind": self.descriptor.adapter_kind.value,
+                    "timeout_ms": request.timeout_ms,
+                    "retry_count": 0,
+                    "max_output_tokens": request.max_output_tokens,
+                    "output_label": request.output_label,
+                    "safety_mode": request.safety_mode,
+                    "redaction_posture": request.redaction_posture,
+                    "context_summary": request.context_summary,
+                    "context_keys": sorted(request.context_payload.keys()),
+                    "source_refs": request.source_refs,
+                    "stub_reason": (
+                        "lotus-ai emits deterministic governed Idea explanation posture before "
+                        "live provider rollout is enabled for this workflow pack."
+                    ),
+                },
+            )
         advisory_copilot_result = build_advisory_copilot_stub_result(
             context_payload=request.context_payload,
         )

--- a/src/app/repositories/memory_caller_policy_repository.py
+++ b/src/app/repositories/memory_caller_policy_repository.py
@@ -85,6 +85,22 @@ _DEFAULT_POLICIES = [
         restricted_tenant_ids=[],
     ),
     CallerPolicyDescriptor(
+        caller_app="lotus-idea",
+        lifecycle_status=CallerLifecycleStatus.ACTIVE,
+        description=(
+            "Idea service caller for review-gated explanation generation over redacted "
+            "opportunity evidence packets."
+        ),
+        allowed_task_ids=["explain.v1"],
+        allowed_retrieval_source_ids=[],
+        allow_live_provider=False,
+        allow_async_control=False,
+        allow_prompt_control=False,
+        allow_provider_control=False,
+        tenant_policy_mode=TenantPolicyMode.RESTRICTED,
+        restricted_tenant_ids=["tenant-sg-001"],
+    ),
+    CallerPolicyDescriptor(
         caller_app="lotus-workbench",
         lifecycle_status=CallerLifecycleStatus.ACTIVE,
         description="Workbench caller for bounded retrieval exploration.",

--- a/src/app/services/idea_explanation_guardrails.py
+++ b/src/app/services/idea_explanation_guardrails.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import HTTPException, status
+
+_FORBIDDEN_REQUESTED_OUTPUTS = {
+    "approve_idea",
+    "client_message",
+    "client_ready_publication",
+    "final_investment_recommendation",
+    "portfolio_rebalance_instruction",
+    "publish_to_client",
+    "suitability_approval",
+    "trade_or_order",
+}
+
+_ALLOWED_REQUESTED_OUTPUTS = {
+    "advisor_review_summary",
+    "evidence_gap_questions",
+    "rationale_draft",
+    "source_evidence_summary",
+    "unsupported_claim_check",
+}
+
+_REQUIRED_UNSUPPORTED_CLAIMS = {
+    "client_ready_publication",
+    "final_investment_recommendation",
+    "suitability_approval",
+    "trade_or_order_action",
+}
+
+_REQUIRED_FORBIDDEN_ACTIONS = {
+    "approve_suitability",
+    "contact_client",
+    "invent_missing_evidence",
+    "make_final_recommendation",
+    "place_orders",
+}
+
+_FORBIDDEN_TECHNICAL_KEYS = {
+    "correlation_id",
+    "prompt",
+    "provider_response",
+    "raw_payload",
+    "raw_prompt",
+    "raw_provider_output",
+    "trace_id",
+}
+
+
+def validate_idea_explanation_payload(payload: dict[str, object]) -> None:
+    redacted_evidence = _require_dict(payload, "redacted_evidence_packet")
+    explanation_request = _require_dict(payload, "explanation_request")
+    supportability = _require_dict(payload, "supportability")
+
+    _reject_technical_keys(payload)
+    _validate_redacted_evidence(redacted_evidence)
+    _validate_explanation_request(explanation_request)
+    _validate_supportability(supportability)
+
+
+def _validate_redacted_evidence(redacted_evidence: dict[str, object]) -> None:
+    required_keys = {
+        "candidate_id",
+        "evidence_content_hash",
+        "evidence_packet_id",
+        "family",
+        "lifecycle_status",
+        "reason_codes",
+        "review_posture",
+        "source_refs",
+        "source_signal_count",
+        "supportability",
+    }
+    missing = sorted(key for key in required_keys if not _has_value(redacted_evidence.get(key)))
+    if missing:
+        _reject("Idea explanation redacted evidence missing: " + ", ".join(missing))
+    if not _as_str(redacted_evidence.get("evidence_content_hash")).startswith("sha256:"):
+        _reject("Idea explanation evidence must carry a sha256 content hash.")
+
+    source_refs = _require_list(
+        redacted_evidence.get("source_refs"),
+        "Idea explanation redacted evidence must include source refs.",
+    )
+    if not source_refs:
+        _reject("Idea explanation redacted evidence must include source refs.")
+    for source_ref in source_refs:
+        if not isinstance(source_ref, dict):
+            _reject("Idea explanation source refs must be structured objects.")
+        source_ref_dict = cast(dict[str, object], source_ref)
+        if not _as_str(source_ref_dict.get("source_system")):
+            _reject("Idea explanation source refs must include source_system.")
+        if not _as_str(source_ref_dict.get("product_id")):
+            _reject("Idea explanation source refs must include product_id.")
+
+
+def _validate_explanation_request(explanation_request: dict[str, object]) -> None:
+    if not _as_str(explanation_request.get("request_id")):
+        _reject("Idea explanation request must include request_id.")
+    if _as_str(explanation_request.get("workflow_pack_id")) not in {
+        "lotus-ai:idea-explanation:v1",
+        "idea_explanation.pack",
+    }:
+        _reject("Idea explanation request must identify the Idea workflow pack.")
+    requested_outputs = _require_list(
+        explanation_request.get("requested_outputs"),
+        "Idea explanation request must include bounded requested_outputs.",
+    )
+    requested_output_set = {_as_str(item) for item in requested_outputs}
+    forbidden = sorted(_FORBIDDEN_REQUESTED_OUTPUTS.intersection(requested_output_set))
+    if forbidden:
+        _reject("Forbidden Idea explanation outputs requested: " + ", ".join(forbidden))
+    unsupported = sorted(requested_output_set.difference(_ALLOWED_REQUESTED_OUTPUTS))
+    if unsupported:
+        _reject("Unsupported Idea explanation outputs requested: " + ", ".join(unsupported))
+
+
+def _validate_supportability(supportability: dict[str, object]) -> None:
+    if supportability.get("human_review_required") is not True:
+        _reject("Idea explanation output must require human review.")
+    if _as_str(supportability.get("client_ready_publication")) != "BLOCKED":
+        _reject("Idea explanation supportability must block client-ready publication.")
+    unsupported_claims = {
+        _as_str(item)
+        for item in _require_list(
+            supportability.get("unsupported_claims"),
+            "Idea explanation supportability must include unsupported claims.",
+        )
+    }
+    missing_claims = sorted(_REQUIRED_UNSUPPORTED_CLAIMS.difference(unsupported_claims))
+    if missing_claims:
+        _reject(
+            "Idea explanation supportability missing unsupported claims: "
+            + ", ".join(missing_claims)
+        )
+    forbidden_actions = {
+        _as_str(item)
+        for item in _require_list(
+            supportability.get("forbidden_actions"),
+            "Idea explanation supportability must include forbidden actions.",
+        )
+    }
+    missing_actions = sorted(_REQUIRED_FORBIDDEN_ACTIONS.difference(forbidden_actions))
+    if missing_actions:
+        _reject(
+            "Idea explanation supportability missing forbidden actions: "
+            + ", ".join(missing_actions)
+        )
+
+
+def _reject_technical_keys(value: object) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in _FORBIDDEN_TECHNICAL_KEYS:
+                _reject(f"Idea explanation payload cannot include technical field `{key}`.")
+            _reject_technical_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            _reject_technical_keys(child)
+
+
+def _require_dict(payload: dict[str, object], key: str) -> dict[str, object]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        _reject(f"Idea explanation payload requires `{key}`.")
+    return cast(dict[str, object], value)
+
+
+def _require_list(value: object, detail: str) -> list[object]:
+    if not isinstance(value, list):
+        _reject(detail)
+    return cast(list[object], value)
+
+
+def _has_value(value: object) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return bool(value)
+    return value is not None
+
+
+def _reject(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail)
+
+
+def _as_str(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""

--- a/src/app/services/workflow_pack_execution.py
+++ b/src/app/services/workflow_pack_execution.py
@@ -38,6 +38,7 @@ from app.services.advisory_copilot_guardrails import validate_advisory_copilot_p
 from app.services.dpm_exception_summary_guardrails import (
     validate_dpm_exception_summary_payload,
 )
+from app.services.idea_explanation_guardrails import validate_idea_explanation_payload
 from app.services.outcome_review_narrative_guardrails import (
     validate_outcome_review_narrative_payload,
 )
@@ -169,6 +170,8 @@ def validate_workflow_pack_execution_binding(
         validate_dpm_exception_summary_payload(request.task_request.context.payload)
     if request.pack_id == "pm_quality_summary.pack" and request.version == "v1":
         validate_pm_quality_summary_payload(request.task_request.context.payload)
+    if request.pack_id == "idea_explanation.pack" and request.version == "v1":
+        validate_idea_explanation_payload(request.task_request.context.payload)
     if request.pack_id.startswith("advisory_copilot_") and request.version == "v1":
         validate_advisory_copilot_payload(request.task_request.context.payload)
 

--- a/tests/support/workflow_pack_fixtures.py
+++ b/tests/support/workflow_pack_fixtures.py
@@ -1228,3 +1228,113 @@ def pm_quality_summary_workflow_pack_execution_request_json(
     if workflow_surface is not None:
         request["workflow_surface"] = workflow_surface
     return request
+
+
+def idea_explanation_payload(*, requested_outputs: list[str] | None = None) -> dict[str, object]:
+    return {
+        "redacted_evidence_packet": {
+            "candidate_id": "idea_high_cash_001",
+            "family": "HIGH_CASH",
+            "lifecycle_status": "READY_FOR_REVIEW",
+            "review_posture": "ADVISOR_REVIEW_REQUIRED",
+            "evidence_packet_id": "idea_evidence_high_cash_001",
+            "evidence_content_hash": "sha256:idea-evidence-high-cash-001",
+            "supportability": "READY",
+            "score_policy_version": "idea-score-policy.v1",
+            "score": "0.82",
+            "source_signal_count": 3,
+            "reason_codes": [
+                "HIGH_CASH_WEIGHT",
+                "BENCHMARK_DRIFT_ATTENTION",
+            ],
+            "source_refs": [
+                {
+                    "source_system": "lotus-core",
+                    "product_id": "core-position-snapshot",
+                    "product_version": "2026.06",
+                    "source_id": "PB_SG_GLOBAL_BAL_001:positions:2026-06-25",
+                    "content_hash": "sha256:core-position-snapshot-001",
+                },
+                {
+                    "source_system": "lotus-risk",
+                    "product_id": "risk-concentration-snapshot",
+                    "product_version": "2026.06",
+                    "source_id": "PB_SG_GLOBAL_BAL_001:risk:2026-06-25",
+                    "content_hash": "sha256:risk-concentration-snapshot-001",
+                },
+            ],
+        },
+        "explanation_request": {
+            "request_id": "idea-explanation-request-001",
+            "workflow_pack_id": "lotus-ai:idea-explanation:v1",
+            "workflow_pack_version": "v1",
+            "purpose": "unsupported_claim_verification",
+            "evaluation_ref": "idea-explanation-eval-pack.v1",
+            "audience": "advisor",
+            "requested_outputs": requested_outputs
+            or [
+                "advisor_review_summary",
+                "source_evidence_summary",
+                "unsupported_claim_check",
+            ],
+        },
+        "supportability": {
+            "human_review_required": True,
+            "client_ready_publication": "BLOCKED",
+            "forbidden_actions": [
+                "approve_suitability",
+                "contact_client",
+                "invent_missing_evidence",
+                "make_final_recommendation",
+                "place_orders",
+            ],
+            "unsupported_claims": [
+                "client_ready_publication",
+                "final_investment_recommendation",
+                "suitability_approval",
+                "trade_or_order_action",
+            ],
+        },
+    }
+
+
+def idea_explanation_workflow_pack_execution_request_json(
+    *,
+    correlation_id: str,
+    task_id: str = "explain.v1",
+    caller_app: str = "lotus-idea",
+    workflow_surface: str | None = "idea-explanation-evidence",
+    environment: str = "DEVELOPMENT",
+    caller_identity_class: str = "INTERNAL_SERVICE",
+    requested_outputs: list[str] | None = None,
+) -> dict[str, object]:
+    request: dict[str, object] = {
+        "pack_id": "idea_explanation.pack",
+        "version": "v1",
+        "environment": environment,
+        "caller_identity_class": caller_identity_class,
+        "task_request": {
+            "task_id": task_id,
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": caller_app,
+                "correlation_id": correlation_id,
+                "tenant_id": "tenant-sg-001",
+            },
+            "context": {
+                "summary": (
+                    "Generate a review-gated Idea explanation from redacted source evidence."
+                ),
+                "payload": idea_explanation_payload(requested_outputs=requested_outputs),
+                "source_refs": [
+                    "lotus-idea:evidence-packet:idea_evidence_high_cash_001",
+                    "lotus-core:positions:PB_SG_GLOBAL_BAL_001:2026-06-25",
+                    "lotus-risk:concentration:PB_SG_GLOBAL_BAL_001:2026-06-25",
+                ],
+            },
+            "expected_output_label": "EXPLANATION_ONLY",
+        },
+    }
+    if workflow_surface is not None:
+        request["workflow_surface"] = workflow_surface
+    return request

--- a/tests/unit/test_access_control_authorization.py
+++ b/tests/unit/test_access_control_authorization.py
@@ -123,6 +123,18 @@ def test_authorize_request_allows_advise_singapore_tenant_for_canonical_workflow
     assert decision.outcome == AuthorizationOutcome.ALLOWED
 
 
+def test_authorize_request_allows_lotus_idea_review_gated_task() -> None:
+    decision = authorize_request(
+        caller_app="lotus-idea",
+        capability_type=AuthorizationCapabilityType.TASK_EXECUTION,
+        tenant_id="tenant-sg-001",
+        task_id="explain.v1",
+    )
+
+    assert decision.allowed is True
+    assert decision.outcome == AuthorizationOutcome.ALLOWED
+
+
 def test_authorize_request_uses_sql_backed_registry_when_configured(tmp_path: Path) -> None:
     database_url = f"sqlite:///{tmp_path / 'access-control-authorization.db'}"
     upgrade_database_to_head(database_url)

--- a/tests/unit/test_idea_explanation_guardrails.py
+++ b/tests/unit/test_idea_explanation_guardrails.py
@@ -1,7 +1,9 @@
 from typing import Any, cast
 
 from fastapi import HTTPException
+import pytest
 
+from app.providers.idea_explanation_stub import build_idea_explanation_stub_result
 from app.services.idea_explanation_guardrails import validate_idea_explanation_payload
 from tests.support.workflow_pack_fixtures import idea_explanation_payload
 
@@ -61,3 +63,123 @@ def test_idea_explanation_guardrails_require_review_and_forbidden_actions() -> N
         assert "make_final_recommendation" in str(exc.detail)
     else:
         raise AssertionError("expected missing forbidden actions to block execution")
+
+
+@pytest.mark.parametrize(
+    ("mutator", "expected_detail"),
+    [
+        (
+            lambda payload: cast(dict[str, Any], payload["redacted_evidence_packet"]).pop(
+                "candidate_id"
+            ),
+            "redacted evidence missing: candidate_id",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["redacted_evidence_packet"]).__setitem__(
+                "evidence_content_hash",
+                "md5:not-supported",
+            ),
+            "must carry a sha256 content hash",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["redacted_evidence_packet"]).__setitem__(
+                "source_refs",
+                [],
+            ),
+            "redacted evidence missing: source_refs",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["redacted_evidence_packet"]).__setitem__(
+                "source_refs",
+                ["not-structured"],
+            ),
+            "source refs must be structured objects",
+        ),
+        (
+            lambda payload: cast(
+                list[dict[str, Any]],
+                cast(dict[str, Any], payload["redacted_evidence_packet"])["source_refs"],
+            )[0].pop("source_system"),
+            "source refs must include source_system",
+        ),
+        (
+            lambda payload: cast(
+                list[dict[str, Any]],
+                cast(dict[str, Any], payload["redacted_evidence_packet"])["source_refs"],
+            )[0].pop("product_id"),
+            "source refs must include product_id",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["explanation_request"]).pop("request_id"),
+            "request must include request_id",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["explanation_request"]).__setitem__(
+                "workflow_pack_id",
+                "wrong.pack",
+            ),
+            "must identify the Idea workflow pack",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["explanation_request"]).__setitem__(
+                "requested_outputs",
+                ["advisor_review_summary", "unsupported_output"],
+            ),
+            "Unsupported Idea explanation outputs requested: unsupported_output",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["supportability"]).__setitem__(
+                "client_ready_publication",
+                "ALLOWED",
+            ),
+            "must block client-ready publication",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["supportability"]).__setitem__(
+                "unsupported_claims",
+                ["client_ready_publication"],
+            ),
+            "missing unsupported claims",
+        ),
+        (
+            lambda payload: payload.__setitem__("redacted_evidence_packet", []),
+            "payload requires `redacted_evidence_packet`",
+        ),
+        (
+            lambda payload: cast(dict[str, Any], payload["explanation_request"]).__setitem__(
+                "requested_outputs",
+                "advisor_review_summary",
+            ),
+            "must include bounded requested_outputs",
+        ),
+    ],
+)
+def test_idea_explanation_guardrails_reject_invalid_source_safe_contracts(
+    mutator: Any,
+    expected_detail: str,
+) -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    mutator(payload)
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_idea_explanation_payload(payload)
+
+    assert exc_info.value.status_code == 422
+    assert expected_detail in str(exc_info.value.detail)
+
+
+def test_idea_explanation_stub_ignores_non_idea_context_payload() -> None:
+    assert build_idea_explanation_stub_result(context_payload={}) is None
+
+
+def test_idea_explanation_stub_coerces_malformed_lists_to_empty_output() -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    cast(dict[str, Any], payload["redacted_evidence_packet"])["reason_codes"] = "not-a-list"
+    cast(dict[str, Any], payload["explanation_request"])["requested_outputs"] = "not-a-list"
+
+    result = build_idea_explanation_stub_result(context_payload=payload)
+
+    assert result is not None
+    _, structured_output = result
+    assert structured_output["reason_codes"] == []
+    assert structured_output["requested_outputs"] == []

--- a/tests/unit/test_idea_explanation_guardrails.py
+++ b/tests/unit/test_idea_explanation_guardrails.py
@@ -1,0 +1,63 @@
+from typing import Any, cast
+
+from fastapi import HTTPException
+
+from app.services.idea_explanation_guardrails import validate_idea_explanation_payload
+from tests.support.workflow_pack_fixtures import idea_explanation_payload
+
+
+def test_idea_explanation_guardrails_accept_redacted_review_gated_payload() -> None:
+    validate_idea_explanation_payload(idea_explanation_payload())
+
+
+def test_idea_explanation_guardrails_block_raw_provider_fields() -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    cast(dict[str, Any], payload["redacted_evidence_packet"])["raw_payload"] = {"unsafe": True}
+
+    try:
+        validate_idea_explanation_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "technical field `raw_payload`" in str(exc.detail)
+    else:
+        raise AssertionError("expected raw payload field to block Idea explanation execution")
+
+
+def test_idea_explanation_guardrails_block_forbidden_requested_output() -> None:
+    payload = idea_explanation_payload(
+        requested_outputs=["advisor_review_summary", "client_message"]
+    )
+
+    try:
+        validate_idea_explanation_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden Idea explanation outputs requested: client_message" in str(exc.detail)
+    else:
+        raise AssertionError("expected client-message output to block Idea explanation execution")
+
+
+def test_idea_explanation_guardrails_require_review_and_forbidden_actions() -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    supportability = cast(dict[str, Any], payload["supportability"])
+    supportability["human_review_required"] = False
+
+    try:
+        validate_idea_explanation_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "must require human review" in str(exc.detail)
+    else:
+        raise AssertionError("expected missing human-review posture to block execution")
+
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    cast(dict[str, Any], payload["supportability"])["forbidden_actions"] = ["place_orders"]
+
+    try:
+        validate_idea_explanation_payload(payload)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "missing forbidden actions" in str(exc.detail)
+        assert "make_final_recommendation" in str(exc.detail)
+    else:
+        raise AssertionError("expected missing forbidden actions to block execution")

--- a/tests/unit/test_memory_caller_policy_repository.py
+++ b/tests/unit/test_memory_caller_policy_repository.py
@@ -10,6 +10,7 @@ def test_memory_caller_policy_repository_lists_seeded_policies() -> None:
     assert policies[0].caller_app == "lotus-advise"
     assert any(policy.caller_app == "lotus-platform" for policy in policies)
     assert any(policy.caller_app == "lotus-performance" for policy in policies)
+    assert any(policy.caller_app == "lotus-idea" for policy in policies)
 
 
 def test_memory_caller_policy_repository_returns_policy_by_caller_app() -> None:
@@ -32,6 +33,18 @@ def test_memory_caller_policy_repository_allows_lotus_gateway_live_explain() -> 
     assert policy.allow_live_provider is True
     assert policy.allowed_task_ids == ["explain.v1"]
     assert policy.tenant_policy_mode.value == "OPTIONAL"
+
+
+def test_memory_caller_policy_repository_allows_lotus_idea_review_gated_explain() -> None:
+    repository = InMemoryCallerPolicyRepository()
+
+    policy = repository.get_policy("lotus-idea")
+
+    assert policy is not None
+    assert policy.allow_live_provider is False
+    assert policy.allowed_task_ids == ["explain.v1"]
+    assert policy.tenant_policy_mode.value == "RESTRICTED"
+    assert policy.restricted_tenant_ids == ["tenant-sg-001"]
 
 
 def test_memory_caller_policy_repository_returns_none_for_unknown_caller() -> None:

--- a/tests/unit/test_sqlalchemy_caller_policy_repository.py
+++ b/tests/unit/test_sqlalchemy_caller_policy_repository.py
@@ -15,6 +15,7 @@ def test_sqlalchemy_caller_policy_repository_lists_seeded_policies(tmp_path: Pat
     assert any(policy.caller_app == "lotus-platform" for policy in policies)
     assert any(policy.caller_app == "lotus-gateway" for policy in policies)
     assert any(policy.caller_app == "lotus-performance" for policy in policies)
+    assert any(policy.caller_app == "lotus-idea" for policy in policies)
 
 
 def test_sqlalchemy_caller_policy_repository_survives_reopen(tmp_path: Path) -> None:
@@ -28,6 +29,7 @@ def test_sqlalchemy_caller_policy_repository_survives_reopen(tmp_path: Path) -> 
     lotus_advise_policy = second_repository.get_policy("lotus-advise")
     lotus_performance_policy = second_repository.get_policy("lotus-performance")
     lotus_gateway_policy = second_repository.get_policy("lotus-gateway")
+    lotus_idea_policy = second_repository.get_policy("lotus-idea")
 
     assert first_policy is not None
     assert second_policy is not None
@@ -45,6 +47,11 @@ def test_sqlalchemy_caller_policy_repository_survives_reopen(tmp_path: Path) -> 
     assert lotus_gateway_policy is not None
     assert lotus_gateway_policy.allowed_task_ids == ["explain.v1"]
     assert lotus_gateway_policy.tenant_policy_mode == "OPTIONAL"
+    assert lotus_idea_policy is not None
+    assert lotus_idea_policy.allowed_task_ids == ["explain.v1"]
+    assert lotus_idea_policy.allow_live_provider is False
+    assert lotus_idea_policy.tenant_policy_mode == "RESTRICTED"
+    assert lotus_idea_policy.restricted_tenant_ids == ["tenant-sg-001"]
 
 
 def test_sqlalchemy_caller_policy_repository_returns_none_for_unknown_caller(

--- a/tests/unit/test_workflow_pack_bindings.py
+++ b/tests/unit/test_workflow_pack_bindings.py
@@ -24,6 +24,7 @@ from tests.support.workflow_pack_fixtures import outcome_review_narrative_payloa
 from tests.support.workflow_pack_fixtures import operations_handoff_summary_payload
 from tests.support.workflow_pack_fixtures import proof_pack_pm_memo_payload
 from tests.support.workflow_pack_fixtures import wave_pm_memo_payload
+from tests.support.workflow_pack_fixtures import idea_explanation_payload
 
 
 def test_get_workflow_pack_execution_binding_returns_phase1_binding() -> None:
@@ -121,13 +122,7 @@ def test_get_workflow_pack_execution_binding_returns_idea_explanation_binding() 
     assert binding is not None
     assert binding.task_id == "explain.v1"
     assert binding.default_workflow_surface == "idea-explanation-evidence"
-    assert binding.validate_task_request_payload(
-        payload={
-            "redacted_evidence_packet": {},
-            "explanation_request": {},
-            "supportability": {},
-        }
-    )
+    assert binding.validate_task_request_payload(payload=idea_explanation_payload())
     registration = get_workflow_pack_registration(
         pack_id="idea_explanation.pack",
         version="v1",

--- a/tests/unit/test_workflow_pack_execution.py
+++ b/tests/unit/test_workflow_pack_execution.py
@@ -9,6 +9,7 @@ from app.services.workflow_pack_bindings import get_workflow_pack_execution_bind
 from tests.support.workflow_pack_fixtures import (
     advisory_copilot_workflow_pack_execution_request_json,
     dpm_exception_summary_workflow_pack_execution_request_json,
+    idea_explanation_workflow_pack_execution_request_json,
     operations_handoff_summary_workflow_pack_execution_request_json,
     outcome_review_narrative_workflow_pack_execution_request_json,
     pm_quality_summary_workflow_pack_execution_request_json,
@@ -126,6 +127,49 @@ def test_execute_workflow_pack_records_review_gated_advisory_copilot_output() ->
     assert structured_output["model_risk"]["evaluation_pack_ref"] == (
         "advisory-copilot-eval-pack.v1"
     )
+
+
+def test_execute_workflow_pack_records_review_gated_idea_explanation_output() -> None:
+    request = WorkflowPackExecutionRequest.model_validate(
+        idea_explanation_workflow_pack_execution_request_json(
+            correlation_id="corr-execution-idea-explanation"
+        )
+    )
+
+    response = execute_workflow_pack(request)
+
+    structured_output = response.execution.result.structured_output
+    assert response.execution.status.value == "COMPLETED"
+    assert response.workflow_pack_run.pack_id == "idea_explanation.pack"
+    assert response.workflow_pack_run.workflow_authority_owner == "lotus-idea"
+    assert structured_output["workflow_pack_family"] == "idea_explanation"
+    assert structured_output["state"] == "REVIEW_REQUIRED"
+    assert structured_output["client_ready_publication"] == "BLOCKED"
+    assert structured_output["downstream_authority"] == "BLOCKED"
+    assert structured_output["evidence_content_hash"] == "sha256:idea-evidence-high-cash-001"
+    assert structured_output["human_review_required"] is True
+    assert structured_output["source_ref_count"] == 2
+
+
+def test_validate_workflow_pack_execution_binding_runs_idea_explanation_guardrails() -> None:
+    request_payload = idea_explanation_workflow_pack_execution_request_json(
+        correlation_id="corr-execution-idea-explanation-guardrail",
+        requested_outputs=["advisor_review_summary", "client_message"],
+    )
+    request = WorkflowPackExecutionRequest.model_validate(request_payload)
+    binding = get_workflow_pack_execution_binding(
+        pack_id="idea_explanation.pack",
+        version="v1",
+    )
+    assert binding is not None
+
+    try:
+        validate_workflow_pack_execution_binding(request=request, binding=binding)
+    except HTTPException as exc:
+        assert exc.status_code == 422
+        assert "Forbidden Idea explanation outputs requested: client_message" in str(exc.detail)
+    else:
+        raise AssertionError("expected Idea explanation guardrails to reject client output")
 
 
 def test_validate_workflow_pack_execution_binding_runs_advisory_copilot_guardrails() -> None:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -269,7 +269,9 @@ Use `idea_explanation.pack@v1` only when the caller supplies:
 The idea explanation pack blocks suitability approval, proposal authority, rebalance authority,
 client-ready publication, supported-feature promotion, raw source payload exposure, raw prompt or
 generated-output exposure, and invented missing evidence before run, audit, or task-flow records are
-written. It does not own idea lifecycle truth; that authority stays in `lotus-idea`.
+written. It does not own idea lifecycle truth; that authority stays in `lotus-idea`. The
+`lotus-idea` caller policy is restricted to `explain.v1` for the governed tenant scope and does not
+grant live-provider or control-plane privilege.
 
 ```mermaid
 sequenceDiagram

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -203,7 +203,9 @@ For AI-backed product-surface support, also confirm:
     idea-evidence contracts; treat suitability approval, proposal authority, rebalance authority,
     client-ready publication, supported-feature promotion, raw payload exposure, raw prompt/output
     exposure, and invented missing evidence as guardrail-blocked requests. The pack is
-    review-gated explanation support only and does not own idea lifecycle truth.
+    review-gated explanation support only and does not own idea lifecycle truth. The caller policy
+    should allow `lotus-idea` only for restricted-tenant `explain.v1` execution and should not grant
+    live-provider or control-plane privilege.
 
 The owner-facing source for that procedure is:
 


### PR DESCRIPTION
## Summary
- Adds deterministic review-gated runtime execution for the `lotus-idea` explanation workflow pack in `lotus-ai`.
- Enforces source-safe Idea explanation guardrails before workflow execution.
- Seeds bounded `lotus-idea` caller policy for `explain.v1` without provider-control or live-provider privileges.
- Updates integration, runbook, README, repository context, and wiki truth.
- Fixes the PR auto-merge helper to use rebase auto-merge with `LOTUS_AUTOMERGE_TOKEN` and to skip cleanly when that token is unavailable.

## Validation
- `python -m pytest tests/unit/test_idea_explanation_guardrails.py tests/unit/test_workflow_pack_execution.py tests/unit/test_workflow_pack_bindings.py tests/unit/test_access_control_authorization.py tests/unit/test_memory_caller_policy_repository.py tests/unit/test_sqlalchemy_caller_policy_repository.py` (77 passed)
- `python -m pytest tests/unit/test_idea_explanation_guardrails.py tests/unit/test_workflow_pack_execution.py --cov=app.services.idea_explanation_guardrails --cov=app.providers.idea_explanation_stub --cov-report=term-missing` (38 passed; targeted module coverage 99%)
- `python -m ruff check src/app/providers/idea_explanation_stub.py src/app/providers/stub_text_provider.py src/app/services/idea_explanation_guardrails.py src/app/services/workflow_pack_execution.py src/app/repositories/memory_caller_policy_repository.py tests/support/workflow_pack_fixtures.py tests/unit/test_idea_explanation_guardrails.py tests/unit/test_workflow_pack_execution.py tests/unit/test_workflow_pack_bindings.py tests/unit/test_access_control_authorization.py tests/unit/test_memory_caller_policy_repository.py tests/unit/test_sqlalchemy_caller_policy_repository.py`
- `python -m ruff format tests/unit/test_idea_explanation_guardrails.py`
- `make migration-smoke`
- `make check` (ruff, format check, mypy, OpenAPI, migration, runtime-mode, artifacts, 1239 unit tests)
- `git diff --check`

## CI note
- The current `Queue Auto Merge` check is non-required and fails from the base-branch `pull_request_target` workflow before this PR's helper fix can take effect. This PR updates the base workflow for future PRs; required merge checks remain the merge control.

## Wiki
- Repo-local wiki source changed. Publish `lotus-ai` wiki after merge using `lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-ai`.

## Enterprise posture
- Keeps `lotus-idea` as workflow authority and `lotus-ai` as execution capability owner.
- Blocks client-ready publication, downstream authority, live provider execution, and supported-feature promotion until downstream certification evidence exists.