### PR TITLE
[codex] Tolerate idle async delivery dequeues

### DIFF
--- a/src/app/services/async_delivery_queue.py
+++ b/src/app/services/async_delivery_queue.py
@@ -10,6 +10,13 @@ from typing import Protocol
 from app.config import settings
 
 
+def _is_redis_idle_timeout(exc: Exception) -> bool:
+    return (
+        exc.__class__.__name__ == "TimeoutError"
+        and exc.__class__.__module__.startswith("redis")
+    )
+
+
 @dataclass(frozen=True)
 class AsyncQueueDeliveryMessage:
     delivery_id: str
@@ -156,7 +163,12 @@ class RedisAsyncDeliveryQueue:
 
     def dequeue(self, *, timeout_seconds: int) -> AsyncQueueDeliveryMessage | None:
         client = self._get_client()
-        result = client.blpop(self._queue_name, timeout=timeout_seconds)
+        try:
+            result = client.blpop(self._queue_name, timeout=timeout_seconds)
+        except Exception as exc:
+            if _is_redis_idle_timeout(exc):
+                return None
+            raise
         if result is None:
             return None
         client.hincrby(f"{self._queue_name}:stats", "dequeued_delivery_count", 1)

--- a/src/app/services/async_delivery_queue.py
+++ b/src/app/services/async_delivery_queue.py
@@ -11,10 +11,7 @@ from app.config import settings
 
 
 def _is_redis_idle_timeout(exc: Exception) -> bool:
-    return (
-        exc.__class__.__name__ == "TimeoutError"
-        and exc.__class__.__module__.startswith("redis")
-    )
+    return exc.__class__.__name__ == "TimeoutError" and exc.__class__.__module__.startswith("redis")
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_async_delivery_queue.py
+++ b/tests/unit/test_async_delivery_queue.py
@@ -235,6 +235,34 @@ def test_redis_async_delivery_queue_dequeues_and_reports_snapshot(
     assert snapshot.dequeued_delivery_count == 1
 
 
+def test_redis_async_delivery_queue_treats_idle_timeout_as_empty_queue(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    redis_timeout_error = type(
+        "TimeoutError",
+        (Exception,),
+        {"__module__": "redis.exceptions"},
+    )
+
+    class FakeRedisClient:
+        def blpop(self, queue_name: str, timeout: int) -> None:
+            raise redis_timeout_error("Timeout reading from socket")
+
+    fake_redis_module = SimpleNamespace(
+        Redis=SimpleNamespace(from_url=lambda url, decode_responses: FakeRedisClient())
+    )
+    monkeypatch.setattr(
+        "app.services.async_delivery_queue.importlib.import_module",
+        lambda module_name: fake_redis_module,
+    )
+    queue = RedisAsyncDeliveryQueue(
+        redis_url="redis://localhost:6379/0",
+        queue_name="lotus-ai:async:jobs",
+    )
+
+    assert queue.dequeue(timeout_seconds=3) is None
+
+
 def test_redis_async_delivery_queue_snapshot_reports_backend_unavailable(
     monkeypatch: MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- make async delivery queue dequeue return cleanly on idle timeout
- add regression coverage for idle Redis dequeue behavior

## Validation
- `python -m pytest tests/unit/test_async_delivery_queue.py -q`
- rebuilt the AI worker in the canonical local stack and confirmed it remained running
- coordinated `npm run live:validate` passed for `PB_SG_GLOBAL_BAL_001` from `lotus-workbench`

## Notes
- This supports clean stack bring-up by avoiding worker instability when no delivery item is immediately available.
