### PR TITLE
feat: issue governed provider retention confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Important posture limits:
 6. workflow-pack registrations must point to real owning-repository artifacts rather than placeholder definitions in `lotus-ai`,
 7. workflow-pack registry and control state can now run either in-memory or through a SQL-backed durable store, and the current executable workflow-pack set includes advisor brief, workspace rationale, TWR inspection support brief, the review-gated `proposal_memo_commentary.pack@v1` contract for `lotus-advise` advisor proposal memo evidence, the six review-gated `advisory_copilot_*.pack@v1` contracts for RFC-0027 `lotus-advise` evidence packets, the review-gated `dpm_pm_memo.pack@v1` contract for `lotus-manage` `DpmProofPackAiEvidenceInput`, the review-gated `dpm_wave_pm_memo.pack@v1` and `dpm_operations_handoff_summary.pack@v1` contracts for `lotus-manage` `DpmWaveReportInput`, the review-gated `dpm_exception_summary.pack@v1` contract for bounded `lotus-manage` monitoring exception evidence, the review-gated `outcome_review_narrative.pack@v1` contract for `lotus-manage` `DpmOutcomeAiEvidenceInput`, and the review-gated `idea_explanation.pack@v1` contract for `lotus-idea` redacted opportunity evidence packets,
 8. the service should be treated as a governed capability layer, not a business-domain authority.
+9. AI provider operations can issue a limited, not-certified Ed25519-signed retention/deletion
+   confirmation for completed live `idea_explanation.pack` runs. The recorder is AI-owned;
+   `lotus-idea` is only the audience. SQL persistence, tenant binding, idempotency, provider failure
+   posture, and no-raw-content claims are implementation-backed, while provider-native and bank
+   approvals remain blocked.
 
 For proposal memo commentary, RFC-0027 advisory copilot, DPM PM memo, exception summary,
 operations handoff summary, and idea explanation support, `lotus-ai` owns workflow-pack execution, provider mode, safety, guardrail validation,

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -110,6 +110,10 @@ Current repository posture:
     durable run facts, exact time-bounded model-risk inventory decisions, canonical serialization,
     Ed25519 signing, public-key discovery, and fail-closed issuance use separate interfaces without
     adding a runtime service boundary. Consumers own receipt persistence and replay protection.
+12. `src/app/provider_retention_confirmations/` is a separate internal capability package for
+    AI-provider-operations-owned retention/deletion outcomes. It reuses workflow-attestation key
+    discovery but has its own strict claims, repository port, memory/SQL adapters, migration,
+    issuance, verification, and API contract. `lotus-idea` cannot record its own provider outcome.
 
 ## Architecture And Module Map
 

--- a/alembic/versions/0039_add_provider_retention_confirmations.py
+++ b/alembic/versions/0039_add_provider_retention_confirmations.py
@@ -1,0 +1,77 @@
+"""add provider retention confirmations
+
+Revision ID: 0039_add_provider_retention_confirmations
+Revises: 0038_add_workflow_run_model_approval_ref
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0039_add_provider_retention_confirmations"
+down_revision = "0038_add_workflow_run_model_approval_ref"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_retention_confirmations",
+        sa.Column("confirmation_id", sa.String(length=128), nullable=False),
+        sa.Column("workflow_run_id", sa.String(length=128), nullable=False),
+        sa.Column("tenant_id", sa.String(length=128), nullable=False),
+        sa.Column("provider_confirmation_ref", sa.String(length=256), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=False),
+        sa.Column("request_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("outcome", sa.String(length=64), nullable=False),
+        sa.Column("envelope_payload", sa.JSON(), nullable=False),
+        sa.Column("recorded_at", sa.String(length=64), nullable=False),
+        sa.PrimaryKeyConstraint("confirmation_id"),
+        sa.UniqueConstraint("idempotency_key"),
+        sa.UniqueConstraint("provider_confirmation_ref"),
+    )
+    op.create_index(
+        "ix_provider_retention_confirmations_workflow_run_id",
+        "provider_retention_confirmations",
+        ["workflow_run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_provider_retention_confirmations_tenant_id",
+        "provider_retention_confirmations",
+        ["tenant_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_provider_retention_confirmations_outcome",
+        "provider_retention_confirmations",
+        ["outcome"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_provider_retention_confirmations_recorded_at",
+        "provider_retention_confirmations",
+        ["recorded_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_provider_retention_confirmations_recorded_at",
+        table_name="provider_retention_confirmations",
+    )
+    op.drop_index(
+        "ix_provider_retention_confirmations_outcome",
+        table_name="provider_retention_confirmations",
+    )
+    op.drop_index(
+        "ix_provider_retention_confirmations_tenant_id",
+        table_name="provider_retention_confirmations",
+    )
+    op.drop_index(
+        "ix_provider_retention_confirmations_workflow_run_id",
+        table_name="provider_retention_confirmations",
+    )
+    op.drop_table("provider_retention_confirmations")

--- a/contracts/provider-retention-confirmations/README.md
+++ b/contracts/provider-retention-confirmations/README.md
@@ -1,0 +1,10 @@
+# Provider Retention Confirmations
+
+This contract family is owned by `lotus-ai` provider operations. It records source-safe provider
+storage/deletion posture for completed live Idea explanation runs and signs the result for
+`lotus-idea` verification through the existing workflow-attestation public-key discovery path.
+
+It does not contain prompts, generated output, client identifiers, or provider secrets. It does
+not grant `lotus-idea` AI infrastructure or provider-deletion authority.
+
+Current status is `not_certified`; see the contract `remaining_blockers` for production closure.

--- a/contracts/provider-retention-confirmations/lotus-ai-provider-retention-confirmation.v1.json
+++ b/contracts/provider-retention-confirmations/lotus-ai-provider-retention-confirmation.v1.json
@@ -1,0 +1,63 @@
+{
+  "contract_id": "lotus-ai-provider-retention-confirmation",
+  "contract_version": "1.0.0",
+  "product_id": "lotus-ai:ProviderRetentionConfirmation:v1",
+  "owner_repository": "lotus-ai",
+  "approved_recorder": "lotus-ai-provider-operations",
+  "approved_consumer": "lotus-idea",
+  "method": "POST",
+  "route": "/platform/provider-operations/workflow-runs/{run_id}/retention-confirmations",
+  "key_discovery_path": "/.well-known/lotus-ai-workflow-attestation-keys",
+  "signing": {
+    "algorithm": "EdDSA",
+    "curve": "Ed25519",
+    "ttl_seconds": 300,
+    "key_rotation": "active, rotated, and revoked key posture uses the workflow attestation trust bundle"
+  },
+  "outcomes": [
+    "NO_PROVIDER_STORAGE",
+    "RETENTION_CONFIRMED",
+    "DELETION_CONFIRMED",
+    "PROVIDER_FAILURE"
+  ],
+  "authority": {
+    "provider_execution_and_storage": "lotus-ai/provider operations",
+    "idea_workflow_lineage": "lotus-idea",
+    "model_and_provider_execution": "lotus-ai",
+    "client_advice_suitability_execution": "not_granted"
+  },
+  "required_headers": [
+    "Idempotency-Key",
+    "X-Caller-App",
+    "X-Tenant-Id"
+  ],
+  "required_request_fields": [
+    "provider_confirmation_ref",
+    "retention_policy_id",
+    "outcome",
+    "provider_decision_at_utc",
+    "evidence_sha256"
+  ],
+  "invariants": [
+    "Only lotus-ai-provider-operations records provider outcomes.",
+    "Only completed, non-stub, live idea_explanation.pack runs are eligible.",
+    "Provider, model, workflow, and tenant identity are derived from the persisted run.",
+    "Caller tenant must match the persisted run tenant.",
+    "PROVIDER_FAILURE is signed with BLOCKED supportability and never implies deletion.",
+    "Same-key same-input replay returns the original envelope; changed input conflicts.",
+    "Raw prompts, unrestricted outputs, client identifiers, provider secrets, and API keys are forbidden."
+  ],
+  "persistence": {
+    "memory": "local/test only",
+    "sqlalchemy": "migration-backed provider_retention_confirmations table",
+    "migration": "0039_add_provider_retention_confirmations"
+  },
+  "supportability_status": "not_certified",
+  "remaining_blockers": [
+    "provider-native confirmation integration and approval",
+    "production SQL runtime evidence",
+    "managed signing-key and rotation evidence",
+    "bank privacy, outsourcing, and model-risk approval",
+    "mainline consumer verification proof"
+  ]
+}

--- a/docs/architecture/feature-status-and-roadmap.md
+++ b/docs/architecture/feature-status-and-roadmap.md
@@ -1,5 +1,14 @@
 # Feature Status and Roadmap
 
+## Provider Retention Confirmation
+
+`lotus-ai:ProviderRetentionConfirmation:v1` is implementation-backed but `not_certified` for
+completed live `idea_explanation.pack` runs. AI provider operations records source-safe provider
+no-storage, retention, deletion, or failure evidence; Lotus AI binds it to persisted run/provider/
+model/tenant identity, persists replay state through memory or SQL adapters, and signs the envelope
+with the existing Ed25519 workflow-attestation key family. Provider-native integration, managed-key
+runtime evidence, and privacy/outsourcing/model-risk approval remain required before promotion.
+
 This document is the quickest way to understand what `lotus-ai` supports today, what is governed but still intentionally limited, and what major feature areas are next.
 
 ## Current Product Shape

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -1,5 +1,17 @@
 # Service Operations Runbook
 
+## Provider Retention Confirmation
+
+1. Record outcomes only through AI provider operations at
+   `POST /platform/provider-operations/workflow-runs/{run_id}/retention-confirmations`.
+2. Verify the persisted run is a completed, non-stub `idea_explanation.pack` run and the caller
+   tenant matches before investigating a rejected confirmation.
+3. Treat `PROVIDER_FAILURE` plus `BLOCKED` as unresolved provider posture, never deletion proof.
+4. Consumers verify signature, key status/rotation epoch, expiry, tenant, and replay nonce using
+   `/.well-known/lotus-ai-workflow-attestation-keys` and fail closed on any mismatch.
+5. Never put prompts, generated outputs, client identifiers, provider secrets, or API keys in the
+   request, persisted envelope, logs, or support evidence.
+
 ## Standard Commands
 
 - make lint

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -47,6 +47,7 @@ class Settings(BaseSettings):
     access_control_store_mode: str = "memory"
     workflow_pack_registry_store_mode: str = "memory"
     provider_operations_store_mode: str = "memory"
+    provider_retention_confirmation_store_mode: str = "memory"
     async_runtime_store_mode: str = "memory"
     workflow_pack_run_store_mode: str = "memory"
     workflow_pack_task_flow_store_mode: str = "memory"

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -475,6 +475,22 @@ class WorkflowPackRunEventModel(Base):
     run: Mapped["WorkflowPackRunModel"] = relationship(back_populates="events")
 
 
+class ProviderRetentionConfirmationModel(Base):
+    __tablename__ = "provider_retention_confirmations"
+
+    confirmation_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    workflow_run_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    tenant_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    provider_confirmation_ref: Mapped[str] = mapped_column(
+        String(256), nullable=False, unique=True
+    )
+    idempotency_key: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    request_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    outcome: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    envelope_payload: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
 class WorkflowPackTaskFlowModel(Base):
     __tablename__ = "workflow_pack_task_flows"
 

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -481,9 +481,7 @@ class ProviderRetentionConfirmationModel(Base):
     confirmation_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     workflow_run_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
     tenant_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
-    provider_confirmation_ref: Mapped[str] = mapped_column(
-        String(256), nullable=False, unique=True
-    )
+    provider_confirmation_ref: Mapped[str] = mapped_column(String(256), nullable=False, unique=True)
     idempotency_key: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
     request_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
     outcome: Mapped[str] = mapped_column(String(64), nullable=False, index=True)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -33,6 +33,9 @@ from app.routers.task_runtime import router as task_runtime_router
 from app.routers.use_cases import router as use_cases_router
 from app.routers.workflow_packs import router as workflow_packs_router
 from app.routers.workflow_run_attestations import router as workflow_run_attestations_router
+from app.routers.provider_retention_confirmations import (
+    router as provider_retention_confirmations_router,
+)
 from app.services.startup_policy import apply_startup_readiness_policy
 
 SERVICE_NAME = settings.service_name
@@ -177,6 +180,7 @@ app.include_router(task_runtime_router)
 app.include_router(use_cases_router)
 app.include_router(workflow_packs_router)
 app.include_router(workflow_run_attestations_router)
+app.include_router(provider_retention_confirmations_router)
 app.include_router(tasks_router)
 app.include_router(audit_router)
 _install_problem_details_openapi(app)

--- a/src/app/provider_retention_confirmations/__init__.py
+++ b/src/app/provider_retention_confirmations/__init__.py
@@ -1,0 +1,1 @@
+"""Provider retention and deletion confirmation capability."""

--- a/src/app/provider_retention_confirmations/contracts.py
+++ b/src/app/provider_retention_confirmations/contracts.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.contracts.workflow_run_attestation import WorkflowRunAttestationSignature
+
+
+class ProviderRetentionOutcome(StrEnum):
+    NO_PROVIDER_STORAGE = "NO_PROVIDER_STORAGE"
+    RETENTION_CONFIRMED = "RETENTION_CONFIRMED"
+    DELETION_CONFIRMED = "DELETION_CONFIRMED"
+    PROVIDER_FAILURE = "PROVIDER_FAILURE"
+
+
+class ProviderRetentionConfirmationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    provider_confirmation_ref: str = Field(min_length=3, max_length=256)
+    retention_policy_id: str = Field(min_length=3, max_length=128)
+    outcome: ProviderRetentionOutcome
+    provider_decision_at_utc: str
+    evidence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    provider_failure_code: str | None = Field(default=None, min_length=3, max_length=128)
+
+    @model_validator(mode="after")
+    def validate_failure_posture(self) -> ProviderRetentionConfirmationRequest:
+        if self.outcome is ProviderRetentionOutcome.PROVIDER_FAILURE:
+            if self.provider_failure_code is None:
+                raise ValueError("provider failure outcome requires provider_failure_code")
+        elif self.provider_failure_code is not None:
+            raise ValueError("provider_failure_code is allowed only for provider failure")
+        return self
+
+
+class ProviderRetentionConfirmationClaims(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(pattern=r"^lotus-ai\.provider-retention-confirmation\.v1$")
+    issuer: str = Field(pattern=r"^lotus-ai$")
+    audience: str = Field(pattern=r"^lotus-idea$")
+    recorded_by: str = Field(pattern=r"^lotus-ai-provider-operations$")
+    confirmation_id: str = Field(min_length=1, max_length=128)
+    workflow_run_id: str = Field(min_length=1, max_length=128)
+    workflow_pack_id: str = Field(pattern=r"^idea_explanation\.pack$")
+    tenant_id: str = Field(min_length=1, max_length=128)
+    provider_id: str = Field(min_length=1, max_length=128)
+    provider_mode: str = Field(min_length=1, max_length=64)
+    model_id: str = Field(min_length=1, max_length=128)
+    model_version: str = Field(min_length=1, max_length=64)
+    provider_confirmation_ref: str = Field(min_length=3, max_length=256)
+    retention_policy_id: str = Field(min_length=3, max_length=128)
+    outcome: ProviderRetentionOutcome
+    provider_decision_at_utc: str
+    evidence_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    provider_failure_code: str | None = Field(default=None, min_length=3, max_length=128)
+    deletion_confirmed: bool
+    raw_prompt_included: bool = Field(default=False)
+    raw_output_included: bool = Field(default=False)
+    client_identifier_included: bool = Field(default=False)
+    supportability_status: str = Field(pattern=r"^(READY|BLOCKED)$")
+    issued_at_utc: str
+    expires_at_utc: str
+    replay_nonce: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class ProviderRetentionConfirmationEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    claims: ProviderRetentionConfirmationClaims
+    signature: WorkflowRunAttestationSignature
+    key_discovery_path: str = Field(pattern=r"^/\.well-known/lotus-ai-workflow-attestation-keys$")

--- a/src/app/provider_retention_confirmations/memory_repository.py
+++ b/src/app/provider_retention_confirmations/memory_repository.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from app.provider_retention_confirmations.repository import (
+    ProviderRetentionConfirmationConflictError,
+    ProviderRetentionConfirmationRecord,
+)
+
+
+class InMemoryProviderRetentionConfirmationRepository:
+    def __init__(self) -> None:
+        self._records: dict[str, ProviderRetentionConfirmationRecord] = {}
+        self._idempotency_key_by_provider_ref: dict[str, str] = {}
+
+    def get_by_idempotency_key(
+        self, *, idempotency_key: str
+    ) -> ProviderRetentionConfirmationRecord | None:
+        return self._records.get(idempotency_key)
+
+    def get_by_provider_confirmation_ref(
+        self, *, provider_confirmation_ref: str
+    ) -> ProviderRetentionConfirmationRecord | None:
+        idempotency_key = self._idempotency_key_by_provider_ref.get(provider_confirmation_ref)
+        return self._records.get(idempotency_key) if idempotency_key is not None else None
+
+    def save(
+        self, record: ProviderRetentionConfirmationRecord
+    ) -> ProviderRetentionConfirmationRecord:
+        existing = self._records.get(record.idempotency_key)
+        if existing is not None:
+            if existing.request_fingerprint != record.request_fingerprint:
+                raise ProviderRetentionConfirmationConflictError(
+                    "idempotency key was reused with different provider confirmation input"
+                )
+            return existing
+        self._records[record.idempotency_key] = record
+        self._idempotency_key_by_provider_ref[record.envelope.claims.provider_confirmation_ref] = (
+            record.idempotency_key
+        )
+        return record

--- a/src/app/provider_retention_confirmations/repository.py
+++ b/src/app/provider_retention_confirmations/repository.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.provider_retention_confirmations.contracts import (
+    ProviderRetentionConfirmationEnvelope,
+)
+
+
+class ProviderRetentionConfirmationConflictError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProviderRetentionConfirmationRecord:
+    idempotency_key: str
+    request_fingerprint: str
+    envelope: ProviderRetentionConfirmationEnvelope
+
+
+class ProviderRetentionConfirmationRepository(Protocol):
+    def get_by_idempotency_key(
+        self, *, idempotency_key: str
+    ) -> ProviderRetentionConfirmationRecord | None: ...
+
+    def get_by_provider_confirmation_ref(
+        self, *, provider_confirmation_ref: str
+    ) -> ProviderRetentionConfirmationRecord | None: ...
+
+    def save(
+        self, record: ProviderRetentionConfirmationRecord
+    ) -> ProviderRetentionConfirmationRecord: ...

--- a/src/app/provider_retention_confirmations/service.py
+++ b/src/app/provider_retention_confirmations/service.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from typing import NoReturn
+
+from app.contracts.workflow_run_attestation import WorkflowRunAttestationSignature
+from app.provider_retention_confirmations.contracts import (
+    ProviderRetentionConfirmationClaims,
+    ProviderRetentionConfirmationEnvelope,
+    ProviderRetentionConfirmationRequest,
+    ProviderRetentionOutcome,
+)
+from app.provider_retention_confirmations.repository import (
+    ProviderRetentionConfirmationConflictError,
+    ProviderRetentionConfirmationRecord,
+    ProviderRetentionConfirmationRepository,
+)
+from app.repositories.workflow_pack_run_repository import WorkflowPackRunRepository
+from app.services.workflow_run_attestation_signing import WorkflowRunAttestationSigner
+
+
+class ProviderRetentionConfirmationNotFoundError(LookupError):
+    pass
+
+
+class ProviderRetentionConfirmationNotIssuableError(ValueError):
+    def __init__(self, reason_code: str, message: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(message)
+
+
+def issue_provider_retention_confirmation(
+    *,
+    run_id: str,
+    request: ProviderRetentionConfirmationRequest,
+    idempotency_key: str,
+    caller_app: str,
+    tenant_id: str,
+    run_repository: WorkflowPackRunRepository,
+    confirmation_repository: ProviderRetentionConfirmationRepository,
+    signer: WorkflowRunAttestationSigner,
+    issued_at_utc: datetime | None = None,
+    ttl_seconds: int = 300,
+) -> ProviderRetentionConfirmationEnvelope:
+    fingerprint = _fingerprint(run_id, request, caller_app, tenant_id)
+    run = run_repository.get_run(run_id=run_id)
+    if run is None:
+        raise ProviderRetentionConfirmationNotFoundError(run_id)
+    if run.pack_id != "idea_explanation.pack" or run.caller_app != "lotus-idea":
+        _reject("run_not_idea_owned", "Run is not an Idea explanation workflow run.")
+    if caller_app != "lotus-ai-provider-operations":
+        _reject("caller_not_authorized", "Only AI provider operations may record outcomes.")
+    if run.tenant_id is None or tenant_id != run.tenant_id:
+        _reject("tenant_mismatch", "Caller tenant does not match the workflow run.")
+    if run.runtime_state != "COMPLETED" or run.completed_at is None:
+        _reject("run_not_completed", "Workflow run is not completed.")
+    if run.stubbed or run.provider_mode in {"disabled", "stub"}:
+        _reject("provider_execution_not_live", "Stubbed provider execution cannot be confirmed.")
+    if run.provider_id == "unverifiable" or run.model_id == "unverifiable":
+        _reject("provider_identity_unverifiable", "Provider identity is not verifiable.")
+    existing = confirmation_repository.get_by_idempotency_key(idempotency_key=idempotency_key)
+    if existing is not None:
+        if existing.request_fingerprint != fingerprint:
+            raise ProviderRetentionConfirmationConflictError(
+                "idempotency key was reused with different provider confirmation input"
+            )
+        return existing.envelope
+    replayed_provider_ref = confirmation_repository.get_by_provider_confirmation_ref(
+        provider_confirmation_ref=request.provider_confirmation_ref
+    )
+    if replayed_provider_ref is not None:
+        raise ProviderRetentionConfirmationConflictError(
+            "provider confirmation reference was already recorded"
+        )
+    if ttl_seconds < 1 or ttl_seconds > 3600:
+        raise ValueError("provider retention confirmation TTL must be between 1 and 3600 seconds")
+    provider_decision_at = _parse_timestamp(
+        request.provider_decision_at_utc,
+        "provider_decision_at_utc",
+    )
+    issued_at = issued_at_utc or datetime.now(UTC)
+    if issued_at.tzinfo is None or issued_at.utcoffset() is None:
+        raise ValueError("confirmation issue time must be timezone-aware")
+    if provider_decision_at > issued_at:
+        _reject("provider_decision_in_future", "Provider decision time cannot be in the future.")
+
+    confirmation_id = (
+        "provider_retention_"
+        + hashlib.sha256(f"{idempotency_key}:{fingerprint}".encode("utf-8")).hexdigest()[:24]
+    )
+    claims = ProviderRetentionConfirmationClaims(
+        schema_version="lotus-ai.provider-retention-confirmation.v1",
+        issuer="lotus-ai",
+        audience="lotus-idea",
+        recorded_by="lotus-ai-provider-operations",
+        confirmation_id=confirmation_id,
+        workflow_run_id=run.run_id,
+        workflow_pack_id=run.pack_id,
+        tenant_id=run.tenant_id,
+        provider_id=run.provider_id,
+        provider_mode=run.provider_mode,
+        model_id=run.model_id,
+        model_version=run.model_version,
+        provider_confirmation_ref=request.provider_confirmation_ref,
+        retention_policy_id=request.retention_policy_id,
+        outcome=request.outcome,
+        provider_decision_at_utc=_timestamp(provider_decision_at),
+        evidence_sha256=request.evidence_sha256,
+        provider_failure_code=request.provider_failure_code,
+        deletion_confirmed=request.outcome is ProviderRetentionOutcome.DELETION_CONFIRMED,
+        raw_prompt_included=False,
+        raw_output_included=False,
+        client_identifier_included=False,
+        supportability_status=(
+            "BLOCKED" if request.outcome is ProviderRetentionOutcome.PROVIDER_FAILURE else "READY"
+        ),
+        issued_at_utc=_timestamp(issued_at),
+        expires_at_utc=_timestamp(issued_at + timedelta(seconds=ttl_seconds)),
+        replay_nonce=hashlib.sha256(
+            f"{run.replay_nonce}:{request.provider_confirmation_ref}:{fingerprint}".encode()
+        ).hexdigest(),
+    )
+    signed = signer.sign(canonical_confirmation_payload(claims))
+    if signed.algorithm != "EdDSA" or not signed.signature:
+        raise ValueError("provider retention confirmation signer returned invalid signature")
+    envelope = ProviderRetentionConfirmationEnvelope(
+        claims=claims,
+        signature=WorkflowRunAttestationSignature(
+            algorithm=signed.algorithm,
+            key_id=signed.key_id,
+            rotation_epoch=signed.rotation_epoch,
+            signature_base64url=base64.urlsafe_b64encode(signed.signature)
+            .rstrip(b"=")
+            .decode("ascii"),
+        ),
+        key_discovery_path="/.well-known/lotus-ai-workflow-attestation-keys",
+    )
+    stored = confirmation_repository.save(
+        ProviderRetentionConfirmationRecord(
+            idempotency_key=idempotency_key,
+            request_fingerprint=fingerprint,
+            envelope=envelope,
+        )
+    )
+    return stored.envelope
+
+
+def canonical_confirmation_payload(claims: ProviderRetentionConfirmationClaims) -> bytes:
+    return json.dumps(
+        claims.model_dump(mode="json"),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+
+
+def _fingerprint(
+    run_id: str,
+    request: ProviderRetentionConfirmationRequest,
+    caller_app: str,
+    tenant_id: str,
+) -> str:
+    payload = {
+        "run_id": run_id,
+        "request": request.model_dump(mode="json"),
+        "caller_app": caller_app,
+        "tenant_id": tenant_id,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _parse_timestamp(value: str, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{label} must be timezone-aware")
+    return parsed.astimezone(UTC)
+
+
+def _timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _reject(reason_code: str, message: str) -> NoReturn:
+    raise ProviderRetentionConfirmationNotIssuableError(reason_code, message)

--- a/src/app/provider_retention_confirmations/sqlalchemy_repository.py
+++ b/src/app/provider_retention_confirmations/sqlalchemy_repository.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models import ProviderRetentionConfirmationModel
+from app.provider_retention_confirmations.contracts import (
+    ProviderRetentionConfirmationEnvelope,
+)
+from app.provider_retention_confirmations.repository import (
+    ProviderRetentionConfirmationConflictError,
+    ProviderRetentionConfirmationRecord,
+)
+from app.repositories.sqlalchemy_repository_base import SqlAlchemyRepositoryBase
+
+
+class SqlAlchemyProviderRetentionConfirmationRepository(SqlAlchemyRepositoryBase):
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+        if database_url.startswith("sqlite"):
+            database_path = database_url.split("///", maxsplit=1)[-1]
+            if database_path and database_path != ":memory:":
+                Path(database_path).parent.mkdir(parents=True, exist_ok=True)
+        self._configure_sqlalchemy(database_url)
+
+    def get_by_idempotency_key(
+        self, *, idempotency_key: str
+    ) -> ProviderRetentionConfirmationRecord | None:
+        with self._session_factory() as session:
+            model = session.scalar(
+                select(ProviderRetentionConfirmationModel).where(
+                    ProviderRetentionConfirmationModel.idempotency_key == idempotency_key
+                )
+            )
+            return self._to_record(model) if model is not None else None
+
+    def get_by_provider_confirmation_ref(
+        self, *, provider_confirmation_ref: str
+    ) -> ProviderRetentionConfirmationRecord | None:
+        with self._session_factory() as session:
+            model = session.scalar(
+                select(ProviderRetentionConfirmationModel).where(
+                    ProviderRetentionConfirmationModel.provider_confirmation_ref
+                    == provider_confirmation_ref
+                )
+            )
+            return self._to_record(model) if model is not None else None
+
+    def save(
+        self, record: ProviderRetentionConfirmationRecord
+    ) -> ProviderRetentionConfirmationRecord:
+        model = ProviderRetentionConfirmationModel(
+            confirmation_id=record.envelope.claims.confirmation_id,
+            workflow_run_id=record.envelope.claims.workflow_run_id,
+            tenant_id=record.envelope.claims.tenant_id,
+            provider_confirmation_ref=(record.envelope.claims.provider_confirmation_ref),
+            idempotency_key=record.idempotency_key,
+            request_fingerprint=record.request_fingerprint,
+            outcome=record.envelope.claims.outcome.value,
+            envelope_payload=record.envelope.model_dump(mode="json"),
+            recorded_at=record.envelope.claims.issued_at_utc,
+        )
+        with self._session_factory() as session:
+            session.add(model)
+            try:
+                session.commit()
+            except IntegrityError as exc:
+                session.rollback()
+                existing = self.get_by_idempotency_key(idempotency_key=record.idempotency_key)
+                if existing and existing.request_fingerprint == record.request_fingerprint:
+                    return existing
+                raise ProviderRetentionConfirmationConflictError(
+                    "idempotency key was reused with different provider confirmation input"
+                ) from exc
+        return record
+
+    @staticmethod
+    def _to_record(
+        model: ProviderRetentionConfirmationModel,
+    ) -> ProviderRetentionConfirmationRecord:
+        return ProviderRetentionConfirmationRecord(
+            idempotency_key=model.idempotency_key,
+            request_fingerprint=model.request_fingerprint,
+            envelope=ProviderRetentionConfirmationEnvelope.model_validate(model.envelope_payload),
+        )

--- a/src/app/provider_retention_confirmations/store.py
+++ b/src/app/provider_retention_confirmations/store.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from app.config import settings
+from app.provider_retention_confirmations.memory_repository import (
+    InMemoryProviderRetentionConfirmationRepository,
+)
+from app.provider_retention_confirmations.repository import (
+    ProviderRetentionConfirmationRepository,
+)
+from app.provider_retention_confirmations.sqlalchemy_repository import (
+    SqlAlchemyProviderRetentionConfirmationRepository,
+)
+
+_memory_repository = InMemoryProviderRetentionConfirmationRepository()
+_sqlalchemy_repository: SqlAlchemyProviderRetentionConfirmationRepository | None = None
+
+
+def get_provider_retention_confirmation_store() -> ProviderRetentionConfirmationRepository:
+    if settings.provider_retention_confirmation_store_mode == "memory":
+        return _memory_repository
+    if settings.provider_retention_confirmation_store_mode == "sqlalchemy":
+        if not settings.database_url:
+            raise RuntimeError(
+                "LOTUS_AI_DATABASE_URL is required when provider retention confirmation store "
+                "mode is sqlalchemy."
+            )
+        global _sqlalchemy_repository
+        if _sqlalchemy_repository is None:
+            _sqlalchemy_repository = SqlAlchemyProviderRetentionConfirmationRepository(
+                settings.database_url
+            )
+        return _sqlalchemy_repository
+    raise RuntimeError("Unsupported provider retention confirmation store mode.")
+
+
+def reset_provider_retention_confirmation_store_cache() -> None:
+    global _memory_repository
+    global _sqlalchemy_repository
+    _memory_repository = InMemoryProviderRetentionConfirmationRepository()
+    _sqlalchemy_repository = None

--- a/src/app/provider_retention_confirmations/verification.py
+++ b/src/app/provider_retention_confirmations/verification.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from app.contracts.workflow_run_attestation import WorkflowRunAttestationKeyDiscoveryResponse
+from app.provider_retention_confirmations.contracts import (
+    ProviderRetentionConfirmationEnvelope,
+)
+from app.provider_retention_confirmations.service import canonical_confirmation_payload
+
+
+def verify_provider_retention_confirmation(
+    envelope: ProviderRetentionConfirmationEnvelope,
+    *,
+    key_discovery: WorkflowRunAttestationKeyDiscoveryResponse,
+    expected_tenant_id: str,
+    at_utc: datetime | None = None,
+) -> None:
+    now = at_utc or datetime.now(UTC)
+    issued = _timestamp(envelope.claims.issued_at_utc)
+    expires = _timestamp(envelope.claims.expires_at_utc)
+    if now < issued or now >= expires:
+        raise ValueError("provider retention confirmation is not currently valid")
+    if envelope.claims.tenant_id != expected_tenant_id:
+        raise ValueError("provider retention confirmation tenant does not match")
+    matching = [
+        key
+        for key in key_discovery.keys
+        if key.key_id == envelope.signature.key_id
+        and key.rotation_epoch == envelope.signature.rotation_epoch
+    ]
+    if len(matching) != 1:
+        raise ValueError("provider retention confirmation key is unknown or ambiguous")
+    key = matching[0]
+    if key.status == "revoked":
+        raise ValueError("provider retention confirmation key is revoked")
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(_decode(key.public_key_base64url))
+        public_key.verify(
+            _decode(envelope.signature.signature_base64url),
+            canonical_confirmation_payload(envelope.claims),
+        )
+    except (InvalidSignature, ValueError) as exc:
+        raise ValueError("provider retention confirmation signature verification failed") from exc
+
+
+def _decode(value: str) -> bytes:
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def _timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("provider retention confirmation timestamp must be timezone-aware")
+    return parsed.astimezone(UTC)

--- a/src/app/routers/provider_retention_confirmations.py
+++ b/src/app/routers/provider_retention_confirmations.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Header, HTTPException, status
+
+from app.config import settings
+from app.provider_retention_confirmations.contracts import (
+    ProviderRetentionConfirmationEnvelope,
+    ProviderRetentionConfirmationRequest,
+)
+from app.provider_retention_confirmations.repository import (
+    ProviderRetentionConfirmationConflictError,
+)
+from app.provider_retention_confirmations.service import (
+    ProviderRetentionConfirmationNotFoundError,
+    ProviderRetentionConfirmationNotIssuableError,
+    issue_provider_retention_confirmation,
+)
+from app.provider_retention_confirmations.store import (
+    get_provider_retention_confirmation_store,
+)
+from app.providers.configured_workflow_run_attestation_keys import (
+    ConfiguredWorkflowRunAttestationKeys,
+)
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+
+router = APIRouter(tags=["platform"])
+
+
+@router.post(
+    "/platform/provider-operations/workflow-runs/{run_id}/retention-confirmations",
+    response_model=ProviderRetentionConfirmationEnvelope,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="issueProviderRetentionConfirmation",
+    summary="Issue a signed provider retention or deletion confirmation",
+    description=(
+        "Allows only AI provider operations to record and sign source-safe provider retention, "
+        "no-storage, deletion, or failure posture for a completed live Idea explanation run. "
+        "Provider/model/tenant "
+        "identity comes from the persisted run; prompts, outputs, client identifiers, and "
+        "provider secrets are forbidden."
+    ),
+    responses={
+        201: {"description": "Signed provider retention confirmation issued or replayed."},
+        404: {"description": "Workflow run not found."},
+        409: {"description": "Run is ineligible or the idempotency key conflicts."},
+        422: {"description": "Request or required headers are invalid."},
+        503: {"description": "Signing or confirmation persistence is unavailable."},
+    },
+)
+def issue_provider_retention_confirmation_route(
+    run_id: str,
+    request: ProviderRetentionConfirmationRequest,
+    idempotency_key: Annotated[str, Header(alias="Idempotency-Key", min_length=1)],
+    caller_app: Annotated[str, Header(alias="X-Caller-App", min_length=1)],
+    tenant_id: Annotated[str, Header(alias="X-Tenant-Id", min_length=1)],
+) -> ProviderRetentionConfirmationEnvelope:
+    try:
+        return issue_provider_retention_confirmation(
+            run_id=run_id,
+            request=request,
+            idempotency_key=idempotency_key.strip(),
+            caller_app=caller_app.strip(),
+            tenant_id=tenant_id.strip(),
+            run_repository=get_workflow_pack_run_store(),
+            confirmation_repository=get_provider_retention_confirmation_store(),
+            signer=ConfiguredWorkflowRunAttestationKeys(settings=settings),
+            ttl_seconds=settings.workflow_run_attestation_ttl_seconds,
+        )
+    except ProviderRetentionConfirmationNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except (
+        ProviderRetentionConfirmationConflictError,
+        ProviderRetentionConfirmationNotIssuableError,
+    ) as exc:
+        reason_code = getattr(exc, "reason_code", "idempotency_conflict")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error_code": "LOTUS_AI_PROVIDER_RETENTION_CONFIRMATION_NOT_ISSUABLE",
+                "detail": str(exc),
+                "metadata": {"reason_code": reason_code, "run_id": run_id},
+            },
+        ) from exc
+    except (RuntimeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "error_code": "LOTUS_AI_PROVIDER_RETENTION_CONFIRMATION_UNAVAILABLE",
+                "detail": f"Provider retention confirmation is unavailable: {exc}",
+            },
+        ) from exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ from app.services.prompt_store import reset_prompt_store_cache
 from app.services.provider_budget_policy import reset_provider_budget_state
 from app.services.provider_degradation_state import reset_provider_degradation_state
 from app.services.provider_operations_store import reset_provider_operations_store_cache
+from app.provider_retention_confirmations.store import (
+    reset_provider_retention_confirmation_store_cache,
+)
 from app.services.provider_quota_policy import reset_provider_quota_counters
 from app.services.retrieval_store import reset_retrieval_repository
 from app.services.workflow_pack_registry import reset_workflow_pack_registry_state
@@ -64,6 +67,9 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         "access_control_store_mode": settings.access_control_store_mode,
         "workflow_pack_registry_store_mode": settings.workflow_pack_registry_store_mode,
         "provider_operations_store_mode": settings.provider_operations_store_mode,
+        "provider_retention_confirmation_store_mode": (
+            settings.provider_retention_confirmation_store_mode
+        ),
         "async_runtime_store_mode": settings.async_runtime_store_mode,
         "workflow_pack_run_store_mode": settings.workflow_pack_run_store_mode,
         "workflow_pack_task_flow_store_mode": settings.workflow_pack_task_flow_store_mode,
@@ -105,6 +111,7 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         reset_provider_degradation_state()
         reset_provider_quota_counters()
         reset_provider_operations_store_cache()
+        reset_provider_retention_confirmation_store_cache()
         reset_local_openai_compatible_endpoint_probe_cache()
         reset_async_delivery_queue_cache()
         reset_async_runtime_store_cache()

--- a/tests/integration/test_provider_retention_confirmation_api_contract.py
+++ b/tests/integration/test_provider_retention_confirmation_api_contract.py
@@ -1,0 +1,106 @@
+import base64
+from dataclasses import replace
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
+
+from app.config import settings
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+from tests.support.workflow_pack_fixtures import (
+    idea_explanation_workflow_pack_execution_request_json,
+)
+
+
+def test_provider_retention_confirmation_api_is_tenant_bound_and_idempotent(
+    client: TestClient,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    execute_response = client.post(
+        "/platform/workflow-packs/execute",
+        json=idea_explanation_workflow_pack_execution_request_json(
+            correlation_id="corr-provider-retention-001"
+        ),
+    )
+    assert execute_response.status_code == 200
+    run_id = execute_response.json()["workflow_pack_run"]["run_id"]
+    repository = get_workflow_pack_run_store()
+    run = repository.get_run(run_id=run_id)
+    assert run is not None
+    repository.save_run(
+        replace(
+            run,
+            tenant_id="tenant-sg-001",
+            provider_mode="openai",
+            provider_id="text.openai",
+            model_id="gpt-5.4",
+            model_version="2026-06-01",
+            stubbed=False,
+        )
+    )
+    _configure_key(monkeypatch)
+    headers = {
+        "Idempotency-Key": "provider-retention-api-001",
+        "X-Caller-App": "lotus-ai-provider-operations",
+        "X-Tenant-Id": "tenant-sg-001",
+    }
+    payload = _payload()
+
+    first = client.post(
+        f"/platform/provider-operations/workflow-runs/{run_id}/retention-confirmations",
+        json=payload,
+        headers=headers,
+    )
+    replay = client.post(
+        f"/platform/provider-operations/workflow-runs/{run_id}/retention-confirmations",
+        json=payload,
+        headers=headers,
+    )
+    wrong_tenant = client.post(
+        f"/platform/provider-operations/workflow-runs/{run_id}/retention-confirmations",
+        json=payload,
+        headers={**headers, "Idempotency-Key": "wrong-tenant", "X-Tenant-Id": "tenant-other"},
+    )
+    conflict = client.post(
+        f"/platform/provider-operations/workflow-runs/{run_id}/retention-confirmations",
+        json={**payload, "provider_confirmation_ref": "provider-confirmation-changed"},
+        headers=headers,
+    )
+
+    assert first.status_code == 201
+    assert replay.json() == first.json()
+    assert first.json()["claims"]["provider_id"] == "text.openai"
+    assert first.json()["claims"]["tenant_id"] == "tenant-sg-001"
+    assert first.json()["claims"]["deletion_confirmed"] is True
+    assert first.json()["claims"]["raw_prompt_included"] is False
+    assert first.json()["claims"]["raw_output_included"] is False
+    assert first.json()["claims"]["client_identifier_included"] is False
+    assert wrong_tenant.status_code == 409
+    assert wrong_tenant.json()["metadata"]["reason_code"] == "tenant_mismatch"
+    assert conflict.status_code == 409
+    assert conflict.json()["metadata"]["reason_code"] == "idempotency_conflict"
+    for forbidden in ("pb_sg_global_bal_001", "client-name", "sk-test-secret"):
+        assert forbidden not in first.text.lower()
+
+
+def _configure_key(monkeypatch: MonkeyPatch) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    encoded = base64.urlsafe_b64encode(private_key.private_bytes_raw()).rstrip(b"=").decode()
+    monkeypatch.setattr(settings, "workflow_run_attestation_key_id", "attestation-key-2026-07")
+    monkeypatch.setattr(settings, "workflow_run_attestation_rotation_epoch", 1)
+    monkeypatch.setattr(settings, "workflow_run_attestation_private_key_base64url", encoded)
+    monkeypatch.setattr(
+        settings,
+        "workflow_run_attestation_key_not_before_utc",
+        "2026-07-01T00:00:00Z",
+    )
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "provider_confirmation_ref": "provider-confirmation-001",
+        "retention_policy_id": "idea-provider-zero-retention-v1",
+        "outcome": "DELETION_CONFIRMED",
+        "provider_decision_at_utc": "2026-07-12T01:59:00Z",
+        "evidence_sha256": "e" * 64,
+    }

--- a/tests/integration/test_provider_retention_confirmation_api_contract.py
+++ b/tests/integration/test_provider_retention_confirmation_api_contract.py
@@ -83,6 +83,55 @@ def test_provider_retention_confirmation_api_is_tenant_bound_and_idempotent(
         assert forbidden not in first.text.lower()
 
 
+def test_provider_retention_confirmation_api_maps_missing_run_and_signing_failure(
+    client: TestClient,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    headers = {
+        "Idempotency-Key": "provider-retention-api-failure",
+        "X-Caller-App": "lotus-ai-provider-operations",
+        "X-Tenant-Id": "tenant-sg-001",
+    }
+    missing = client.post(
+        "/platform/provider-operations/workflow-runs/missing-run/retention-confirmations",
+        json=_payload(),
+        headers=headers,
+    )
+    assert missing.status_code == 404
+
+    execute_response = client.post(
+        "/platform/workflow-packs/execute",
+        json=idea_explanation_workflow_pack_execution_request_json(
+            correlation_id="corr-provider-retention-signing-failure"
+        ),
+    )
+    run_id = execute_response.json()["workflow_pack_run"]["run_id"]
+    repository = get_workflow_pack_run_store()
+    run = repository.get_run(run_id=run_id)
+    assert run is not None
+    repository.save_run(
+        replace(
+            run,
+            tenant_id="tenant-sg-001",
+            provider_mode="openai",
+            provider_id="text.openai",
+            model_id="gpt-5.4",
+            model_version="2026-06-01",
+            stubbed=False,
+        )
+    )
+    monkeypatch.setattr(settings, "workflow_run_attestation_private_key_base64url", "")
+    unavailable = client.post(
+        f"/platform/provider-operations/workflow-runs/{run_id}/retention-confirmations",
+        json={**_payload(), "provider_confirmation_ref": "provider-signing-failure"},
+        headers=headers,
+    )
+    assert unavailable.status_code == 503
+    assert unavailable.json()["error_code"] == (
+        "LOTUS_AI_PROVIDER_RETENTION_CONFIRMATION_UNAVAILABLE"
+    )
+
+
 def _configure_key(monkeypatch: MonkeyPatch) -> None:
     private_key = Ed25519PrivateKey.generate()
     encoded = base64.urlsafe_b64encode(private_key.private_bytes_raw()).rstrip(b"=").decode()

--- a/tests/unit/test_provider_retention_confirmation.py
+++ b/tests/unit/test_provider_retention_confirmation.py
@@ -22,6 +22,7 @@ from app.provider_retention_confirmations.repository import (
     ProviderRetentionConfirmationConflictError,
 )
 from app.provider_retention_confirmations.service import (
+    ProviderRetentionConfirmationNotFoundError,
     ProviderRetentionConfirmationNotIssuableError,
     issue_provider_retention_confirmation,
 )
@@ -67,6 +68,13 @@ def test_provider_failure_is_signed_as_blocked_not_deletion_proof() -> None:
     assert envelope.claims.provider_failure_code == "PROVIDER_TIMEOUT"
     assert envelope.claims.supportability_status == "BLOCKED"
     assert envelope.claims.deletion_confirmed is False
+
+
+def test_request_rejects_inconsistent_provider_failure_details() -> None:
+    with pytest.raises(ValueError, match="requires provider_failure_code"):
+        _request(outcome="PROVIDER_FAILURE")
+    with pytest.raises(ValueError, match="allowed only for provider failure"):
+        _request(provider_failure_code="UNEXPECTED_CODE")
 
 
 def test_same_input_replays_and_changed_input_conflicts() -> None:
@@ -134,6 +142,77 @@ def test_confirmation_fails_closed_for_untrusted_run_or_caller_posture(
     assert caught.value.reason_code == reason_code
 
 
+def test_confirmation_rejects_missing_run_invalid_time_and_ttl() -> None:
+    empty_runs = InMemoryWorkflowPackRunRepository()
+    confirmations = InMemoryProviderRetentionConfirmationRepository()
+    with pytest.raises(ProviderRetentionConfirmationNotFoundError):
+        _issue_with_stores(_request(), empty_runs, confirmations)
+    with pytest.raises(ValueError, match="ISO-8601"):
+        _issue(BASE_RUN, _request(provider_decision_at_utc="not-a-time"))
+    with pytest.raises(ValueError, match="timezone-aware"):
+        _issue(BASE_RUN, _request(provider_decision_at_utc="2026-07-12T01:59:00"))
+    with pytest.raises(ProviderRetentionConfirmationNotIssuableError) as caught:
+        _issue(BASE_RUN, _request(provider_decision_at_utc="2026-07-12T02:01:00Z"))
+    assert caught.value.reason_code == "provider_decision_in_future"
+    with pytest.raises(ValueError, match="TTL"):
+        issue_provider_retention_confirmation(
+            run_id=BASE_RUN.run_id,
+            request=_request(),
+            idempotency_key="invalid-ttl",
+            caller_app="lotus-ai-provider-operations",
+            tenant_id="tenant-sg-001",
+            run_repository=_runs(BASE_RUN),
+            confirmation_repository=confirmations,
+            signer=Ed25519WorkflowRunAttestationSigner(
+                private_key=PRIVATE_KEY,
+                key_id="workflow-attestation-2026-07",
+                rotation_epoch=2,
+            ),
+            issued_at_utc=NOW,
+            ttl_seconds=0,
+        )
+
+
+def test_confirmation_rejects_naive_issue_time_and_invalid_signer_result() -> None:
+    class InvalidSigner:
+        def sign(self, payload: bytes) -> object:
+            del payload
+            return type(
+                "InvalidSignatureResult",
+                (),
+                {"algorithm": "RS256", "signature": b"", "key_id": "bad", "rotation_epoch": 1},
+            )()
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        issue_provider_retention_confirmation(
+            run_id=BASE_RUN.run_id,
+            request=_request(),
+            idempotency_key="naive-issue-time",
+            caller_app="lotus-ai-provider-operations",
+            tenant_id="tenant-sg-001",
+            run_repository=_runs(BASE_RUN),
+            confirmation_repository=InMemoryProviderRetentionConfirmationRepository(),
+            signer=Ed25519WorkflowRunAttestationSigner(
+                private_key=PRIVATE_KEY,
+                key_id="workflow-attestation-2026-07",
+                rotation_epoch=2,
+            ),
+            issued_at_utc=NOW.replace(tzinfo=None),
+        )
+    with pytest.raises(ValueError, match="invalid signature"):
+        issue_provider_retention_confirmation(
+            run_id=BASE_RUN.run_id,
+            request=_request(),
+            idempotency_key="invalid-signer",
+            caller_app="lotus-ai-provider-operations",
+            tenant_id="tenant-sg-001",
+            run_repository=_runs(BASE_RUN),
+            confirmation_repository=InMemoryProviderRetentionConfirmationRepository(),
+            signer=InvalidSigner(),  # type: ignore[arg-type]
+            issued_at_utc=NOW,
+        )
+
+
 def test_verification_rejects_forged_expired_revoked_and_wrong_tenant() -> None:
     envelope = _issue(BASE_RUN, _request())
     forged = envelope.model_copy(
@@ -168,6 +247,25 @@ def test_verification_rejects_forged_expired_revoked_and_wrong_tenant() -> None:
             envelope,
             key_discovery=_discovery(),
             expected_tenant_id="tenant-other",
+            at_utc=NOW + timedelta(minutes=1),
+        )
+    with pytest.raises(ValueError, match="unknown or ambiguous"):
+        verify_provider_retention_confirmation(
+            envelope,
+            key_discovery=_discovery(key_id="another-key"),
+            expected_tenant_id="tenant-sg-001",
+            at_utc=NOW + timedelta(minutes=1),
+        )
+    naive_timestamp = envelope.model_copy(
+        update={
+            "claims": envelope.claims.model_copy(update={"issued_at_utc": "2026-07-12T02:00:00"})
+        }
+    )
+    with pytest.raises(ValueError, match="timestamp must be timezone-aware"):
+        verify_provider_retention_confirmation(
+            naive_timestamp,
+            key_discovery=_discovery(),
+            expected_tenant_id="tenant-sg-001",
             at_utc=NOW + timedelta(minutes=1),
         )
 
@@ -233,13 +331,16 @@ def _request(**overrides: object) -> ProviderRetentionConfirmationRequest:
     return ProviderRetentionConfirmationRequest.model_validate(values)
 
 
-def _discovery(status: str = "active") -> WorkflowRunAttestationKeyDiscoveryResponse:
+def _discovery(
+    status: str = "active",
+    key_id: str = "workflow-attestation-2026-07",
+) -> WorkflowRunAttestationKeyDiscoveryResponse:
     return WorkflowRunAttestationKeyDiscoveryResponse(
         schema_version="lotus-ai.workflow-run-attestation-keys.v1",
         issuer="lotus-ai",
         keys=[
             WorkflowRunAttestationPublicKey(
-                key_id="workflow-attestation-2026-07",
+                key_id=key_id,
                 algorithm="EdDSA",
                 curve="Ed25519",
                 public_key_base64url=base64.urlsafe_b64encode(

--- a/tests/unit/test_provider_retention_confirmation.py
+++ b/tests/unit/test_provider_retention_confirmation.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from app.contracts.workflow_run_attestation import (
+    WorkflowRunAttestationKeyDiscoveryResponse,
+    WorkflowRunAttestationPublicKey,
+)
+from app.provider_retention_confirmations.contracts import (
+    ProviderRetentionConfirmationEnvelope,
+    ProviderRetentionConfirmationRequest,
+)
+from app.provider_retention_confirmations.memory_repository import (
+    InMemoryProviderRetentionConfirmationRepository,
+)
+from app.provider_retention_confirmations.repository import (
+    ProviderRetentionConfirmationConflictError,
+)
+from app.provider_retention_confirmations.service import (
+    ProviderRetentionConfirmationNotIssuableError,
+    issue_provider_retention_confirmation,
+)
+from app.provider_retention_confirmations.verification import (
+    verify_provider_retention_confirmation,
+)
+from app.providers.ed25519_workflow_run_signer import Ed25519WorkflowRunAttestationSigner
+from app.repositories.memory_workflow_pack_run_repository import InMemoryWorkflowPackRunRepository
+from app.repositories.workflow_pack_run_repository import WorkflowPackRunRecord
+from tests.unit.test_workflow_run_attestation_issuance import _record as workflow_run_record
+
+NOW = datetime(2026, 7, 12, 2, 0, tzinfo=UTC)
+PRIVATE_KEY = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+BASE_RUN = workflow_run_record()
+
+
+def test_issues_and_verifies_source_safe_deletion_confirmation() -> None:
+    envelope = _issue(BASE_RUN, _request(outcome="DELETION_CONFIRMED"))
+
+    assert envelope.claims.provider_id == "text.openai"
+    assert envelope.claims.model_id == "gpt-5.4"
+    assert envelope.claims.tenant_id == "tenant-sg-001"
+    assert envelope.claims.deletion_confirmed is True
+    assert envelope.claims.supportability_status == "READY"
+    assert envelope.claims.raw_prompt_included is False
+    assert envelope.claims.raw_output_included is False
+    assert envelope.claims.client_identifier_included is False
+    verify_provider_retention_confirmation(
+        envelope,
+        key_discovery=_discovery(),
+        expected_tenant_id="tenant-sg-001",
+        at_utc=NOW + timedelta(minutes=1),
+    )
+
+
+def test_provider_failure_is_signed_as_blocked_not_deletion_proof() -> None:
+    envelope = _issue(
+        BASE_RUN,
+        _request(outcome="PROVIDER_FAILURE", provider_failure_code="PROVIDER_TIMEOUT"),
+    )
+
+    assert envelope.claims.outcome == "PROVIDER_FAILURE"
+    assert envelope.claims.provider_failure_code == "PROVIDER_TIMEOUT"
+    assert envelope.claims.supportability_status == "BLOCKED"
+    assert envelope.claims.deletion_confirmed is False
+
+
+def test_same_input_replays_and_changed_input_conflicts() -> None:
+    runs = _runs(BASE_RUN)
+    confirmations = InMemoryProviderRetentionConfirmationRepository()
+    first = _issue_with_stores(_request(), runs, confirmations)
+    replay = _issue_with_stores(_request(), runs, confirmations)
+
+    assert replay == first
+    with pytest.raises(ProviderRetentionConfirmationConflictError):
+        _issue_with_stores(
+            _request(provider_confirmation_ref="provider-confirmation-changed"),
+            runs,
+            confirmations,
+        )
+    with pytest.raises(ProviderRetentionConfirmationConflictError):
+        _issue_with_stores(
+            _request(),
+            runs,
+            confirmations,
+            idempotency_key="provider-retention-key-new",
+        )
+
+
+@pytest.mark.parametrize(
+    ("run", "caller_app", "tenant_id", "reason_code"),
+    [
+        (
+            replace(BASE_RUN, pack_id="advisor_brief.pack"),
+            "lotus-ai-provider-operations",
+            "tenant-sg-001",
+            "run_not_idea_owned",
+        ),
+        (BASE_RUN, "lotus-idea", "tenant-sg-001", "caller_not_authorized"),
+        (BASE_RUN, "lotus-ai-provider-operations", "tenant-other", "tenant_mismatch"),
+        (
+            replace(BASE_RUN, runtime_state="FAILED"),
+            "lotus-ai-provider-operations",
+            "tenant-sg-001",
+            "run_not_completed",
+        ),
+        (
+            replace(BASE_RUN, stubbed=True),
+            "lotus-ai-provider-operations",
+            "tenant-sg-001",
+            "provider_execution_not_live",
+        ),
+        (
+            replace(BASE_RUN, provider_id="unverifiable"),
+            "lotus-ai-provider-operations",
+            "tenant-sg-001",
+            "provider_identity_unverifiable",
+        ),
+    ],
+)
+def test_confirmation_fails_closed_for_untrusted_run_or_caller_posture(
+    run: WorkflowPackRunRecord,
+    caller_app: str,
+    tenant_id: str,
+    reason_code: str,
+) -> None:
+    with pytest.raises(ProviderRetentionConfirmationNotIssuableError) as caught:
+        _issue(run, _request(), caller_app=caller_app, tenant_id=tenant_id)
+
+    assert caught.value.reason_code == reason_code
+
+
+def test_verification_rejects_forged_expired_revoked_and_wrong_tenant() -> None:
+    envelope = _issue(BASE_RUN, _request())
+    forged = envelope.model_copy(
+        update={
+            "claims": envelope.claims.model_copy(update={"retention_policy_id": "forged-policy"})
+        }
+    )
+
+    with pytest.raises(ValueError, match="signature verification"):
+        verify_provider_retention_confirmation(
+            forged,
+            key_discovery=_discovery(),
+            expected_tenant_id="tenant-sg-001",
+            at_utc=NOW + timedelta(minutes=1),
+        )
+    with pytest.raises(ValueError, match="not currently valid"):
+        verify_provider_retention_confirmation(
+            envelope,
+            key_discovery=_discovery(),
+            expected_tenant_id="tenant-sg-001",
+            at_utc=datetime.fromisoformat(envelope.claims.expires_at_utc.replace("Z", "+00:00")),
+        )
+    with pytest.raises(ValueError, match="revoked"):
+        verify_provider_retention_confirmation(
+            envelope,
+            key_discovery=_discovery(status="revoked"),
+            expected_tenant_id="tenant-sg-001",
+            at_utc=NOW + timedelta(minutes=1),
+        )
+    with pytest.raises(ValueError, match="tenant does not match"):
+        verify_provider_retention_confirmation(
+            envelope,
+            key_discovery=_discovery(),
+            expected_tenant_id="tenant-other",
+            at_utc=NOW + timedelta(minutes=1),
+        )
+
+
+def _issue(
+    run: WorkflowPackRunRecord,
+    request: ProviderRetentionConfirmationRequest,
+    *,
+    caller_app: str = "lotus-ai-provider-operations",
+    tenant_id: str = "tenant-sg-001",
+    idempotency_key: str = "provider-retention-key-001",
+) -> ProviderRetentionConfirmationEnvelope:
+    return _issue_with_stores(
+        request,
+        _runs(run),
+        InMemoryProviderRetentionConfirmationRepository(),
+        caller_app=caller_app,
+        tenant_id=tenant_id,
+    )
+
+
+def _issue_with_stores(
+    request: ProviderRetentionConfirmationRequest,
+    runs: InMemoryWorkflowPackRunRepository,
+    confirmations: InMemoryProviderRetentionConfirmationRepository,
+    *,
+    caller_app: str = "lotus-ai-provider-operations",
+    tenant_id: str = "tenant-sg-001",
+    idempotency_key: str = "provider-retention-key-001",
+) -> ProviderRetentionConfirmationEnvelope:
+    return issue_provider_retention_confirmation(
+        run_id="packrun_idea_explanation_request-001",
+        request=request,
+        idempotency_key=idempotency_key,
+        caller_app=caller_app,
+        tenant_id=tenant_id,
+        run_repository=runs,
+        confirmation_repository=confirmations,
+        signer=Ed25519WorkflowRunAttestationSigner(
+            private_key=PRIVATE_KEY,
+            key_id="workflow-attestation-2026-07",
+            rotation_epoch=2,
+        ),
+        issued_at_utc=NOW,
+    )
+
+
+def _runs(run: WorkflowPackRunRecord) -> InMemoryWorkflowPackRunRepository:
+    repository = InMemoryWorkflowPackRunRepository()
+    repository.save_run(run)
+    return repository
+
+
+def _request(**overrides: object) -> ProviderRetentionConfirmationRequest:
+    values: dict[str, object] = {
+        "provider_confirmation_ref": "provider-confirmation-001",
+        "retention_policy_id": "idea-provider-zero-retention-v1",
+        "outcome": "NO_PROVIDER_STORAGE",
+        "provider_decision_at_utc": "2026-07-12T01:59:00Z",
+        "evidence_sha256": "e" * 64,
+    }
+    values.update(overrides)
+    return ProviderRetentionConfirmationRequest.model_validate(values)
+
+
+def _discovery(status: str = "active") -> WorkflowRunAttestationKeyDiscoveryResponse:
+    return WorkflowRunAttestationKeyDiscoveryResponse(
+        schema_version="lotus-ai.workflow-run-attestation-keys.v1",
+        issuer="lotus-ai",
+        keys=[
+            WorkflowRunAttestationPublicKey(
+                key_id="workflow-attestation-2026-07",
+                algorithm="EdDSA",
+                curve="Ed25519",
+                public_key_base64url=base64.urlsafe_b64encode(
+                    PRIVATE_KEY.public_key().public_bytes_raw()
+                )
+                .rstrip(b"=")
+                .decode(),
+                rotation_epoch=2,
+                status=status,
+                not_before_utc="2026-07-01T00:00:00Z",
+                not_after_utc="2026-10-01T00:00:00Z",
+            )
+        ],
+    )

--- a/tests/unit/test_provider_retention_confirmation_contract.py
+++ b/tests/unit/test_provider_retention_confirmation_contract.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+from app.main import app
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_provider_retention_contract_matches_openapi_and_authority_boundary() -> None:
+    contract = json.loads(
+        (
+            ROOT
+            / "contracts"
+            / "provider-retention-confirmations"
+            / "lotus-ai-provider-retention-confirmation.v1.json"
+        ).read_text(encoding="utf-8")
+    )
+    operation = app.openapi()["paths"][contract["route"]]["post"]
+
+    assert contract["method"] == "POST"
+    assert contract["approved_recorder"] == "lotus-ai-provider-operations"
+    assert contract["approved_consumer"] == "lotus-idea"
+    assert contract["signing"]["curve"] == "Ed25519"
+    assert contract["supportability_status"] == "not_certified"
+    assert "ProviderRetentionConfirmationRequest" in str(operation["requestBody"])
+    assert "ProviderRetentionConfirmationEnvelope" in str(operation["responses"]["201"])
+    assert {"404", "409", "422", "503"}.issubset(operation["responses"])

--- a/tests/unit/test_provider_retention_confirmation_store.py
+++ b/tests/unit/test_provider_retention_confirmation_store.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+from pytest import MonkeyPatch
+
+from app.config import settings
+from app.provider_retention_confirmations.memory_repository import (
+    InMemoryProviderRetentionConfirmationRepository,
+)
+from app.provider_retention_confirmations.sqlalchemy_repository import (
+    SqlAlchemyProviderRetentionConfirmationRepository,
+)
+from app.provider_retention_confirmations.store import (
+    get_provider_retention_confirmation_store,
+    reset_provider_retention_confirmation_store_cache,
+)
+
+
+def test_store_factory_selects_memory_and_caches_sqlalchemy(
+    monkeypatch: MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    reset_provider_retention_confirmation_store_cache()
+    monkeypatch.setattr(settings, "provider_retention_confirmation_store_mode", "memory")
+    assert isinstance(
+        get_provider_retention_confirmation_store(),
+        InMemoryProviderRetentionConfirmationRepository,
+    )
+
+    database_path = str(tmp_path) + "/retention-confirmations.db"
+    monkeypatch.setattr(settings, "provider_retention_confirmation_store_mode", "sqlalchemy")
+    monkeypatch.setattr(settings, "database_url", f"sqlite:///{database_path}")
+    first = get_provider_retention_confirmation_store()
+    assert isinstance(first, SqlAlchemyProviderRetentionConfirmationRepository)
+    assert get_provider_retention_confirmation_store() is first
+
+
+def test_store_factory_fails_closed_for_invalid_configuration(monkeypatch: MonkeyPatch) -> None:
+    reset_provider_retention_confirmation_store_cache()
+    monkeypatch.setattr(settings, "provider_retention_confirmation_store_mode", "sqlalchemy")
+    monkeypatch.setattr(settings, "database_url", None)
+    with pytest.raises(RuntimeError, match="LOTUS_AI_DATABASE_URL"):
+        get_provider_retention_confirmation_store()
+
+    monkeypatch.setattr(settings, "provider_retention_confirmation_store_mode", "unsupported")
+    with pytest.raises(RuntimeError, match="Unsupported"):
+        get_provider_retention_confirmation_store()

--- a/tests/unit/test_sqlalchemy_provider_retention_confirmation_repository.py
+++ b/tests/unit/test_sqlalchemy_provider_retention_confirmation_repository.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from app.provider_retention_confirmations.memory_repository import (
+    InMemoryProviderRetentionConfirmationRepository,
+)
+from app.provider_retention_confirmations.repository import (
+    ProviderRetentionConfirmationRecord,
+)
+from app.provider_retention_confirmations.sqlalchemy_repository import (
+    SqlAlchemyProviderRetentionConfirmationRepository,
+)
+from tests.support.migration_runner import upgrade_database_to_head
+from tests.unit.test_provider_retention_confirmation import BASE_RUN, _issue, _request
+
+
+def test_sqlalchemy_confirmation_survives_repository_restart(tmp_path: Path) -> None:
+    database_url = f"sqlite:///{tmp_path / 'provider-retention.sqlite3'}"
+    upgrade_database_to_head(database_url)
+    envelope = _issue(BASE_RUN, _request())
+    record = ProviderRetentionConfirmationRecord(
+        idempotency_key="sql-provider-retention-001",
+        request_fingerprint="f" * 64,
+        envelope=envelope,
+    )
+    first = SqlAlchemyProviderRetentionConfirmationRepository(database_url)
+    first.save(record)
+    first.close()
+
+    restarted = SqlAlchemyProviderRetentionConfirmationRepository(database_url)
+    loaded = restarted.get_by_idempotency_key(idempotency_key="sql-provider-retention-001")
+    loaded_by_provider_ref = restarted.get_by_provider_confirmation_ref(
+        provider_confirmation_ref="provider-confirmation-001"
+    )
+    restarted.close()
+
+    assert loaded == record
+    assert loaded_by_provider_ref == record
+
+
+def test_memory_repository_replays_same_record() -> None:
+    envelope = _issue(BASE_RUN, _request())
+    record = ProviderRetentionConfirmationRecord(
+        idempotency_key="memory-provider-retention-001",
+        request_fingerprint="f" * 64,
+        envelope=envelope,
+    )
+    repository = InMemoryProviderRetentionConfirmationRepository()
+
+    assert repository.save(record) == record
+    assert repository.save(record) == record

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -32,6 +32,14 @@ The baseline rules are:
 3. no silent use of sensitive data,
 4. explicit output labeling and safety posture,
 5. full correlation and audit metadata for every AI execution.
+6. provider retention/deletion outcomes are recorded only by AI provider operations and signed for
+   bounded consumers; domain consumers cannot self-assert provider deletion.
+
+Provider retention confirmation for Idea explanation runs is currently `not_certified`. The
+implementation binds provider/model/tenant identity to the durable workflow run, signs source-safe
+outcomes with Ed25519, and persists idempotency through memory or SQL adapters. Provider-native
+confirmation, managed-key runtime proof, and bank privacy/outsourcing/model-risk approvals remain
+required; `PROVIDER_FAILURE` is explicitly blocked posture rather than deletion evidence.
 
 ## Boundary Rules
 


### PR DESCRIPTION
## Scope

Implements the Lotus AI producer side of RFC-0002 Slice 06 provider-retention evidence for `idea_explanation.pack` runs.

- introduces an internal `provider_retention_confirmations` capability package with stable service/repository interfaces;
- derives tenant, provider, provider mode, model, version, and workflow identity from a completed persisted run;
- restricts recording to AI provider operations and signs a short-lived `lotus-ai.provider-retention-confirmation.v1` envelope for audience `lotus-idea`;
- supports memory and migration-backed SQL persistence with exact idempotency and confirmation/reference/nonce replay fencing;
- reuses governed Ed25519 workflow-attestation key discovery without transferring provider authority to consumers;
- excludes raw prompts, outputs, client identifiers, and provider payloads;
- synchronizes contract, API/OpenAPI, migration, operations docs, repository context, README, and repo-authored wiki source.

## Boundary

Lotus AI owns provider-operation evidence. Lotus Idea can verify and persist the signed receipt but cannot create, override, or infer provider retention/deletion outcomes. This PR does not certify a provider, approve model risk, or claim production deletion compliance.

## Verification

- `make check`: passed, including 1,348 unit tests and static/OpenAPI/migration/runtime checks
- `make ci`: passed, including 1,350 unit tests, isolated integration/E2E/coverage/security lanes, dependency audit, and Docker build
- branch is current with `origin/main`, clean, and contains 4 scoped commits
- stranded truth: only this active branch is unmerged relative to `origin/main`
- supported capability remains `not_certified`

## Non-Degradation

No runtime service split was introduced. Provider retention remains an internal bounded module in the existing Lotus AI service, with explicit ports and adapters. Raw sensitive content is not persisted or signed.

## Remaining Certification

Provider-native live confirmation, managed signing keys, production SQL evidence, privacy/outsourcing/model-risk approval, mainline release evidence, consumer live proof, and post-merge wiki publication remain required.

Progresses #115. Supports `lotus-idea#344` and `lotus-idea#340` without closing either consumer certification issue.