### PR TITLE
Align AI workflow action runtime baseline

### DIFF
--- a/.github/workflows/feature-lane.yml
+++ b/.github/workflows/feature-lane.yml
@@ -22,14 +22,14 @@ jobs:
     name: Feature Lane / Workflow Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-actionlint@v1
 
   lint-typecheck-governance:
     name: Feature Lane / Lint Typecheck Governance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -60,7 +60,7 @@ jobs:
     needs: [lint-typecheck-governance]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -23,14 +23,14 @@ jobs:
     name: Main Releasability / Workflow Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-actionlint@v1
 
   lint-typecheck-security:
     name: Main Releasability / Lint Typecheck Security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -73,7 +73,7 @@ jobs:
           - suite: e2e
             path: tests/e2e
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -90,7 +90,7 @@ jobs:
             python -m pytest ${{ matrix.path }} --cov=src --cov-report=
           fi
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-data-${{ matrix.suite }}
           path: .coverage.${{ matrix.suite }}
@@ -102,7 +102,7 @@ jobs:
     needs: [lint-typecheck-security]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -116,8 +116,10 @@ jobs:
     name: Main Releasability / Coverage Gate (Combined)
     needs: [test-suites, runtime-mode-smoke]
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--no-deprecation"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -125,7 +127,7 @@ jobs:
       - name: Install
         run: make install
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -140,6 +142,6 @@ jobs:
     needs: [coverage-gate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build Docker image
         run: make docker-build

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -23,14 +23,14 @@ jobs:
     name: PR Merge Gate / Workflow Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-actionlint@v1
 
   lint-typecheck-security:
     name: PR Merge Gate / Lint Typecheck Security
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -73,7 +73,7 @@ jobs:
           - suite: e2e
             path: tests/e2e
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -90,7 +90,7 @@ jobs:
             python -m pytest ${{ matrix.path }} --cov=src --cov-report=
           fi
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-data-${{ matrix.suite }}
           path: .coverage.${{ matrix.suite }}
@@ -102,7 +102,7 @@ jobs:
     needs: [lint-typecheck-security]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -116,8 +116,10 @@ jobs:
     name: PR Merge Gate / Coverage Gate (Combined)
     needs: [test-suites, runtime-mode-smoke]
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--no-deprecation"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -125,7 +127,7 @@ jobs:
       - name: Install
         run: make install
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -140,6 +142,6 @@ jobs:
     needs: [coverage-gate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Build Docker image
         run: make docker-build


### PR DESCRIPTION
## Summary
- Align lotus-ai GitHub workflow core action majors with the platform action runtime baseline.
- Update checkout to `actions/checkout@v7`, coverage upload to `actions/upload-artifact@v7`, and coverage download to `actions/download-artifact@v8`.
- Set `NODE_OPTIONS=--no-deprecation` on coverage aggregation jobs that use `download-artifact@v8`, per platform baseline guidance.

## Evidence
- Baseline trigger: Main Releasability run 29293931184 on `8c6d6626af54f830a7be960892a44e173c5aca22` passed but emitted Node 20 deprecation annotations for `upload-artifact@v4` and `download-artifact@v4`.
- Official release metadata checked: `actions/upload-artifact` latest `v7.0.1`; `actions/download-artifact` latest `v8.0.1`.
- Local focused validation:
  - `rg -n "actions/(checkout@v6|upload-artifact@v4|download-artifact@v4)" .github/workflows` returned no matches.
  - `git diff --check` passed.
  - `docker run --rm -v ${PWD}:/repo -w /repo rhysd/actionlint:latest` passed.

## Governance
- Stranded truth: `git fetch origin --prune` and `git branch -r --no-merged origin/main` found no unmerged governance branches.
- Docs/wiki/context: no change. Workflow action versions now match the existing platform standard; repo commands, lane names, and operator-facing truth did not change.
- Skill/context: no change. Existing `lotus-ci-enforcement-governance` and platform action runtime baseline already describe this failure mode.