### PR TITLE
fix(ai): preserve advisory copilot grounding evidence

### DIFF
--- a/src/app/providers/advisory_copilot_stub.py
+++ b/src/app/providers/advisory_copilot_stub.py
@@ -6,6 +6,7 @@ from typing import Any
 def build_advisory_copilot_stub_result(
     *,
     context_payload: dict[str, object],
+    source_refs: list[str] | None = None,
 ) -> tuple[str, dict[str, object]] | None:
     evidence_packet = context_payload.get("copilot_evidence_packet")
     copilot_request = context_payload.get("copilot_request")
@@ -22,7 +23,11 @@ def build_advisory_copilot_stub_result(
     action_family = _as_str(copilot_request.get("action_family"))
     evidence_packet_id = _as_str(evidence_packet.get("evidence_packet_id"))
     evidence_packet_hash = _as_str(evidence_packet.get("evidence_packet_hash"))
-    sections = _sections(evidence_packet.get("sections"), action_family=action_family)
+    sections = _sections(
+        evidence_packet.get("sections"),
+        action_family=action_family,
+        source_refs=source_refs or [],
+    )
     unsupported_evidence = evidence_packet.get("unsupported_evidence")
 
     message = (
@@ -46,6 +51,8 @@ def build_advisory_copilot_stub_result(
         "human_review_required": True,
         "unsupported_claims": _string_list(supportability.get("unsupported_claims")),
         "model_risk": {
+            "approved_provider_id": _as_str(model_risk_controls.get("approved_provider_id")),
+            "approved_model_version": _as_str(model_risk_controls.get("approved_model_version")),
             "approved_instruction_set": _as_str(
                 model_risk_controls.get("approved_instruction_set")
             ),
@@ -62,30 +69,69 @@ def build_advisory_copilot_stub_result(
     return message, structured_output
 
 
-def _sections(value: object, *, action_family: str) -> list[dict[str, str]]:
+def _sections(
+    value: object,
+    *,
+    action_family: str,
+    source_refs: list[str],
+) -> list[dict[str, object]]:
     if not isinstance(value, list):
         return []
-    sections: list[dict[str, str]] = []
+    sections: list[dict[str, object]] = []
     for item in value[:8]:
         if not isinstance(item, dict):
             continue
         section_key = _as_str(item.get("section_key"))
         title = _as_str(item.get("title"))
-        summary_items = item.get("summary_items")
-        summary_text = "; ".join(_string_list(summary_items))
-        if not section_key or not title or not summary_text:
+        section_source_refs = _section_source_refs(item.get("source_refs"), source_refs)
+        if not section_key or not title or not section_source_refs:
             continue
         sections.append(
             {
                 "section_key": section_key,
                 "title": title,
                 "text": (
-                    f"{title}: {summary_text} This {action_family.lower().replace('_', ' ')} "
-                    "draft is bounded to supplied source evidence and requires review."
+                    f"{title}: Review the supplied source-backed evidence for this "
+                    f"{action_family.lower().replace('_', ' ')} draft before advisor use."
                 ),
+                "claims": [
+                    {
+                        "claim_id": f"{section_key.lower()}_source_backed_review",
+                        "claim_text": (
+                            f"{title} is supported by the supplied governed source evidence."
+                        ),
+                        "source_refs": section_source_refs[:8],
+                    }
+                ],
             }
         )
     return sections
+
+
+def _section_source_refs(value: object, source_refs: list[str]) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    matched: list[str] = []
+    for item in value[:8]:
+        if not isinstance(item, dict):
+            continue
+        source_system = _as_str(item.get("source_system"))
+        source_type = _as_str(item.get("source_type"))
+        content_hash = _source_ref_content_hash(item.get("content_hash"))
+        if not source_system or not source_type:
+            continue
+        prefix = f"{source_system}:{source_type}:"
+        suffix = f":{content_hash}"
+        for source_ref in source_refs:
+            if source_ref.startswith(prefix) and source_ref.endswith(suffix):
+                matched.append(source_ref)
+                break
+    return matched
+
+
+def _source_ref_content_hash(value: object) -> str:
+    content_hash = _as_str(value)
+    return content_hash or "no-content-hash"
 
 
 def _pack_family(action_family: str) -> str:

--- a/src/app/providers/stub_text_provider.py
+++ b/src/app/providers/stub_text_provider.py
@@ -81,6 +81,7 @@ class StubTextProvider:
             )
         advisory_copilot_result = build_advisory_copilot_stub_result(
             context_payload=request.context_payload,
+            source_refs=request.source_refs,
         )
         if request.task_id == "explain.v1" and advisory_copilot_result:
             message, structured_output = advisory_copilot_result
@@ -94,26 +95,7 @@ class StubTextProvider:
                 max_output_tokens=request.max_output_tokens,
                 stubbed=True,
                 message=message,
-                structured_output={
-                    **structured_output,
-                    "phase": settings.delivery_phase,
-                    "provider_id": self.descriptor.provider_id,
-                    "provider_mode": settings.provider_mode,
-                    "adapter_kind": self.descriptor.adapter_kind.value,
-                    "timeout_ms": request.timeout_ms,
-                    "retry_count": 0,
-                    "max_output_tokens": request.max_output_tokens,
-                    "output_label": request.output_label,
-                    "safety_mode": request.safety_mode,
-                    "redaction_posture": request.redaction_posture,
-                    "context_summary": request.context_summary,
-                    "context_keys": sorted(request.context_payload.keys()),
-                    "source_refs": request.source_refs,
-                    "stub_reason": (
-                        "lotus-ai emits deterministic governed advisory copilot posture before "
-                        "live provider rollout is enabled for this workflow pack."
-                    ),
-                },
+                structured_output=structured_output,
             )
         proposal_memo_commentary_result = build_proposal_memo_commentary_stub_result(
             context_payload=request.context_payload,

--- a/src/app/services/task_execution_mapping.py
+++ b/src/app/services/task_execution_mapping.py
@@ -74,6 +74,8 @@ def build_task_result_payload(
     context: TaskExecutionContext,
     resolved: ResolvedTaskExecution,
 ) -> dict[str, object]:
+    if _is_domain_only_workflow_pack_output(resolved.provider_execution.structured_output):
+        return dict(resolved.provider_execution.structured_output)
     payload = {
         **resolved.provider_execution.structured_output,
         "input_mode": context.request.input_mode,
@@ -84,6 +86,13 @@ def build_task_result_payload(
     ):
         payload["caller_app"] = context.request.caller.caller_app
     return payload
+
+
+def _is_domain_only_workflow_pack_output(payload: dict[str, object]) -> bool:
+    workflow_pack_family = payload.get("workflow_pack_family")
+    return isinstance(workflow_pack_family, str) and workflow_pack_family.startswith(
+        "advisory_copilot_"
+    )
 
 
 def _utcnow() -> str:

--- a/tests/support/workflow_pack_fixtures.py
+++ b/tests/support/workflow_pack_fixtures.py
@@ -232,6 +232,8 @@ def advisory_copilot_payload(*, requested_outputs: list[str] | None = None) -> d
             "requested_by": "advisor_001",
         },
         "model_risk_controls": {
+            "approved_provider_id": "lotus-ai",
+            "approved_model_version": "lotus-ai-governed-model.v1",
             "approved_instruction_set": "advisory-copilot-instructions.v1",
             "prompt_template_version": "advisory-copilot-prompt-template.v1",
             "output_schema_version": "advisory-copilot-output-schema.v1",
@@ -273,7 +275,10 @@ def advisory_copilot_workflow_pack_execution_request_json(
             "context": {
                 "summary": "Generate review-gated advisory copilot draft from bounded evidence.",
                 "payload": advisory_copilot_payload(requested_outputs=requested_outputs),
-                "source_refs": ["lotus-advise:copilot-evidence-packet:copilot_packet_pb_sg_001"],
+                "source_refs": [
+                    "lotus-advise:copilot-evidence-packet:copilot_packet_pb_sg_001",
+                    ("lotus-advise:POLICY_EVALUATION:policy_eval_sg_001:sha256:policy-evaluation"),
+                ],
             },
             "expected_output_label": "EXPLANATION_ONLY",
         },

--- a/tests/unit/test_advisory_copilot_guardrails.py
+++ b/tests/unit/test_advisory_copilot_guardrails.py
@@ -198,10 +198,13 @@ def test_build_advisory_copilot_stub_result_returns_review_gated_output() -> Non
     assert structured_output["client_ready_publication"] == "BLOCKED"
     assert structured_output["human_review_required"] is True
     assert structured_output["section_count"] == 1
-    section = structured_output["sections"][0]
-    assert "policy_eval_sg_001" not in section["text"]
-    assert "PB_SG_GLOBAL_BAL_001" not in section["text"]
-    assert section["claims"][0]["source_refs"] == [
+    sections = cast(list[dict[str, object]], structured_output["sections"])
+    section = sections[0]
+    section_text = cast(str, section["text"])
+    section_claims = cast(list[dict[str, object]], section["claims"])
+    assert "policy_eval_sg_001" not in section_text
+    assert "PB_SG_GLOBAL_BAL_001" not in section_text
+    assert section_claims[0]["source_refs"] == [
         "lotus-advise:POLICY_EVALUATION:policy_eval_sg_001:sha256:policy-evaluation"
     ]
     assert structured_output["unsupported_evidence_count"] == 0
@@ -255,7 +258,9 @@ def test_build_advisory_copilot_stub_result_preserves_no_content_hash_grounding(
         "advisory_copilot_operations_report_handoff"
     )
     assert structured_output["section_count"] == 1
-    assert structured_output["sections"][0]["claims"][0]["source_refs"] == [
+    sections = cast(list[dict[str, object]], structured_output["sections"])
+    section_claims = cast(list[dict[str, object]], sections[0]["claims"])
+    assert section_claims[0]["source_refs"] == [
         "lotus-advise:PROPOSAL_WORKFLOW_EVENT:event_execution_ready_001:no-content-hash"
     ]
 

--- a/tests/unit/test_advisory_copilot_guardrails.py
+++ b/tests/unit/test_advisory_copilot_guardrails.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from typing import cast
 
@@ -181,7 +182,12 @@ def test_validate_advisory_copilot_payload_rejects_technical_leakage_anywhere() 
 
 
 def test_build_advisory_copilot_stub_result_returns_review_gated_output() -> None:
-    result = build_advisory_copilot_stub_result(context_payload=_payload())
+    result = build_advisory_copilot_stub_result(
+        context_payload=_payload(),
+        source_refs=[
+            ("lotus-advise:POLICY_EVALUATION:policy_eval_sg_001:sha256:policy-evaluation")
+        ],
+    )
 
     assert result is not None
     message, structured_output = result
@@ -192,6 +198,12 @@ def test_build_advisory_copilot_stub_result_returns_review_gated_output() -> Non
     assert structured_output["client_ready_publication"] == "BLOCKED"
     assert structured_output["human_review_required"] is True
     assert structured_output["section_count"] == 1
+    section = structured_output["sections"][0]
+    assert "policy_eval_sg_001" not in section["text"]
+    assert "PB_SG_GLOBAL_BAL_001" not in section["text"]
+    assert section["claims"][0]["source_refs"] == [
+        "lotus-advise:POLICY_EVALUATION:policy_eval_sg_001:sha256:policy-evaluation"
+    ]
     assert structured_output["unsupported_evidence_count"] == 0
     unsupported_claims = structured_output["unsupported_claims"]
     assert isinstance(unsupported_claims, list)
@@ -199,7 +211,53 @@ def test_build_advisory_copilot_stub_result_returns_review_gated_output() -> Non
 
     model_risk = structured_output["model_risk"]
     assert isinstance(model_risk, dict)
+    assert model_risk["approved_provider_id"] == "lotus-ai"
+    assert model_risk["approved_model_version"] == "lotus-ai-governed-model.v1"
     assert model_risk["evaluation_pack_ref"] == "advisory-copilot-eval-pack.v1"
+    assert len(json.dumps(structured_output, sort_keys=True, separators=(",", ":"))) < 2500
+
+
+def test_build_advisory_copilot_stub_result_preserves_no_content_hash_grounding() -> None:
+    payload = _payload()
+    evidence_packet = _dict_at(payload, "copilot_evidence_packet")
+    evidence_packet["action_family"] = "OPERATIONS_REPORT_HANDOFF"
+    evidence_packet["sections"] = [
+        {
+            "section_key": "OPERATIONS_HANDOFF",
+            "title": "Operations handoff",
+            "evidence_class": "OPERATIONS_HANDOFF_EVIDENCE",
+            "summary_items": [
+                "Latest implementation handoff posture is EXECUTION_READY.",
+            ],
+            "source_refs": [
+                {
+                    "source_system": "lotus-advise",
+                    "source_type": "PROPOSAL_WORKFLOW_EVENT",
+                    "source_ref_token": "tok_source-ref_001",
+                    "content_hash": None,
+                    "access_class": "OPERATIONS_HANDOFF_EVIDENCE",
+                }
+            ],
+        }
+    ]
+    _dict_at(payload, "copilot_request")["action_family"] = "OPERATIONS_REPORT_HANDOFF"
+
+    result = build_advisory_copilot_stub_result(
+        context_payload=payload,
+        source_refs=[
+            "lotus-advise:PROPOSAL_WORKFLOW_EVENT:event_execution_ready_001:no-content-hash"
+        ],
+    )
+
+    assert result is not None
+    _, structured_output = result
+    assert structured_output["workflow_pack_family"] == (
+        "advisory_copilot_operations_report_handoff"
+    )
+    assert structured_output["section_count"] == 1
+    assert structured_output["sections"][0]["claims"][0]["source_refs"] == [
+        "lotus-advise:PROPOSAL_WORKFLOW_EVENT:event_execution_ready_001:no-content-hash"
+    ]
 
 
 def test_build_advisory_copilot_stub_result_requires_governed_context_sections() -> None:

--- a/tests/unit/test_workflow_pack_execution.py
+++ b/tests/unit/test_workflow_pack_execution.py
@@ -124,9 +124,84 @@ def test_execute_workflow_pack_records_review_gated_advisory_copilot_output() ->
     assert structured_output["client_ready_publication"] == "BLOCKED"
     assert structured_output["human_review_required"] is True
     assert structured_output["evidence_packet_hash"] == "sha256:copilot-evidence-packet-001"
+    assert structured_output["sections"][0]["claims"][0]["source_refs"] == [
+        "lotus-advise:POLICY_EVALUATION:policy_eval_sg_001:sha256:policy-evaluation"
+    ]
+    assert "policy_eval_sg_001" not in structured_output["sections"][0]["text"]
+    assert "caller_app" not in structured_output
+    assert "input_mode" not in structured_output
+    assert "source_refs" not in structured_output
+    assert "context_summary" not in structured_output
+    assert "phase" not in structured_output
+    assert "output_label" not in structured_output
+    assert "safety_mode" not in structured_output
+    assert "redaction_posture" not in structured_output
+    assert "context_keys" not in structured_output
+    assert "stub_reason" not in structured_output
+    assert structured_output["model_risk"]["approved_provider_id"] == "lotus-ai"
+    assert structured_output["model_risk"]["approved_model_version"] == (
+        "lotus-ai-governed-model.v1"
+    )
     assert structured_output["model_risk"]["evaluation_pack_ref"] == (
         "advisory-copilot-eval-pack.v1"
     )
+
+
+def test_execute_workflow_pack_preserves_advisory_copilot_no_content_hash_grounding() -> None:
+    request_payload = advisory_copilot_workflow_pack_execution_request_json(
+        correlation_id="corr-execution-advisory-copilot-operations-handoff"
+    )
+    request_payload["pack_id"] = "advisory_copilot_operations_report_handoff.pack"
+    request_payload["workflow_surface"] = "advisory-copilot-operations-report-handoff"
+    task_request = request_payload["task_request"]
+    assert isinstance(task_request, dict)
+    context = task_request["context"]
+    assert isinstance(context, dict)
+    payload = context["payload"]
+    assert isinstance(payload, dict)
+    copilot_request = payload["copilot_request"]
+    assert isinstance(copilot_request, dict)
+    copilot_request["action_family"] = "OPERATIONS_REPORT_HANDOFF"
+    evidence_packet = payload["copilot_evidence_packet"]
+    assert isinstance(evidence_packet, dict)
+    evidence_packet["action_family"] = "OPERATIONS_REPORT_HANDOFF"
+    evidence_packet["sections"] = [
+        {
+            "section_key": "OPERATIONS_HANDOFF",
+            "title": "Operations handoff",
+            "evidence_class": "OPERATIONS_HANDOFF_EVIDENCE",
+            "summary_items": [
+                "Latest implementation handoff posture is EXECUTION_READY.",
+            ],
+            "source_refs": [
+                {
+                    "source_system": "lotus-advise",
+                    "source_type": "PROPOSAL_WORKFLOW_EVENT",
+                    "source_ref_token": "tok_source-ref_001",
+                    "content_hash": None,
+                    "access_class": "OPERATIONS_HANDOFF_EVIDENCE",
+                }
+            ],
+        }
+    ]
+    context["source_refs"] = [
+        "lotus-advise:copilot-evidence-packet:copilot_packet_pb_sg_001",
+        "lotus-advise:PROPOSAL_WORKFLOW_EVENT:event_execution_ready_001:no-content-hash",
+    ]
+    request = WorkflowPackExecutionRequest.model_validate(request_payload)
+
+    response = execute_workflow_pack(request)
+
+    structured_output = response.execution.result.structured_output
+    assert response.execution.status.value == "COMPLETED"
+    assert response.workflow_pack_run.pack_id == "advisory_copilot_operations_report_handoff.pack"
+    assert structured_output["workflow_pack_family"] == (
+        "advisory_copilot_operations_report_handoff"
+    )
+    assert structured_output["section_count"] == 1
+    assert structured_output["sections"][0]["claims"][0]["source_refs"] == [
+        "lotus-advise:PROPOSAL_WORKFLOW_EVENT:event_execution_ready_001:no-content-hash"
+    ]
 
 
 def test_execute_workflow_pack_records_review_gated_idea_explanation_output() -> None:


### PR DESCRIPTION
## Summary
- preserve Advisory Copilot source grounding for governed no-content-hash source references
- keep generated output bounded to source refs and model-risk posture without echoing raw identifiers as narrative content
- add guardrail and workflow-pack execution coverage for the grounding behavior

## Related issues
- Keep #124 open until merge-to-main, exact-main validation, and QA closure evidence are recorded.

## Local validation
- `python -m ruff check src/app/providers/advisory_copilot_stub.py src/app/providers/stub_text_provider.py src/app/services/task_execution_mapping.py tests/support/workflow_pack_fixtures.py tests/unit/test_advisory_copilot_guardrails.py tests/unit/test_workflow_pack_execution.py` — passed
- `python -m pytest tests/unit/test_advisory_copilot_guardrails.py tests/unit/test_workflow_pack_execution.py -q` — 46 passed
- `git diff --check` — passed

## Evidence posture
- Tiering: local focused feature proof complete; PR checks are required before merge.
- Non-degradation: preserves AI/domain authority boundary; no live-provider, client-ready, retention/deletion, or production model-risk certification claim is made by this PR.
- Stranded truth: no docs/wiki/context/contract files changed in this PR.