### PR TITLE
Align advisory copilot governed model identity

### DIFF
--- a/src/app/providers/stub_text_provider.py
+++ b/src/app/providers/stub_text_provider.py
@@ -85,14 +85,17 @@ class StubTextProvider:
         )
         if request.task_id == "explain.v1" and advisory_copilot_result:
             message, structured_output = advisory_copilot_result
+            provider_id, model_version = _advisory_copilot_model_risk_identity(structured_output)
             return ProviderExecutionResponse(
-                provider_id=self.descriptor.provider_id,
+                provider_id=provider_id,
                 provider_mode=settings.provider_mode,
                 adapter_kind=self.descriptor.adapter_kind,
                 failure_category=None,
                 timeout_ms=request.timeout_ms,
                 retry_count=0,
                 max_output_tokens=request.max_output_tokens,
+                model_id="advisory-copilot-deterministic-stub",
+                model_version=model_version,
                 stubbed=True,
                 message=message,
                 structured_output=structured_output,
@@ -100,6 +103,7 @@ class StubTextProvider:
         proposal_memo_commentary_result = build_proposal_memo_commentary_stub_result(
             context_payload=request.context_payload,
         )
+
         if request.task_id == "explain.v1" and proposal_memo_commentary_result:
             message, structured_output = proposal_memo_commentary_result
             return ProviderExecutionResponse(
@@ -419,3 +423,21 @@ class StubTextProvider:
                 ),
             },
         )
+
+
+def _advisory_copilot_model_risk_identity(
+    structured_output: dict[str, object],
+) -> tuple[str, str | None]:
+    model_risk = structured_output.get("model_risk")
+    if not isinstance(model_risk, dict):
+        return StubTextProvider.descriptor.provider_id, None
+    provider_id = model_risk.get("approved_provider_id")
+    model_version = model_risk.get("approved_model_version")
+    return (
+        (
+            provider_id
+            if isinstance(provider_id, str) and provider_id
+            else StubTextProvider.descriptor.provider_id
+        ),
+        model_version if isinstance(model_version, str) and model_version else None,
+    )

--- a/tests/unit/test_workflow_pack_execution.py
+++ b/tests/unit/test_workflow_pack_execution.py
@@ -6,6 +6,7 @@ from app.services.workflow_pack_execution import (
     validate_workflow_pack_execution_binding,
 )
 from app.services.workflow_pack_bindings import get_workflow_pack_execution_binding
+from app.services.workflow_pack_run_ledger import load_workflow_pack_run_context
 from tests.support.workflow_pack_fixtures import (
     advisory_copilot_workflow_pack_execution_request_json,
     dpm_exception_summary_workflow_pack_execution_request_json,
@@ -145,6 +146,14 @@ def test_execute_workflow_pack_records_review_gated_advisory_copilot_output() ->
     assert structured_output["model_risk"]["evaluation_pack_ref"] == (
         "advisory-copilot-eval-pack.v1"
     )
+    assert response.execution.audit.provider_id == "lotus-ai"
+    assert response.execution.audit.model_version == "lotus-ai-governed-model.v1"
+    assert response.execution.audit.adapter_kind is not None
+    assert response.execution.audit.adapter_kind.value == "STUB"
+    assert response.execution.audit.stubbed is True
+    recorded_run = load_workflow_pack_run_context(run_id=response.workflow_pack_run.run_id).record
+    assert recorded_run.provider_id == "lotus-ai"
+    assert recorded_run.model_version == "lotus-ai-governed-model.v1"
 
 
 def test_execute_workflow_pack_preserves_advisory_copilot_no_content_hash_grounding() -> None:


### PR DESCRIPTION
## Summary
- Aligns advisory copilot stub execution identity to the governed lotus-ai provider/model identity.
- Preserves review-gated advisory copilot output posture and audit lineage.

## Issues
- Addresses sgajbi/lotus-ai#126.
- Keep issue open until merged-main validation and QA lifecycle closure are recorded.

## Validation
- Static: included in `make check`.
- Unit: `python -m pytest tests\unit\test_workflow_pack_execution.py::test_execute_workflow_pack_records_review_gated_advisory_copilot_output tests\unit\test_advisory_copilot_guardrails.py::test_build_advisory_copilot_stub_result_returns_review_gated_output -q` => 2 passed.
- Unit broader: `python -m pytest tests\unit\test_workflow_pack_execution.py tests\unit\test_advisory_copilot_guardrails.py tests\unit\test_task_execution_mapping.py -q` => 49 passed.
- Repo gate: `make check` => passed, 1376 unit tests passed.
- Runtime: rebuilt lotus-ai/worker; live workflow-pack execution returned 200 with audit provider `lotus-ai`, governed model version, `STUB`, and review state `AWAITING_REVIEW`.

## Governance
- Tiering: draft PR; required GitHub PR checks must pass before merge.
- Post-merge mainline proof: pending after merge.
- Wiki: no repo wiki source changed.
- Non-degradation: bounded identity correction only; no API expansion, no provider rollout, no domain authority movement.