### PR TITLE
ci: dispatch main releasability after merged PRs

### DIFF
--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -1,0 +1,23 @@
+name: Merged PR Main Releasability Dispatch
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch-main-releasability:
+    name: Dispatch Main Releasability
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dispatch main releasability gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main

--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ Local Docker runtime notes:
 2. `Pull Request Merge Gate`
 3. `Main Releasability Gate`
 
+Merged pull requests to `main` also dispatch `main-releasability.yml` through
+`.github/workflows/merged-pr-main-releasability.yml`, giving RFC and release-governance work
+exact-main evidence instead of relying on stale branch checks or manual reruns.
+
 Repo-native validation mapping:
 
 - fast local gate: `make check`

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -199,6 +199,10 @@ Use these commands as the primary local contract:
 2. `Pull Request Merge Gate`
 3. `Main Releasability Gate`
 
+Merged PRs to `main` dispatch `main-releasability.yml` through
+`.github/workflows/merged-pr-main-releasability.yml`, so post-merge RFC and release evidence can
+bind to the exact mainline commit.
+
 Important validation expectations:
 
 1. OpenAPI, evaluation-manifest, evaluation-run, async-job, and migration gates are active,

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+
+
+def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "pull_request_target:" in text
+    assert "types: [closed]" in text
+    assert "actions: write" in text
+    assert "contents: read" in text
+    assert "github.event.pull_request.merged == true" in text
+    assert "github.event.pull_request.base.ref == 'main'" in text
+    assert "timeout-minutes: 10" in text
+    assert 'gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main' in text
+
+
+def test_main_releasability_gate_remains_dispatchable() -> None:
+    workflow = WORKFLOW_DIR / "main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in text
+    assert 'branches: [ "main" ]' in text
+    assert "name: Main Releasability Gate" in text

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -9,6 +9,9 @@
 3. `Main Releasability Gate`
 
 The repo-native commands are designed to map to those lanes rather than to ad hoc local habits.
+When a PR is merged into `main`, `.github/workflows/merged-pr-main-releasability.yml` dispatches
+`main-releasability.yml` on `main` so release evidence and RFC closure can cite exact-main proof
+rather than branch-only checks.
 
 ## Primary Commands
 


### PR DESCRIPTION
## Summary
- add the governed merged-PR dispatcher for `main-releasability.yml`
- add a focused workflow-contract test so dispatcher deletion or target drift is caught locally
- update README, repo context, and repo-authored wiki CI source with the new exact-main release-evidence behavior

Tracks #128.

## Evidence
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` -> 2 passed
- `make check` -> 1378 passed; lint, format-check, typecheck, OpenAPI gate, eval-manifest gate, eval-run gate, async-job gate, RFC-0002 Idea explanation proof gate, migration smoke, runtime-mode smoke, and unit tests passed
- `python automation/validate_auto_merge_releasability.py --require-local-repos` from `lotus-platform` -> passed with local `lotus-ai` dispatcher present
- `powershell -ExecutionPolicy Bypass -File automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai -AllowUnpublishedSourceChanges` from `lotus-platform` -> expected DiffCount 1 because this branch intentionally updates repo-authored wiki source

## Scope and non-goals
- CI/release-governance only; no AI runtime, provider, prompt, retention, model-risk, authn, or authz behavior changed.
- No API, migration, OpenAPI, or container runtime behavior changed.

## Wiki decision
Repo-authored wiki source changed in `wiki/Validation-and-CI.md`; publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-ai`, then run strict `-CheckOnly` parity.

## Stranded truth
`git fetch origin --prune` and `git branch -r --no-merged origin/main` showed no unmerged `lotus-ai` remote branches before this work.

## Post-merge requirement
After merge, verify the exact merge SHA has a successful Main Releasability Gate run. Then update `sgajbi/lotus-platform#520` so the `lotus-ai` temporary exception can be removed in the platform exception cleanup sweep.