### PR TITLE
CI: remove duplicate main releasability trigger

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -1,8 +1,6 @@
 name: Main Releasability Gate
 
 on:
-  push:
-    branches: [ "main" ]
   workflow_dispatch:
 
 concurrency:

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -19,10 +19,11 @@ def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
     assert 'gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main' in text
 
 
-def test_main_releasability_gate_remains_dispatchable() -> None:
+def test_main_releasability_gate_is_dispatchable_without_duplicate_push_trigger() -> None:
     workflow = WORKFLOW_DIR / "main-releasability.yml"
     text = workflow.read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in text
-    assert 'branches: [ "main" ]' in text
+    assert "push:" not in text
+    assert 'branches: [ "main" ]' not in text
     assert "name: Main Releasability Gate" in text


### PR DESCRIPTION
## Summary

- Remove the duplicate direct `push` trigger from `main-releasability.yml` now that `merged-pr-main-releasability.yml` owns automatic post-merge dispatch.
- Keep manual `workflow_dispatch` support for explicit exact-main validation.
- Strengthen the repo-local workflow contract test so the duplicate automatic trigger cannot be reintroduced silently.

## Issue tracking

Issue: #130

Keep #130 open for issue-loop lifecycle until this PR is merged, exact-main validation passes, wiki/no-wiki evidence is recorded, and branch cleanup is complete.

## Validation

- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` => 2 passed
- `git diff --check` => passed
- `make check` => ruff, format check, mypy, OpenAPI gate, eval fixture/run gates, async job gate, RFC-0002 Idea explanation proof, migration contract check, runtime-mode integration smoke, and 1378 unit tests passed

## Stranded truth reconciliation

- `git fetch origin --prune` completed.
- `git branch -r --no-merged origin/main` returned no unmerged remote branches requiring durable-truth reconciliation.

## Wiki decision

No repo-local `wiki/` source changed. This is workflow and workflow-contract-test hardening only.

## Non-degradation

This is CI-governance hardening. It preserves exact-main validation semantics while avoiding duplicate automatic Main Releasability runs and keeps the manual dispatch path available for operator-controlled validation.