### PR TITLE
ci: assert exact merged sha in releasability dispatch

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -2,6 +2,15 @@ name: Main Releasability Gate
 
 on:
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: "Optional merged pull-request SHA that this run must validate."
+        required: false
+        type: string
+      triggering_pr:
+        description: "Optional pull request number that dispatched this mainline validation."
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,8 +26,32 @@ env:
   COVERAGE_FAIL_UNDER: "99"
 
 jobs:
+  exact-revision-assertion:
+    name: Main Releasability / Exact Revision Assertion
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert expected merged PR SHA
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          TRIGGERING_PR: ${{ inputs.triggering_pr }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          if [ -z "$EXPECTED_SHA" ]; then
+            echo "No expected_sha input supplied; treating this as an operator-dispatched main releasability run."
+            exit 0
+          fi
+          if [ "$actual_sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::Main releasability checkout SHA $actual_sha does not match expected merged PR SHA $EXPECTED_SHA for PR ${TRIGGERING_PR:-unknown}."
+            exit 1
+          fi
+          echo "Validated exact merged PR SHA $EXPECTED_SHA for PR ${TRIGGERING_PR:-unknown}."
+
   workflow-lint:
     name: Main Releasability / Workflow Lint
+    needs: [exact-revision-assertion]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -26,6 +59,7 @@ jobs:
 
   lint-typecheck-security:
     name: Main Releasability / Lint Typecheck Security
+    needs: [exact-revision-assertion]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -20,4 +20,15 @@ jobs:
       - name: Dispatch main releasability gate
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$MERGE_COMMIT_SHA" ]; then
+            echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
+            exit 1
+          fi
+          gh workflow run main-releasability.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f expected_sha="$MERGE_COMMIT_SHA" \
+            -f triggering_pr="$PR_NUMBER"

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -16,7 +16,11 @@ def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
     assert "github.event.pull_request.merged == true" in text
     assert "github.event.pull_request.base.ref == 'main'" in text
     assert "timeout-minutes: 10" in text
-    assert 'gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main' in text
+    assert "gh workflow run main-releasability.yml" in text
+    assert "--ref main" in text
+    assert "github.event.pull_request.merge_commit_sha" in text
+    assert '-f expected_sha="$MERGE_COMMIT_SHA"' in text
+    assert '-f triggering_pr="$PR_NUMBER"' in text
 
 
 def test_main_releasability_gate_is_dispatchable_without_duplicate_push_trigger() -> None:
@@ -24,6 +28,9 @@ def test_main_releasability_gate_is_dispatchable_without_duplicate_push_trigger(
     text = workflow.read_text(encoding="utf-8")
 
     assert "workflow_dispatch:" in text
+    assert "expected_sha:" in text
+    assert "triggering_pr:" in text
+    assert "git rev-parse HEAD" in text
     assert "push:" not in text
     assert 'branches: [ "main" ]' not in text
     assert "name: Main Releasability Gate" in text


### PR DESCRIPTION
## Summary
- Passes the merged PR `merge_commit_sha` into Main Releasability as `expected_sha`.
- Adds an exact-revision assertion so a dispatched run fails if GitHub resolves `main` to a later SHA.
- Preserves manual `workflow_dispatch` without `expected_sha` for operator validation of current `main`.

## RFC-0002 / issue traceability
- Related to sgajbi/lotus-platform#691.
- RFC-0002 Slice 17 release evidence hardening.
- Keep sgajbi/lotus-platform#691 open until the platform validator and remaining Workbench rollout posture are merged/validated.

## Validation
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q`
- `git diff --check`