### PR TITLE
ci: dispatch main releasability by immutable ref

### DIFF
--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
 
 jobs:
   dispatch-main-releasability:
@@ -23,12 +23,29 @@ jobs:
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           if [ -z "$MERGE_COMMIT_SHA" ]; then
             echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
             exit 1
           fi
+
+          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"
+          existing_ref_sha=""
+          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then
+            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then
+              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"
+              exit 1
+            fi
+          else
+            existing_ref_sha=""
+          fi
+          if [ -z "$existing_ref_sha" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$dispatch_ref" \
+              -f sha="$MERGE_COMMIT_SHA" >/dev/null
+          fi
           gh workflow run main-releasability.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref main \
+            --ref "$dispatch_ref" \
             -f expected_sha="$MERGE_COMMIT_SHA" \
             -f triggering_pr="$PR_NUMBER"

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -3,24 +3,118 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
+IMMUTABLE_REF_LOOKUP_CONDITION = (
+    'if existing_ref_sha="$(gh api '
+    '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+    '--jq .object.sha 2>/dev/null)"; then'
+)
+LOOKUP_FAILURE_RESET_BLOCK = '\n          else\n            existing_ref_sha=""\n          fi\n'
+
+
+def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
+    errors: list[str] = []
+    required_fragments = (
+        "pull_request_target:",
+        "types: [closed]",
+        "actions: write",
+        "contents: write",
+        "github.event.pull_request.merged == true",
+        "github.event.pull_request.base.ref == 'main'",
+        "timeout-minutes: 10",
+        "set -euo pipefail",
+        "github.event.pull_request.merge_commit_sha",
+        'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+        'existing_ref_sha=""',
+        IMMUTABLE_REF_LOOKUP_CONDITION,
+        "repos/$GITHUB_REPOSITORY/git/refs",
+        'ref="refs/tags/$dispatch_ref"',
+        "gh workflow run main-releasability.yml",
+        '--ref "$dispatch_ref"',
+        '-f expected_sha="$MERGE_COMMIT_SHA"',
+        '-f triggering_pr="$PR_NUMBER"',
+    )
+    for fragment in required_fragments:
+        if fragment not in text:
+            errors.append(f"merged-pr-main-releasability.yml missing `{fragment}`")
+    if "--ref main" in text:
+        errors.append("merged-pr-main-releasability.yml must not dispatch mutable `--ref main`")
+    if "git/ref/tags/$dispatch_ref" in text and IMMUTABLE_REF_LOOKUP_CONDITION not in text:
+        errors.append(
+            "merged-pr-main-releasability.yml must use the complete immutable-ref lookup "
+            "condition ending immediately in `; then`"
+        )
+    if LOOKUP_FAILURE_RESET_BLOCK not in text:
+        errors.append(
+            "merged-pr-main-releasability.yml lookup failure arm must only reset "
+            "`existing_ref_sha` before the outer `fi`"
+        )
+    return errors
 
 
 def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
     workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
     text = workflow.read_text(encoding="utf-8")
 
-    assert "pull_request_target:" in text
-    assert "types: [closed]" in text
-    assert "actions: write" in text
-    assert "contents: read" in text
-    assert "github.event.pull_request.merged == true" in text
-    assert "github.event.pull_request.base.ref == 'main'" in text
-    assert "timeout-minutes: 10" in text
-    assert "gh workflow run main-releasability.yml" in text
-    assert "--ref main" in text
-    assert "github.event.pull_request.merge_commit_sha" in text
-    assert '-f expected_sha="$MERGE_COMMIT_SHA"' in text
-    assert '-f triggering_pr="$PR_NUMBER"' in text
+    assert _merged_pr_dispatch_contract_errors(text) == []
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_mutable_ref() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace('--ref "$dispatch_ref"', "--ref main")
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert "merged-pr-main-releasability.yml must not dispatch mutable `--ref main`" in errors
+    assert 'merged-pr-main-releasability.yml missing `--ref "$dispatch_ref"`' in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_unguarded_lookup() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        IMMUTABLE_REF_LOOKUP_CONDITION,
+        'existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"',
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must use the complete immutable-ref lookup "
+        "condition ending immediately in `; then`"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_lookup_condition_suffix() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        IMMUTABLE_REF_LOOKUP_CONDITION,
+        IMMUTABLE_REF_LOOKUP_CONDITION.replace("; then", " && false; then"),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must use the complete immutable-ref lookup "
+        "condition ending immediately in `; then`"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_trailing_reset_command() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        LOOKUP_FAILURE_RESET_BLOCK,
+        (
+            '\n          else\n            existing_ref_sha=""\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/actions/runs?per_page=1" >/dev/null\n'
+            "          fi\n"
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml lookup failure arm must only reset "
+        "`existing_ref_sha` before the outer `fi`"
+    ) in errors
 
 
 def test_main_releasability_gate_is_dispatchable_without_duplicate_push_trigger() -> None:


### PR DESCRIPTION
## Summary

Closes #133.

This PR removes the mutable-branch race from the merged-PR main releasability dispatcher for RFC-0002 Slice 17. The dispatcher now creates/reuses an immutable per-merge tag ref tied to `github.event.pull_request.merge_commit_sha` and dispatches `main-releasability.yml` through that ref instead of mutable `main`.

## Scope

- Updates `.github/workflows/merged-pr-main-releasability.yml` to:
  - run under `set -euo pipefail`,
  - create `main-releasability-${MERGE_COMMIT_SHA}` as an immutable dispatch ref,
  - fail closed if an existing dispatch ref points to a different SHA,
  - dispatch `main-releasability.yml` with `--ref "$dispatch_ref"`,
  - use `contents: write` only because tag ref creation requires it.
- Strengthens `tests/unit/test_ci_workflow_contracts.py` so the repo-local workflow contract rejects:
  - mutable `--ref main`,
  - unguarded immutable-ref lookup,
  - lookup conditions with appended shell suffixes,
  - trailing executable commands after the lookup failure reset.

## RFC-0002 boundary

This is release-evidence hardening only. It does not change AI product behavior, live-provider posture, model-risk approval posture, supported-feature truth, workflow-pack semantics, or downstream Idea proof claims.

## Local evidence

- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged remote branches
- `python -m ruff format tests/unit/test_ci_workflow_contracts.py`
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py`
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` -> 6 passed
- `make lint`
- `make check` -> includes `tests/unit` full suite, 1,382 passed
- `git diff --check`

## Wiki / docs decision

No wiki or supported-feature update in this PR. The change is an internal CI release-governance control and keeps existing RFC-0002 support truth unchanged.

## Branch hygiene

Branch: `issue-133-dispatch-ref-lookup-guard`
Merge method: rebase merge expected after Feature Lane and PR Merge Gate pass. Branch cleanup and exact-main releasability proof remain required after merge before closing execution evidence.