### PR TITLE
ci: enforce structural dispatch contract

### DIFF
--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -179,6 +179,7 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
             command == IMMUTABLE_REF_CREATION_COMMAND
             or command.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
         )
+        and "||" not in command
         and IMMUTABLE_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_REF_CREATION_SHA_FIELD in command
     )
@@ -214,9 +215,16 @@ def _immutable_ref_lookup_blocks(text: str) -> list[str]:
 def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
     lines = text.splitlines()
     blocks: list[str] = []
+    outer_depth = 0
     for index, line in enumerate(lines):
         stripped_line = line.strip()
-        if stripped_line not in IMMUTABLE_REF_LOOKUP_CONDITIONS:
+        if stripped_line not in IMMUTABLE_REF_LOOKUP_CONDITIONS or outer_depth != 0:
+            if not stripped_line or _is_shell_comment(stripped_line):
+                continue
+            if _opens_nested_shell_scope(stripped_line):
+                outer_depth += 1
+            if _closes_nested_shell_scope(stripped_line):
+                outer_depth -= 1
             continue
 
         block_lines = [line]
@@ -231,6 +239,10 @@ def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
             if depth == 0:
                 break
         blocks.append("\n".join(block_lines))
+        if _opens_nested_shell_scope(stripped_line):
+            outer_depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            outer_depth -= 1
     return blocks
 
 
@@ -750,6 +762,61 @@ def test_merged_pr_main_releasability_dispatcher_rejects_commented_payload_field
         "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
         "inside the empty existing-ref branch with exact ref and SHA fields"
     ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_masked_ref_creation_failure() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" '
+            '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" || true'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_function_scoped_lookup_guard() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = (
+        workflow.read_text(encoding="utf-8")
+        .replace(
+            (
+                '          if existing_ref_sha="$(gh api '
+                '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+                '--jq .object.sha 2>/dev/null)"; then\n'
+            ),
+            (
+                "          lookup_dispatch_ref() {\n"
+                '            if existing_ref_sha="$(gh api '
+                '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+                '--jq .object.sha 2>/dev/null)"; then\n'
+            ),
+            1,
+        )
+        .replace(
+            ('          fi\n          if [ -z "$existing_ref_sha" ]; then\n'),
+            ('            fi\n          }\n          if [ -z "$existing_ref_sha" ]; then\n'),
+            1,
+        )
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must guard immutable-ref lookup with an if/else reset "
+        "before dispatch" in errors
+    )
 
 
 def test_merged_pr_main_releasability_dispatcher_binds_payload_to_creation_command() -> None:

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -3,12 +3,20 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
-IMMUTABLE_REF_LOOKUP_CONDITION = (
-    'if existing_ref_sha="$(gh api '
-    '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
-    '--jq .object.sha 2>/dev/null)"; then'
+IMMUTABLE_REF_LOOKUP_CONDITIONS = (
+    (
+        'if existing_ref_sha="$(gh api '
+        '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+        '--jq .object.sha 2>/dev/null)"; then'
+    ),
+    (
+        'if existing_ref_sha="$(gh api '
+        '"repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" '
+        '--jq .object.sha 2>/dev/null)"; then'
+    ),
 )
-LOOKUP_FAILURE_RESET_BLOCK = '\n          else\n            existing_ref_sha=""\n          fi\n'
+IMMUTABLE_REF_LOOKUP_CONDITION = IMMUTABLE_REF_LOOKUP_CONDITIONS[0]
+IMMUTABLE_REF_MISMATCH_CONDITION = 'if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then'
 
 
 def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
@@ -25,7 +33,6 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
         "github.event.pull_request.merge_commit_sha",
         'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
         'existing_ref_sha=""',
-        IMMUTABLE_REF_LOOKUP_CONDITION,
         "repos/$GITHUB_REPOSITORY/git/refs",
         'ref="refs/tags/$dispatch_ref"',
         "gh workflow run main-releasability.yml",
@@ -38,17 +45,200 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
             errors.append(f"merged-pr-main-releasability.yml missing `{fragment}`")
     if "--ref main" in text:
         errors.append("merged-pr-main-releasability.yml must not dispatch mutable `--ref main`")
-    if "git/ref/tags/$dispatch_ref" in text and IMMUTABLE_REF_LOOKUP_CONDITION not in text:
+    if not _has_conditionally_guarded_immutable_ref_lookup(text):
         errors.append(
-            "merged-pr-main-releasability.yml must use the complete immutable-ref lookup "
-            "condition ending immediately in `; then`"
+            "merged-pr-main-releasability.yml must guard immutable-ref lookup "
+            "with an if/else reset before dispatch"
         )
-    if LOOKUP_FAILURE_RESET_BLOCK not in text:
+    elif not _guarded_lookup_success_arms_fail_on_ref_mismatch(text):
         errors.append(
-            "merged-pr-main-releasability.yml lookup failure arm must only reset "
-            "`existing_ref_sha` before the outer `fi`"
+            "merged-pr-main-releasability.yml must fail closed with exit 1 when "
+            "an existing immutable dispatch ref points to a different SHA"
+        )
+    if any("||" in block for block in _immutable_ref_lookup_blocks(text)):
+        errors.append(
+            "merged-pr-main-releasability.yml must not mask immutable-ref lookup "
+            "failures with shell OR fallbacks"
         )
     return errors
+
+
+def _opens_nested_shell_scope(stripped_line: str) -> bool:
+    return (
+        stripped_line == "("
+        or stripped_line.startswith("(")
+        or stripped_line.startswith(("if ", "for ", "while ", "until ", "case "))
+        or stripped_line.startswith("function ")
+        or stripped_line.endswith("() {")
+        or stripped_line.endswith("(){")
+        or stripped_line.endswith(" {")
+    )
+
+
+def _closes_nested_shell_scope(stripped_line: str) -> bool:
+    return stripped_line in {"fi", "done", "esac", "}"} or stripped_line.startswith(")")
+
+
+def _is_shell_comment(stripped_line: str) -> bool:
+    return stripped_line.startswith("#")
+
+
+def _contains_immutable_dispatch_ref_lookup(text: str) -> bool:
+    return "git/ref/tags/$dispatch_ref" in text or "git/ref/tags/${dispatch_ref}" in text
+
+
+def _immutable_ref_lookup_blocks(text: str) -> list[str]:
+    lines = text.splitlines()
+    blocks: list[str] = []
+    for index, line in enumerate(lines):
+        stripped_line = line.strip()
+        if _is_shell_comment(stripped_line) or not _contains_immutable_dispatch_ref_lookup(line):
+            continue
+
+        block_lines = [line]
+        if (
+            stripped_line == "then"
+            or stripped_line.endswith("; then")
+            or stripped_line.endswith(')"')
+        ):
+            blocks.append("\n".join(block_lines))
+            continue
+        for follow in lines[index + 1 :]:
+            block_lines.append(follow)
+            stripped = follow.strip()
+            if stripped == "then" or stripped.endswith("; then"):
+                break
+            if not follow.rstrip().endswith("\\") and stripped.endswith(')"'):
+                break
+        blocks.append("\n".join(block_lines))
+    return blocks
+
+
+def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
+    lines = text.splitlines()
+    blocks: list[str] = []
+    for index, line in enumerate(lines):
+        stripped_line = line.strip()
+        if stripped_line not in IMMUTABLE_REF_LOOKUP_CONDITIONS:
+            continue
+
+        block_lines = [line]
+        depth = 1
+        for follow in lines[index + 1 :]:
+            block_lines.append(follow)
+            stripped_follow = follow.strip()
+            if _opens_nested_shell_scope(stripped_follow):
+                depth += 1
+            if _closes_nested_shell_scope(stripped_follow):
+                depth -= 1
+            if depth == 0:
+                break
+        blocks.append("\n".join(block_lines))
+    return blocks
+
+
+def _outer_lookup_else_arm_has_unconditional_reset(block: str) -> bool:
+    lines = block.splitlines()
+    else_index: int | None = None
+    depth = 1
+    for index, line in enumerate(lines[1:], start=1):
+        stripped = line.strip()
+        if stripped == "else" and depth == 1:
+            else_index = index
+            break
+        if _opens_nested_shell_scope(stripped):
+            depth += 1
+        if _closes_nested_shell_scope(stripped):
+            depth -= 1
+
+    if else_index is None:
+        return False
+
+    executable_commands: list[str] = []
+    depth = 1
+    for line in lines[else_index + 1 :]:
+        stripped = line.strip()
+        if stripped == "fi" and depth == 1:
+            break
+        if not stripped or _is_shell_comment(stripped):
+            continue
+        executable_commands.append(stripped)
+        if _opens_nested_shell_scope(stripped):
+            depth += 1
+        if _closes_nested_shell_scope(stripped):
+            depth -= 1
+    return executable_commands == ['existing_ref_sha=""']
+
+
+def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
+    lines = block.splitlines()
+    then_arm: list[str] = []
+    depth = 1
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "else" and depth == 1:
+            break
+        then_arm.append(line)
+        if _opens_nested_shell_scope(stripped):
+            depth += 1
+        if _closes_nested_shell_scope(stripped):
+            depth -= 1
+
+    condition_depth = 1
+    for index, line in enumerate(then_arm):
+        stripped_line = line.strip()
+        if stripped_line != IMMUTABLE_REF_MISMATCH_CONDITION or condition_depth != 1:
+            if _opens_nested_shell_scope(stripped_line):
+                condition_depth += 1
+            if _closes_nested_shell_scope(stripped_line):
+                condition_depth -= 1
+            continue
+
+        direct_executable_commands: list[str] = []
+        depth = 1
+        for follow in then_arm[index + 1 :]:
+            stripped_follow = follow.strip()
+            if stripped_follow == "fi" and depth == 1:
+                break
+            if not stripped_follow or _is_shell_comment(stripped_follow):
+                continue
+            if depth == 1:
+                direct_executable_commands.append(stripped_follow)
+            if _opens_nested_shell_scope(stripped_follow):
+                depth += 1
+            if _closes_nested_shell_scope(stripped_follow):
+                depth -= 1
+        return "exit 1" in direct_executable_commands
+    return False
+
+
+def _is_conditionally_guarded_immutable_ref_lookup_block(block: str) -> bool:
+    return (
+        _contains_immutable_dispatch_ref_lookup(block)
+        and "\n" in block
+        and "else" in block
+        and _outer_lookup_else_arm_has_unconditional_reset(block)
+        and block.strip().endswith("fi")
+    )
+
+
+def _has_conditionally_guarded_immutable_ref_lookup(text: str) -> bool:
+    lookup_blocks = _immutable_ref_lookup_blocks(text)
+    guarded_blocks = _immutable_ref_lookup_guard_blocks(text)
+    return (
+        bool(lookup_blocks)
+        and len(lookup_blocks) == len(guarded_blocks)
+        and all(
+            _is_conditionally_guarded_immutable_ref_lookup_block(block) for block in guarded_blocks
+        )
+    )
+
+
+def _guarded_lookup_success_arms_fail_on_ref_mismatch(text: str) -> bool:
+    guarded_blocks = _immutable_ref_lookup_guard_blocks(text)
+    return bool(guarded_blocks) and all(
+        _outer_lookup_then_arm_has_mismatch_exit(block) for block in guarded_blocks
+    )
 
 
 def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
@@ -78,8 +268,71 @@ def test_merged_pr_main_releasability_dispatcher_rejects_unguarded_lookup() -> N
     errors = _merged_pr_dispatch_contract_errors(text)
 
     assert (
-        "merged-pr-main-releasability.yml must use the complete immutable-ref lookup "
-        "condition ending immediately in `; then`"
+        "merged-pr-main-releasability.yml must guard immutable-ref lookup "
+        "with an if/else reset before dispatch"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_accepts_braced_lookup() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        "git/ref/tags/$dispatch_ref",
+        "git/ref/tags/${dispatch_ref}",
+    )
+
+    assert _merged_pr_dispatch_contract_errors(text) == []
+
+
+def test_merged_pr_main_releasability_dispatcher_ignores_commented_lookup() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        IMMUTABLE_REF_LOOKUP_CONDITION,
+        (
+            "          # Lookup repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref "
+            "before creating it.\n"
+            f"          {IMMUTABLE_REF_LOOKUP_CONDITION}"
+        ),
+    )
+
+    assert _merged_pr_dispatch_contract_errors(text) == []
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_later_braced_unguarded_lookup() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        '          if [ -z "$existing_ref_sha" ]; then',
+        (
+            '          existing_ref_sha="$(gh api '
+            '"repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" '
+            '--jq .object.sha 2>/dev/null)"\n'
+            '          if [ -z "$existing_ref_sha" ]; then'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must guard immutable-ref lookup "
+        "with an if/else reset before dispatch"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_masked_lookup_fallback() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        IMMUTABLE_REF_LOOKUP_CONDITION,
+        (
+            'existing_ref_sha="$(gh api '
+            '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+            '--jq .object.sha 2>/dev/null || :)"'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must not mask immutable-ref lookup "
+        "failures with shell OR fallbacks"
     ) in errors
 
 
@@ -93,15 +346,15 @@ def test_merged_pr_main_releasability_dispatcher_rejects_lookup_condition_suffix
     errors = _merged_pr_dispatch_contract_errors(text)
 
     assert (
-        "merged-pr-main-releasability.yml must use the complete immutable-ref lookup "
-        "condition ending immediately in `; then`"
+        "merged-pr-main-releasability.yml must guard immutable-ref lookup "
+        "with an if/else reset before dispatch"
     ) in errors
 
 
 def test_merged_pr_main_releasability_dispatcher_rejects_trailing_reset_command() -> None:
     workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
     text = workflow.read_text(encoding="utf-8").replace(
-        LOOKUP_FAILURE_RESET_BLOCK,
+        '\n          else\n            existing_ref_sha=""\n          fi\n',
         (
             '\n          else\n            existing_ref_sha=""\n'
             '            gh api "repos/$GITHUB_REPOSITORY/actions/runs?per_page=1" >/dev/null\n'
@@ -112,8 +365,93 @@ def test_merged_pr_main_releasability_dispatcher_rejects_trailing_reset_command(
     errors = _merged_pr_dispatch_contract_errors(text)
 
     assert (
-        "merged-pr-main-releasability.yml lookup failure arm must only reset "
-        "`existing_ref_sha` before the outer `fi`"
+        "merged-pr-main-releasability.yml must guard immutable-ref lookup "
+        "with an if/else reset before dispatch"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_non_failing_mismatch_branch() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace("              exit 1", "              :")
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must fail closed with exit 1 when "
+        "an existing immutable dispatch ref points to a different SHA"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_function_scoped_mismatch_exit() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        "              exit 1",
+        "              collision_failure() {\n                exit 1\n              }",
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must fail closed with exit 1 when "
+        "an existing immutable dispatch ref points to a different SHA"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_nested_mismatch_condition() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then\n'
+            '              echo "::error::Dispatch ref $dispatch_ref points to '
+            '$existing_ref_sha, expected $MERGE_COMMIT_SHA"\n'
+            "              exit 1\n"
+            "            fi"
+        ),
+        (
+            "            if false; then\n"
+            '              if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then\n'
+            '                echo "::error::Dispatch ref $dispatch_ref points to '
+            '$existing_ref_sha, expected $MERGE_COMMIT_SHA"\n'
+            "                exit 1\n"
+            "              fi\n"
+            "            fi"
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must fail closed with exit 1 when "
+        "an existing immutable dispatch ref points to a different SHA"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_subshell_masked_mismatch_exit() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then\n'
+            '              echo "::error::Dispatch ref $dispatch_ref points to '
+            '$existing_ref_sha, expected $MERGE_COMMIT_SHA"\n'
+            "              exit 1\n"
+            "            fi"
+        ),
+        (
+            "            (\n"
+            '              if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then\n'
+            '                echo "::error::Dispatch ref $dispatch_ref points to '
+            '$existing_ref_sha, expected $MERGE_COMMIT_SHA"\n'
+            "                exit 1\n"
+            "              fi\n"
+            "            ) || true"
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must fail closed with exit 1 when "
+        "an existing immutable dispatch ref points to a different SHA"
     ) in errors
 
 

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -27,18 +27,34 @@ def _step_block(text: str, step_name: str) -> str:
     start = text.find(f"- name: {step_name}")
     if start == -1:
         return ""
-    next_step = text.find("\n      - name:", start + 1)
-    next_uses = text.find("\n      - uses:", start + 1)
-    candidates = [index for index in (next_step, next_uses) if index != -1]
-    end = min(candidates) if candidates else len(text)
+    next_step = text.find("\n      - ", start + 1)
+    end = next_step if next_step != -1 else len(text)
     return text[start:end]
+
+
+def _strip_shell_inline_comment(stripped_line: str) -> str:
+    in_single_quote = False
+    in_double_quote = False
+    for index, character in enumerate(stripped_line):
+        if character == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif character == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+        elif (
+            character == "#"
+            and not in_single_quote
+            and not in_double_quote
+            and (index == 0 or stripped_line[index - 1].isspace())
+        ):
+            return stripped_line[:index].rstrip()
+    return stripped_line
 
 
 def _continued_shell_command(lines: list[str], start_index: int) -> tuple[str, int]:
     command_parts: list[str] = []
     index = start_index
     while index < len(lines):
-        stripped = lines[index].strip()
+        stripped = _strip_shell_inline_comment(lines[index].strip())
         if stripped.endswith("\\"):
             command_parts.append(stripped[:-1].rstrip())
             index += 1
@@ -658,6 +674,40 @@ def test_merged_pr_main_releasability_dispatcher_rejects_split_run_steps() -> No
     ) in errors
 
 
+def test_merged_pr_main_releasability_dispatcher_rejects_split_unnamed_run_step() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '          if [ -z "$existing_ref_sha" ]; then\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          fi\n"
+            "          gh workflow run main-releasability.yml \\"
+        ),
+        (
+            "      - run: |\n"
+            '          if [ -z "$existing_ref_sha" ]; then\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          fi\n"
+            "          gh workflow run main-releasability.yml \\"
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml missing `gh workflow run main-releasability.yml`"
+        in errors
+    )
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
 def test_merged_pr_main_releasability_dispatcher_rejects_trailing_ref_creation() -> None:
     workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
     text = workflow.read_text(encoding="utf-8").replace(
@@ -670,6 +720,28 @@ def test_merged_pr_main_releasability_dispatcher_rejects_trailing_ref_creation()
             "          gh workflow run main-releasability.yml \\"
         ),
         1,
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_commented_payload_fields() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" '
+            '# -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"'
+        ),
     )
 
     errors = _merged_pr_dispatch_contract_errors(text)

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -17,6 +17,8 @@ IMMUTABLE_REF_LOOKUP_CONDITIONS = (
 )
 IMMUTABLE_REF_LOOKUP_CONDITION = IMMUTABLE_REF_LOOKUP_CONDITIONS[0]
 IMMUTABLE_REF_MISMATCH_CONDITION = 'if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then'
+IMMUTABLE_REF_CREATION_CONDITION = 'if [ -z "$existing_ref_sha" ]; then'
+IMMUTABLE_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/refs"'
 
 
 def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
@@ -59,6 +61,11 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
         errors.append(
             "merged-pr-main-releasability.yml must not mask immutable-ref lookup "
             "failures with shell OR fallbacks"
+        )
+    if not _conditionally_creates_absent_immutable_ref(text):
+        errors.append(
+            "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+            "inside the empty existing-ref branch"
         )
     return errors
 
@@ -239,6 +246,40 @@ def _guarded_lookup_success_arms_fail_on_ref_mismatch(text: str) -> bool:
     return bool(guarded_blocks) and all(
         _outer_lookup_then_arm_has_mismatch_exit(block) for block in guarded_blocks
     )
+
+
+def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
+    lines = text.splitlines()
+    depth = 0
+    for index, line in enumerate(lines):
+        stripped_line = line.strip()
+        if stripped_line == IMMUTABLE_REF_CREATION_CONDITION and depth == 0:
+            direct_executable_commands: list[str] = []
+            creation_depth = 1
+            for follow in lines[index + 1 :]:
+                stripped_follow = follow.strip()
+                if stripped_follow == "fi" and creation_depth == 1:
+                    break
+                if not stripped_follow or _is_shell_comment(stripped_follow):
+                    continue
+                if creation_depth == 1:
+                    direct_executable_commands.append(stripped_follow)
+                if _opens_nested_shell_scope(stripped_follow):
+                    creation_depth += 1
+                if _closes_nested_shell_scope(stripped_follow):
+                    creation_depth -= 1
+            return any(
+                command == IMMUTABLE_REF_CREATION_COMMAND
+                or command.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
+                for command in direct_executable_commands
+            )
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+    return False
 
 
 def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
@@ -452,6 +493,31 @@ def test_merged_pr_main_releasability_dispatcher_rejects_subshell_masked_mismatc
     assert (
         "merged-pr-main-releasability.yml must fail closed with exit 1 when "
         "an existing immutable dispatch ref points to a different SHA"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_unconditional_ref_creation() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '          if [ -z "$existing_ref_sha" ]; then\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          fi"
+        ),
+        (
+            '          gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '            -f ref="refs/tags/$dispatch_ref" \\\n'
+            '            -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch"
     ) in errors
 
 

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -19,6 +19,8 @@ IMMUTABLE_REF_LOOKUP_CONDITION = IMMUTABLE_REF_LOOKUP_CONDITIONS[0]
 IMMUTABLE_REF_MISMATCH_CONDITION = 'if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then'
 IMMUTABLE_REF_CREATION_CONDITION = 'if [ -z "$existing_ref_sha" ]; then'
 IMMUTABLE_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/refs"'
+IMMUTABLE_REF_CREATION_REF_FIELD = '-f ref="refs/tags/$dispatch_ref"'
+IMMUTABLE_REF_CREATION_SHA_FIELD = '-f sha="$MERGE_COMMIT_SHA"'
 
 
 def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
@@ -65,7 +67,7 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
     if not _conditionally_creates_absent_immutable_ref(text):
         errors.append(
             "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
-            "inside the empty existing-ref branch"
+            "inside the empty existing-ref branch with exact ref and SHA fields"
         )
     return errors
 
@@ -268,10 +270,15 @@ def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
                     creation_depth += 1
                 if _closes_nested_shell_scope(stripped_follow):
                     creation_depth -= 1
-            return any(
-                command == IMMUTABLE_REF_CREATION_COMMAND
-                or command.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
-                for command in direct_executable_commands
+            creation_text = "\n".join(direct_executable_commands)
+            return (
+                any(
+                    command == IMMUTABLE_REF_CREATION_COMMAND
+                    or command.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
+                    for command in direct_executable_commands
+                )
+                and IMMUTABLE_REF_CREATION_REF_FIELD in creation_text
+                and IMMUTABLE_REF_CREATION_SHA_FIELD in creation_text
             )
         if not stripped_line or _is_shell_comment(stripped_line):
             continue
@@ -517,7 +524,22 @@ def test_merged_pr_main_releasability_dispatcher_rejects_unconditional_ref_creat
 
     assert (
         "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
-        "inside the empty existing-ref branch"
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_wrong_ref_creation_payload() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        '-f sha="$MERGE_COMMIT_SHA" >/dev/null',
+        '-f sha="$WRONG_SHA" >/dev/null',
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
     ) in errors
 
 

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -180,6 +180,7 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
             or command.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
         )
         and "||" not in command
+        and not command.rstrip().endswith("&")
         and IMMUTABLE_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_REF_CREATION_SHA_FIELD in command
     )
@@ -775,6 +776,28 @@ def test_merged_pr_main_releasability_dispatcher_rejects_masked_ref_creation_fai
         (
             '            gh api "repos/$GITHUB_REPOSITORY/git/refs" '
             '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" || true'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_backgrounded_ref_creation() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" '
+            '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" &'
         ),
     )
 

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -174,6 +174,7 @@ def _immutable_ref_creation_commands(text: str) -> list[str]:
 
 
 def _is_exact_immutable_ref_creation_command(command: str) -> bool:
+    padded_command = f" {command} "
     return (
         (
             command == IMMUTABLE_REF_CREATION_COMMAND
@@ -181,6 +182,9 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
         )
         and "||" not in command
         and not command.rstrip().endswith("&")
+        and "--method" not in padded_command
+        and " -X" not in padded_command
+        and "--input" not in padded_command
         and IMMUTABLE_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_REF_CREATION_SHA_FIELD in command
     )
@@ -798,6 +802,28 @@ def test_merged_pr_main_releasability_dispatcher_rejects_backgrounded_ref_creati
         (
             '            gh api "repos/$GITHUB_REPOSITORY/git/refs" '
             '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" &'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_non_post_ref_creation_override() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" --method GET '
+            '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"'
         ),
     )
 

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -23,8 +23,40 @@ IMMUTABLE_REF_CREATION_REF_FIELD = '-f ref="refs/tags/$dispatch_ref"'
 IMMUTABLE_REF_CREATION_SHA_FIELD = '-f sha="$MERGE_COMMIT_SHA"'
 
 
+def _step_block(text: str, step_name: str) -> str:
+    start = text.find(f"- name: {step_name}")
+    if start == -1:
+        return ""
+    next_step = text.find("\n      - name:", start + 1)
+    next_uses = text.find("\n      - uses:", start + 1)
+    candidates = [index for index in (next_step, next_uses) if index != -1]
+    end = min(candidates) if candidates else len(text)
+    return text[start:end]
+
+
+def _continued_shell_command(lines: list[str], start_index: int) -> tuple[str, int]:
+    command_parts: list[str] = []
+    index = start_index
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if stripped.endswith("\\"):
+            command_parts.append(stripped[:-1].rstrip())
+            index += 1
+            continue
+        command_parts.append(stripped)
+        break
+    return " ".join(command_parts), index
+
+
 def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
     errors: list[str] = []
+    dispatch_step_text = _step_block(text, "Dispatch main releasability gate")
+    if not dispatch_step_text:
+        errors.append(
+            "merged-pr-main-releasability.yml must keep lookup, conditional ref creation, "
+            "and workflow dispatch in one named run step"
+        )
+    dispatch_contract_text = dispatch_step_text or text
     required_fragments = (
         "pull_request_target:",
         "types: [closed]",
@@ -45,26 +77,39 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
         '-f triggering_pr="$PR_NUMBER"',
     )
     for fragment in required_fragments:
-        if fragment not in text:
+        search_text = text
+        if fragment in {
+            "github.event.pull_request.merge_commit_sha",
+            'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+            'existing_ref_sha=""',
+            "repos/$GITHUB_REPOSITORY/git/refs",
+            'ref="refs/tags/$dispatch_ref"',
+            "gh workflow run main-releasability.yml",
+            '--ref "$dispatch_ref"',
+            '-f expected_sha="$MERGE_COMMIT_SHA"',
+            '-f triggering_pr="$PR_NUMBER"',
+        }:
+            search_text = dispatch_contract_text
+        if fragment not in search_text:
             errors.append(f"merged-pr-main-releasability.yml missing `{fragment}`")
     if "--ref main" in text:
         errors.append("merged-pr-main-releasability.yml must not dispatch mutable `--ref main`")
-    if not _has_conditionally_guarded_immutable_ref_lookup(text):
+    if not _has_conditionally_guarded_immutable_ref_lookup(dispatch_contract_text):
         errors.append(
             "merged-pr-main-releasability.yml must guard immutable-ref lookup "
             "with an if/else reset before dispatch"
         )
-    elif not _guarded_lookup_success_arms_fail_on_ref_mismatch(text):
+    elif not _guarded_lookup_success_arms_fail_on_ref_mismatch(dispatch_contract_text):
         errors.append(
             "merged-pr-main-releasability.yml must fail closed with exit 1 when "
             "an existing immutable dispatch ref points to a different SHA"
         )
-    if any("||" in block for block in _immutable_ref_lookup_blocks(text)):
+    if any("||" in block for block in _immutable_ref_lookup_blocks(dispatch_contract_text)):
         errors.append(
             "merged-pr-main-releasability.yml must not mask immutable-ref lookup "
             "failures with shell OR fallbacks"
         )
-    if not _conditionally_creates_absent_immutable_ref(text):
+    if not _conditionally_creates_absent_immutable_ref(dispatch_contract_text):
         errors.append(
             "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
             "inside the empty existing-ref branch with exact ref and SHA fields"
@@ -94,6 +139,33 @@ def _is_shell_comment(stripped_line: str) -> bool:
 
 def _contains_immutable_dispatch_ref_lookup(text: str) -> bool:
     return "git/ref/tags/$dispatch_ref" in text or "git/ref/tags/${dispatch_ref}" in text
+
+
+def _immutable_ref_creation_commands(text: str) -> list[str]:
+    lines = text.splitlines()
+    commands: list[str] = []
+    index = 0
+    while index < len(lines):
+        stripped_line = lines[index].strip()
+        if not _is_shell_comment(stripped_line) and (
+            stripped_line == IMMUTABLE_REF_CREATION_COMMAND
+            or stripped_line.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
+        ):
+            command, index = _continued_shell_command(lines, index)
+            commands.append(command)
+        index += 1
+    return commands
+
+
+def _is_exact_immutable_ref_creation_command(command: str) -> bool:
+    return (
+        (
+            command == IMMUTABLE_REF_CREATION_COMMAND
+            or command.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
+        )
+        and IMMUTABLE_REF_CREATION_REF_FIELD in command
+        and IMMUTABLE_REF_CREATION_SHA_FIELD in command
+    )
 
 
 def _immutable_ref_lookup_blocks(text: str) -> list[str]:
@@ -252,41 +324,49 @@ def _guarded_lookup_success_arms_fail_on_ref_mismatch(text: str) -> bool:
 
 def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
     lines = text.splitlines()
+    creation_commands = _immutable_ref_creation_commands(text)
+    guarded_creation_commands: list[str] = []
     depth = 0
     for index, line in enumerate(lines):
         stripped_line = line.strip()
         if stripped_line == IMMUTABLE_REF_CREATION_CONDITION and depth == 0:
-            direct_executable_commands: list[str] = []
             creation_depth = 1
-            for follow in lines[index + 1 :]:
+            follow_index = index + 1
+            while follow_index < len(lines):
+                follow = lines[follow_index]
                 stripped_follow = follow.strip()
                 if stripped_follow == "fi" and creation_depth == 1:
                     break
                 if not stripped_follow or _is_shell_comment(stripped_follow):
+                    follow_index += 1
                     continue
-                if creation_depth == 1:
-                    direct_executable_commands.append(stripped_follow)
+                if creation_depth == 1 and (
+                    stripped_follow == IMMUTABLE_REF_CREATION_COMMAND
+                    or stripped_follow.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
+                ):
+                    command, follow_index = _continued_shell_command(lines, follow_index)
+                    guarded_creation_commands.append(command)
+                    follow_index += 1
+                    continue
                 if _opens_nested_shell_scope(stripped_follow):
                     creation_depth += 1
                 if _closes_nested_shell_scope(stripped_follow):
                     creation_depth -= 1
-            creation_text = "\n".join(direct_executable_commands)
-            return (
-                any(
-                    command == IMMUTABLE_REF_CREATION_COMMAND
-                    or command.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
-                    for command in direct_executable_commands
-                )
-                and IMMUTABLE_REF_CREATION_REF_FIELD in creation_text
-                and IMMUTABLE_REF_CREATION_SHA_FIELD in creation_text
-            )
+                follow_index += 1
         if not stripped_line or _is_shell_comment(stripped_line):
             continue
         if _opens_nested_shell_scope(stripped_line):
             depth += 1
         if _closes_nested_shell_scope(stripped_line):
             depth -= 1
-    return False
+    return (
+        bool(guarded_creation_commands)
+        and len(guarded_creation_commands) == len(creation_commands)
+        and all(
+            _is_exact_immutable_ref_creation_command(command)
+            for command in guarded_creation_commands
+        )
+    )
 
 
 def test_merged_pr_main_releasability_dispatcher_targets_main_gate() -> None:
@@ -533,6 +613,86 @@ def test_merged_pr_main_releasability_dispatcher_rejects_wrong_ref_creation_payl
     text = workflow.read_text(encoding="utf-8").replace(
         '-f sha="$MERGE_COMMIT_SHA" >/dev/null',
         '-f sha="$WRONG_SHA" >/dev/null',
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_split_run_steps() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '          if [ -z "$existing_ref_sha" ]; then\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          fi\n"
+            "          gh workflow run main-releasability.yml \\"
+        ),
+        (
+            "      - name: Create and dispatch main releasability\n"
+            "        run: |\n"
+            '          if [ -z "$existing_ref_sha" ]; then\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          fi\n"
+            "          gh workflow run main-releasability.yml \\"
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml missing `gh workflow run main-releasability.yml`"
+        in errors
+    )
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_trailing_ref_creation() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        ("          fi\n          gh workflow run main-releasability.yml \\"),
+        (
+            "          fi\n"
+            '          gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '            -f ref="refs/tags/$dispatch_ref" \\\n'
+            '            -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          gh workflow run main-releasability.yml \\"
+        ),
+        1,
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_binds_payload_to_creation_command() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs"\n'
+            '            printf "%s" \'-f ref="refs/tags/$dispatch_ref"\'\n'
+            '            printf "%s" \'-f sha="$MERGE_COMMIT_SHA"\''
+        ),
     )
 
     errors = _merged_pr_dispatch_contract_errors(text)


### PR DESCRIPTION
## Summary - Hardens the merged-PR Main Releasability dispatcher contract for RFC-0002 Slice 17 release-evidence integrity. - Replaces broad text checks with structural policy checks for immutable dispatch-ref lookup, fail-closed mismatch handling, conditional absent-ref creation, exact dispatch creation payload, one-shell-step execution, every creation invocation, command-bound payload fields, unnamed sibling-step delimiting, and inline-comment stripping. - Adds regression tests for commented lookups, subshell-masked mismatch exits, unconditional ref creation, wrong ref-creation SHA payload, split run steps, trailing creation commands, and detached payload fields.  ## Risk / Rollback - Risk is limited to CI contract enforcement. AI workflow-pack runtime behavior is not changed. - Rollback: revert the CI contract test commits if the dispatcher policy needs to be relaxed, but doing so would reopen #135.  ## Evidence - `python -m ruff format tests/unit/test_ci_workflow_contracts.py` — passed at final head. - `python -m ruff check tests/unit/test_ci_workflow_contracts.py` — passed at final head. - `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` — 21 passed at final head. - `git diff --check` — passed before final commit. - Earlier full branch validation before the final same-pattern review hardening: `make check` passed, including ruff, format check, mypy, OpenAPI quality gate, eval/async manifests, RFC-0002 Idea explanation proof, migration SQL contract, runtime-mode integration tests, and 1,392 unit tests. Final-head full validation is delegated to GitHub PR Merge Gate unless a check fails. - Signed branch commit verification: all commits from `origin/main..HEAD` report `G`.  ## RFC / issue traceability - RFC-0002 Slice 17 dependency: #135. - This PR intentionally does not certify live provider retention, model-risk operations, production IdP, or final Idea live-journey proof; those remain tracked by separate RFC-0002 issues.  ## Documentation / wiki / context decision - No README/wiki/context change is required for this CI-enforcement-only guardrail. - No supported-feature or product-readiness claim is promoted.
### Same-pattern hardening update ($(System.Collections.Hashtable.commit))

Ported the final dispatch-policy review hardening: immutable dispatch-ref creation rejects failure masking and lookup guards must be at executable outer shell scope. Added focused regression tests.

Local validation:

- python -m ruff format ...
- python -m ruff check ...
- python -m pytest tests/unit/test_ci_workflow_contracts.py -q (`23 passed`)
- git diff --check

No wiki/source truth changed; scope remains CI dispatch contract enforcement.

### Backgrounded creation hardening update (`1a9fa68`)

Ported the final backgrounding guard: immutable dispatch-ref creation commands ending with `&` are rejected so the dispatch cannot race asynchronous tag creation or hide creation failure.

Local validation:

- `python -m ruff format tests/unit/test_ci_workflow_contracts.py`
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py`
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` (`24 passed`)
- `git diff --check`


### Method override hardening update (`6cd1874`)

Ported the final POST-semantics guard: immutable dispatch-ref creation rejects `gh api` method/input overrides such as `--method GET`, `-X`, and `--input`.

Local validation:

- `python -m ruff format tests/unit/test_ci_workflow_contracts.py`
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py`
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` (`25 passed`)
- `git diff --check`

Platform skill guidance is tracked in sgajbi/lotus-platform#694 / PR #695.
