### PR TITLE
ci: enforce dispatch ordering and POST override semantics

### DIFF
--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -21,6 +21,7 @@ IMMUTABLE_REF_CREATION_CONDITION = 'if [ -z "$existing_ref_sha" ]; then'
 IMMUTABLE_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/refs"'
 IMMUTABLE_REF_CREATION_REF_FIELD = '-f ref="refs/tags/$dispatch_ref"'
 IMMUTABLE_REF_CREATION_SHA_FIELD = '-f sha="$MERGE_COMMIT_SHA"'
+MAIN_RELEASABILITY_DISPATCH_COMMAND = "gh workflow run main-releasability.yml"
 
 
 def _step_block(text: str, step_name: str) -> str:
@@ -130,6 +131,11 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
             "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
             "inside the empty existing-ref branch with exact ref and SHA fields"
         )
+    elif not _dispatches_after_absent_ref_creation(dispatch_contract_text):
+        errors.append(
+            "merged-pr-main-releasability.yml must run the main releasability dispatch "
+            "only after the absent immutable-ref creation branch has completed"
+        )
     return errors
 
 
@@ -174,7 +180,6 @@ def _immutable_ref_creation_commands(text: str) -> list[str]:
 
 
 def _is_exact_immutable_ref_creation_command(command: str) -> bool:
-    padded_command = f" {command} "
     return (
         (
             command == IMMUTABLE_REF_CREATION_COMMAND
@@ -182,12 +187,26 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
         )
         and "||" not in command
         and not command.rstrip().endswith("&")
-        and "--method" not in padded_command
-        and " -X" not in padded_command
-        and "--input" not in padded_command
+        and not _has_disallowed_immutable_ref_creation_override(command)
         and IMMUTABLE_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_REF_CREATION_SHA_FIELD in command
     )
+
+
+def _has_disallowed_immutable_ref_creation_override(command: str) -> bool:
+    tokens = command.split()
+    for index, token in enumerate(tokens):
+        if token == "--input" or token.startswith("--input="):
+            return True
+        if token == "--method":
+            return index + 1 >= len(tokens) or tokens[index + 1].upper() != "POST"
+        if token.startswith("--method="):
+            return token.partition("=")[2].upper() != "POST"
+        if token == "-X":
+            return index + 1 >= len(tokens) or tokens[index + 1].upper() != "POST"
+        if token.startswith("-X") and len(token) > 2:
+            return token[2:].upper() != "POST"
+    return False
 
 
 def _immutable_ref_lookup_blocks(text: str) -> list[str]:
@@ -399,6 +418,71 @@ def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
             _is_exact_immutable_ref_creation_command(command)
             for command in guarded_creation_commands
         )
+    )
+
+
+def _main_releasability_dispatch_command_indices(text: str) -> list[int]:
+    lines = text.splitlines()
+    indices: list[int] = []
+    index = 0
+    while index < len(lines):
+        stripped_line = lines[index].strip()
+        if not _is_shell_comment(stripped_line) and (
+            stripped_line == MAIN_RELEASABILITY_DISPATCH_COMMAND
+            or stripped_line.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
+        ):
+            _, index = _continued_shell_command(lines, index)
+            indices.append(index)
+        index += 1
+    return indices
+
+
+def _absent_ref_creation_block_end_index(text: str) -> int | None:
+    lines = text.splitlines()
+    depth = 0
+    for index, line in enumerate(lines):
+        stripped_line = line.strip()
+        if stripped_line == IMMUTABLE_REF_CREATION_CONDITION and depth == 0:
+            saw_creation_command = False
+            creation_depth = 1
+            follow_index = index + 1
+            while follow_index < len(lines):
+                follow = lines[follow_index]
+                stripped_follow = follow.strip()
+                if stripped_follow == "fi" and creation_depth == 1:
+                    return follow_index if saw_creation_command else None
+                if not stripped_follow or _is_shell_comment(stripped_follow):
+                    follow_index += 1
+                    continue
+                if creation_depth == 1 and (
+                    stripped_follow == IMMUTABLE_REF_CREATION_COMMAND
+                    or stripped_follow.startswith(f"{IMMUTABLE_REF_CREATION_COMMAND} ")
+                ):
+                    command, follow_index = _continued_shell_command(lines, follow_index)
+                    saw_creation_command = _is_exact_immutable_ref_creation_command(command)
+                    follow_index += 1
+                    continue
+                if _opens_nested_shell_scope(stripped_follow):
+                    creation_depth += 1
+                if _closes_nested_shell_scope(stripped_follow):
+                    creation_depth -= 1
+                follow_index += 1
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+    return None
+
+
+def _dispatches_after_absent_ref_creation(text: str) -> bool:
+    dispatch_indices = _main_releasability_dispatch_command_indices(text)
+    creation_block_end_index = _absent_ref_creation_block_end_index(text)
+    return (
+        len(dispatch_indices) == 1
+        and creation_block_end_index is not None
+        and dispatch_indices[0] > creation_block_end_index
     )
 
 
@@ -832,6 +916,78 @@ def test_merged_pr_main_releasability_dispatcher_rejects_non_post_ref_creation_o
     assert (
         "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
         "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_allows_explicit_post_ref_creation_method() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\',
+        '            gh api "repos/$GITHUB_REPOSITORY/git/refs" --method POST \\',
+        1,
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) not in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_input_body_ref_creation_override() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" --input ref.json '
+            '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_dispatch_before_ref_creation() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '          if [ -z "$existing_ref_sha" ]; then\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          fi\n"
+            "          gh workflow run main-releasability.yml \\"
+        ),
+        (
+            "          gh workflow run main-releasability.yml \\\n"
+            '            --ref "$dispatch_ref" \\\n'
+            '            -f expected_sha="$MERGE_COMMIT_SHA" \\\n'
+            '            -f triggering_pr="$PR_NUMBER"\n'
+            '          if [ -z "$existing_ref_sha" ]; then\n'
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null\n'
+            "          fi\n"
+            "          : # displaced dispatch command"
+        ),
+        1,
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must run the main releasability dispatch "
+        "only after the absent immutable-ref creation branch has completed"
     ) in errors
 
 


### PR DESCRIPTION
## Summary

- Closes #137.
- Allows safe explicit POST overrides for immutable dispatch-ref creation while continuing to reject non-POST method overrides and input-body overrides.
- Rejects merged-PR main-releasability dispatches that run before the absent immutable-ref creation branch completes.
- Adds focused regression coverage for explicit POST, input-body override rejection, and dispatch-before-ref-creation rejection.

## Validation

- `python -m ruff format tests/unit/test_ci_workflow_contracts.py` passed.
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py` passed.
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` passed: 28 passed.
- `make check` passed, including ruff, mypy, OpenAPI gate, eval/async artifact validators, RFC-0002 Idea explanation proof, migration contract check, runtime-mode integration smoke, and 1404 unit tests.
- `git diff --check` passed before commit.

## Risk / Rollback

Low-risk CI contract hardening. Runtime application code is unchanged. Rollback is reverting this PR if the generated workflow-policy interpretation proves too strict in GitHub.

## RFC / Issue Traceability

RFC-0002 Slice 17, release-evidence hardening. This follows the durable guidance captured in sgajbi/lotus-platform#694 and the matching Manage fix-forward pattern in sgajbi/lotus-manage#636.