### PR TITLE
ci: harden dispatch ref creation contract

### DIFF
--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -187,10 +187,15 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
         )
         and "||" not in command
         and not command.rstrip().endswith("&")
+        and not _has_disallowed_immutable_ref_creation_shell_control(command)
         and not _has_disallowed_immutable_ref_creation_override(command)
         and IMMUTABLE_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_REF_CREATION_SHA_FIELD in command
     )
+
+
+def _has_disallowed_immutable_ref_creation_shell_control(command: str) -> bool:
+    return ";" in command or "&&" in command
 
 
 def _has_disallowed_immutable_ref_creation_override(command: str) -> bool:
@@ -886,6 +891,28 @@ def test_merged_pr_main_releasability_dispatcher_rejects_backgrounded_ref_creati
         (
             '            gh api "repos/$GITHUB_REPOSITORY/git/refs" '
             '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" &'
+        ),
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
+        "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_chained_ref_creation_command() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\\n'
+            '              -f ref="refs/tags/$dispatch_ref" \\\n'
+            '              -f sha="$MERGE_COMMIT_SHA" >/dev/null'
+        ),
+        (
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" '
+            '-f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" ; exit 0'
         ),
     )
 


### PR DESCRIPTION
## Summary
- hardens the merged-PR main-releasability workflow contract against chained immutable dispatch-ref creation commands
- rejects top-level mutation of the looked-up `existing_ref_sha` before collision comparison
- requires exactly one guarded immutable-ref creation invocation
- preserves explicit POST override allowance and non-POST/input-body rejection semantics from PR #138

## Issues
- #139
- #141
- Closure will be handled after merged-main validation and QA evidence are recorded.

## Validation
- `python -m ruff format tests/unit/test_ci_workflow_contracts.py` — unchanged after latest commit
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py` — passed
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` — 31 passed
- `git diff --check` — passed

## Branch hygiene
- Replacement branch: `issue-139-chained-dispatch-ref-creation`
- Removed stale remote branch: `issue-137-dispatch-order-post-semantics`

## Scope boundary
This is CI/release-evidence governance only. It does not claim live AI workflow execution, provider retention, model-risk approval, or production readiness for RFC-0002.