### PR TITLE
ci: harden releasability dispatch command

### DIFF
--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -429,20 +429,44 @@ def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
     )
 
 
-def _main_releasability_dispatch_command_indices(text: str) -> list[int]:
+def _main_releasability_dispatch_commands(text: str) -> list[tuple[int, str]]:
     lines = text.splitlines()
-    indices: list[int] = []
+    commands: list[tuple[int, str]] = []
+    depth = 0
     index = 0
     while index < len(lines):
         stripped_line = lines[index].strip()
-        if not _is_shell_comment(stripped_line) and (
+        if not stripped_line or _is_shell_comment(stripped_line):
+            index += 1
+            continue
+        if depth == 0 and (
             stripped_line == MAIN_RELEASABILITY_DISPATCH_COMMAND
             or stripped_line.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
         ):
-            _, index = _continued_shell_command(lines, index)
-            indices.append(index)
+            command, index = _continued_shell_command(lines, index)
+            commands.append((index, command))
+            index += 1
+            continue
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
         index += 1
-    return indices
+    return commands
+
+
+def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
+    normalized_command = " ".join(command.split())
+    if not normalized_command.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} "):
+        return False
+    if any(token in normalized_command for token in (" || ", " && ", " ; ")):
+        return False
+    if normalized_command.endswith(" &"):
+        return False
+    return (
+        '--ref "$dispatch_ref"' in normalized_command
+        and '-f expected_sha="$MERGE_COMMIT_SHA"' in normalized_command
+    )
 
 
 def _absent_ref_creation_block_end_index(text: str) -> int | None:
@@ -485,12 +509,13 @@ def _absent_ref_creation_block_end_index(text: str) -> int | None:
 
 
 def _dispatches_after_absent_ref_creation(text: str) -> bool:
-    dispatch_indices = _main_releasability_dispatch_command_indices(text)
+    dispatch_commands = _main_releasability_dispatch_commands(text)
     creation_block_end_index = _absent_ref_creation_block_end_index(text)
     return (
-        len(dispatch_indices) == 1
+        len(dispatch_commands) == 1
         and creation_block_end_index is not None
-        and dispatch_indices[0] > creation_block_end_index
+        and dispatch_commands[0][0] > creation_block_end_index
+        and _is_exact_main_releasability_dispatch_command(dispatch_commands[0][1])
     )
 
 
@@ -864,6 +889,52 @@ def test_merged_pr_main_releasability_dispatcher_rejects_trailing_ref_creation()
     assert (
         "merged-pr-main-releasability.yml must create the immutable dispatch ref only "
         "inside the empty existing-ref branch with exact ref and SHA fields"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_masked_dispatch_failure() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        '-f triggering_pr="$PR_NUMBER"',
+        '-f triggering_pr="$PR_NUMBER" || true',
+        1,
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must run the main releasability dispatch "
+        "only after the absent immutable-ref creation branch has completed"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_nested_dispatch_command() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        (
+            "          gh workflow run main-releasability.yml \\\n"
+            '            --repo "$GITHUB_REPOSITORY" \\\n'
+            '            --ref "$dispatch_ref" \\\n'
+            '            -f expected_sha="$MERGE_COMMIT_SHA" \\\n'
+            '            -f triggering_pr="$PR_NUMBER"'
+        ),
+        (
+            "          if false; then\n"
+            "            gh workflow run main-releasability.yml \\\n"
+            '              --repo "$GITHUB_REPOSITORY" \\\n'
+            '              --ref "$dispatch_ref" \\\n'
+            '              -f expected_sha="$MERGE_COMMIT_SHA" \\\n'
+            '              -f triggering_pr="$PR_NUMBER"\n'
+            "          fi"
+        ),
+        1,
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must run the main releasability dispatch "
+        "only after the absent immutable-ref creation branch has completed"
     ) in errors
 
 


### PR DESCRIPTION
Issue: #143

Summary:
- Harden the merged-PR main releasability workflow contract so dispatch detection only accepts an outer-scope command after immutable-ref creation.
- Reject dispatch commands that mask failures with shell OR, run inside nested shell control flow, or otherwise fail the exact immutable-ref / expected-SHA dispatch shape.
- Add regression tests for masked and nested dispatch drift discovered from the same-pattern Manage review findings.

Local validation:
- `python -m ruff format tests/unit/test_ci_workflow_contracts.py` — unchanged
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py` — passed
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` — 33 passed
- `git diff --check` — passed

No-claim boundary:
This PR only closes the RFC-0002 Slice 17 CI/release-evidence guard gap for masked or nested releasability dispatch commands. It does not certify live workflow-pack execution, provider retention, or model-risk operations.

Keep #143 open until merge, exact-main validation, and branch cleanup evidence are recorded.