### PR TITLE
ci: key main releasability concurrency by expected sha

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -1210,6 +1210,7 @@ def test_main_releasability_gate_is_dispatchable_without_duplicate_push_trigger(
     assert "expected_sha:" in text
     assert "triggering_pr:" in text
     assert "git rev-parse HEAD" in text
+    assert "group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}" in text
     assert "push:" not in text
     assert 'branches: [ "main" ]' not in text
     assert "name: Main Releasability Gate" in text


### PR DESCRIPTION
Issue: #133

Summary:
- Reopened #133 after platform validation proved the earlier closure missed `main-releasability.missing-revision-aware-concurrency`.
- Change `main-releasability.yml` concurrency from mutable ref identity to `${{ inputs.expected_sha || github.sha }}` so merged-PR exact-main runs isolate by merge SHA.
- Add a workflow-contract assertion so this cannot regress silently.

Local validation:
- `python -m ruff format tests/unit/test_ci_workflow_contracts.py` — unchanged
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py` — passed
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` — 33 passed
- `git diff --check` — passed

No-claim boundary:
This PR only closes the RFC-0002 Slice 17 main-releasability concurrency gap. It does not certify live workflow-pack execution, provider retention, or model-risk operations.

Keep #133 open until merge, exact-main validation, platform validator proof, and branch cleanup evidence are recorded.