### PR TITLE
ci: reject dispatch ref reassignment before release dispatch

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -508,6 +508,22 @@ def _absent_ref_creation_block_end_index(text: str) -> int | None:
     return None
 
 
+def _has_dispatch_ref_reassignment_between(text: str, *, start_index: int, end_index: int) -> bool:
+    lines = text.splitlines()
+    depth = 0
+    for line in lines[start_index + 1 : end_index + 1]:
+        stripped_line = line.strip()
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if depth == 0 and stripped_line.startswith("dispatch_ref="):
+            return True
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+    return False
+
+
 def _dispatches_after_absent_ref_creation(text: str) -> bool:
     dispatch_commands = _main_releasability_dispatch_commands(text)
     creation_block_end_index = _absent_ref_creation_block_end_index(text)
@@ -515,6 +531,11 @@ def _dispatches_after_absent_ref_creation(text: str) -> bool:
         len(dispatch_commands) == 1
         and creation_block_end_index is not None
         and dispatch_commands[0][0] > creation_block_end_index
+        and not _has_dispatch_ref_reassignment_between(
+            text,
+            start_index=creation_block_end_index,
+            end_index=dispatch_commands[0][0],
+        )
         and _is_exact_main_releasability_dispatch_command(dispatch_commands[0][1])
     )
 
@@ -927,6 +948,22 @@ def test_merged_pr_main_releasability_dispatcher_rejects_nested_dispatch_command
             '              -f triggering_pr="$PR_NUMBER"\n'
             "          fi"
         ),
+        1,
+    )
+
+    errors = _merged_pr_dispatch_contract_errors(text)
+
+    assert (
+        "merged-pr-main-releasability.yml must run the main releasability dispatch "
+        "only after the absent immutable-ref creation branch has completed"
+    ) in errors
+
+
+def test_merged_pr_main_releasability_dispatcher_rejects_dispatch_ref_reassignment() -> None:
+    workflow = WORKFLOW_DIR / "merged-pr-main-releasability.yml"
+    text = workflow.read_text(encoding="utf-8").replace(
+        "          gh workflow run main-releasability.yml \\",
+        "          dispatch_ref=main\n          gh workflow run main-releasability.yml \\",
         1,
     )
 

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -1210,6 +1210,7 @@ def test_main_releasability_gate_is_dispatchable_without_duplicate_push_trigger(
     assert "expected_sha:" in text
     assert "triggering_pr:" in text
     assert "git rev-parse HEAD" in text
+    assert "group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}" in text
     assert "push:" not in text
     assert 'branches: [ "main" ]' not in text
     assert "name: Main Releasability Gate" in text


### PR DESCRIPTION
Issue: #133

Summary:
- Follow-up to PR #145 after auto-merge completed before the same-pattern dispatch-ref reassignment guard landed.
- Reject top-level `dispatch_ref=` reassignment after immutable ref creation and before `gh workflow run`, preventing the dispatcher from retargeting a mutable ref such as `main`.
- Add a CI-contract regression for the reassignment path.

Local validation:
- `python -m ruff format tests/unit/test_ci_workflow_contracts.py` — reformatted
- `python -m ruff check tests/unit/test_ci_workflow_contracts.py` — passed
- `python -m pytest tests/unit/test_ci_workflow_contracts.py -q` — 34 passed
- `git diff --check` — passed

No-claim boundary:
This PR only closes the dispatch-ref reassignment part of the RFC-0002 Slice 17 release-evidence race. It does not certify live workflow-pack execution, provider retention, or model-risk operations.

Keep #133 open until this follow-up merges, exact-main validation passes, platform validator proof clears, and branch cleanup evidence is recorded.