### PR TITLE
docs(wiki): state caller-identity coverage over the published surface, and its limit (#149)

### DIFF
--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -73,7 +73,9 @@ workflow-pack, retrieval, prompt, provider, or domain business logic. Ingress ca
 direct service access is no longer left to implicit defaults.
 
 Protected data-plane and control-plane routes require a trusted upstream caller identity in
-`X-Caller-App`. `lotus-ai` binds that authenticated caller to request-declared `caller_app`
+`X-Caller-App`. Measured on `main`: of **173 published operations, the 167 that are not on the
+public allowlist all refuse a caller with no identity**; the six allowlisted paths (`/`, `/health`,
+`/health/live`, `/health/ready`, `/metadata`, `/metrics`) still answer. `lotus-ai` binds that authenticated caller to request-declared `caller_app`
 metadata before protected routes mutate state, invoke retrieval or provider execution, retain
 audit/control evidence, or run workflow-pack retry/replay execution. Missing, empty, unknown,
 disabled, or mismatched caller identity fails closed with a safe `403` response.
@@ -141,8 +143,17 @@ Examples:
 4. durable stores existing in code does not mean production-ready posture is satisfied,
 5. task support does not mean every caller is authorized to use that path.
 
-Every route included from a named product router now binds caller-policy authorization to a trusted
-`X-Caller-App` HTTP caller identity supplied by ingress or service-to-service routing. Where a
+Every published non-public operation binds caller-policy authorization to a trusted `X-Caller-App`
+HTTP caller identity supplied by ingress or service-to-service routing. The guarantee is stated over
+the *published* surface rather than over a list of routers on purpose: a router included outside the
+protected inventory would otherwise be unenforced and invisible to the check that claims to cover
+it.
+
+**This identity is asserted by the upstream, not cryptographically verified.** The trust source is
+`trusted_http_header`, so the guarantee holds only as far as ingress is trusted to set the header
+and to strip any value a client supplies. A caller that can reach the service directly can assert
+any identity. Binding coverage is complete; verification is not, and issue #149 remains open for it.
+Do not read `403` on a missing header as proof that the caller is who it claims to be. Where a
 route declares body-level `caller_app`, it remains API and audit metadata, and missing, empty,
 unknown, disabled, or body-mismatched caller identity fails closed before protected task, retrieval,
 async, prompt, provider, workflow-pack, review, or queue recovery side effects. Authorization


### PR DESCRIPTION
Progresses #149. Wiki truth for the caller-identity fence merged in #163.

## Two corrections

### 1. The coverage claim was framed over an inventory

```
Every route included from a named product router now binds caller-policy authorization ...
```

That is the same gap the route-coverage test had before it was rewritten: **a router included
outside the protected inventory would be unenforced and invisible to the thing claiming to cover
it.** Restated over the *published* surface, which is what an operator can actually verify, with the
measurement taken from `main` @ `fa62883`:

```
published operations:                  173
non-public operations:                 167
reachable without caller identity:       0
public paths answering 200:            6 / 6
```

### 2. The page implied verification it does not perform

Neither passage said that this identity is **asserted by the upstream, not cryptographically
verified**. The trust source is `trusted_http_header`, so the guarantee holds only as far as ingress
is trusted to set the header and to strip any client-supplied value. A caller that reaches the
service directly can assert any identity.

A reader could reasonably have concluded from the previous wording that callers are authenticated.
They are not. The page now says so, and points at #149, which stays open for exactly that.

**A page that claims a stronger guarantee than the code provides is the same defect as a test named
for a property the code lacks** — it occupies the place people look for the truth. That is why this
is a correction rather than an addition.

## Note on what the wiki said before #163

The page already claimed *"protected data-plane and control-plane routes require a trusted upstream
caller identity"* while **13 of 20 routers had no caller binding at all**. The documentation was
ahead of the code, and nothing reconciled them. That direction of drift is worth naming: a false
security claim in a wiki is not discovered by CI, and no gate in this repository would have caught
it.

## No code change

Documentation only. The behaviour it describes merged in #163 and is validated on `main` by
[32973698616](https://github.com/sgajbi/lotus-ai/actions/runs/32973698616), including
`Exact Revision Assertion`.
