### PR TITLE
docs: align lotus-ai wiki and repository documentation with the implementation

### DIFF
--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -262,7 +262,15 @@ Before treating the in-service observability layer as governed rollout posture:
 9. confirm represented AI-backed surfaces carry `no_sensitive_content_telemetry=true` before treating generated commentary, rationale, or brief surfaces as free of sensitive-content telemetry gaps
 10. inspect `ai_surface_supportability.surfaces[*].supportability_reason` to distinguish no-sensitive-telemetry degradation from workflow-pack action-required, ready, historical, or supported-no-activity posture without inspecting raw prompts or generated content
 11. treat `GET /platform/observability/activation-readiness` and `GET /platform/observability/governance-status` as blocked while `ai_surface_supportability` reports degraded or unavailable posture, missing no-sensitive-content telemetry, action-required surfaces, or unavailable surface supportability
-12. confirm `GET /platform/observability/breakdowns` still exposes bounded caller, tenant, and capability samples without leaking unauthorized tenant data
+12. treat `GET /platform/observability/breakdowns` as an **all-tenant** read. It performs an
+    unrestricted audit read (`INTERNAL_AGGREGATE_AUDIT_SCOPE`) and applies no per-caller tenant
+    scope, so any authenticated caller receives every tenant id and per-tenant execution volume,
+    and the access is not written to the audit access trail. Do not grant this route to a caller
+    that must not see cross-tenant data, and do not treat its output as scoped. Tracked as
+    [#168](https://github.com/sgajbi/lotus-ai/issues/168); the `resolve_audit_read_scope` fence that
+    governs `/ai/audit` is not applied here. This item previously read "confirm ... without leaking
+    unauthorized tenant data", which asserted a property the implementation does not provide and
+    offered no way to check it.
 13. confirm observability incident items now expose governed artifact descriptors rather than raw payloads or backend URLs
 14. treat SQL-backed audit and caller-policy stores as the restart-safe activation gate that composes with domain coverage, incident evidence, and AI no-sensitive telemetry posture
 

--- a/docs/security/security-and-governance.md
+++ b/docs/security/security-and-governance.md
@@ -127,6 +127,15 @@ enabled for a local runtime. Startup and readiness policies do not alter authori
 promoted runtime it fails closed until the caller trust source is a verified service JWT or mTLS
 SAN. The effective local-header posture is exposed by `GET /platform/runtime-status`.
 
+That authority governs the two `/ai/audit` routes. It is not service-wide.
+`GET /platform/observability/breakdowns` reads the same audit records under
+`INTERNAL_AGGREGATE_AUDIT_SCOPE` without calling `resolve_audit_read_scope`, so it returns every
+tenant id and per-tenant execution volume to any authenticated caller, and writes no access event.
+The `allow_audit_read_all_tenants` capability, the privileged-identity requirement and the
+fail-closed evidence write described above therefore do not constrain that route. Tracked as
+[#168](https://github.com/sgajbi/lotus-ai/issues/168); until it is closed, treat route-level access
+to the breakdowns surface as equivalent to granting an all-tenant audit read.
+
 The current `X-Caller-App` trust boundary is deployment-established service identity, not
 cryptographic proof. Issue #149 owns delivery of verified service JWT or mTLS identity and remains
 required for the promoted-production boundary; audit tenant isolation recognizes those trust-source
@@ -139,7 +148,25 @@ rejections, and unexpected failures are mapped through the same handler. Unexpec
 sanitized detail and must not expose stack traces, raw upstream payloads, credentials, prompts,
 generated output, tenant-sensitive identifiers, or internal endpoint internals.
 
+## Known Gaps in Delivered Behaviour
+
+Distinct from the deferred work below. These are properties of the service **as it exists on
+`main`**, verified against the implementation, and recorded so that absent behaviour is not read as
+working.
+
+| gap | effect | tracked |
+|---|---|---|
+| `GET /platform/observability/breakdowns` reads audit records under `INTERNAL_AGGREGATE_AUDIT_SCOPE` without `resolve_audit_read_scope` | any authenticated caller receives every tenant id and per-tenant execution volume; no access event is written | [#168](https://github.com/sgajbi/lotus-ai/issues/168) |
+| caller identity is asserted by the upstream, not cryptographically verified | the trust source is `trusted_http_header`; a caller able to reach the service directly can assert any identity. `403` on a missing header is not proof of who the caller is | [#149](https://github.com/sgajbi/lotus-ai/issues/149) |
+| `safety_mode` defaults to `documented_only` | redaction posture is declared per task, not enforced at runtime | — |
+| `monetary-float-guard` is declared in the `Makefile` and invoked by no lane | it does not run in CI; executed by hand it exits non-zero with findings | [#165](https://github.com/sgajbi/lotus-ai/issues/165) |
+| `GET /.well-known/lotus-ai-workflow-attestation-keys` requires caller identity (`403` without) | attestation public keys are not anonymously discoverable, so an external or offline verifier cannot fetch them | — |
+| context minimisation is the caller's responsibility | the service does not trim caller-supplied context before provider execution | — |
+
 ## Deferred Security Work
+
+Planned hardening that has not been started. Unlike the table above, nothing here describes a
+property the service currently claims.
 
 1. secret scanning for prompt assets,
 2. sensitive-data classifiers,

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,91 +1,214 @@
 # Architecture
 
-## Architectural Shape
+Implementation-backed description of `lotus-ai` as it exists on `main`. Every measurement below was
+taken from the running application or the source tree; where something is planned rather than built,
+it says so. Counts were measured on 2026-08-27.
 
-`lotus-ai` is a FastAPI service built around explicit seams and bounded control planes. The
-architecture is designed so the service can expose governed AI capabilities without hiding policy,
-audit, or rollout behavior behind framework abstractions.
+## What this service is
 
-The core runtime principle is:
+`lotus-ai` is a **governed AI execution service**, and in surface area it is overwhelmingly a
+control plane. Measured from the published OpenAPI document:
 
-1. keep public contracts explicit,
-2. keep policy and rollout state inspectable,
-3. keep audit and evidence generation part of execution rather than an afterthought,
-4. keep the service stateless at the API-serving layer while durable state moves into governed
-   stores.
+| segment | operations |
+|---|---|
+| `/platform/**` — governance, rollout, evidence | **163** |
+| `/ai/**` — the AI data plane | **3** |
+| operational and discovery (`/`, `/health`, `/health/live`, `/health/ready`, `/metadata`, `/metrics`, `/.well-known/lotus-ai-workflow-attestation-keys`) | 7 |
+| **total published operations** | **173** |
 
-## Primary Runtime Areas
+The entire AI data plane is three endpoints:
 
-1. `src/app/contracts/`
-   public task and platform contract models.
-2. `src/app/services/`
-   orchestration logic, runtime-context building, response mapping, and audit flow.
-3. `src/app/providers/`
-   provider adapters, rollout, quota, budget, and degradation handling.
-4. `src/app/prompts/`
-   prompt definitions, rollout state, control history, and runtime selection.
-5. `src/app/retrieval/`
-   source governance, document governance, indexed-search posture, and retrieval execution seams.
-6. `src/app/safety/`
-   output-label-aware policy and runtime safety behavior.
-7. `src/app/evals/`
-   fixture inventory, runtime execution, approval gates, and evaluation artifacts.
-8. `src/app/routers/`
-   public API surfaces for task execution and platform inspection.
+```
+POST /ai/tasks/execute      execute a governed task
+GET  /ai/audit              list audit records, tenant-scoped
+GET  /ai/audit/{request_id} read one audit record, tenant-scoped
+```
 
-## Execution Flow
+Everything else exists to decide whether that execution is allowed, with what prompt, against which
+provider, under which policy — and to prove afterwards what happened. A new engineer who expects an
+"AI service" will find a governance service with an AI seam, and reading it the other way round is
+the fastest way to get lost.
 
-The task runtime is intentionally split into small stages:
+The largest `/platform` groups, by operation count: `workflow-packs` (29), `retrieval` (21),
+`observability` (12), `providers` (12), `async` (11), `prompts` (10), `app-capability-rollouts` (8),
+`capability-packs` (8).
 
-1. validate the task and request shape,
-2. build one shared runtime context,
-3. resolve prompt and safety posture,
-4. execute through the provider or retrieval seam,
-5. assemble evidence and operator-facing metadata,
-6. persist the audit record.
+## Runtime shape
 
-This keeps the runtime understandable and makes later rollout changes less dangerous than embedding
-policy, prompt, safety, and response logic in one orchestration block.
+```mermaid
+flowchart LR
+  subgraph edge["HTTP edge"]
+    MW["middleware<br/>correlation · http_boundary"]
+  end
+  subgraph api["API process (src/app/main.py)"]
+    DP["/ai — data plane<br/>3 operations"]
+    CP["/platform — control plane<br/>163 operations"]
+  end
+  subgraph work["Worker process (src/app/worker_main.py)"]
+    WF["async_worker_fleet<br/>run_dedicated_worker_loop"]
+  end
+  subgraph stores["Repository seams (14 independent store modes)"]
+    MEM["in-memory<br/>DEFAULT"]
+    SQL["SQLAlchemy<br/>requires LOTUS_AI_DATABASE_URL"]
+  end
+  PROV["provider adapters<br/>DEFAULT: disabled"]
+  RET["retrieval<br/>DEFAULT: disabled"]
 
-## Durability Model
+  MW --> DP
+  MW --> CP
+  DP --> PROV
+  DP --> RET
+  DP --> stores
+  CP --> stores
+  WF --> stores
+```
 
-The architecture supports memory-backed and SQL-backed modes through repository seams.
+Two deployable processes share one codebase and one configuration surface: the FastAPI application,
+and a dedicated worker (`src/app/worker_main.py` → `run_dedicated_worker_loop`) driven by
+`LOTUS_AI_ASYNC_WORKER_ID` and `LOTUS_AI_ASYNC_WORKER_QUEUE_POLL_SECONDS`.
 
-Important examples:
+## The default posture is non-durable and non-live
 
-1. prompt rollout state can be durable,
-2. audit persistence can be durable,
-3. retrieval metadata can be durable,
-4. provider operations state can be durable,
-5. async runtime and evaluation runtime can be durable.
+This is the single most operationally important fact about the service, and it is easy to miss
+because it is spread across fourteen independent settings.
 
-The durable path matters because `lotus-ai` is designed for restart-safe governance rather than
-process-local convenience.
+**Every durable store defaults to `memory`.** A restart loses all of it.
 
-## Architectural Boundaries
+```
+audit_store_mode                          prompt_store_mode
+retrieval_store_mode                      access_control_store_mode
+workflow_pack_registry_store_mode         provider_operations_store_mode
+provider_retention_confirmation_store_mode  async_runtime_store_mode
+workflow_pack_run_store_mode              workflow_pack_task_flow_store_mode
+workflow_pack_queue_event_store_mode      evaluation_runtime_store_mode
+artifact_store_mode                       artifact_object_store_mode
+```
 
-The service is intentionally not the place for:
+**Every outbound capability defaults to off:**
 
-1. business-domain ownership,
-2. uncontrolled autonomous tool use in production-facing paths,
-3. opaque orchestration frameworks becoming the public architecture,
-4. unstated rollout assumptions.
+| setting | default | meaning at default |
+|---|---|---|
+| `provider_mode` | `disabled` | no live model calls |
+| `retrieval_mode` | `disabled` | no retrieval execution |
+| `embedding_provider_mode` | `disabled` | no embedding calls |
+| `safety_mode` | `documented_only` | safety posture is declared, not enforced at runtime |
+| `async_queue_backend_mode` | `none` | no managed queue |
+| `local_header_caller_identity_enabled` | `false` | header-asserted identity is not accepted as privileged |
 
-The current framework stance is conservative: use libraries where they reduce plumbing, but do not
-let them obscure task contracts, audit boundaries, or policy gates.
+All settings take the `LOTUS_AI_` environment prefix (`src/app/config.py:93`,
+`env_prefix="LOTUS_AI_"`). Store modes accept exactly `memory` or `sqlalchemy`.
 
-## Source Documents
+### How the switches behave
 
-For the detailed architecture and implementation rationale, read:
+Selection is fail-closed, which is worth relying on (`src/app/services/audit_store.py:12-24` is the
+pattern the other stores follow):
 
-- `docs/architecture/system-overview.md`
-- `docs/architecture/scalability-and-deployment-model.md`
-- `docs/architecture/startup-readiness-deployment-policy.md`
-- `docs/architecture/decision-log.md`
-- `docs/architecture/feature-status-and-roadmap.md`
+- `sqlalchemy` **without** `LOTUS_AI_DATABASE_URL` → `RuntimeError`, naming the missing variable.
+- any value that is neither `memory` nor `sqlalchemy` → `RuntimeError: Unsupported ..._STORE_MODE.`
 
-## Read Next
+The settings are plain `str` fields with no `Literal` constraint, so a typo is caught at first use
+rather than at startup validation. Treat a store-mode change as needing a smoke request against a
+route that touches that store.
 
-1. use [Platform Surfaces](./Platform-Surfaces.md) for the grouped public route map,
-2. use [Getting Started](./Getting-Started.md) for local runtime choices,
-3. use [Development Workflow](./Development-Workflow.md) for the working loop.
+## Request lifecycle
+
+For `POST /ai/tasks/execute`, the runtime is deliberately staged rather than one orchestration block:
+
+1. validate the task and request shape against the contracts in `src/app/contracts/`
+2. build one shared runtime context
+3. resolve prompt selection and safety posture
+4. execute through the provider or retrieval seam
+5. assemble evidence and operator-facing metadata
+6. persist the audit record
+
+Stages 3–6 are where the governance surfaces attach; the split exists so a rollout or policy change
+does not require editing the execution path.
+
+## Caller identity and tenant scope
+
+Protected routes require a trusted upstream caller identity in `X-Caller-App`. Measured on `main`:
+of 173 published operations, the **167** not on the public allowlist all refuse a caller with no
+identity; the six allowlisted paths (`/`, `/health`, `/health/live`, `/health/ready`, `/metadata`,
+`/metrics`) still answer. This is enforced by a test derived from the published OpenAPI surface
+rather than a hand-maintained list, so a new route is covered the moment it is published.
+
+Audit reads are additionally **tenant-scoped from server-side policy**
+(`src/app/services/audit_read_authorization.py:26-38`):
+
+- the caller's `CallerPolicyDescriptor` is looked up by authenticated `caller_app`
+- a missing or non-`ACTIVE` policy → `403`
+- `allow_audit_read_all_tenants` grants all-tenant reads **only** for a privileged identity
+  (`is_privileged_caller_identity_accepted`), and only when no restricted tenant list is also set
+- otherwise the scope is restricted to the policy's tenant list; an empty list → `403`
+
+The tenant is never taken from the request: `/ai/audit` rejects a client-supplied `tenant_id` query
+parameter with `422`. `RESTRICTED_TENANTS` is applied as a SQL predicate, not an application-layer
+filter after fetching.
+
+### Attestation keys are not publicly discoverable
+
+`GET /.well-known/lotus-ai-workflow-attestation-keys` is **not** in `PUBLIC_UNAUTHENTICATED_PATHS`
+and returns **`403`** to a caller without identity — verified against the running application.
+
+This is worth stating explicitly because it cuts against the convention of the `.well-known`
+namespace, which exists so that a party who does *not* yet hold credentials can discover a service's
+public material. As implemented, only an already-trusted caller can fetch the public keys needed to
+verify a workflow-run attestation.
+
+If the intended verifiers are all internal trusted callers, this is correct and simply
+non-obvious — integrators should not plan on anonymous key fetch. If an external or offline verifier
+is ever in scope, the endpoint's placement in the protected set needs revisiting. Recorded here as
+observed behaviour, not as a defect judgement.
+
+## Known gaps
+
+Recorded so they are not mistaken for behaviour that works. Each is a tracked issue.
+
+| gap | effect | issue |
+|---|---|---|
+| `GET /platform/observability/breakdowns` performs an all-tenant audit read with no per-caller scope check | any authenticated caller can enumerate every tenant id and per-tenant execution volume; not recorded in the audit access trail | [#168](https://github.com/sgajbi/lotus-ai/issues/168) |
+| `monetary-float-guard` is declared in the `Makefile` and invoked by nothing | run by hand it exits 1 with five findings, two genuinely monetary | [#165](https://github.com/sgajbi/lotus-ai/issues/165) |
+| `safety_mode` defaults to `documented_only` | redaction posture is declared per task, not enforced at runtime | — |
+| callers remain responsible for context minimisation | the service does not trim caller-supplied context | — |
+
+The `#168` gap matters for how you read the tenant-scope section above: that model is real and
+enforced on `/ai/audit`, and one observability route currently sits outside it.
+
+## Architectural boundaries
+
+The service deliberately does not own:
+
+1. business-domain state — it holds no portfolio, position or client record
+2. uncontrolled autonomous tool use on production-facing paths
+3. orchestration frameworks as public architecture — libraries may reduce plumbing, but task
+   contracts, audit boundaries and policy gates stay explicit
+4. context minimisation on the caller's behalf
+
+## Source map
+
+| area | path | notes |
+|---|---|---|
+| API composition, allowlist | `src/app/main.py` | single `include_router` loop over `PROTECTED_ROUTER_BINDINGS` |
+| public contracts | `src/app/contracts/` | 32 modules |
+| routers | `src/app/routers/` | 20 modules, one per surface group |
+| orchestration and runtime | `src/app/services/` | 229 modules — the bulk of the service |
+| repository seams | `src/app/repositories/` | 38 modules; memory and SQLAlchemy pairs |
+| provider adapters | `src/app/providers/` | rollout, quota, budget, degradation |
+| retrieval | `src/app/retrieval/` | source and document governance, search posture |
+| safety | `src/app/safety/` | output-label-aware policy |
+| evaluations | `src/app/evals/` | fixtures, runtime, approval gates |
+| middleware | `src/app/middleware/` | `correlation`, `http_boundary` |
+| worker entrypoint | `src/app/worker_main.py` | dedicated fleet loop |
+| settings | `src/app/config.py` | 96 lines; every posture switch |
+
+Deeper rationale lives in `docs/architecture/system-overview.md`,
+`docs/architecture/scalability-and-deployment-model.md`,
+`docs/architecture/startup-readiness-deployment-policy.md` and
+`docs/architecture/decision-log.md`.
+
+## Read next
+
+1. [Platform Surfaces](./Platform-Surfaces.md) — the grouped route map
+2. [Security and Governance](./Security-and-Governance.md) — caller identity, output labelling, evidence
+3. [Getting Started](./Getting-Started.md) — local runtime choices
+4. [Operations Runbook](./Operations-Runbook.md) — running and supporting the service

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -84,6 +84,36 @@ All API failures use a bounded `application/problem+json` envelope with stable `
 `correlation_id`, and optional source-safe metadata. Clients and support tooling should use those
 fields instead of parsing prose-only FastAPI `detail` values.
 
+## Tenant Scope on Audit Reads
+
+Caller identity answers *who is calling*. Tenant scope answers *what they may read*, and it is a
+separate control implemented in `src/app/services/audit_read_authorization.py:26-38`.
+
+`resolve_audit_read_scope` derives the scope from **server-side caller policy**, never from the
+request:
+
+1. the caller's `CallerPolicyDescriptor` is looked up by the authenticated `caller_app`
+2. a missing policy, or one whose `lifecycle_status` is not `ACTIVE`, fails closed with `403`
+3. `allow_audit_read_all_tenants` grants an all-tenant scope **only** when the caller also satisfies
+   `is_privileged_caller_identity_accepted`, and only when no restricted tenant list is set as well
+4. otherwise the scope is `RESTRICTED_TENANTS` for the policy's tenant list; an empty list is `403`
+
+Two properties are worth relying on. The tenant is never taken from the caller: `/ai/audit` rejects a
+client-supplied `tenant_id` query parameter with `422`. And `RESTRICTED_TENANTS` is applied as a SQL
+predicate rather than an application-layer filter after fetching, so a scoped caller's query does not
+transit other tenants' rows.
+
+### Where this control does not currently apply
+
+`GET /platform/observability/breakdowns` performs an **unrestricted** audit read
+(`INTERNAL_AGGREGATE_AUDIT_SCOPE`) and does not call `resolve_audit_read_scope`. Any authenticated
+caller therefore receives every tenant id and per-tenant execution volume, and the access is not
+written to the audit access trail that governs `/ai/audit` reads.
+
+Read the four rules above as covering `/ai/audit`, not the whole service. Do not grant the
+breakdowns route to a caller that must not see cross-tenant data. Tracked as
+[#168](https://github.com/sgajbi/lotus-ai/issues/168).
+
 ## Data Handling and Output Policy
 
 The initial data-handling posture is deliberately conservative:

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -13,6 +13,29 @@ When a PR is merged into `main`, `.github/workflows/merged-pr-main-releasability
 `main-releasability.yml` on `main` so release evidence and RFC closure can cite exact-main proof
 rather than branch-only checks.
 
+### What CI actually invokes
+
+The mapping is deliberate but not one-to-one, and the difference matters when deciding what a green
+local run has proven. **No workflow invokes `make check` or `make ci`.** The lanes call individual
+targets, measured across `.github/workflows/*.yml` on `main`:
+
+```
+async-job-gate   docker-build   eval-manifest-gate   eval-run-gate   install
+lint             migration-smoke   openapi-gate      runtime-mode-smoke
+security-audit   test-unit      typecheck           verify-dependencies
+```
+
+Two consequences to keep in mind:
+
+1. **`rfc0002-idea-proof-gate` runs locally only.** It is a prerequisite of both `check` and `ci`,
+   and no workflow invokes it. Passing `make check` proves the RFC-0002 Idea explanation path; CI
+   does not re-prove it, so a change that breaks only that path will not be caught by a lane.
+2. CI runs `test-unit` rather than the broader `test` / `test-coverage` targets that `check` and
+   `ci` pull in. Coverage-bearing runs come from the lane's own steps, not from these targets.
+
+Neither is a defect in the commands; both are reasons to run `make check` before pushing rather than
+relying on the lanes to repeat it.
+
 ## Primary Commands
 
 - `make check` - fast local gate


### PR DESCRIPTION
## Summary

Documentation alignment for `lotus-ai`. Every claim added here was measured against the running
application or the source tree on `main`; nothing is aspirational. **No application code is
changed** — the diff is five Markdown files.

The most important change is a correction: an operator runbook check asserted a security property
the implementation does not provide.

## 1. A runbook check asserted an unheld property

`docs/runbooks/service-operations.md` told operators to:

> confirm `GET /platform/observability/breakdowns` still exposes bounded caller, tenant, and
> capability samples **without leaking unauthorized tenant data**

That endpoint reads audit records under `INTERNAL_AGGREGATE_AUDIT_SCOPE` and never calls
`resolve_audit_read_scope`, so any authenticated caller receives every tenant id and per-tenant
execution volume, and the access is not written to the audit access trail. The check asked for
confirmation of something untrue and supplied no method, so it would be ticked off in good faith.

Replaced with what is true and what to do: treat the output as an all-tenant read, and do not grant
the route to a caller that must not see cross-tenant data. Tracked as #168.

## 2. The tenant-scope model was undocumented, then unbounded

`wiki/Security-and-Governance.md` did not describe the audit tenant-scope model at all, although it
is a core control delivered by #160 and #161. Added the four rules `resolve_audit_read_scope`
applies, and the two properties worth relying on: the tenant is never taken from the request
(`/ai/audit?tenant_id=` returns `422`, verified), and `RESTRICTED_TENANTS` is a SQL predicate rather
than a post-fetch filter.

`docs/security/security-and-governance.md` described that authority precisely but without a
boundary, so a reader would take it as service-wide. Scoped it to the two `/ai/audit` routes and
named where it does not apply.

## 3. Known gaps are now structurally separate from planned work

The deep security doc had "Deferred Security Work" but nowhere for defects in delivered behaviour,
so a live gap would be misfiled as roadmap or omitted. Added a **Known Gaps in Delivered Behaviour**
table — properties of the service as it exists on `main` — and made the distinction explicit on the
deferred list.

Recorded: #168, #149 (identity is asserted by the upstream, not cryptographically verified — `403`
on a missing header is not proof of identity), #165, `safety_mode` defaulting to `documented_only`,
attestation keys requiring caller identity, and context minimisation remaining the caller's
responsibility. All three cited issues verified open.

## 4. `wiki/Architecture.md` rewritten from measured facts

The page described principles and directory names; a reader learned no checkable fact from it, and
`src/app/services/` (229 modules) was summarised as "orchestration logic". Now:

- **the surface shape**: 163 of 173 published operations are `/platform` governance; the entire AI
  data plane is three endpoints. Reading this as an AI service rather than a governance service with
  an AI seam is the fastest way to misread the codebase.
- **the default posture**, previously unstated and the most operationally significant fact: all
  fourteen durable stores default to `memory`; provider, retrieval and embedding default to
  `disabled`; safety to `documented_only`. Out of the box the service persists nothing and calls
  nothing.
- store selection is **fail-closed** — an unsupported mode, or `sqlalchemy` without
  `LOTUS_AI_DATABASE_URL`, raises naming the missing variable.
- a runtime diagram, the two-process deployment shape, known gaps, and a source map.

It also records that `GET /.well-known/lotus-ai-workflow-attestation-keys` returns **403** to an
unauthenticated caller (verified). The `.well-known` namespace exists for discovery by parties
without credentials, so an external verifier cannot fetch the keys to check an attestation. Stated
as observed behaviour with both readings, not as a defect judgement.

## 5. `wiki/Validation-and-CI.md`: what CI actually invokes

The page said the repo-native commands "are designed to map to those lanes", implying a parity that
does not hold. **No workflow invokes `make check` or `make ci`**; the lanes call thirteen individual
targets. Two consequences now stated: `rfc0002-idea-proof-gate` is a prerequisite of both lanes and
is invoked by no workflow, so it runs locally only; and CI runs `test-unit` rather than the broader
`test` / `test-coverage` targets.

## Verification

| claim | how checked |
|---|---|
| 173 / 163 / 3 operations, 7 operational | `app.openapi()` on `main` |
| 32 / 20 / 229 / 38 modules, 14 store modes | `git ls-tree`, `config.py` |
| 17 workflow-pack surfaces | live `GET /platform/observability/runtime-status` |
| `/ai/audit?tenant_id=` → `422` | live request |
| `.well-known` attestation keys → `403` | live request |
| `resolve_audit_read_scope` rules | source, lines 26-38 |
| CI target set | `git grep` over `.github/workflows` |
| #149, #165, #168 open | `gh issue view` |

All 27 `LOTUS_AI_*` variables referenced across the wiki were checked against `config.py` — all
real. All 43 endpoint citations in the Operations Runbook were checked against the published
surface — all real.

`Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai -AllowUnpublishedSourceChanges` run: reports the
expected source-ahead-of-published state for the three changed wiki pages.

**Note for the publish step:** the published wiki is currently missing PR #166's security
correction (published 24 Aug, #166 merged 26 Aug). The live wiki still omits "asserted by the
upstream, not cryptographically verified". Publishing after this merge closes that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
