### PR TITLE
docs: add configuration reference and glossary, and a business rationale on Home

### DIFF
--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -1,0 +1,201 @@
+# Configuration Reference
+
+Every setting `lotus-ai` reads, with the default that applies when the variable is unset. Generated
+from `src/app/config.py` on `main` and verified against it; if this page and that file disagree, the
+file is right and this page is a bug.
+
+All variables take the **`LOTUS_AI_`** prefix (`env_prefix="LOTUS_AI_"`). Unknown variables are
+ignored (`extra="ignore"`), so a misspelled name is silently inert rather than an error — check the
+spelling against this page when a setting appears to have no effect.
+
+## Reading the defaults
+
+Two things are true of the default configuration and are easy to miss because they are spread across
+many settings:
+
+1. **Nothing is persisted.** All fourteen `*_STORE_MODE` settings default to `memory`. A restart
+   discards audit records, prompt rollout state, workflow-pack runs, artifacts and everything else.
+2. **Nothing is called.** `PROVIDER_MODE`, `RETRIEVAL_MODE` and `EMBEDDING_PROVIDER_MODE` default to
+   `disabled`; `SAFETY_MODE` defaults to `documented_only`; `ASYNC_QUEUE_BACKEND_MODE` to `none`.
+
+An unconfigured instance is therefore a governed, inspectable, entirely local service that executes
+nothing against a provider and remembers nothing across restarts. That is a deliberate posture, not
+an incomplete install.
+
+## Durable stores
+
+Each accepts `memory` or `sqlalchemy`. Selecting `sqlalchemy` requires `LOTUS_AI_DATABASE_URL`;
+omitting it raises at first use with a message naming the missing variable. Any other value raises
+`Unsupported ..._STORE_MODE`. Selection is fail-closed, and because these are plain strings with no
+`Literal` constraint, a typo surfaces on the first request that touches the store rather than at
+startup — smoke-test a route that uses the store after changing one.
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_AUDIT_STORE_MODE` | `memory` |
+| `LOTUS_AI_PROMPT_STORE_MODE` | `memory` |
+| `LOTUS_AI_RETRIEVAL_STORE_MODE` | `memory` |
+| `LOTUS_AI_ACCESS_CONTROL_STORE_MODE` | `memory` |
+| `LOTUS_AI_WORKFLOW_PACK_REGISTRY_STORE_MODE` | `memory` |
+| `LOTUS_AI_PROVIDER_OPERATIONS_STORE_MODE` | `memory` |
+| `LOTUS_AI_PROVIDER_RETENTION_CONFIRMATION_STORE_MODE` | `memory` |
+| `LOTUS_AI_ASYNC_RUNTIME_STORE_MODE` | `memory` |
+| `LOTUS_AI_WORKFLOW_PACK_RUN_STORE_MODE` | `memory` |
+| `LOTUS_AI_WORKFLOW_PACK_TASK_FLOW_STORE_MODE` | `memory` |
+| `LOTUS_AI_WORKFLOW_PACK_QUEUE_EVENT_STORE_MODE` | `memory` |
+| `LOTUS_AI_EVALUATION_RUNTIME_STORE_MODE` | `memory` |
+| `LOTUS_AI_ARTIFACT_STORE_MODE` | `memory` |
+| `LOTUS_AI_ARTIFACT_OBJECT_STORE_MODE` | `memory` |
+| `LOTUS_AI_DATABASE_URL` | *(none)* — required by any `sqlalchemy` mode |
+| `LOTUS_AI_ARTIFACT_OBJECT_STORE_ROOT` | *(none)* |
+
+## Service identity
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_SERVICE_NAME` | `lotus-ai` |
+| `LOTUS_AI_SERVICE_VERSION` | `0.1.0` |
+| `LOTUS_AI_DELIVERY_PHASE` | `foundation` |
+
+## Provider execution
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_PROVIDER_MODE` | `disabled` |
+| `LOTUS_AI_PROVIDER_ROLLOUT_STATE` | `STUB_DEFAULT` |
+| `LOTUS_AI_PROVIDER_TIMEOUT_MS` | `4000` |
+| `LOTUS_AI_PROVIDER_RETRY_LIMIT` | `0` |
+| `LOTUS_AI_PROVIDER_MAX_OUTPUT_TOKENS` | `512` |
+| `LOTUS_AI_SECRET_SOURCE_MODE` | `local_or_unspecified` |
+
+### Live text provider
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_LIVE_TEXT_PROVIDER_ID` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_MODEL_ID` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_MODEL_VERSION` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_PROVIDER_API_KEY` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_API_BASE` | `https://api.openai.com/v1` |
+| `LOTUS_AI_LIVE_TEXT_ALLOWED_TASK_IDS` | `""` — empty allows none |
+| `LOTUS_AI_LIVE_TEXT_LOCAL_PROBE_TIMEOUT_MS` | `1500` |
+| `LOTUS_AI_LIVE_TEXT_LOCAL_PROBE_CACHE_SECONDS` | `15` |
+
+### Cost, quota, budget and degradation
+
+Each enforcement switch is **off** by default. Turning enforcement on without setting the
+corresponding limit leaves the limit `None`; set both together.
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_LIVE_TEXT_INPUT_COST_PER_1K_TOKENS` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_OUTPUT_COST_PER_1K_TOKENS` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_QUOTA_ENFORCED` | `false` |
+| `LOTUS_AI_LIVE_TEXT_DEFAULT_QUOTA_LIMIT` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_TASK_QUOTA_LIMITS` | `""` |
+| `LOTUS_AI_LIVE_TEXT_CALLER_QUOTA_LIMITS` | `""` |
+| `LOTUS_AI_LIVE_TEXT_TENANT_QUOTA_LIMITS` | `""` |
+| `LOTUS_AI_LIVE_TEXT_BUDGET_ENFORCED` | `false` |
+| `LOTUS_AI_LIVE_TEXT_SOFT_BUDGET_USD` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_HARD_BUDGET_USD` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_DEGRADATION_ENFORCED` | `false` |
+| `LOTUS_AI_LIVE_TEXT_DEGRADED_FAILURE_COUNT_THRESHOLD` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_CIRCUIT_OPEN_FAILURE_COUNT_THRESHOLD` | *(none)* |
+| `LOTUS_AI_LIVE_TEXT_CIRCUIT_OPEN_SECONDS` | *(none)* |
+
+### Embeddings
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_EMBEDDING_PROVIDER_MODE` | `disabled` |
+| `LOTUS_AI_LIVE_EMBEDDING_PROVIDER_ID` | *(none)* |
+| `LOTUS_AI_LIVE_EMBEDDING_MODEL_ID` | *(none)* |
+| `LOTUS_AI_LIVE_EMBEDDING_PROVIDER_API_KEY` | *(none)* |
+
+## Retrieval and safety
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_RETRIEVAL_MODE` | `disabled` |
+| `LOTUS_AI_SAFETY_MODE` | `documented_only` — posture is declared per task, not enforced at runtime |
+
+## Async runtime and worker fleet
+
+The worker is a second process (`src/app/worker_main.py`) sharing this configuration.
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_ASYNC_CUTOVER_STATE` | `in_process_only` |
+| `LOTUS_AI_ASYNC_QUEUE_BACKEND_MODE` | `none` |
+| `LOTUS_AI_ASYNC_QUEUE_REDIS_URL` | *(none)* |
+| `LOTUS_AI_ASYNC_QUEUE_NAME` | `lotus-ai:async:jobs` |
+| `LOTUS_AI_ASYNC_WORKER_ID` | `lotus-ai-worker-1` |
+| `LOTUS_AI_ASYNC_WORKER_QUEUE_POLL_SECONDS` | `5` |
+| `LOTUS_AI_ASYNC_WORKER_DRAIN_ENABLED` | `false` |
+
+## Workflow-run attestation
+
+Signing material for workflow-run attestations. The public keys are served from
+`GET /.well-known/lotus-ai-workflow-attestation-keys`, which **requires caller identity** — it is
+not in the public allowlist, so an anonymous verifier cannot fetch them.
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_KEY_ID` | *(none)* |
+| `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_PRIVATE_KEY_BASE64URL` | *(none)* |
+| `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_ROTATION_EPOCH` | *(none)* |
+| `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_KEY_NOT_BEFORE_UTC` | *(none)* |
+| `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_KEY_NOT_AFTER_UTC` | *(none)* |
+| `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_ROTATED_PUBLIC_KEYS_JSON` | `[]` |
+| `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_TTL_SECONDS` | `300` |
+| `LOTUS_AI_WORKFLOW_RUN_MODEL_RISK_INVENTORY_JSON` | `[]` |
+
+## Deployment, startup and readiness
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_DEPLOYMENT_SPLIT_STAGE` | `unified` |
+| `LOTUS_AI_STARTUP_READINESS_POLICY` | `warn` |
+| `LOTUS_AI_READINESS_PROBE_POLICY` | `observe` |
+
+Readiness policy does not alter authorization — a permissive readiness posture never relaxes a
+security control.
+
+## HTTP boundary
+
+Transport-only controls. They contain no task, workflow-pack, retrieval, prompt, provider or domain
+logic, and ingress may be stricter.
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_HTTP_ALLOWED_HOSTS` | `*` |
+| `LOTUS_AI_HTTP_CORS_ALLOWED_ORIGINS` | *(bounded list in `config.py`)* |
+| `LOTUS_AI_HTTP_CORS_ALLOWED_METHODS` | `GET,POST,PUT,PATCH,DELETE,OPTIONS` |
+| `LOTUS_AI_HTTP_CORS_ALLOWED_HEADERS` | *(bounded list in `config.py`)* |
+| `LOTUS_AI_HTTP_CORS_ALLOW_CREDENTIALS` | `false` |
+| `LOTUS_AI_HTTP_SECURE_HEADERS_ENABLED` | `true` |
+| `LOTUS_AI_HTTP_HSTS_ENABLED` | `false` |
+| `LOTUS_AI_HTTP_HSTS_MAX_AGE_SECONDS` | `31536000` |
+| `LOTUS_AI_HTTP_MAX_REQUEST_BODY_BYTES` | `1048576` — oversize requests get `413 application/problem+json` before any handler runs |
+
+## Caller identity
+
+| variable | default |
+|---|---|
+| `LOTUS_AI_LOCAL_HEADER_CALLER_IDENTITY_ENABLED` | `false` |
+
+Default-closed. When enabled, header-asserted identity may exercise the privileged all-tenant audit
+capability — intended for local runtimes only. In a promoted runtime the privileged path fails
+closed unless the caller trust source is a verified service JWT or mTLS SAN. The effective posture
+is exposed by `GET /platform/runtime-status`.
+
+Caller identity itself is **asserted by the upstream, not cryptographically verified**
+([#149](https://github.com/sgajbi/lotus-ai/issues/149)); see
+[Security and Governance](./Security-and-Governance.md).
+
+## Read next
+
+1. [Getting Started](./Getting-Started.md) — choosing a local runtime posture
+2. [Architecture](./Architecture.md) — what these switches select between
+3. [Operations Runbook](./Operations-Runbook.md) — changing posture on a running service
+4. [Security and Governance](./Security-and-Governance.md) — the controls these settings bound

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -1,0 +1,144 @@
+# Glossary
+
+The vocabulary `lotus-ai` uses in its routes, contracts and evidence. Definitions are taken from the
+implementation on `main`, not from intent. `src/app/contracts/` declares 124 enum types; this page
+covers the terms you need to read the service, not all of them.
+
+## The four posture questions
+
+Almost every platform group answers the same four questions, which is why the surface is large
+without being complicated. **57 of the 163 `/platform` operations are these four repeated per
+domain** — learn them once.
+
+| surface | question it answers | groups exposing it | key fields |
+|---|---|---|---|
+| `runtime-status` | *What is true right now?* | 14 | `posture`, `domains`, `freshness`, `*_count` |
+| `activation-readiness` | *Could this be switched on?* | 12 | `activation_ready`, `activation_path`, `blocking_findings` |
+| `runbook-readiness` | *Have the operator prerequisites been completed?* | 14 | `runbook_ready`, `items`, `required_item_count`, `completed_required_item_count` |
+| `governance-status` | *Do the three above agree?* | 17 | `governance_ready`, and nested `runtime_status`, `activation_readiness`, `runbook_readiness` |
+
+`governance-status` is the composite: it embeds the other three and adds `blocking_area_count`. When
+a group is not behaving, read `governance-status` first and follow `blocking_findings` down.
+
+**Readiness is not authorization.** A permissive readiness posture never relaxes a security control.
+
+## Execution vocabulary
+
+**Task** — the bounded unit of AI execution, submitted to `POST /ai/tasks/execute`. A task has an
+identifier, a declared contract in `src/app/contracts/`, and a resolved prompt, provider and safety
+posture at execution time.
+
+**Workflow pack** — a registered, governed bundle executed through
+`POST /platform/workflow-packs/execute` when a caller needs registered-pack eligibility, run
+recording and explicit run identity in one step. Workflow packs are the largest platform group (29
+operations) and carry their own registry, run store, task-flow store and queue-event store.
+
+**Capability pack** — an *app-facing* packaging of AI capability, distinct from a workflow pack. It
+carries `pack_id`, `family_id` and a `family_kind` of `COMMENTARY` or `EXPLANATION`, and a
+`CapabilityPackMaturityStage` of `EXPERIMENTAL`, `REUSABLE` or `APPROVED`. Workflow packs are *what
+runs*; capability packs are *what an application adopts*.
+
+**Task flow** — the recorded progression of a workflow-pack run, stored separately from the run
+itself so review state and heartbeat/attention posture survive independently.
+
+**Output label** — the declared intended use of AI output, one of `EXPLANATION_ONLY`, `DRAFT`,
+`CLASSIFICATION`, `RETRIEVAL_ANSWER`. **No label implies authoritative business execution.** Labels
+are enforced; they are the contract between the service and a consuming application about what the
+output may be used for.
+
+**Async job status** — `STAGED`, `QUEUED`, `CLAIMED`, `RUNNING`, `FAILED`, `COMPLETED`,
+`ABANDONED`, `SUPERSEDED`. Staging and queueing are distinct: a staged job exists durably before any
+queue backend accepts it, which is what makes recovery possible when a queue loses a delivery.
+`ABANDONED` and `SUPERSEDED` are outcomes of operator recovery actions, not of execution.
+
+## Identity and scope
+
+**Caller app** — the upstream service identity, supplied in the `X-Caller-App` header. Every
+published operation except six operational paths refuses a caller with no identity.
+
+**Caller policy** — the server-side `CallerPolicyDescriptor` for a caller app, holding its
+lifecycle status, tenant restrictions and capabilities. It is the authority for what a caller may
+read; the request never carries it.
+
+**Tenant scope** — the set of tenants a caller may read audit records for, derived from caller
+policy by `resolve_audit_read_scope`. Either `RESTRICTED_TENANTS` (a named list, applied as a SQL
+predicate) or all-tenants (privileged identity only). See
+[Security and Governance](./Security-and-Governance.md) for the rules and for the one route that
+sits outside them.
+
+**Trust source** — how the caller identity arrived: `trusted_http_header`, a verified service JWT,
+or an mTLS SAN. The header source is *asserted*, not verified
+([#149](https://github.com/sgajbi/lotus-ai/issues/149)).
+
+## Evidence vocabulary
+
+**Audit record** — the durable record of one execution, readable through `/ai/audit`. Persisted only
+when `LOTUS_AI_AUDIT_STORE_MODE=sqlalchemy`; the default `memory` mode discards it on restart.
+
+**Correlation id** — the identifier threading a request through middleware, execution, evidence and
+problem responses. Present in every `application/problem+json` body; use it rather than parsing
+`detail`.
+
+**Attestation** — a signed statement about a workflow run. Signing material is configured through
+`LOTUS_AI_WORKFLOW_RUN_ATTESTATION_*`; public keys are served from
+`/.well-known/lotus-ai-workflow-attestation-keys`, which **requires caller identity**. Stub
+execution is `test_only` and cannot receive an approved attestation.
+
+**Retention confirmation** — provider-side evidence that data was retained or deleted as governed,
+tracked in its own store and surface. Distinct from the audit record, which is the service's own
+account of what it did.
+
+**Supportability** — whether an AI-backed surface can currently be supported, exposed as
+`ai_surface_supportability` on `runtime-status` with a bounded `supportability_reason` per surface.
+It covers 17 workflow-pack surfaces and carries `no_sensitive_content_telemetry` so an operator can
+judge telemetry posture without inspecting prompts or generated content.
+
+**Posture** — a bounded summary value rather than a raw state dump. The service prefers reporting a
+posture with a reason code over exposing internals; operators and tooling should read the posture
+and its reason, not infer from absence.
+
+## Modes and stages
+
+**Store mode** — `memory` or `sqlalchemy`, chosen independently for each of fourteen stores. See
+[Configuration Reference](./Configuration-Reference.md).
+
+**Provider mode / retrieval mode / embedding provider mode** — `disabled` by default. A disabled
+mode is a governed state, not a broken one.
+
+**Safety mode** — `documented_only` by default: redaction posture is declared per task rather than
+enforced at runtime.
+
+**Rollout state** — the provider's governed activation position, defaulting to `STUB_DEFAULT`.
+
+**Cutover state** — the async runtime's position between in-process execution
+(`in_process_only`) and a managed queue.
+
+**Deployment split stage** — whether runtime, retrieval and evals are deployed together (`unified`)
+or separately.
+
+**Delivery phase** — the service's own declared maturity, `foundation` by default.
+
+## Terms used precisely
+
+**Governed** — subject to an explicit, inspectable policy surface rather than an implicit default.
+Used throughout the codebase and not as a synonym for "good".
+
+**Bounded** — deliberately limited in size or shape, and documented as such: bounded samples,
+bounded problem responses, bounded summaries. Bounded output is a safety property, not a limitation.
+
+**Fail closed** — refuse rather than proceed when a control cannot be evaluated. Applies to unknown
+caller identity, unresolvable tenant scope, unsupported store modes, and evidence that cannot be
+persisted.
+
+**Source-safe** — evidence shaped so it can be shown to an operator without exposing prompts,
+generated content, credentials or tenant-sensitive identifiers.
+
+**Review-gated** — an execution path whose result requires explicit review before it can be treated
+as accepted.
+
+## Read next
+
+1. [Architecture](./Architecture.md) — how these pieces fit together
+2. [Platform Surfaces](./Platform-Surfaces.md) — the grouped route map
+3. [Configuration Reference](./Configuration-Reference.md) — every mode and switch
+4. [Security and Governance](./Security-and-Governance.md) — identity, labelling, evidence

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -5,15 +5,46 @@ execution and operator-facing control planes so downstream Lotus applications ca
 retrieval, safety controls, evaluation gates, async execution, and provider-routing seams without
 moving business authority out of the domain services that already own it.
 
+## Why It Exists
+
+Every Lotus application has work that an AI model could help with — explaining a performance
+result, drafting commentary, classifying an exception, answering from governed documents. Built
+per-application, each of those needs its own provider integration, prompt versioning, spend control,
+safety labelling, audit trail and evaluation. Built five times, they drift, and the bank ends up
+unable to answer a simple question: *what did the AI actually do, for whom, on what evidence?*
+
+`lotus-ai` is that capability built once, with the governance attached rather than added later:
+
+- **Domain authority stays where it belongs.** The service holds no portfolio, position or client
+  record. Every output carries a label declaring its intended use, and no label authorises business
+  execution. An application decides how output is applied; `lotus-ai` decides only that it was
+  produced under policy.
+- **Every execution leaves evidence.** Audit records, correlation identifiers and signed
+  workflow-run attestations are produced by the execution path, not bolted on, so "what happened"
+  is answerable after the fact rather than reconstructed.
+- **Provider risk is bounded centrally.** Quota, budget, timeout, retry and circuit-breaker
+  controls, plus rollout state and degradation posture, live in one place with operator surfaces —
+  not scattered across the applications that call them.
+- **Nothing is on by default.** Provider execution, retrieval and embeddings ship disabled, and
+  activation is evidence-gated. Capability is switched on deliberately, per surface, with a readiness
+  posture an operator can inspect.
+
+The trade is explicitness over convenience: the service is deliberately larger in governance surface
+than in execution surface, because in a private-banking context the question that matters is rarely
+*can it answer* but *may it, and can we prove what it did*.
+
 ## Start Here
 
 If you need the shortest accurate orientation, read these in order:
 
-1. [Overview](./Overview.md)
-2. [Architecture](./Architecture.md)
-3. [Getting Started](./Getting-Started.md)
-4. [Validation and CI](./Validation-and-CI.md)
-5. [Operations Runbook](./Operations-Runbook.md)
+1. [Overview](./Overview.md) — role and ownership boundaries
+2. [Glossary](./Glossary.md) — the vocabulary, including the four posture questions that account for
+   a third of the API surface
+3. [Architecture](./Architecture.md) — measured shape, default posture, known gaps
+4. [Getting Started](./Getting-Started.md) — running it locally
+5. [Configuration Reference](./Configuration-Reference.md) — every setting and its default
+6. [Validation and CI](./Validation-and-CI.md) — gates, and what CI actually invokes
+7. [Operations Runbook](./Operations-Runbook.md) — operating and supporting it
 
 ## Current Posture
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -13,6 +13,7 @@
 
 - [Architecture](Architecture)
 - [Getting Started](Getting-Started)
+- [Configuration Reference](Configuration-Reference)
 - [Development Workflow](Development-Workflow)
 - [Validation and CI](Validation-and-CI)
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -4,6 +4,7 @@
 
 - [Home](Home)
 - [Overview](Overview)
+- [Glossary](Glossary)
 - [Platform Surfaces](Platform-Surfaces)
 - [Integrations](Integrations)
 - [Roadmap](Roadmap)


### PR DESCRIPTION
## Summary

Second documentation tranche for `lotus-ai`, filling the two largest coverage gaps and giving the
wiki a business-facing entry point. **No application code, tests or migrations are changed** — three
Markdown files.

Follows #169, which corrected an operator check that asserted an unheld security property.

## 1. `wiki/Configuration-Reference.md` — new

The 81 settings in `src/app/config.py` had no canonical reference. They were described across
seventeen files, most densely in the integration guide (38 mentions) and two runbooks (28 each), so
answering "what does this default to" meant grepping.

Generated from `config.py` and verified against it: **81 documented, 0 missing, 0 invented.**

Grouped by concern, and leading with the two facts too thinly spread across individual settings to
notice otherwise:

- **nothing is persisted by default** — all fourteen `*_STORE_MODE` settings default to `memory`, so
  a restart discards audit records, prompt rollout state, workflow-pack runs and artifacts
- **nothing is called by default** — provider, retrieval and embedding modes default to `disabled`,
  safety to `documented_only`, queue backend to `none`

An unconfigured instance is a governed, inspectable, entirely local service. The page says so
explicitly, so that posture is not read as an incomplete install.

It also records the operationally sharp edges: unknown variables are ignored (`extra="ignore"`) so a
typo is silently inert; store modes are plain strings with no `Literal` constraint, so a bad value
surfaces on first use rather than at startup; quota, budget and degradation enforcement switches are
independent of their limit values and must be set together; and readiness policy never relaxes
authorization.

## 2. `wiki/Glossary.md` — new

There was no glossary anywhere in the repo, and the service carries heavy vocabulary — workflow
pack, capability pack, task flow, output label, supportability, attestation, retention confirmation,
posture, trust source, cutover state. `src/app/contracts/` declares **124 enum types**; a new
engineer had to infer all of it from call sites.

The most useful entry is structural: **57 of the 163 `/platform` operations are the same four
questions asked per domain** — `runtime-status` (what is true now), `activation-readiness` (could
this be switched on), `runbook-readiness` (are the operator prerequisites done) and
`governance-status` (do the three agree — it embeds them). 12 + 14 + 17 + 14, measured from the
published paths; the key fields listed are what the live endpoints actually return. Learning that
once makes a 163-operation surface tractable.

It also separates pairs that are easy to conflate — workflow pack is *what runs*, capability pack is
*what an application adopts*; audit record is the service's own account, retention confirmation is
the provider's; staging is distinct from queueing, which is what makes queue-loss recovery possible
— and defines the four words the codebase uses precisely and a reader will otherwise skim as filler:
governed, bounded, fail closed, source-safe.

## 3. `wiki/Home.md` — business rationale and a fuller entry path

Home stated accurately what the service owns but not why it exists, so a business or architecture
reader got ownership boundaries without the problem being solved.

Adds **Why It Exists**: the same AI work built per-application needs its own provider integration,
prompt versioning, spend control, safety labelling, audit trail and evaluation — built five times
they drift, until nobody can answer what the AI did, for whom, on what evidence. Then the four
properties that follow, each backed by implemented behaviour, and the trade being made: the service
is deliberately larger in governance surface than execution surface, because the question that
matters is rarely whether it *can* answer but whether it *may*, and whether we can prove what it did.

Start Here now includes the Glossary and Configuration Reference, with a line on what each gives the
reader. Both new pages are linked from `_Sidebar.md`.

## Verification

| claim | how checked |
|---|---|
| 81 settings, all documented, none invented | parsed `config.py`, set-compared against the page |
| 57 = 12 + 14 + 17 + 14 posture operations | counted from `app.openapi()` published paths |
| posture surface key fields | live `GET` against each of the four |
| `AsyncJobStatus` members | `src/app/contracts` |
| 124 enum types in contracts | `git grep` count |
| internal links | 82 wiki + 88 docs/README relative links resolve, **0 broken** |
| cited source paths | all exist |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
