### PR TITLE
docs(wiki): link to page slugs, not .md source files

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -208,7 +208,7 @@ Deeper rationale lives in `docs/architecture/system-overview.md`,
 
 ## Read next
 
-1. [Platform Surfaces](./Platform-Surfaces.md) — the grouped route map
-2. [Security and Governance](./Security-and-Governance.md) — caller identity, output labelling, evidence
-3. [Getting Started](./Getting-Started.md) — local runtime choices
-4. [Operations Runbook](./Operations-Runbook.md) — running and supporting the service
+1. [Platform Surfaces](Platform-Surfaces) — the grouped route map
+2. [Security and Governance](Security-and-Governance) — caller identity, output labelling, evidence
+3. [Getting Started](Getting-Started) — local runtime choices
+4. [Operations Runbook](Operations-Runbook) — running and supporting the service

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -191,11 +191,11 @@ is exposed by `GET /platform/runtime-status`.
 
 Caller identity itself is **asserted by the upstream, not cryptographically verified**
 ([#149](https://github.com/sgajbi/lotus-ai/issues/149)); see
-[Security and Governance](./Security-and-Governance.md).
+[Security and Governance](Security-and-Governance).
 
 ## Read next
 
-1. [Getting Started](./Getting-Started.md) — choosing a local runtime posture
-2. [Architecture](./Architecture.md) — what these switches select between
-3. [Operations Runbook](./Operations-Runbook.md) — changing posture on a running service
-4. [Security and Governance](./Security-and-Governance.md) — the controls these settings bound
+1. [Getting Started](Getting-Started) — choosing a local runtime posture
+2. [Architecture](Architecture) — what these switches select between
+3. [Operations Runbook](Operations-Runbook) — changing posture on a running service
+4. [Security and Governance](Security-and-Governance) — the controls these settings bound

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -76,6 +76,6 @@ Use these as the main working references:
 
 ## Read Next
 
-1. use [Validation and CI](./Validation-and-CI.md) for the gate meanings,
-2. use [Platform Surfaces](./Platform-Surfaces.md) when the change touches public APIs,
-3. use [RFC Index](./RFC-Index.md) when the change is governed by a specific capability RFC family.
+1. use [Validation and CI](Validation-and-CI) for the gate meanings,
+2. use [Platform Surfaces](Platform-Surfaces) when the change touches public APIs,
+3. use [RFC Index](RFC-Index) when the change is governed by a specific capability RFC family.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -126,7 +126,7 @@ Source:
 
 After the service is up:
 
-1. use [Platform Surfaces](./Platform-Surfaces.md) to understand the API groups,
-2. use [Validation and CI](./Validation-and-CI.md) to choose the right gate,
-3. use [Operations Runbook](./Operations-Runbook.md) when the runtime posture matters,
-4. use [Troubleshooting](./Troubleshooting.md) when startup or readiness is not behaving as expected.
+1. use [Platform Surfaces](Platform-Surfaces) to understand the API groups,
+2. use [Validation and CI](Validation-and-CI) to choose the right gate,
+3. use [Operations Runbook](Operations-Runbook) when the runtime posture matters,
+4. use [Troubleshooting](Troubleshooting) when startup or readiness is not behaving as expected.

--- a/wiki/Glossary.md
+++ b/wiki/Glossary.md
@@ -63,7 +63,7 @@ read; the request never carries it.
 **Tenant scope** — the set of tenants a caller may read audit records for, derived from caller
 policy by `resolve_audit_read_scope`. Either `RESTRICTED_TENANTS` (a named list, applied as a SQL
 predicate) or all-tenants (privileged identity only). See
-[Security and Governance](./Security-and-Governance.md) for the rules and for the one route that
+[Security and Governance](Security-and-Governance) for the rules and for the one route that
 sits outside them.
 
 **Trust source** — how the caller identity arrived: `trusted_http_header`, a verified service JWT,
@@ -100,7 +100,7 @@ and its reason, not infer from absence.
 ## Modes and stages
 
 **Store mode** — `memory` or `sqlalchemy`, chosen independently for each of fourteen stores. See
-[Configuration Reference](./Configuration-Reference.md).
+[Configuration Reference](Configuration-Reference).
 
 **Provider mode / retrieval mode / embedding provider mode** — `disabled` by default. A disabled
 mode is a governed state, not a broken one.
@@ -138,7 +138,7 @@ as accepted.
 
 ## Read next
 
-1. [Architecture](./Architecture.md) — how these pieces fit together
-2. [Platform Surfaces](./Platform-Surfaces.md) — the grouped route map
-3. [Configuration Reference](./Configuration-Reference.md) — every mode and switch
-4. [Security and Governance](./Security-and-Governance.md) — identity, labelling, evidence
+1. [Architecture](Architecture) — how these pieces fit together
+2. [Platform Surfaces](Platform-Surfaces) — the grouped route map
+3. [Configuration Reference](Configuration-Reference) — every mode and switch
+4. [Security and Governance](Security-and-Governance) — identity, labelling, evidence

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -37,14 +37,14 @@ than in execution surface, because in a private-banking context the question tha
 
 If you need the shortest accurate orientation, read these in order:
 
-1. [Overview](./Overview.md) — role and ownership boundaries
-2. [Glossary](./Glossary.md) — the vocabulary, including the four posture questions that account for
+1. [Overview](Overview) — role and ownership boundaries
+2. [Glossary](Glossary) — the vocabulary, including the four posture questions that account for
    a third of the API surface
-3. [Architecture](./Architecture.md) — measured shape, default posture, known gaps
-4. [Getting Started](./Getting-Started.md) — running it locally
-5. [Configuration Reference](./Configuration-Reference.md) — every setting and its default
-6. [Validation and CI](./Validation-and-CI.md) — gates, and what CI actually invokes
-7. [Operations Runbook](./Operations-Runbook.md) — operating and supporting it
+3. [Architecture](Architecture) — measured shape, default posture, known gaps
+4. [Getting Started](Getting-Started) — running it locally
+5. [Configuration Reference](Configuration-Reference) — every setting and its default
+6. [Validation and CI](Validation-and-CI) — gates, and what CI actually invokes
+7. [Operations Runbook](Operations-Runbook) — operating and supporting it
 
 ## Current Posture
 
@@ -133,11 +133,11 @@ Current task families include:
 
 If you are:
 
-1. integrating another Lotus app, start with [Integrations](./Integrations.md)
-2. operating the service, start with [Operations Runbook](./Operations-Runbook.md)
-3. validating a change, start with [Validation and CI](./Validation-and-CI.md)
-4. learning the repository, start with [Architecture](./Architecture.md)
-5. debugging local runtime problems, start with [Troubleshooting](./Troubleshooting.md)
+1. integrating another Lotus app, start with [Integrations](Integrations)
+2. operating the service, start with [Operations Runbook](Operations-Runbook)
+3. validating a change, start with [Validation and CI](Validation-and-CI)
+4. learning the repository, start with [Architecture](Architecture)
+5. debugging local runtime problems, start with [Troubleshooting](Troubleshooting)
 
 ## Source Documents
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -9,7 +9,7 @@ inspection so consumers do not mistake an available route for transferred busine
 | Reader need | Start here | Evidence or decision |
 |---|---|---|
 | Execute a bounded AI task | [Primary Executable Contracts](#primary-executable-contracts) | Request, response, audit, and evidence contract |
-| Integrate a workflow pack | [Workflow-Pack Integration](#workflow-pack-integration) | Registration, eligibility, review, and authority boundary |
+| Integrate a workflow pack | [Downstream Adoption Surfaces](#downstream-adoption-surfaces) | Registration, eligibility, review, and authority boundary |
 | Verify portable provenance | [Signed Workflow-Run Provenance](#signed-workflow-run-provenance) | Signed claims and public-key discovery |
 | Diagnose provider or safety posture | [Provider and Safety Expectations](#provider-and-safety-expectations) | Runtime operator surfaces and fail-closed controls |
 
@@ -412,7 +412,7 @@ When the integration depends on blocked, redacted, or label-sensitive output han
 
 ## Read Next
 
-1. use [Platform Surfaces](./Platform-Surfaces.md) for the grouped public route map,
-2. use [Security and Governance](./Security-and-Governance.md) for the boundary rules that constrain integrations,
-3. use [Operations Runbook](./Operations-Runbook.md) when workflow-pack rollout or operator control posture needs a live check,
-4. use [Troubleshooting](./Troubleshooting.md) when a runtime mode or provider path is not behaving as expected.
+1. use [Platform Surfaces](Platform-Surfaces) for the grouped public route map,
+2. use [Security and Governance](Security-and-Governance) for the boundary rules that constrain integrations,
+3. use [Operations Runbook](Operations-Runbook) when workflow-pack rollout or operator control posture needs a live check,
+4. use [Troubleshooting](Troubleshooting) when a runtime mode or provider path is not behaving as expected.

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -92,7 +92,7 @@ The service exposes a broad platform surface. The main groups are:
 11. capability packs, workflow packs, app-capability rollouts, and first-use-case surfaces
    adoption and rollout governance rather than direct execution
 
-For the grouped route map, use [Platform Surfaces](./Platform-Surfaces.md).
+For the grouped route map, use [Platform Surfaces](Platform-Surfaces).
 
 ## Operator-First Route Families
 
@@ -383,6 +383,6 @@ abandon the queued job with operator evidence; do not repair this state with ad 
 
 ## Read Next
 
-1. use [Platform Surfaces](./Platform-Surfaces.md) for the grouped route map,
-2. use [Troubleshooting](./Troubleshooting.md) for common failure patterns,
-3. use [Security and Governance](./Security-and-Governance.md) when the question is about what the runtime is actually allowed to do.
+1. use [Platform Surfaces](Platform-Surfaces) for the grouped route map,
+2. use [Troubleshooting](Troubleshooting) for common failure patterns,
+3. use [Security and Governance](Security-and-Governance) when the question is about what the runtime is actually allowed to do.

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -63,6 +63,6 @@ business truth. `lotus-ai` is designed to keep that line clear:
 
 ## Read Next
 
-1. use [Architecture](./Architecture.md) for the runtime shape and execution flow,
-2. use [Platform Surfaces](./Platform-Surfaces.md) for the grouped public API map,
-3. use [Roadmap](./Roadmap.md) for what is intentionally bounded versus expanding.
+1. use [Architecture](Architecture) for the runtime shape and execution flow,
+2. use [Platform Surfaces](Platform-Surfaces) for the grouped public API map,
+3. use [Roadmap](Roadmap) for what is intentionally bounded versus expanding.

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -503,6 +503,6 @@ one isolated task call.
 
 ## Read Next
 
-1. use [Integrations](./Integrations.md) for how downstream systems should consume these surfaces,
-2. use [Operations Runbook](./Operations-Runbook.md) for the runtime interpretation of these groups,
-3. use [Troubleshooting](./Troubleshooting.md) when one surface says something different from another.
+1. use [Integrations](Integrations) for how downstream systems should consume these surfaces,
+2. use [Operations Runbook](Operations-Runbook) for the runtime interpretation of these groups,
+3. use [Troubleshooting](Troubleshooting) when one surface says something different from another.

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -93,6 +93,6 @@ Do not load the entire RFC estate unless the task is specifically governance-hea
 
 ## Read Next
 
-1. use [Roadmap](./Roadmap.md) for how the RFC program translates into platform phases,
-2. use [Security and Governance](./Security-and-Governance.md) for the practical runtime interpretation,
-3. use [Development Workflow](./Development-Workflow.md) when the RFC work implies code and docs changes in the same slice.
+1. use [Roadmap](Roadmap) for how the RFC program translates into platform phases,
+2. use [Security and Governance](Security-and-Governance) for the practical runtime interpretation,
+3. use [Development Workflow](Development-Workflow) when the RFC work implies code and docs changes in the same slice.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -95,6 +95,6 @@ of an AI runtime alone.
 
 ## Read Next
 
-1. use [RFC Index](./RFC-Index.md) for the governing decision inventory,
-2. use [Integrations](./Integrations.md) to see how roadmap expansion affects downstream adoption,
-3. use [Security and Governance](./Security-and-Governance.md) to understand why some expansion remains intentionally bounded.
+1. use [RFC Index](RFC-Index) for the governing decision inventory,
+2. use [Integrations](Integrations) to see how roadmap expansion affects downstream adoption,
+3. use [Security and Governance](Security-and-Governance) to understand why some expansion remains intentionally bounded.

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -158,7 +158,7 @@ The key governance surfaces are grouped by domain:
 7. use cases
    - bounded downstream rollout readiness and onboarding templates
 
-For the grouped route map, use [Platform Surfaces](./Platform-Surfaces.md).
+For the grouped route map, use [Platform Surfaces](Platform-Surfaces).
 
 ## Operational Security Interpretation
 
@@ -210,6 +210,6 @@ Some security work is intentionally not being overstated as complete:
 
 ## Read Next
 
-1. use [Platform Surfaces](./Platform-Surfaces.md) for the grouped governance route map,
-2. use [RFC Index](./RFC-Index.md) to find the decision trail behind a capability area,
-3. use [Troubleshooting](./Troubleshooting.md) when the runtime posture and expected governance state do not align.
+1. use [Platform Surfaces](Platform-Surfaces) for the grouped governance route map,
+2. use [RFC Index](RFC-Index) to find the decision trail behind a capability area,
+3. use [Troubleshooting](Troubleshooting) when the runtime posture and expected governance state do not align.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -138,8 +138,8 @@ change can still affect a large platform surface.
 
 Use:
 
-- [Validation and CI](./Validation-and-CI.md)
-- [Development Workflow](./Development-Workflow.md)
+- [Validation and CI](Validation-and-CI)
+- [Development Workflow](Development-Workflow)
 
 ## The Wiki or Docs Feel Out of Sync with the Runtime
 
@@ -157,9 +157,9 @@ Start from code:
 
 Then compare against:
 
-1. [Platform Surfaces](./Platform-Surfaces.md)
-2. [Security and Governance](./Security-and-Governance.md)
-3. [Roadmap](./Roadmap.md)
+1. [Platform Surfaces](Platform-Surfaces)
+2. [Security and Governance](Security-and-Governance)
+3. [Roadmap](Roadmap)
 
 In `lotus-ai`, docs are part of the control-plane contract. If the runtime truth changed, the docs
 should change in the same slice.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -124,6 +124,6 @@ just developer convenience.
 
 ## Read Next
 
-1. use [Development Workflow](./Development-Workflow.md) for the repo's actual working loop,
-2. use [Troubleshooting](./Troubleshooting.md) when a local gate fails for runtime or policy reasons,
-3. use [Operations Runbook](./Operations-Runbook.md) when the issue is about live runtime posture.
+1. use [Development Workflow](Development-Workflow) for the repo's actual working loop,
+2. use [Troubleshooting](Troubleshooting) when a local gate fails for runtime or policy reasons,
+3. use [Operations Runbook](Operations-Runbook) when the issue is about live runtime posture.


### PR DESCRIPTION
Documentation only.

## The defect

A `.md` link inside a published GitHub wiki does not resolve to the rendered page. Verified directly:

```
GET https://github.com/sgajbi/lotus-render/wiki/Architecture.md
→ 302 https://raw.githubusercontent.com/wiki/sgajbi/lotus-render/Architecture.md
```

The reader is dropped into **unrendered markdown** — no sidebar, no navigation, no working onward links. It is not a 404, which is precisely why it went unnoticed: the link appears to work.

This wiki had **66 such links across 15 pages**, so most in-wiki navigation led out of the wiki.

Found by a reviewer on lotus-performance#492; it applies to four repos and this is one of them.

## The fix

All 66 rewritten to page slugs, anchors preserved. Only targets that are real wiki pages were rewritten — links to repository files keep their absolute `blob/main` URLs.

Also fixes a **pre-existing broken anchor**: the Integrations reader map pointed at `#workflow-pack-integration`, which is not a heading on that page. The section that actually covers workflow-pack registration, eligibility and the authority boundary is *Downstream Adoption Surfaces*, so the row now points there.

## Verification

96 wiki links checked — every page reference, every cross-page anchor and every self-anchor. **0 broken.**