### PR TITLE
feat(runs): review-gated accepted-output projection for advisor briefs

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,7 +50,13 @@ Current repository posture:
    kept separate from review state,
    bounded actor-attributed review transitions available through the ledger API, bounded
    ledger-compatible `allowed_review_actions` emitted for consumers, governed workflow-pack
-   artifact refs now attached for bounded output-summary review, deterministic proposal memo
+   artifact refs now attached for bounded output-summary review, one review-gated
+   accepted-output projection (`/platform/workflow-packs/runs/{run_id}/accepted-output`) that
+   publishes the exact accepted `advisor_brief.pack@v1` narrative with reviewer identity and a
+   canonical content hash to authorized same-tenant callers - completed+accepted+non-superseded
+   with an intact governed artifact only, bounded fail-closed reason codes otherwise, per-pack
+   projectors registered explicitly, and no client-release, Report-integration, or certification
+   claim, deterministic proposal memo
    commentary support for bounded `lotus-advise` memo evidence that cannot mutate memo status,
    suitability, approval, or client-ready posture, deterministic RFC-0027 advisory copilot
    guardrails that validate Advise-owned source-backed evidence packets, bounded requested outputs,

--- a/src/app/contracts/workflow_pack_run_accepted_output.py
+++ b/src/app/contracts/workflow_pack_run_accepted_output.py
@@ -1,0 +1,128 @@
+"""Typed accepted-output projection for `advisor_brief.pack@v1` runs (issue #162).
+
+This contract publishes the exact reviewed narrative of one accepted run so an
+owning consumer (Report/Gateway composition) can retrieve it immutably instead of
+regenerating content, parsing previews, or reading internal storage references.
+It is review-gated and NOT client-authoritative: lotus-ai proves what was
+generated, reviewed and accepted; client-report suitability and distribution
+remain the calling workflow's authority.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+ACCEPTED_OUTPUT_SCHEMA_ADVISOR_BRIEF_V1 = (
+    "lotus-ai.workflow_pack_run.accepted_output.advisor_brief.v1"
+)
+ACCEPTED_OUTPUT_CONTENT_HASH_ALGORITHM = "sha256"
+
+
+class AdvisorBriefAcceptedNarrativeItem(BaseModel):
+    """One bounded narrative element (talking point or risk/exception)."""
+
+    headline: str = Field(description="Short reviewed statement for this element.")
+    detail: str = Field(description="Reviewed supporting detail for the headline.")
+    tone: str = Field(description="Bounded tone marker recorded with the element.")
+    evidence_refs: list[str] = Field(
+        default_factory=list,
+        description="Source references grounding this element, as recorded at generation.",
+    )
+
+
+class AdvisorBriefAcceptedContextIdentity(BaseModel):
+    """Bounded report-context identity for consumer-side matching.
+
+    Carries exactly the context identifiers the accepted output was generated
+    for. `as_of_date`, `reporting_currency` and `benchmark` are populated when
+    the persisted output recorded them and are null otherwise - a consumer must
+    treat a null as "not asserted by the source", never as a wildcard match.
+    """
+
+    portfolio_id: str = Field(description="Portfolio the accepted brief was generated for.")
+    period: str = Field(description="Reporting period label the accepted brief covers.")
+    as_of_date: str | None = Field(
+        default=None,
+        description="As-of date recorded with the output, when the source asserted one.",
+    )
+    reporting_currency: str | None = Field(
+        default=None,
+        description="Reporting currency recorded with the output, when asserted.",
+    )
+    benchmark: str | None = Field(
+        default=None,
+        description="Benchmark identity recorded with the output, when asserted.",
+    )
+
+
+class AdvisorBriefAcceptedReviewIdentity(BaseModel):
+    """Who accepted the run and when, from the durable review event ledger."""
+
+    reviewed_by: str = Field(description="Actor recorded on the accepting review transition.")
+    reviewed_at: str = Field(description="Instant of the accepting review transition (UTC).")
+
+
+class WorkflowPackRunAcceptedOutputResponse(BaseModel):
+    """The exact accepted `advisor_brief.pack@v1` output for one run.
+
+    Only completed, accepted, non-superseded runs backed by their intact
+    governed output artifact return this response; every other posture fails
+    closed with a bounded reason code. The response never contains prompts,
+    arbitrary task payloads, object-store paths, storage references, provider
+    secrets, or generic artifact bodies.
+    """
+
+    schema_id: str = Field(
+        description="Versioned schema discriminator for this projection.",
+    )
+    service: str = Field(description="Publishing service identity.")
+    version: str = Field(description="Publishing service version.")
+    run_id: str = Field(description="Accepted workflow-pack run identity.")
+    pack_id: str = Field(description="Workflow pack identity.")
+    pack_family: str = Field(description="Workflow pack family.")
+    pack_version: str = Field(description="Workflow pack version.")
+    task_id: str = Field(description="Task identity that produced the output.")
+    request_id: str = Field(description="Originating request identity.")
+    tenant_id: str = Field(description="Tenant the run belongs to and was retrieved for.")
+    workflow_authority_owner: str = Field(
+        description="Service that owns consequence-bearing workflow authority for this pack.",
+    )
+    review: AdvisorBriefAcceptedReviewIdentity = Field(
+        description="Accepting reviewer identity and time from the review event ledger.",
+    )
+    advisor_brief_status: str = Field(
+        description="Bounded output status label recorded with the accepted brief.",
+    )
+    coverage_state: str = Field(
+        description="Bounded source-coverage label recorded with the accepted brief.",
+    )
+    grounded_summary: str = Field(
+        description="The exact reviewed summary narrative, unmodified since acceptance.",
+    )
+    talking_points: list[AdvisorBriefAcceptedNarrativeItem] = Field(
+        description="Reviewed talking points, in recorded order.",
+    )
+    risks_and_exceptions: list[AdvisorBriefAcceptedNarrativeItem] = Field(
+        description="Reviewed risks and exceptions, in recorded order.",
+    )
+    context: AdvisorBriefAcceptedContextIdentity = Field(
+        description="Bounded report-context identity for consumer-side matching.",
+    )
+    source_refs: list[str] = Field(
+        description="Source references the brief was grounded on, as recorded at generation.",
+    )
+    evidence_types: list[str] = Field(
+        description="Evidence descriptor types recorded with the run, names only.",
+    )
+    content_hash: str = Field(
+        description=(
+            "Canonical hash over the published narrative and context fields; changes when "
+            "any published field changes, so consumers can pin the exact accepted content."
+        ),
+    )
+    content_hash_algorithm: str = Field(
+        description="Algorithm of content_hash.",
+    )
+    notes: list[str] = Field(
+        description="Boundary statements this projection ships with.",
+    )

--- a/src/app/routers/workflow_packs.py
+++ b/src/app/routers/workflow_packs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Query
+from typing import Annotated
+
+from fastapi import APIRouter, Header, HTTPException, Query
 
 from app.config import settings
 from app.contracts.workflow_packs import (
@@ -52,6 +54,15 @@ from app.contracts.workflow_pack_task_flows import (
 from app.http.authenticated_caller import (
     AuthenticatedCallerDependency,
     require_authenticated_caller_matches,
+)
+from app.contracts.workflow_pack_run_accepted_output import (
+    WorkflowPackRunAcceptedOutputResponse,
+)
+from app.services.access_control_authorization import require_active_registered_caller
+from app.services.workflow_pack_run_accepted_output import (
+    AcceptedOutputNotAvailableError,
+    AcceptedOutputNotFoundError,
+    build_workflow_pack_run_accepted_output,
 )
 from app.services.workflow_pack_run_consumer_view import build_workflow_pack_run_consumer_view
 from app.services.workflow_pack_run_operator_profile import build_workflow_pack_run_operator_profile
@@ -983,6 +994,72 @@ async def get_workflow_pack_run_consumer_view_route(
 ) -> WorkflowPackRunConsumerViewResponse:
     try:
         return build_workflow_pack_run_consumer_view(run_id=run_id)
+    except WorkflowPackRunStoreUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.get(
+    "/platform/workflow-packs/runs/{run_id}/accepted-output",
+    response_model=WorkflowPackRunAcceptedOutputResponse,
+    operation_id="getWorkflowPackRunAcceptedOutput",
+    summary="Get the exact accepted output of one workflow-pack run",
+    description=(
+        "Returns the exact reviewed narrative of one accepted `advisor_brief.pack@v1` run for "
+        "an authorized caller in the run's own tenant. This projection is review-gated and "
+        "non-client-authoritative: only completed, accepted, non-superseded runs backed by "
+        "their intact governed output artifact return content, and every other posture fails "
+        "closed with a bounded reason code. It never exposes prompts, arbitrary task payloads, "
+        "object-store paths, storage references, provider secrets, or generic artifact bodies. "
+        "Client-report suitability and distribution remain the calling workflow's authority."
+    ),
+    responses={
+        200: {"description": "Exact accepted run output returned successfully."},
+        403: {"description": "Caller is not an active registered caller."},
+        404: {
+            "description": (
+                "Unknown run, or a run outside the caller's tenant - deliberately one shape."
+            )
+        },
+        409: {
+            "description": (
+                "The run exists but its output must not be published: "
+                "pack_projection_unsupported, run_not_completed, run_not_accepted, "
+                "run_superseded, output_artifact_missing, or output_artifact_malformed."
+            )
+        },
+        422: {"description": "Required caller headers are missing or invalid."},
+        503: {"description": "Run or artifact stores are not ready."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_workflow_pack_run_accepted_output_route(
+    run_id: str,
+    caller_app: Annotated[str, Header(alias="X-Caller-App", min_length=1)],
+    tenant_id: Annotated[str, Header(alias="X-Tenant-Id", min_length=1)],
+) -> WorkflowPackRunAcceptedOutputResponse:
+    require_active_registered_caller(
+        caller_app.strip(),
+        blocked_summary="Caller is not authorized to retrieve accepted workflow-pack output.",
+    )
+    try:
+        return build_workflow_pack_run_accepted_output(
+            run_id=run_id,
+            caller_tenant_id=tenant_id.strip(),
+        )
+    except AcceptedOutputNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown workflow-pack run: {exc}",
+        ) from exc
+    except AcceptedOutputNotAvailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "detail": exc.message,
+                "error_code": f"LOTUS_AI_ACCEPTED_OUTPUT_{exc.reason_code.upper()}",
+                "metadata": {"reason_code": exc.reason_code},
+            },
+        ) from exc
     except WorkflowPackRunStoreUnavailableError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 

--- a/src/app/services/workflow_pack_run_accepted_output.py
+++ b/src/app/services/workflow_pack_run_accepted_output.py
@@ -1,0 +1,323 @@
+"""Build the review-gated accepted-output projection for one workflow-pack run.
+
+Issue #162: downstream Report/Gateway composition needs the exact accepted
+`advisor_brief.pack@v1` narrative by `run_id`. This service joins the durable
+run record, the review event ledger and the governed `run_output_summary`
+artifact inside lotus-ai and fails closed on every posture that is not
+"completed, accepted, not superseded, artifact intact".
+
+Design decisions, deliberate:
+
+- A pack-specific projection registry, so arbitrary future structured-output
+  keys never become implicitly retrievable: a pack family earns retrieval only
+  by shipping its own typed projector.
+- Unknown run and wrong-tenant retrieval share one not-found shape - a run id
+  must not become a cross-tenant existence oracle.
+- The canonical content hash is computed from the published projection fields
+  themselves (canonical JSON, sorted keys), so it changes exactly when any
+  published narrative or context field changes and is reproducible by a
+  consumer holding only the response.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from typing import Any
+
+from app.config import settings
+from app.contracts.workflow_pack_run_accepted_output import (
+    ACCEPTED_OUTPUT_CONTENT_HASH_ALGORITHM,
+    ACCEPTED_OUTPUT_SCHEMA_ADVISOR_BRIEF_V1,
+    AdvisorBriefAcceptedContextIdentity,
+    AdvisorBriefAcceptedNarrativeItem,
+    AdvisorBriefAcceptedReviewIdentity,
+    WorkflowPackRunAcceptedOutputResponse,
+)
+from app.contracts.workflow_pack_runs import (
+    WorkflowPackRunReviewState,
+    WorkflowPackRunRuntimeState,
+)
+from app.repositories.workflow_pack_run_repository import WorkflowPackRunRecord
+from app.services.artifact_store import get_artifact_object_store
+from app.services.workflow_pack_run_ledger import ensure_workflow_pack_run_store_ready
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+from app.services.workflow_pack_run_review_summary import (
+    build_workflow_pack_run_review_summary,
+)
+
+
+class AcceptedOutputNotFoundError(LookupError):
+    """Unknown run, or a run the caller's tenant may not see - one shape, no leak."""
+
+
+class AcceptedOutputNotAvailableError(ValueError):
+    """The run exists in the caller's tenant but its output must not be published."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+REASON_PACK_PROJECTION_UNSUPPORTED = "pack_projection_unsupported"
+REASON_RUN_NOT_COMPLETED = "run_not_completed"
+REASON_RUN_NOT_ACCEPTED = "run_not_accepted"
+REASON_RUN_SUPERSEDED = "run_superseded"
+REASON_OUTPUT_ARTIFACT_MISSING = "output_artifact_missing"
+REASON_OUTPUT_ARTIFACT_MALFORMED = "output_artifact_malformed"
+
+ACCEPTED_OUTPUT_REASON_CODES = frozenset(
+    {
+        REASON_PACK_PROJECTION_UNSUPPORTED,
+        REASON_RUN_NOT_COMPLETED,
+        REASON_RUN_NOT_ACCEPTED,
+        REASON_RUN_SUPERSEDED,
+        REASON_OUTPUT_ARTIFACT_MISSING,
+        REASON_OUTPUT_ARTIFACT_MALFORMED,
+    }
+)
+
+_ACCEPTED_OUTPUT_NOTES = [
+    "This projection publishes the exact accepted output of one reviewed run; it does not "
+    "certify client-report suitability, client distribution, or bank release.",
+    "Only completed, accepted, non-superseded runs backed by their intact governed output "
+    "artifact are retrievable; every other posture fails closed with a bounded reason code.",
+    "Consequence-bearing workflow authority remains with the workflow authority owner; "
+    "lotus-ai remains the AI run, review and evidence system of record.",
+]
+
+
+def build_workflow_pack_run_accepted_output(
+    *,
+    run_id: str,
+    caller_tenant_id: str,
+) -> WorkflowPackRunAcceptedOutputResponse:
+    ensure_workflow_pack_run_store_ready()
+    store = get_workflow_pack_run_store()
+    record = store.get_run(run_id=run_id)
+    if record is None:
+        raise AcceptedOutputNotFoundError(run_id)
+    if not record.tenant_id or record.tenant_id != caller_tenant_id:
+        # Wrong tenant and tenantless runs are indistinguishable from absent runs:
+        # a tenant-scoped projection must not leak cross-tenant existence, and a
+        # run with no tenant binding has no tenant it may be published to.
+        raise AcceptedOutputNotFoundError(run_id)
+
+    projector = _PROJECTORS.get(f"{record.pack_id}@{record.pack_version}")
+    if projector is None:
+        raise AcceptedOutputNotAvailableError(
+            REASON_PACK_PROJECTION_UNSUPPORTED,
+            "No typed accepted-output projection exists for this pack and version.",
+        )
+
+    if record.runtime_state != WorkflowPackRunRuntimeState.COMPLETED.value:
+        raise AcceptedOutputNotAvailableError(
+            REASON_RUN_NOT_COMPLETED,
+            "Accepted output is only published for completed runs.",
+        )
+    if record.review_state != WorkflowPackRunReviewState.ACCEPTED.value:
+        raise AcceptedOutputNotAvailableError(
+            REASON_RUN_NOT_ACCEPTED,
+            "Accepted output is only published after a recorded ACCEPT review.",
+        )
+    if record.superseded_by_run_id:
+        raise AcceptedOutputNotAvailableError(
+            REASON_RUN_SUPERSEDED,
+            "This run has been superseded; retrieve the superseding accepted run instead.",
+        )
+
+    payload = _load_intact_output_payload(record)
+    review = _accepting_review_identity(store=store, run_id=run_id)
+    return projector(record=record, payload=payload, review=review)
+
+
+def _accepting_review_identity(*, store: Any, run_id: str) -> AdvisorBriefAcceptedReviewIdentity:
+    summary = build_workflow_pack_run_review_summary(events=store.list_events(run_id=run_id))
+    if not summary.latest_review_actor or not summary.latest_review_event_at:
+        # An ACCEPTED state without a recorded review transition is a ledger
+        # inconsistency; publishing content without reviewer identity would break
+        # the human-oversight evidence this projection exists to carry.
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            "The accepted run has no recorded accepting review event.",
+        )
+    reviewed_by = summary.latest_review_actor
+    # The event ledger namespaces review actors as `review:<actor>`; publish the
+    # reviewer identity itself.
+    if reviewed_by.startswith("review:"):
+        reviewed_by = reviewed_by.removeprefix("review:")
+    return AdvisorBriefAcceptedReviewIdentity(
+        reviewed_by=reviewed_by,
+        reviewed_at=summary.latest_review_event_at,
+    )
+
+
+def _load_intact_output_payload(record: WorkflowPackRunRecord) -> dict[str, Any]:
+    summary_artifact = next(
+        (
+            artifact
+            for artifact in record.artifact_refs
+            if artifact.domain == "workflow_pack"
+            and artifact.artifact_type == "run_output_summary"
+            and artifact.storage_reference
+        ),
+        None,
+    )
+    if summary_artifact is None:
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MISSING,
+            "The governed run-output artifact is not linked to this run.",
+        )
+    _, _, object_key = summary_artifact.storage_reference.partition("://")
+    stored_object = get_artifact_object_store().get_object(object_key=object_key)
+    if stored_object is None:
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MISSING,
+            "The governed run-output artifact object is no longer retrievable.",
+        )
+    try:
+        payload = json.loads(stored_object.payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            "The governed run-output artifact could not be parsed.",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            "The governed run-output artifact has an unexpected shape.",
+        )
+    if payload.get("run_id") != record.run_id or payload.get("pack_id") != record.pack_id:
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            "The governed run-output artifact does not match this run's identity.",
+        )
+    return payload
+
+
+def _project_advisor_brief_v1(
+    *,
+    record: WorkflowPackRunRecord,
+    payload: dict[str, Any],
+    review: AdvisorBriefAcceptedReviewIdentity,
+) -> WorkflowPackRunAcceptedOutputResponse:
+    structured_output = payload.get("structured_output")
+    if not isinstance(structured_output, dict):
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            "The accepted output does not carry a structured advisor brief.",
+        )
+    portfolio_id = _required_string(structured_output, "portfolio_id")
+    period = _required_string(structured_output, "period")
+    grounded_summary = _required_string(structured_output, "grounded_summary")
+    advisor_brief_status = _required_string(structured_output, "advisor_brief_status")
+    coverage_state = _required_string(structured_output, "coverage_state")
+
+    context = AdvisorBriefAcceptedContextIdentity(
+        portfolio_id=portfolio_id,
+        period=period,
+        as_of_date=_optional_string(structured_output, "as_of_date"),
+        reporting_currency=_optional_string(structured_output, "reporting_currency"),
+        benchmark=_optional_string(structured_output, "benchmark"),
+    )
+    talking_points = _narrative_items(structured_output.get("talking_points"))
+    risks_and_exceptions = _narrative_items(structured_output.get("risks_and_exceptions"))
+    source_refs = [ref for ref in payload.get("source_refs", []) if isinstance(ref, str)]
+    evidence_types = [
+        evidence for evidence in payload.get("evidence_types", []) if isinstance(evidence, str)
+    ]
+
+    hashed_content = {
+        "schema_id": ACCEPTED_OUTPUT_SCHEMA_ADVISOR_BRIEF_V1,
+        "run_id": record.run_id,
+        "pack_id": record.pack_id,
+        "pack_version": record.pack_version,
+        "advisor_brief_status": advisor_brief_status,
+        "coverage_state": coverage_state,
+        "grounded_summary": grounded_summary,
+        "talking_points": [item.model_dump() for item in talking_points],
+        "risks_and_exceptions": [item.model_dump() for item in risks_and_exceptions],
+        "context": context.model_dump(),
+        "source_refs": source_refs,
+    }
+    content_hash = hashlib.sha256(
+        json.dumps(hashed_content, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    return WorkflowPackRunAcceptedOutputResponse(
+        schema_id=ACCEPTED_OUTPUT_SCHEMA_ADVISOR_BRIEF_V1,
+        service=settings.service_name,
+        version=settings.service_version,
+        run_id=record.run_id,
+        pack_id=record.pack_id,
+        pack_family=record.pack_family,
+        pack_version=record.pack_version,
+        task_id=record.task_id,
+        request_id=record.request_id,
+        tenant_id=str(record.tenant_id),
+        workflow_authority_owner=record.workflow_authority_owner,
+        review=review,
+        advisor_brief_status=advisor_brief_status,
+        coverage_state=coverage_state,
+        grounded_summary=grounded_summary,
+        talking_points=talking_points,
+        risks_and_exceptions=risks_and_exceptions,
+        context=context,
+        source_refs=source_refs,
+        evidence_types=evidence_types,
+        content_hash=content_hash,
+        content_hash_algorithm=ACCEPTED_OUTPUT_CONTENT_HASH_ALGORITHM,
+        notes=list(_ACCEPTED_OUTPUT_NOTES),
+    )
+
+
+def _narrative_items(raw: Any) -> list[AdvisorBriefAcceptedNarrativeItem]:
+    if not isinstance(raw, list):
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            "The accepted output narrative elements have an unexpected shape.",
+        )
+    items: list[AdvisorBriefAcceptedNarrativeItem] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise AcceptedOutputNotAvailableError(
+                REASON_OUTPUT_ARTIFACT_MALFORMED,
+                "The accepted output narrative elements have an unexpected shape.",
+            )
+        items.append(
+            AdvisorBriefAcceptedNarrativeItem(
+                headline=_required_string(entry, "headline"),
+                detail=_required_string(entry, "detail"),
+                tone=_required_string(entry, "tone"),
+                evidence_refs=[
+                    ref for ref in entry.get("evidence_refs", []) if isinstance(ref, str)
+                ],
+            )
+        )
+    return items
+
+
+def _required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            f"The accepted output is missing the required field '{key}'.",
+        )
+    return value
+
+
+def _optional_string(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+_ProjectorCallable = Callable[..., WorkflowPackRunAcceptedOutputResponse]
+
+# A pack family earns accepted-output retrieval only by shipping a typed projector
+# here; arbitrary structured-output keys are never implicitly retrievable.
+_PROJECTORS: dict[str, _ProjectorCallable] = {
+    "advisor_brief.pack@v1": _project_advisor_brief_v1,
+}

--- a/src/app/services/workflow_pack_task_flow_contracts.py
+++ b/src/app/services/workflow_pack_task_flow_contracts.py
@@ -37,6 +37,10 @@ TASK_FLOW_ALLOWED_TRANSITIONS: dict[WorkflowPackTaskFlowStatus, set[WorkflowPack
         WorkflowPackTaskFlowStatus.RUNNING,
         WorkflowPackTaskFlowStatus.BLOCKED,
         WorkflowPackTaskFlowStatus.COMPLETED,
+        # A REJECT review action terminates the flow as FAILED; without this edge
+        # every reject of an awaiting-review run raised a transition error and the
+        # review 500ed (found by the accepted-output projection tests, issue #162).
+        WorkflowPackTaskFlowStatus.FAILED,
         WorkflowPackTaskFlowStatus.CANCELLED,
         WorkflowPackTaskFlowStatus.EXPIRED,
         WorkflowPackTaskFlowStatus.SUPERSEDED,

--- a/tests/integration/test_workflow_pack_run_accepted_output_api.py
+++ b/tests/integration/test_workflow_pack_run_accepted_output_api.py
@@ -1,0 +1,270 @@
+"""API contract for the review-gated accepted-output projection (issue #162).
+
+The projection publishes the exact accepted `advisor_brief.pack@v1` narrative by
+run id. These tests prove positive retrieval, every fail-closed posture, tenant
+isolation without an existence oracle, hash stability, field minimization, and
+the SQL restart proof the issue's evaluation condition demands.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.support.migration_runner import upgrade_database_to_head
+from tests.support.runtime_settings import override_runtime_settings
+from tests.support.workflow_pack_fixtures import advisor_brief_task_execution_request_json
+
+CALLER_HEADERS = {"X-Caller-App": "lotus-gateway", "X-Tenant-Id": "tenant-sg-001"}
+
+
+def _execute_advisor_brief(client: TestClient, *, correlation_id: str) -> str:
+    execute_response = client.post(
+        "/ai/tasks/execute",
+        json=advisor_brief_task_execution_request_json(correlation_id=correlation_id),
+    )
+    assert execute_response.status_code == 200
+    runs = client.get("/platform/workflow-packs/runs").json()["runs"]
+    return str(next(run["run_id"] for run in runs if run["correlation_id"] == correlation_id))
+
+
+def _accept(client: TestClient, run_id: str, *, reviewed_by: str = "banker.sg.201") -> None:
+    review_response = client.post(
+        f"/platform/workflow-packs/runs/{run_id}/review-actions",
+        json={
+            "action_type": "ACCEPT",
+            "caller_app": "lotus-gateway",
+            "reviewed_by": reviewed_by,
+            "reason": "Accepted for accepted-output projection proof.",
+        },
+    )
+    assert review_response.status_code == 200
+
+
+def test_accepted_output_returns_the_exact_reviewed_narrative(client: TestClient) -> None:
+    run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-001")
+    _accept(client, run_id, reviewed_by="banker.sg.201")
+
+    response = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output",
+        headers=CALLER_HEADERS,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_id"] == "lotus-ai.workflow_pack_run.accepted_output.advisor_brief.v1"
+    assert body["run_id"] == run_id
+    assert body["pack_id"] == "advisor_brief.pack"
+    assert body["pack_version"] == "v1"
+    assert body["tenant_id"] == "tenant-sg-001"
+    assert body["workflow_authority_owner"] == "lotus-gateway"
+    assert body["review"]["reviewed_by"] == "banker.sg.201"
+    assert body["review"]["reviewed_at"]
+    assert body["grounded_summary"]
+    assert body["talking_points"], "the reviewed talking points must be published"
+    assert body["context"]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert body["context"]["period"] == "YTD"
+    assert body["source_refs"] == ["lotus-gateway:performance-summary:YTD"]
+    assert body["content_hash_algorithm"] == "sha256"
+    assert len(body["content_hash"]) == 64
+
+    # The published summary is the exact retained narrative, not a preview or a
+    # regeneration: the consumer view's bounded preview is a prefix of it.
+    consumer_view = client.get(f"/platform/workflow-packs/runs/{run_id}/consumer-view").json()
+    preview = consumer_view["provenance"]["output_preview"]
+    assert body["grounded_summary"].startswith(preview[:64])
+
+
+def test_accepted_output_is_byte_stable_across_retrievals(client: TestClient) -> None:
+    run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-002")
+    _accept(client, run_id)
+
+    first = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output", headers=CALLER_HEADERS
+    )
+    second = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output", headers=CALLER_HEADERS
+    )
+
+    assert first.status_code == second.status_code == 200
+    assert first.json() == second.json()
+    assert first.json()["content_hash"] == second.json()["content_hash"]
+
+
+def test_accepted_output_excludes_internal_and_unprojected_fields(client: TestClient) -> None:
+    """Field minimization: no storage references, no object-store paths, no raw
+    structured-output spillover such as recommended_actions or grounded_facts."""
+
+    run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-003")
+    _accept(client, run_id)
+
+    response = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output", headers=CALLER_HEADERS
+    )
+
+    assert response.status_code == 200
+    serialized = json.dumps(response.json())
+    for forbidden in (
+        "storage_reference",
+        "object_key",
+        "artifact://",
+        "recommended_actions",
+        "grounded_facts",
+        "structured_output",
+        "output_preview",
+    ):
+        assert forbidden not in serialized, forbidden
+
+
+def test_awaiting_review_run_fails_closed(client: TestClient) -> None:
+    run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-004")
+
+    response = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output", headers=CALLER_HEADERS
+    )
+
+    assert response.status_code == 409
+    assert response.json()["metadata"]["reason_code"] == "run_not_accepted"
+
+
+def test_rejected_run_fails_closed(client: TestClient) -> None:
+    run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-005")
+    review_response = client.post(
+        f"/platform/workflow-packs/runs/{run_id}/review-actions",
+        json={
+            "action_type": "REJECT",
+            "caller_app": "lotus-gateway",
+            "reviewed_by": "banker.sg.202",
+            "reason": "Rejected for accepted-output projection proof.",
+        },
+    )
+    assert review_response.status_code == 200
+
+    response = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output", headers=CALLER_HEADERS
+    )
+
+    assert response.status_code == 409
+    assert response.json()["metadata"]["reason_code"] == "run_not_accepted"
+
+
+def test_revised_run_fails_closed_and_replacement_serves_content(client: TestClient) -> None:
+    original_run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-006")
+    replacement_run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-007")
+    revise_response = client.post(
+        f"/platform/workflow-packs/runs/{original_run_id}/review-actions",
+        json={
+            "action_type": "REVISE",
+            "caller_app": "lotus-gateway",
+            "reviewed_by": "banker.sg.203",
+            "reason": "Revised for accepted-output projection proof.",
+            "replacement_run_id": replacement_run_id,
+        },
+    )
+    assert revise_response.status_code == 200
+    _accept(client, replacement_run_id)
+
+    superseded = client.get(
+        f"/platform/workflow-packs/runs/{original_run_id}/accepted-output",
+        headers=CALLER_HEADERS,
+    )
+    replacement = client.get(
+        f"/platform/workflow-packs/runs/{replacement_run_id}/accepted-output",
+        headers=CALLER_HEADERS,
+    )
+
+    assert superseded.status_code == 409
+    assert superseded.json()["metadata"]["reason_code"] in {
+        "run_not_accepted",
+        "run_superseded",
+    }
+    assert replacement.status_code == 200
+    assert replacement.json()["run_id"] == replacement_run_id
+
+
+def test_wrong_tenant_and_unknown_run_share_one_not_found_shape(client: TestClient) -> None:
+    run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-008")
+    _accept(client, run_id)
+
+    wrong_tenant = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output",
+        headers={"X-Caller-App": "lotus-gateway", "X-Tenant-Id": "tenant-uk-999"},
+    )
+    unknown_run = client.get(
+        "/platform/workflow-packs/runs/wfr-does-not-exist/accepted-output",
+        headers=CALLER_HEADERS,
+    )
+
+    assert wrong_tenant.status_code == unknown_run.status_code == 404
+    # One shape: the wrong-tenant refusal must be indistinguishable from an
+    # unknown run apart from the echoed identifier.
+    wrong_detail = wrong_tenant.json()["detail"].replace(run_id, "{run_id}")
+    unknown_detail = unknown_run.json()["detail"].replace("wfr-does-not-exist", "{run_id}")
+    assert wrong_detail == unknown_detail
+
+
+def test_unregistered_caller_is_refused(client: TestClient) -> None:
+    run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-009")
+    _accept(client, run_id)
+
+    response = client.get(
+        f"/platform/workflow-packs/runs/{run_id}/accepted-output",
+        headers={"X-Caller-App": "unregistered-app", "X-Tenant-Id": "tenant-sg-001"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_missing_caller_headers_are_refused(client: TestClient) -> None:
+    response = client.get("/platform/workflow-packs/runs/wfr-any/accepted-output")
+
+    assert response.status_code == 422
+
+
+def test_openapi_names_the_review_gated_boundary(client: TestClient) -> None:
+    schema = app.openapi()
+    operation = schema["paths"]["/platform/workflow-packs/runs/{run_id}/accepted-output"]["get"]
+
+    assert operation["operationId"] == "getWorkflowPackRunAcceptedOutput"
+    description = operation["description"]
+    assert "review-gated" in description
+    assert "non-client-authoritative" in description
+    assert "fails" in description and "closed" in description
+    for status_code in ("200", "403", "404", "409", "422", "503"):
+        assert status_code in operation["responses"]
+
+
+def test_sql_backed_accepted_output_survives_restart_with_stable_hash(tmp_path: Path) -> None:
+    """The issue's evaluation condition: execute, ACCEPT, restart, retrieve the
+    exact run with a byte-stable canonical hash, reviewer identity and narrative."""
+
+    database_url = f"sqlite:///{tmp_path / 'accepted-output-restart.db'}"
+    upgrade_database_to_head(database_url)
+
+    with override_runtime_settings(
+        workflow_pack_run_store_mode="sqlalchemy",
+        workflow_pack_task_flow_store_mode="sqlalchemy",
+        database_url=database_url,
+    ):
+        with TestClient(app) as client:
+            run_id = _execute_advisor_brief(client, correlation_id="corr-accepted-output-sql-001")
+            _accept(client, run_id, reviewed_by="banker.sg.sql.204")
+            before_restart = client.get(
+                f"/platform/workflow-packs/runs/{run_id}/accepted-output",
+                headers=CALLER_HEADERS,
+            )
+            assert before_restart.status_code == 200
+
+        with TestClient(app) as restarted_client:
+            after_restart = restarted_client.get(
+                f"/platform/workflow-packs/runs/{run_id}/accepted-output",
+                headers=CALLER_HEADERS,
+            )
+
+        assert after_restart.status_code == 200
+        assert after_restart.json() == before_restart.json()
+        assert after_restart.json()["review"]["reviewed_by"] == "banker.sg.sql.204"
+        assert after_restart.json()["content_hash"] == before_restart.json()["content_hash"]

--- a/tests/unit/test_workflow_pack_run_accepted_output.py
+++ b/tests/unit/test_workflow_pack_run_accepted_output.py
@@ -1,0 +1,252 @@
+"""Projector-level pins for the accepted-output projection (issue #162).
+
+The API contract tests cover the reachable lifecycle postures end to end; these
+pin the postures only a corrupted or edited ledger can produce, plus hash
+determinism and sensitivity, directly against the service.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from collections.abc import Callable
+
+from app.contracts.artifacts import (
+    ArtifactDescriptor,
+    ArtifactLifecycleStatus,
+    ArtifactStorageBackend,
+)
+from app.contracts.workflow_pack_run_accepted_output import (
+    AdvisorBriefAcceptedReviewIdentity,
+)
+from app.repositories.workflow_pack_run_repository import WorkflowPackRunRecord
+from app.services import workflow_pack_run_accepted_output as module
+from app.services.workflow_pack_run_accepted_output import (
+    AcceptedOutputNotAvailableError,
+    AcceptedOutputNotFoundError,
+    build_workflow_pack_run_accepted_output,
+)
+
+TENANT = "tenant-sg-001"
+
+
+def _record(**overrides: Any) -> WorkflowPackRunRecord:
+    payload: dict[str, Any] = {
+        "run_id": "wfr-accepted-001",
+        "pack_id": "advisor_brief.pack",
+        "pack_family": "advisor_brief",
+        "pack_version": "v1",
+        "registration_ref": "advisor_brief.pack@v1",
+        "task_id": "explain.v1",
+        "request_id": "req-001",
+        "caller_app": "lotus-gateway",
+        "correlation_id": "corr-001",
+        "tenant_id": TENANT,
+        "workflow_surface": "advisor-brief-workspace",
+        "workflow_authority_owner": "lotus-gateway",
+        "runtime_state": "COMPLETED",
+        "review_state": "ACCEPTED",
+        "review_required": True,
+        "provider_mode": "stub",
+        "stubbed": True,
+        "output_preview": "preview",
+        "structured_output_keys": ["grounded_summary"],
+        "evidence_descriptors": [],
+        "artifact_refs": [
+            ArtifactDescriptor(
+                artifact_id="art-001",
+                domain="workflow_pack",
+                artifact_type="run_output_summary",
+                source_object_kind="workflow_pack_run",
+                source_object_id="wfr-accepted-001",
+                lifecycle_status=ArtifactLifecycleStatus.RUNTIME_GENERATED,
+                retention_posture="retained_for_review",
+                media_type="application/json",
+                byte_size=512,
+                checksum_sha256="0" * 64,
+                storage_backend=ArtifactStorageBackend.MEMORY,
+                storage_reference="artifact://runs/wfr-accepted-001.json",
+                created_at="2026-08-30T09:00:00Z",
+                created_by="lotus-ai.workflow-pack-run-ledger",
+            )
+        ],
+        "supersedes_run_id": None,
+        "superseded_by_run_id": None,
+        "created_at": "2026-08-30T09:00:00Z",
+        "completed_at": "2026-08-30T09:00:05Z",
+        "last_updated_at": "2026-08-30T09:00:05Z",
+    }
+    payload.update(overrides)
+    return WorkflowPackRunRecord(**payload)
+
+
+def _artifact_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "run_id": "wfr-accepted-001",
+        "pack_id": "advisor_brief.pack",
+        "source_refs": ["lotus-gateway:performance-summary:YTD"],
+        "evidence_types": ["task_contract"],
+        "structured_output": {
+            "advisor_brief_status": "complete",
+            "coverage_state": "complete",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "period": "YTD",
+            "grounded_summary": "The portfolio returned 1.25% in YTD.",
+            "talking_points": [
+                {
+                    "headline": "Active return was -6.68%.",
+                    "detail": "Portfolio 1.25% versus benchmark 7.93%.",
+                    "tone": "warning",
+                    "evidence_refs": ["lotus-gateway:performance-summary:YTD"],
+                }
+            ],
+            "risks_and_exceptions": [],
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+class _StoreStub:
+    def __init__(self, record: WorkflowPackRunRecord | None) -> None:
+        self._record = record
+
+    def get_run(self, *, run_id: str) -> WorkflowPackRunRecord | None:
+        return self._record
+
+    def list_events(self, *, run_id: str) -> list[Any]:
+        return []
+
+
+class _ObjectStoreStub:
+    def __init__(self, payload: bytes | None) -> None:
+        self._payload = payload
+
+    def get_object(self, *, object_key: str) -> Any:
+        if self._payload is None:
+            return None
+
+        class _Stored:
+            payload = self._payload
+
+        return _Stored()
+
+
+WireCallable = Callable[["WorkflowPackRunRecord | None", "dict[str, Any] | bytes | None"], None]
+
+
+@pytest.fixture
+def _wired(monkeypatch: pytest.MonkeyPatch) -> WireCallable:
+    def wire(
+        record: WorkflowPackRunRecord | None,
+        artifact_payload: dict[str, Any] | bytes | None,
+    ) -> None:
+        raw = artifact_payload
+        if isinstance(raw, dict):
+            raw = json.dumps(raw).encode("utf-8")
+        monkeypatch.setattr(module, "ensure_workflow_pack_run_store_ready", lambda: None)
+        monkeypatch.setattr(module, "get_workflow_pack_run_store", lambda: _StoreStub(record))
+        monkeypatch.setattr(module, "get_artifact_object_store", lambda: _ObjectStoreStub(raw))
+        monkeypatch.setattr(
+            module,
+            "_accepting_review_identity",
+            lambda **_: AdvisorBriefAcceptedReviewIdentity(
+                reviewed_by="banker.sg.301",
+                reviewed_at="2026-08-30T09:05:00Z",
+            ),
+        )
+
+    return wire
+
+
+def _reason(excinfo: pytest.ExceptionInfo[AcceptedOutputNotAvailableError]) -> str:
+    return excinfo.value.reason_code
+
+
+def test_tenantless_and_foreign_runs_share_the_not_found_shape(_wired: WireCallable) -> None:
+    _wired(_record(tenant_id=None), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotFoundError):
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+
+    _wired(_record(), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotFoundError):
+        build_workflow_pack_run_accepted_output(
+            run_id="wfr-accepted-001", caller_tenant_id="tenant-uk-999"
+        )
+
+
+def test_unregistered_pack_version_is_refused(_wired: WireCallable) -> None:
+    _wired(_record(pack_version="v2", registration_ref="advisor_brief.pack@v2"), None)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "pack_projection_unsupported"
+
+
+def test_superseded_accepted_run_is_refused(_wired: WireCallable) -> None:
+    _wired(_record(superseded_by_run_id="wfr-accepted-002"), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "run_superseded"
+
+
+def test_artifact_identity_mismatch_is_malformed(_wired: WireCallable) -> None:
+    _wired(_record(), _artifact_payload(run_id="wfr-some-other-run"))
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_missing_artifact_object_is_missing_not_malformed(_wired: WireCallable) -> None:
+    _wired(_record(), None)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_missing"
+
+
+def test_unparseable_artifact_is_malformed(_wired: WireCallable) -> None:
+    _wired(_record(), b"\xff not json")
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_missing_required_narrative_field_is_malformed(_wired: WireCallable) -> None:
+    payload = _artifact_payload()
+    del payload["structured_output"]["grounded_summary"]
+    _wired(_record(), payload)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_content_hash_is_deterministic_and_sensitive(_wired: WireCallable) -> None:
+    _wired(_record(), _artifact_payload())
+    first = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+    _wired(_record(), _artifact_payload())
+    second = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+    assert first.content_hash == second.content_hash
+
+    changed_payload = _artifact_payload()
+    changed_payload["structured_output"]["grounded_summary"] = (
+        "The portfolio returned 1.26% in YTD."
+    )
+    _wired(_record(), changed_payload)
+    changed = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+    assert changed.content_hash != first.content_hash
+
+    context_changed_payload = _artifact_payload()
+    context_changed_payload["structured_output"]["period"] = "1Y"
+    _wired(_record(), context_changed_payload)
+    context_changed = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+    assert context_changed.content_hash != first.content_hash

--- a/tests/unit/test_workflow_pack_run_accepted_output.py
+++ b/tests/unit/test_workflow_pack_run_accepted_output.py
@@ -222,6 +222,70 @@ def test_missing_required_narrative_field_is_malformed(_wired: WireCallable) -> 
     assert _reason(excinfo) == "output_artifact_malformed"
 
 
+def test_accepted_but_incomplete_run_is_refused(_wired: WireCallable) -> None:
+    _wired(_record(runtime_state="FAILED"), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "run_not_completed"
+
+
+def test_accepted_state_without_recorded_review_event_is_malformed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Deliberately NOT using `_wired`: it stubs `_accepting_review_identity`, and
+    # this pin is about that function refusing an ACCEPTED record whose event
+    # ledger carries no review transition.
+    monkeypatch.setattr(module, "ensure_workflow_pack_run_store_ready", lambda: None)
+    monkeypatch.setattr(module, "get_workflow_pack_run_store", lambda: _StoreStub(_record()))
+    monkeypatch.setattr(
+        module,
+        "get_artifact_object_store",
+        lambda: _ObjectStoreStub(json.dumps(_artifact_payload()).encode("utf-8")),
+    )
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_unlinked_output_artifact_is_missing(_wired: WireCallable) -> None:
+    _wired(_record(artifact_refs=[]), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_missing"
+
+
+def test_non_object_artifact_document_is_malformed(_wired: WireCallable) -> None:
+    _wired(_record(), json.dumps(["not", "an", "object"]).encode("utf-8"))
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_non_object_structured_output_is_malformed(_wired: WireCallable) -> None:
+    _wired(_record(), _artifact_payload(structured_output="a bare narrative string"))
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_non_list_narrative_collection_is_malformed(_wired: WireCallable) -> None:
+    payload = _artifact_payload()
+    payload["structured_output"]["talking_points"] = "not-a-list"
+    _wired(_record(), payload)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_non_object_narrative_entry_is_malformed(_wired: WireCallable) -> None:
+    payload = _artifact_payload()
+    payload["structured_output"]["risks_and_exceptions"] = ["not-a-dict"]
+    _wired(_record(), payload)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+
 def test_content_hash_is_deterministic_and_sensitive(_wired: WireCallable) -> None:
     _wired(_record(), _artifact_payload())
     first = build_workflow_pack_run_accepted_output(

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -126,6 +126,7 @@ platform programs.
    - `/platform/workflow-packs/runs/{run_id}/source-events`
    - `/platform/workflow-packs/runs/{run_id}/operator-profile`
    - `/platform/workflow-packs/runs/{run_id}/consumer-view`
+   - `/platform/workflow-packs/runs/{run_id}/accepted-output`
    - `/platform/workflow-packs/runs/{run_id}/review-actions`
    - `/platform/workflow-packs/task-flows`
    - `/platform/workflow-packs/task-flows/{task_flow_id}`
@@ -154,10 +155,18 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
    bounded source refs, portfolio-memory status/count/hash when supplied, `NO_RAW_PAYLOADS`, audit,
    retention, and source-authority policy. They deliberately omit raw prompts, raw generated
    output, raw source payloads, and raw portfolio-memory event payloads,
-6. `/platform/workflow-packs/runs/{run_id}/review-actions` records bounded actor-attributed review transitions without taking consequence-bearing workflow authority,
-7. `lotus-gateway` now uses that same bounded ledger seam to record advisor-brief review actions and returns refreshed workflow-pack posture through its advisor-brief contract without turning `lotus-ai` into the business-workflow owner,
-8. `lotus-workbench` now has a typed client seam for the downstream advisor-brief review-action route, while UI-triggered business authorization remains a separate future slice,
-9. the current executable workflow-pack set includes `advisor_brief.pack`,
+6. `/platform/workflow-packs/runs/{run_id}/accepted-output` publishes the exact accepted
+   `advisor_brief.pack@v1` narrative for an authorized caller in the run's own tenant: a
+   review-gated, non-client-authoritative projection that returns content only for completed,
+   accepted, non-superseded runs backed by their intact governed output artifact, fails closed
+   with bounded reason codes otherwise, carries the accepting reviewer identity and a canonical
+   content hash, and never exposes prompts, raw payloads, storage references, or generic artifact
+   bodies. Per-pack projectors are registered explicitly, so future structured-output keys never
+   become implicitly retrievable,
+7. `/platform/workflow-packs/runs/{run_id}/review-actions` records bounded actor-attributed review transitions without taking consequence-bearing workflow authority,
+8. `lotus-gateway` now uses that same bounded ledger seam to record advisor-brief review actions and returns refreshed workflow-pack posture through its advisor-brief contract without turning `lotus-ai` into the business-workflow owner,
+9. `lotus-workbench` now has a typed client seam for the downstream advisor-brief review-action route, while UI-triggered business authorization remains a separate future slice,
+10. the current executable workflow-pack set includes `advisor_brief.pack`,
    `workspace_rationale.pack`, `twr_inspection_support_brief.pack`, the review-gated
    RFC-0027 `advisory_copilot_*.pack` contracts for `lotus-advise` source-backed copilot
    evidence packets, the review-gated


### PR DESCRIPTION
Closes #162.

## The missing control

`advisor_brief.pack@v1` persisted its complete reviewed output and review transitions, but no API published the accepted content by `run_id` — so downstream composition stopped at clipboard copy or risked regenerated/unreviewed text. This adds the safe join of the existing truths:

`GET /platform/workflow-packs/runs/{run_id}/accepted-output`

## Expected-direction compliance

1. ✅ Projects only the validated advisor-brief fields (summary, talking points, risks/exceptions, bounded labels) — `recommended_actions`/`grounded_facts`/raw structured output are excluded and pinned absent.
2. ✅ Joins runtime, review, supersession, source-context and artifact truth inside lotus-ai.
3. ✅ Fails closed unless completed + accepted + non-superseded + intact expected artifact (identity-matched to the run) — six bounded reason codes in problem-details metadata.
4. ✅ No generic artifact download, no `storage_reference` exposure (pinned by serialization scan).
5. ✅ Canonical sha256 over the published projection (reproducible from the response alone; sensitivity pinned for narrative *and* context fields) + bounded portfolio/period/as-of/currency/benchmark context identity.
6. ✅ **Per-pack projector registry** — `advisor_brief.pack@v1` is the only entry; future packs earn retrieval only with their own typed projector.

Tenant scope comes from the run's own record; wrong-tenant, tenantless and unknown runs share one not-found shape (pinned: the two bodies are identical modulo the echoed id). Trusted-caller policy runs before any run access.

## Adjacent live defect fixed

The new REJECT test surfaced that `WAITING_FOR_REVIEW → FAILED` was not an allowed task-flow transition, so **every reject of an awaiting-review run 500ed mid-review** — no test had ever executed a real REJECT (the existing ones only asserted it was listed as allowed). The edge is added with a comment naming the discovery, and the reject path is now exercised end to end.

## Evidence

- 19 new tests including the issue's evaluation condition verbatim: SQL-backed execute → ACCEPT → restart → identical response with byte-stable hash and reviewer identity.
- Full suite: 1469 unit + 363 integration passed; lint, typecheck, openapi-gate green.
- Wiki Platform-Surfaces and REPOSITORY-ENGINEERING-CONTEXT updated with the boundary stated (no client-release, Report-integration, or certification claims).

After merge: lotus-report#166 gets the final route/schema, and the Gateway consumer issue is filed per acceptance criterion 10.