### PR TITLE
docs: describe implemented behaviour for providers, safety, and CI gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,13 @@ Core areas:
 2. `src/app/services/`
    orchestration, runtime-context assembly, evidence mapping, and audit flow.
 3. `src/app/providers/`
-   provider adapters, policy, rollout, quota, budget, and degradation handling.
+   provider adapters and execution transports; provider policy, rollout, quota,
+   budget, and degradation handling live in `src/app/services/` (`provider_*` modules).
 4. `src/app/prompts/`
    prompt definitions, rollout state, and prompt governance surfaces.
 5. `src/app/retrieval/`
    source governance, indexed-search posture, and retrieval execution seams.
-6. `src/app/safety/`
+6. `src/app/services/safety_*.py`
    output-label-aware policy and runtime safety posture.
 7. `src/app/evals/`
    evaluation inventory, runtime execution, and approval-gate evidence.
@@ -229,13 +230,14 @@ The enforced gates currently include:
 3. evaluation fixture manifest validation,
 4. evaluation run artifact validation,
 5. async job artifact validation,
-6. RFC-0002 Idea explanation local-dev proof validation,
-7. migration smoke,
-8. dependency health and security audit,
-9. coverage-backed test execution,
-10. Docker build validation.
+6. migration smoke,
+7. dependency health and security audit,
+8. coverage-backed test execution,
+9. Docker build validation.
 
-The RFC-0002 Idea proof gate is intentionally conservative. It executes
+The RFC-0002 Idea explanation proof gate runs locally through `make check`
+(`make rfc0002-idea-proof-gate`); it is not wired into the CI workflows.
+It is intentionally conservative. It executes
 `idea_explanation.pack@v1` through the governed HTTP boundary, applies a reviewer acceptance,
 verifies source-safe consumer/source-event projections, and verifies that signed workflow-run
 attestation and provider-retention confirmation remain non-issuable in local stub mode. It clears

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -139,12 +139,14 @@ Current repository posture:
 Primary areas:
 
 1. `src/app/providers/`
-   provider adapters and routing.
+   provider adapters and execution transports (provider policy, quota, budget, and
+   degradation state live in `src/app/services/`; model routing/selection does not
+   exist yet — the configured provider mode maps to exactly one adapter).
 2. `src/app/prompts/`
    prompt registry and rollout state.
 3. `src/app/retrieval/`
    retrieval and indexed-search capabilities.
-4. `src/app/safety/`
+4. `src/app/services/safety_*.py`
    output controls and safety policy.
 5. `src/app/evals/`
    evaluation and evidence foundations.

--- a/src/app/safety/__init__.py
+++ b/src/app/safety/__init__.py
@@ -1,1 +1,0 @@
-"""Safety, redaction, and policy enforcement helpers."""

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -193,9 +193,9 @@ The service deliberately does not own:
 | routers | `src/app/routers/` | 20 modules, one per surface group |
 | orchestration and runtime | `src/app/services/` | 229 modules — the bulk of the service |
 | repository seams | `src/app/repositories/` | 38 modules; memory and SQLAlchemy pairs |
-| provider adapters | `src/app/providers/` | rollout, quota, budget, degradation |
+| provider adapters | `src/app/providers/` | adapters and transports; policy, quota, budget, degradation live in `src/app/services/provider_*` |
 | retrieval | `src/app/retrieval/` | source and document governance, search posture |
-| safety | `src/app/safety/` | output-label-aware policy |
+| safety | `src/app/services/safety_*.py` | policy, enforcement, runtime posture (seven modules) |
 | evaluations | `src/app/evals/` | fixtures, runtime, approval gates |
 | middleware | `src/app/middleware/` | `correlation`, `http_boundary` |
 | worker entrypoint | `src/app/worker_main.py` | dedicated fleet loop |


### PR DESCRIPTION
## What

Corrects three architecture claims that contradicted the code, per the control-plane charter invariant that documentation describes implemented behaviour (evidence: 2026-08-30 survey at `a4b369d`, recorded on ledger #85).

1. **Provider package contents** — README (`Architectural Shape` item 3), `REPOSITORY-ENGINEERING-CONTEXT.md` (module map item 1) and `wiki/Architecture.md` (module table) placed provider policy, rollout, quota, budget and degradation handling — and, in the context file, "routing" — inside `src/app/providers/`. Measured: all five live in `src/app/services/provider_*`; no model routing exists (`registry.py` maps the configured mode to exactly one adapter — introducing real routing is #176).
2. **Safety module location** — the same three files credited `src/app/safety/` with "output-label-aware policy". That package was one empty 57-byte `__init__.py`; the real safety logic is the seven `src/app/services/safety_*.py` modules (`safety_policy`, `safety_enforcement`, `safety_runtime`, ...). The empty package is **deleted** — `grep -rn 'app.safety' src/ tests/ scripts/` matches nothing outside regenerated egg-info.
3. **RFC-0002 gate enforcement claim** — README listed "RFC-0002 Idea explanation local-dev proof validation" among "the enforced gates"; `grep -rn rfc0002 .github/workflows/` returns zero matches. It runs only via `make check` locally, exactly as `wiki/Validation-and-CI.md` already stated. The gates list and the following paragraph now say so.

## Evidence

- ruff (715 files), mypy (662 source files), openapi-gate, and 1474 unit tests green after the package deletion.
- No behavioural change: docs + removal of an empty, unimported package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)