### PR TITLE
feat(models): bind live execution to the governed catalogue entry (#175 slice 2a)

### DIFF
--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -44,6 +44,8 @@ class ProviderFailureCategory(str, Enum):
     TASK_NOT_ALLOWLISTED = "TASK_NOT_ALLOWLISTED"
     QUOTA_EXCEEDED = "QUOTA_EXCEEDED"
     BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
+    MODEL_NOT_CATALOGUED = "MODEL_NOT_CATALOGUED"
+    MODEL_LIFECYCLE_INELIGIBLE = "MODEL_LIFECYCLE_INELIGIBLE"
     CIRCUIT_OPEN = "CIRCUIT_OPEN"
     PROVIDER_TIMEOUT = "PROVIDER_TIMEOUT"
     PROVIDER_RATE_LIMITED = "PROVIDER_RATE_LIMITED"
@@ -668,6 +670,19 @@ class ProviderExecutionResponse(BaseModel):
     model_version: str | None = Field(
         default=None,
         description="Governed model release or deployment version used for provider execution.",
+    )
+    model_catalogue_entry_id: str | None = Field(
+        default=None,
+        description=(
+            "Governed model-catalogue entry this execution was bound to, on live provider paths."
+        ),
+    )
+    model_revision_pinned: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the bound catalogue entry pins an exact model revision "
+            "(False means the family/tag fallback identity executed)."
+        ),
     )
     provider_request_id: str | None = Field(
         default=None,

--- a/src/app/services/execution_evidence.py
+++ b/src/app/services/execution_evidence.py
@@ -149,6 +149,29 @@ def _provider_descriptor(
                 if provider_execution.adapter_kind is not None
                 else {}
             ),
+            # The catalogue-binding attributes are read defensively: responses
+            # predating the binding (and stub paths) simply omit them.
+            **(
+                {"model_version": model_version}
+                if (model_version := getattr(provider_execution, "model_version", None)) is not None
+                else {}
+            ),
+            **(
+                {"model_catalogue_entry_id": catalogue_entry_id}
+                if (
+                    catalogue_entry_id := getattr(
+                        provider_execution, "model_catalogue_entry_id", None
+                    )
+                )
+                is not None
+                else {}
+            ),
+            **(
+                {"model_revision_pinned": revision_pinned}
+                if (revision_pinned := getattr(provider_execution, "model_revision_pinned", None))
+                is not None
+                else {}
+            ),
         },
     )
 

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -25,7 +25,8 @@ from app.contracts.model_catalogue import (
     ModelLifecycleState,
     derive_model_catalogue_entry_id,
 )
-from app.contracts.providers import ProviderExecutionMode
+from app.contracts.providers import ProviderExecutionMode, ProviderFailureCategory
+from app.providers.base import ProviderExecutionError
 from app.providers.configured_workflow_run_model_risk_inventory import (
     ConfiguredWorkflowRunModelRiskInventory,
 )
@@ -41,6 +42,17 @@ _LIVE_TEXT_MODES = frozenset(
 # Fields the seeder owns; created_at and last_updated_at carry row provenance
 # and are managed by the idempotency logic, not compared as seed content.
 _SEED_MANAGED_EXCLUDES = {"created_at", "last_updated_at"}
+
+# A model in one of these states must not serve new executions. Reaching them
+# requires an operator lifecycle transition (issue #175 slice 3); the fence is
+# in place first so the transition has teeth from its first use.
+_EXECUTION_INELIGIBLE_LIFECYCLE_STATES = frozenset(
+    {
+        ModelLifecycleState.DEGRADED,
+        ModelLifecycleState.DEPRECATED,
+        ModelLifecycleState.RETIRED,
+    }
+)
 
 
 def upsert_model_catalogue_entry(entry: ModelCatalogueEntry) -> None:
@@ -147,6 +159,12 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
             created += 1
             continue
         candidate = entry.model_copy(update={"created_at": existing.created_at})
+        if candidate.seed_source == existing.seed_source:
+            # Lifecycle state is governed, not configured: once a row exists,
+            # the seed must never revert an operator transition (e.g. RETIRED
+            # back to CATALOGUED). Only a change of seeding authority - the
+            # inventory superseding a settings row - may re-assert lifecycle.
+            candidate = candidate.model_copy(update={"lifecycle_state": existing.lifecycle_state})
         if candidate.model_dump(exclude=_SEED_MANAGED_EXCLUDES) == existing.model_dump(
             exclude=_SEED_MANAGED_EXCLUDES
         ):
@@ -159,6 +177,46 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
         updated_count=updated,
         unchanged_count=unchanged,
     )
+
+
+def bind_live_text_model_catalogue_entry() -> ModelCatalogueEntry:
+    """Resolve the catalogue entry for the configured live-text identity, fail-closed.
+
+    Called on the live execution path: the returned entry is the governed
+    identity this execution runs under. No entry, or an entry in an
+    execution-ineligible lifecycle state, refuses execution with a bounded
+    failure category rather than falling back to raw settings strings.
+    """
+
+    ensure_model_catalogue_seeded()
+    provider_id = settings.live_text_provider_id
+    model_id = settings.live_text_model_id
+    if not provider_id or not model_id:
+        raise ProviderExecutionError(
+            category=ProviderFailureCategory.MODEL_NOT_CATALOGUED,
+            message="Live text execution requires a configured provider and model identity.",
+        )
+    model_revision = settings.live_text_model_version or model_id
+    entry_id = derive_model_catalogue_entry_id(
+        provider_id=provider_id,
+        model_revision=model_revision,
+        deployment=None,
+    )
+    entry = get_model_catalogue_repository().get_entry(entry_id)
+    if entry is None:
+        raise ProviderExecutionError(
+            category=ProviderFailureCategory.MODEL_NOT_CATALOGUED,
+            message=f"No governed model-catalogue entry exists for '{entry_id}'.",
+        )
+    if entry.lifecycle_state in _EXECUTION_INELIGIBLE_LIFECYCLE_STATES:
+        raise ProviderExecutionError(
+            category=ProviderFailureCategory.MODEL_LIFECYCLE_INELIGIBLE,
+            message=(
+                f"Model-catalogue entry '{entry_id}' is {entry.lifecycle_state.value} "
+                "and not eligible to serve new executions."
+            ),
+        )
+    return entry
 
 
 def build_model_catalogue_response() -> ModelCatalogueResponse:

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -9,9 +9,11 @@ from app.contracts.providers import (
     ProviderExecutionResponse,
     ProviderFailureCategory,
 )
+from app.contracts.model_catalogue import ModelCatalogueEntry
 from app.providers.base import ProviderExecutionError
 from app.providers.registry import resolve_text_generation_adapter
 from app.services.access_control_authorization import authorize_request, require_authorized
+from app.services.model_catalogue import bind_live_text_model_catalogue_entry
 from app.services.provider_policy import require_supported_text_generation_mode
 from app.services.provider_budget_policy import enforce_provider_budget, record_provider_spend
 from app.services.provider_degradation_state import (
@@ -40,6 +42,7 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
                 f"{live_execution_state.blocking_reason}"
             ),
         )
+    catalogue_entry: ModelCatalogueEntry | None = None
     if mode in LIVE_TEXT_MODES:
         require_authorized(
             authorize_request(
@@ -53,6 +56,7 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             enforce_provider_quota(request)
             enforce_provider_budget()
             enforce_provider_degradation_preflight()
+            catalogue_entry = bind_live_text_model_catalogue_entry()
         except ProviderExecutionError as exc:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -61,6 +65,13 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
     adapter = resolve_text_generation_adapter(mode)
     try:
         response = adapter.execute(request)
+        if catalogue_entry is not None:
+            # Stamp the governed identity the execution was bound to; the
+            # transport only knows settings strings and the provider echo.
+            response.model_catalogue_entry_id = catalogue_entry.entry_id
+            response.model_revision_pinned = catalogue_entry.revision_pinned
+            if getattr(response, "model_version", None) is None:
+                response.model_version = catalogue_entry.model_revision
         if mode in LIVE_TEXT_MODES:
             record_provider_spend(response)
             record_successful_provider_execution()

--- a/tests/unit/test_execution_evidence.py
+++ b/tests/unit/test_execution_evidence.py
@@ -213,3 +213,45 @@ def test_build_execution_evidence_captures_live_retrieval_request_posture() -> N
     access_control_descriptor = evidence.descriptors[5]
     assert access_control_descriptor.evidence_type == "access_control"
     assert access_control_descriptor.attributes["effective_source_ids"] == ["lotus-platform-rfcs"]
+
+
+def test_provider_descriptor_carries_catalogue_binding_attributes() -> None:
+    from app.services import execution_evidence as execution_evidence_module
+
+    response = ProviderExecutionResponse(
+        provider_id="text.openai",
+        provider_mode="openai",
+        adapter_kind=ProviderAdapterKind.OPENAI_LIVE,
+        model_id="gpt-5.4",
+        model_version="gpt-5.4",
+        model_catalogue_entry_id="text.openai:gpt-5.4",
+        model_revision_pinned=False,
+        stubbed=False,
+        message="live response",
+        structured_output={},
+    )
+
+    descriptor = execution_evidence_module._provider_descriptor(provider_execution=response)
+
+    assert descriptor.attributes["model_version"] == "gpt-5.4"
+    assert descriptor.attributes["model_catalogue_entry_id"] == "text.openai:gpt-5.4"
+    assert descriptor.attributes["model_revision_pinned"] is False
+
+
+def test_provider_descriptor_omits_catalogue_binding_when_absent() -> None:
+    from app.services import execution_evidence as execution_evidence_module
+
+    response = ProviderExecutionResponse(
+        provider_id="text.stub",
+        provider_mode="disabled",
+        adapter_kind=ProviderAdapterKind.STUB,
+        stubbed=True,
+        message="Stub execution completed.",
+        structured_output={},
+    )
+
+    descriptor = execution_evidence_module._provider_descriptor(provider_execution=response)
+
+    assert "model_catalogue_entry_id" not in descriptor.attributes
+    assert "model_revision_pinned" not in descriptor.attributes
+    assert "model_version" not in descriptor.attributes

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -16,11 +16,16 @@ import pytest
 
 from app.config import settings
 from app.contracts.model_catalogue import (
+    ModelCatalogueSeedReport,
     ModelCatalogueSeedSource,
     ModelLifecycleState,
     derive_model_catalogue_entry_id,
 )
+from app.contracts.providers import ProviderFailureCategory
+from app.providers.base import ProviderExecutionError
+from app.services import model_catalogue as model_catalogue_service
 from app.services.model_catalogue import (
+    bind_live_text_model_catalogue_entry,
     build_model_catalogue_response,
     build_seed_model_catalogue_entries,
     ensure_model_catalogue_seeded,
@@ -227,3 +232,75 @@ def test_sqlalchemy_repository_prepares_each_sqlite_location_shape(
     # Non-sqlite URLs are left untouched: no directory side effects at all.
     SqlAlchemyModelCatalogueRepository("postgresql+psycopg://user:secret@localhost:5432/db").close()
     assert list(tmp_path.iterdir()) == [tmp_path / "data"]
+
+
+def test_reseeding_never_reverts_an_operator_lifecycle_transition(
+    _local_unpinned_settings: None,
+) -> None:
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    seeded = repository.get_entry("text.local:qwen3:8b")
+    assert seeded is not None
+    repository.upsert_entry(
+        seeded.model_copy(update={"lifecycle_state": ModelLifecycleState.RETIRED})
+    )
+
+    report = ensure_model_catalogue_seeded()
+
+    assert report.updated_count == 0
+    retired = repository.get_entry("text.local:qwen3:8b")
+    assert retired is not None
+    assert retired.lifecycle_state is ModelLifecycleState.RETIRED
+
+
+def test_binding_returns_the_seeded_entry_for_the_configured_identity(
+    _local_unpinned_settings: None,
+) -> None:
+    entry = bind_live_text_model_catalogue_entry()
+    assert entry.entry_id == "text.local:qwen3:8b"
+    assert entry.revision_pinned is False
+    assert entry.lifecycle_state is ModelLifecycleState.CATALOGUED
+
+
+def test_binding_fails_closed_without_a_configured_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "provider_mode", "openai")
+    monkeypatch.setattr(settings, "live_text_provider_id", None)
+    monkeypatch.setattr(settings, "live_text_model_id", None)
+    monkeypatch.setattr(settings, "workflow_run_model_risk_inventory_json", "[]")
+    with pytest.raises(ProviderExecutionError) as excinfo:
+        bind_live_text_model_catalogue_entry()
+    assert excinfo.value.category is ProviderFailureCategory.MODEL_NOT_CATALOGUED
+
+
+def test_binding_fails_closed_when_the_catalogue_row_is_absent(
+    monkeypatch: pytest.MonkeyPatch, _local_unpinned_settings: None
+) -> None:
+    monkeypatch.setattr(
+        model_catalogue_service,
+        "ensure_model_catalogue_seeded",
+        lambda: ModelCatalogueSeedReport(created_count=0, updated_count=0, unchanged_count=0),
+    )
+    with pytest.raises(ProviderExecutionError) as excinfo:
+        bind_live_text_model_catalogue_entry()
+    assert excinfo.value.category is ProviderFailureCategory.MODEL_NOT_CATALOGUED
+    assert "text.local:qwen3:8b" in excinfo.value.message
+
+
+def test_binding_refuses_an_execution_ineligible_lifecycle_state(
+    _local_unpinned_settings: None,
+) -> None:
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    seeded = repository.get_entry("text.local:qwen3:8b")
+    assert seeded is not None
+    repository.upsert_entry(
+        seeded.model_copy(update={"lifecycle_state": ModelLifecycleState.RETIRED})
+    )
+
+    with pytest.raises(ProviderExecutionError) as excinfo:
+        bind_live_text_model_catalogue_entry()
+
+    assert excinfo.value.category is ProviderFailureCategory.MODEL_LIFECYCLE_INELIGIBLE
+    assert "RETIRED" in excinfo.value.message

--- a/tests/unit/test_provider_gateway.py
+++ b/tests/unit/test_provider_gateway.py
@@ -445,3 +445,112 @@ def test_execute_text_generation_rejects_adapter_execution_errors(
     assert "PROVIDER_UPSTREAM_ERROR" in str(exc_info.value.detail)
 
     settings.provider_mode = "disabled"
+
+
+def test_execute_text_generation_stamps_catalogue_identity_on_live_responses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.model_catalogue_store import reset_model_catalogue_store_cache
+
+    reset_model_catalogue_store_cache()
+
+    class _LiveAdapter:
+        def execute(self, request: ProviderExecutionRequest) -> object:
+            return type(
+                "Response",
+                (),
+                {
+                    "provider_id": "text.openai",
+                    "provider_mode": "openai",
+                    "adapter_kind": ProviderAdapterKind.OPENAI_LIVE,
+                    "failure_category": None,
+                    "timeout_ms": request.timeout_ms,
+                    "retry_count": 0,
+                    "max_output_tokens": request.max_output_tokens,
+                    "model_id": "gpt-5.4",
+                    "provider_request_id": "req_catalogue_1",
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "total_tokens": 30,
+                    "estimated_cost_usd": None,
+                    "stubbed": False,
+                    "message": "live response",
+                    "structured_output": {},
+                },
+            )()
+
+    monkeypatch.setattr(settings, "provider_mode", "openai")
+    monkeypatch.setattr(settings, "provider_rollout_state", "CANARY_ENABLED")
+    monkeypatch.setattr(settings, "live_text_provider_id", "text.openai")
+    monkeypatch.setattr(settings, "live_text_model_id", "gpt-5.4")
+    monkeypatch.setattr(settings, "live_text_model_version", None)
+    monkeypatch.setattr(settings, "live_text_provider_api_key", "secret")
+    monkeypatch.setattr(settings, "live_text_allowed_task_ids", "explain.v1")
+    monkeypatch.setattr(settings, "live_text_quota_enforced", False)
+    monkeypatch.setattr(settings, "live_text_budget_enforced", False)
+    monkeypatch.setattr(settings, "live_text_degradation_enforced", False)
+    monkeypatch.setattr(settings, "workflow_run_model_risk_inventory_json", "[]")
+    monkeypatch.setattr(
+        "app.services.provider_gateway.resolve_text_generation_adapter",
+        lambda mode: _LiveAdapter(),
+    )
+
+    response = execute_text_generation(_request())
+
+    # The transport only knows settings strings; the gateway stamps the
+    # governed identity, including the honest unpinned posture.
+    assert response.model_catalogue_entry_id == "text.openai:gpt-5.4"
+    assert response.model_revision_pinned is False
+    assert response.model_version == "gpt-5.4"
+    reset_model_catalogue_store_cache()
+
+
+def test_execute_text_generation_refuses_a_retired_catalogue_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.contracts.model_catalogue import ModelLifecycleState
+    from app.services.model_catalogue import ensure_model_catalogue_seeded
+    from app.services.model_catalogue_store import (
+        get_model_catalogue_repository,
+        reset_model_catalogue_store_cache,
+    )
+
+    reset_model_catalogue_store_cache()
+    monkeypatch.setattr(settings, "provider_mode", "openai")
+    monkeypatch.setattr(settings, "provider_rollout_state", "CANARY_ENABLED")
+    monkeypatch.setattr(settings, "live_text_provider_id", "text.openai")
+    monkeypatch.setattr(settings, "live_text_model_id", "gpt-5.4")
+    monkeypatch.setattr(settings, "live_text_model_version", None)
+    monkeypatch.setattr(settings, "live_text_provider_api_key", "secret")
+    monkeypatch.setattr(settings, "live_text_allowed_task_ids", "explain.v1")
+    monkeypatch.setattr(settings, "live_text_quota_enforced", False)
+    monkeypatch.setattr(settings, "live_text_budget_enforced", False)
+    monkeypatch.setattr(settings, "live_text_degradation_enforced", False)
+    monkeypatch.setattr(settings, "workflow_run_model_risk_inventory_json", "[]")
+
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    seeded = repository.get_entry("text.openai:gpt-5.4")
+    assert seeded is not None
+    repository.upsert_entry(
+        seeded.model_copy(update={"lifecycle_state": ModelLifecycleState.RETIRED})
+    )
+
+    adapter_calls: list[str] = []
+
+    def _record_adapter_resolution(mode: object) -> object:
+        adapter_calls.append("resolved")
+        return None
+
+    monkeypatch.setattr(
+        "app.services.provider_gateway.resolve_text_generation_adapter",
+        _record_adapter_resolution,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        execute_text_generation(_request())
+
+    assert exc_info.value.status_code == 503
+    assert "MODEL_LIFECYCLE_INELIGIBLE" in str(exc_info.value.detail)
+    assert adapter_calls == [], "a lifecycle-ineligible model must be refused before the adapter"
+    reset_model_catalogue_store_cache()


### PR DESCRIPTION
Part of #175 (slice 2a — execution binding; do not close the issue on merge).

## What

Live text execution now resolves its **governed model-catalogue entry** preflight and carries the bound identity through response and evidence:

- `bind_live_text_model_catalogue_entry()` (services/model_catalogue.py): ensure-seeded → resolve the configured identity → **fail closed** with two new bounded `ProviderFailureCategory` values: `MODEL_NOT_CATALOGUED` and `MODEL_LIFECYCLE_INELIGIBLE` (a DEGRADED/DEPRECATED/RETIRED entry refuses execution **before the adapter is resolved** — proven by test).
- `ProviderExecutionResponse` gains `model_catalogue_entry_id` + `model_revision_pinned`; the gateway backfills `model_version` from the bound revision when the transport left it unset. The transport only knows settings strings and the provider echo; the gateway stamps governance.
- `provider_resolution` evidence now records `model_version`, `model_catalogue_entry_id`, `model_revision_pinned` (defensive reads; stub paths omit them).

## Design fix the negative test exposed

Writing the RETIRED-refusal test surfaced an S1 defect: the idempotent seeder would have **reverted an operator lifecycle transition** on the next read (RETIRED → back to CATALOGUED). The reconcile rule now preserves the existing row's lifecycle unless the *seeding authority itself* changes (inventory superseding a settings row) — pinned by `test_reseeding_never_reverts_an_operator_lifecycle_transition`. This is the property slice 3's operator transitions depend on.

## Deliberately not here

Audit-record identity columns (S2b: migration + retiring the JSON reconstruction and hardcoded provider defaults in `sqlalchemy_audit_repository.py:294-317`), run-ledger rewiring of `workflow_run_model_risk` to catalogue rows, routing candidates (#176).

## Evidence

- 37 focused tests green (catalogue 22, gateway 13 incl. 2 new, evidence 2 new); touched modules `model_catalogue.py`/`provider_gateway.py`/`execution_evidence.py` at **100% coverage**.
- lint, mypy (671 files), openapi-gate green; full combined-coverage lanes running and CI will prove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)