### PR TITLE
feat(models): governed lifecycle transitions with durable history (#175 slice 3)

### DIFF
--- a/alembic/versions/0046_add_model_lifecycle_events.py
+++ b/alembic/versions/0046_add_model_lifecycle_events.py
@@ -1,0 +1,55 @@
+"""add model catalogue lifecycle events
+
+Revision ID: 0046_add_model_lifecycle_events
+Revises: 0045_add_kill_switch_activations
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0046_add_model_lifecycle_events"
+down_revision = "0045_add_kill_switch_activations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_catalogue_lifecycle_events",
+        sa.Column("event_id", sa.String(length=64), nullable=False),
+        sa.Column("entry_id", sa.String(length=256), nullable=False),
+        sa.Column("from_state", sa.String(length=32), nullable=False),
+        sa.Column("to_state", sa.String(length=32), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("requested_by", sa.String(length=128), nullable=False),
+        sa.Column("approved_by", sa.String(length=128), nullable=False),
+        sa.Column("approval_evidence_ref", sa.String(length=256), nullable=True),
+        sa.Column("recorded_at", sa.String(length=64), nullable=False),
+        sa.PrimaryKeyConstraint("event_id"),
+    )
+    op.create_index(
+        "ix_model_catalogue_lifecycle_events_entry_id",
+        "model_catalogue_lifecycle_events",
+        ["entry_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_model_catalogue_lifecycle_events_recorded_at",
+        "model_catalogue_lifecycle_events",
+        ["recorded_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_model_catalogue_lifecycle_events_recorded_at",
+        table_name="model_catalogue_lifecycle_events",
+    )
+    op.drop_index(
+        "ix_model_catalogue_lifecycle_events_entry_id",
+        table_name="model_catalogue_lifecycle_events",
+    )
+    op.drop_table("model_catalogue_lifecycle_events")

--- a/src/app/contracts/model_catalogue.py
+++ b/src/app/contracts/model_catalogue.py
@@ -172,3 +172,115 @@ class ModelCatalogueResponse(BaseModel):
     entries: list[ModelCatalogueEntry] = Field(
         description="Catalogue entries ordered by entry id.",
     )
+
+
+# Governed lifecycle transitions (issue #175, slice 3). The edge table is the
+# policy: every reachable state change is an explicit operator action with a
+# recorded reason, and promotion to APPROVED must carry approval evidence.
+ALLOWED_MODEL_LIFECYCLE_TRANSITIONS: dict[ModelLifecycleState, frozenset[ModelLifecycleState]] = {
+    ModelLifecycleState.DISCOVERED: frozenset({ModelLifecycleState.CATALOGUED}),
+    ModelLifecycleState.CATALOGUED: frozenset(
+        {ModelLifecycleState.EVALUATING, ModelLifecycleState.DEPRECATED}
+    ),
+    ModelLifecycleState.EVALUATING: frozenset(
+        {
+            ModelLifecycleState.APPROVED,
+            ModelLifecycleState.CATALOGUED,
+            ModelLifecycleState.DEPRECATED,
+        }
+    ),
+    ModelLifecycleState.APPROVED: frozenset(
+        {
+            ModelLifecycleState.SHADOW,
+            ModelLifecycleState.CANARY,
+            ModelLifecycleState.PRODUCTION,
+            ModelLifecycleState.DEGRADED,
+            ModelLifecycleState.DEPRECATED,
+        }
+    ),
+    ModelLifecycleState.SHADOW: frozenset(
+        {
+            ModelLifecycleState.CANARY,
+            ModelLifecycleState.APPROVED,
+            ModelLifecycleState.DEPRECATED,
+        }
+    ),
+    ModelLifecycleState.CANARY: frozenset(
+        {
+            ModelLifecycleState.PRODUCTION,
+            ModelLifecycleState.APPROVED,
+            ModelLifecycleState.DEGRADED,
+            ModelLifecycleState.DEPRECATED,
+        }
+    ),
+    ModelLifecycleState.PRODUCTION: frozenset(
+        {ModelLifecycleState.DEGRADED, ModelLifecycleState.DEPRECATED}
+    ),
+    ModelLifecycleState.DEGRADED: frozenset(
+        {
+            ModelLifecycleState.PRODUCTION,
+            ModelLifecycleState.CANARY,
+            ModelLifecycleState.DEPRECATED,
+        }
+    ),
+    ModelLifecycleState.DEPRECATED: frozenset({ModelLifecycleState.RETIRED}),
+    ModelLifecycleState.RETIRED: frozenset(),
+}
+
+# States an operator has deliberately taken a model OUT of service through.
+# Nothing automatic - including a seeding-authority change - may resurrect
+# a model from these; only an explicit operator transition can.
+OPERATOR_TERMINAL_LIFECYCLE_STATES = frozenset(
+    {ModelLifecycleState.DEPRECATED, ModelLifecycleState.RETIRED}
+)
+
+
+class ModelLifecycleTransitionRecord(BaseModel):
+    """One durable lifecycle transition on a catalogue entry."""
+
+    event_id: str = Field(min_length=1, description="Server-assigned event identity.")
+    entry_id: str = Field(min_length=1, description="Catalogue entry the transition applies to.")
+    from_state: ModelLifecycleState = Field(description="State before the transition.")
+    to_state: ModelLifecycleState = Field(description="State after the transition.")
+    reason: str = Field(min_length=1, description="Operator reason recorded with the transition.")
+    requested_by: str = Field(min_length=1, description="Operator who requested the transition.")
+    approved_by: str = Field(min_length=1, description="Operator who approved the transition.")
+    approval_evidence_ref: str | None = Field(
+        default=None,
+        description="Approval evidence reference; required when transitioning to APPROVED.",
+    )
+    recorded_at: str = Field(description="Instant the transition was recorded (UTC).")
+
+
+class ModelLifecycleTransitionRequest(BaseModel):
+    caller_app: str = Field(min_length=1, description="Calling application identity.")
+    to_state: ModelLifecycleState = Field(description="Target lifecycle state.")
+    reason: str = Field(min_length=1, description="Why this transition is being made.")
+    requested_by: str = Field(min_length=1, description="Operator requesting the transition.")
+    approved_by: str = Field(min_length=1, description="Operator approving the transition.")
+    approval_evidence_ref: str | None = Field(
+        default=None,
+        description="Approval evidence reference; required when to_state is APPROVED.",
+    )
+
+
+class ModelLifecycleTransitionResponse(BaseModel):
+    service: str = Field(description="Service name emitting the response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    store_mode: str = Field(description="Where catalogue truth lives: memory or sqlalchemy.")
+    entry: ModelCatalogueEntry = Field(description="The entry after the transition.")
+    transition: ModelLifecycleTransitionRecord = Field(
+        description="The durable transition record this action created.",
+    )
+
+
+class ModelCatalogueEntryDetailResponse(BaseModel):
+    """One catalogue entry with its full lifecycle history."""
+
+    service: str = Field(description="Service name emitting the response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    store_mode: str = Field(description="Where catalogue truth lives: memory or sqlalchemy.")
+    entry: ModelCatalogueEntry = Field(description="The catalogue entry.")
+    lifecycle_events: list[ModelLifecycleTransitionRecord] = Field(
+        description="Every recorded lifecycle transition for this entry, newest first.",
+    )

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -668,6 +668,20 @@ class KillSwitchActivationModel(Base):
     clear_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
+class ModelCatalogueLifecycleEventModel(Base):
+    __tablename__ = "model_catalogue_lifecycle_events"
+
+    event_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    entry_id: Mapped[str] = mapped_column(String(256), nullable=False, index=True)
+    from_state: Mapped[str] = mapped_column(String(32), nullable=False)
+    to_state: Mapped[str] = mapped_column(String(32), nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    requested_by: Mapped[str] = mapped_column(String(128), nullable=False)
+    approved_by: Mapped[str] = mapped_column(String(128), nullable=False)
+    approval_evidence_ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
 class ModelCatalogueEntryModel(Base):
     __tablename__ = "model_catalogue_entries"
 

--- a/src/app/repositories/memory_model_catalogue_repository.py
+++ b/src/app/repositories/memory_model_catalogue_repository.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from app.contracts.model_catalogue import ModelCatalogueEntry
+from app.contracts.model_catalogue import (
+    ModelCatalogueEntry,
+    ModelLifecycleTransitionRecord,
+)
 
 
 class InMemoryModelCatalogueRepository:
     def __init__(self) -> None:
         self._entries: dict[str, ModelCatalogueEntry] = {}
+        self._lifecycle_events: list[ModelLifecycleTransitionRecord] = []
 
     def list_entries(self) -> list[ModelCatalogueEntry]:
         return [self._entries[entry_id].model_copy(deep=True) for entry_id in sorted(self._entries)]
@@ -16,3 +20,17 @@ class InMemoryModelCatalogueRepository:
 
     def upsert_entry(self, entry: ModelCatalogueEntry) -> None:
         self._entries[entry.entry_id] = entry.model_copy(deep=True)
+
+    def append_lifecycle_event(self, event: ModelLifecycleTransitionRecord) -> None:
+        self._lifecycle_events.append(event.model_copy(deep=True))
+
+    def list_lifecycle_events(self, entry_id: str) -> list[ModelLifecycleTransitionRecord]:
+        return sorted(
+            (
+                event.model_copy(deep=True)
+                for event in self._lifecycle_events
+                if event.entry_id == entry_id
+            ),
+            key=lambda event: event.recorded_at,
+            reverse=True,
+        )

--- a/src/app/repositories/model_catalogue_repository.py
+++ b/src/app/repositories/model_catalogue_repository.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from app.contracts.model_catalogue import ModelCatalogueEntry
+from app.contracts.model_catalogue import (
+    ModelCatalogueEntry,
+    ModelLifecycleTransitionRecord,
+)
 
 
 class ModelCatalogueRepository(Protocol):
@@ -11,3 +14,7 @@ class ModelCatalogueRepository(Protocol):
     def get_entry(self, entry_id: str) -> ModelCatalogueEntry | None: ...
 
     def upsert_entry(self, entry: ModelCatalogueEntry) -> None: ...
+
+    def append_lifecycle_event(self, event: ModelLifecycleTransitionRecord) -> None: ...
+
+    def list_lifecycle_events(self, entry_id: str) -> list[ModelLifecycleTransitionRecord]: ...

--- a/src/app/repositories/sqlalchemy_model_catalogue_repository.py
+++ b/src/app/repositories/sqlalchemy_model_catalogue_repository.py
@@ -8,8 +8,9 @@ from app.contracts.model_catalogue import (
     ModelCatalogueEntry,
     ModelCatalogueSeedSource,
     ModelLifecycleState,
+    ModelLifecycleTransitionRecord,
 )
-from app.db.models import ModelCatalogueEntryModel
+from app.db.models import ModelCatalogueEntryModel, ModelCatalogueLifecycleEventModel
 from app.repositories.sqlalchemy_repository_base import SqlAlchemyRepositoryBase
 
 
@@ -61,6 +62,45 @@ class SqlAlchemyModelCatalogueRepository(SqlAlchemyRepositoryBase):
             model.created_at = entry.created_at
             model.last_updated_at = entry.last_updated_at
             session.commit()
+
+    def append_lifecycle_event(self, event: ModelLifecycleTransitionRecord) -> None:
+        with self._session_factory() as session:
+            session.add(
+                ModelCatalogueLifecycleEventModel(
+                    event_id=event.event_id,
+                    entry_id=event.entry_id,
+                    from_state=event.from_state.value,
+                    to_state=event.to_state.value,
+                    reason=event.reason,
+                    requested_by=event.requested_by,
+                    approved_by=event.approved_by,
+                    approval_evidence_ref=event.approval_evidence_ref,
+                    recorded_at=event.recorded_at,
+                )
+            )
+            session.commit()
+
+    def list_lifecycle_events(self, entry_id: str) -> list[ModelLifecycleTransitionRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(ModelCatalogueLifecycleEventModel)
+                .where(ModelCatalogueLifecycleEventModel.entry_id == entry_id)
+                .order_by(ModelCatalogueLifecycleEventModel.recorded_at.desc())
+            ).all()
+            return [
+                ModelLifecycleTransitionRecord(
+                    event_id=model.event_id,
+                    entry_id=model.entry_id,
+                    from_state=ModelLifecycleState(model.from_state),
+                    to_state=ModelLifecycleState(model.to_state),
+                    reason=model.reason,
+                    requested_by=model.requested_by,
+                    approved_by=model.approved_by,
+                    approval_evidence_ref=model.approval_evidence_ref,
+                    recorded_at=model.recorded_at,
+                )
+                for model in models
+            ]
 
     def _to_entry(self, model: ModelCatalogueEntryModel) -> ModelCatalogueEntry:
         return ModelCatalogueEntry(

--- a/src/app/routers/model_catalogue.py
+++ b/src/app/routers/model_catalogue.py
@@ -2,8 +2,17 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from app.contracts.model_catalogue import ModelCatalogueResponse
-from app.services.model_catalogue import build_model_catalogue_response
+from app.contracts.model_catalogue import (
+    ModelCatalogueEntryDetailResponse,
+    ModelCatalogueResponse,
+    ModelLifecycleTransitionRequest,
+    ModelLifecycleTransitionResponse,
+)
+from app.services.model_catalogue import (
+    apply_model_lifecycle_transition,
+    build_model_catalogue_entry_detail,
+    build_model_catalogue_response,
+)
 
 router = APIRouter(prefix="/platform/models", tags=["platform"])
 
@@ -26,3 +35,52 @@ router = APIRouter(prefix="/platform/models", tags=["platform"])
 )
 async def get_model_catalogue_route() -> ModelCatalogueResponse:
     return build_model_catalogue_response()
+
+
+@router.get(
+    "/catalogue/{entry_id}",
+    response_model=ModelCatalogueEntryDetailResponse,
+    operation_id="getModelCatalogueEntryDetail",
+    summary="Get one model-catalogue entry with its lifecycle history",
+    description=(
+        "Returns one governed model-catalogue entry together with every recorded lifecycle "
+        "transition, newest first - the durable evidence trail behind the entry's current state."
+    ),
+    responses={
+        200: {"description": "Model-catalogue entry detail returned successfully."},
+        404: {"description": "No entry exists for the given id."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_model_catalogue_entry_detail_route(
+    entry_id: str,
+) -> ModelCatalogueEntryDetailResponse:
+    return build_model_catalogue_entry_detail(entry_id)
+
+
+@router.post(
+    "/catalogue/{entry_id}/lifecycle-transitions",
+    response_model=ModelLifecycleTransitionResponse,
+    operation_id="applyModelLifecycleTransition",
+    summary="Apply a governed lifecycle transition to a catalogue entry",
+    description=(
+        "Moves one model-catalogue entry along the governed lifecycle edge table with a "
+        "recorded reason, requester and approver. Promotion to APPROVED requires approval "
+        "evidence. DEGRADED, DEPRECATED and RETIRED entries refuse new live executions at the "
+        "provider gateway. Requires provider-control authorization and the durable catalogue "
+        "store."
+    ),
+    responses={
+        200: {"description": "Lifecycle transition applied."},
+        403: {"description": "Caller is not authorized for provider control."},
+        404: {"description": "No entry exists for the given id."},
+        409: {"description": "The durable catalogue store is not configured."},
+        422: {"description": "The transition is not allowed from the current state."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def apply_model_lifecycle_transition_route(
+    entry_id: str,
+    request: ModelLifecycleTransitionRequest,
+) -> ModelLifecycleTransitionResponse:
+    return apply_model_lifecycle_transition(entry_id, request)

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -15,14 +15,24 @@ seeded field actually changed.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import HTTPException, status
 
 from app.config import settings
+from app.contracts.access_control import AuthorizationCapabilityType
 from app.contracts.model_catalogue import (
+    ALLOWED_MODEL_LIFECYCLE_TRANSITIONS,
+    OPERATOR_TERMINAL_LIFECYCLE_STATES,
     ModelCatalogueEntry,
+    ModelCatalogueEntryDetailResponse,
     ModelCatalogueResponse,
     ModelCatalogueSeedReport,
     ModelCatalogueSeedSource,
     ModelLifecycleState,
+    ModelLifecycleTransitionRecord,
+    ModelLifecycleTransitionRequest,
+    ModelLifecycleTransitionResponse,
     derive_model_catalogue_entry_id,
 )
 from app.contracts.providers import ProviderExecutionMode, ProviderFailureCategory
@@ -30,6 +40,7 @@ from app.providers.base import ProviderExecutionError
 from app.providers.configured_workflow_run_model_risk_inventory import (
     ConfiguredWorkflowRunModelRiskInventory,
 )
+from app.services.access_control_authorization import authorize_request, require_authorized
 from app.services.model_catalogue_store import get_model_catalogue_repository
 
 _LIVE_TEXT_MODES = frozenset(
@@ -159,11 +170,16 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
             created += 1
             continue
         candidate = entry.model_copy(update={"created_at": existing.created_at})
-        if candidate.seed_source == existing.seed_source:
+        if (
+            candidate.seed_source == existing.seed_source
+            or existing.lifecycle_state in OPERATOR_TERMINAL_LIFECYCLE_STATES
+        ):
             # Lifecycle state is governed, not configured: once a row exists,
             # the seed must never revert an operator transition (e.g. RETIRED
-            # back to CATALOGUED). Only a change of seeding authority - the
-            # inventory superseding a settings row - may re-assert lifecycle.
+            # back to CATALOGUED). A change of seeding authority - the
+            # inventory superseding a settings row - may re-assert lifecycle,
+            # but never out of an operator-terminal state: a retired model
+            # stays retired until an operator explicitly transitions it.
             candidate = candidate.model_copy(update={"lifecycle_state": existing.lifecycle_state})
         if candidate.model_dump(exclude=_SEED_MANAGED_EXCLUDES) == existing.model_dump(
             exclude=_SEED_MANAGED_EXCLUDES
@@ -217,6 +233,102 @@ def bind_live_text_model_catalogue_entry() -> ModelCatalogueEntry:
             ),
         )
     return entry
+
+
+def apply_model_lifecycle_transition(
+    entry_id: str,
+    request: ModelLifecycleTransitionRequest,
+) -> ModelLifecycleTransitionResponse:
+    """Apply one governed lifecycle transition to a catalogue entry.
+
+    The allowed-edge table is the policy; promotion to APPROVED additionally
+    requires approval evidence. The transition and its rationale are recorded
+    durably beside the entry.
+    """
+
+    require_authorized(
+        authorize_request(
+            caller_app=request.caller_app,
+            capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
+        )
+    )
+    if settings.model_catalogue_store_mode != "sqlalchemy":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Model lifecycle transitions require LOTUS_AI_MODEL_CATALOGUE_STORE_MODE="
+                "sqlalchemy so governed state changes survive restarts."
+            ),
+        )
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(entry_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No model-catalogue entry exists for `{entry_id}`.",
+        )
+    allowed = ALLOWED_MODEL_LIFECYCLE_TRANSITIONS[entry.lifecycle_state]
+    if request.to_state not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Transition {entry.lifecycle_state.value} -> {request.to_state.value} is not "
+                f"allowed; permitted targets: "
+                f"{sorted(state.value for state in allowed) or 'none (terminal state)'}."
+            ),
+        )
+    if request.to_state is ModelLifecycleState.APPROVED and not request.approval_evidence_ref:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Promotion to APPROVED requires an approval_evidence_ref.",
+        )
+
+    now = _utc_now_iso()
+    updates: dict[str, object] = {"lifecycle_state": request.to_state, "last_updated_at": now}
+    if request.approval_evidence_ref:
+        updates["approval_evidence_refs"] = [
+            *entry.approval_evidence_refs,
+            request.approval_evidence_ref,
+        ]
+    updated = entry.model_copy(update=updates)
+    transition = ModelLifecycleTransitionRecord(
+        event_id=f"mlc_{uuid4().hex[:16]}",
+        entry_id=entry_id,
+        from_state=entry.lifecycle_state,
+        to_state=request.to_state,
+        reason=request.reason,
+        requested_by=request.requested_by,
+        approved_by=request.approved_by,
+        approval_evidence_ref=request.approval_evidence_ref,
+        recorded_at=now,
+    )
+    upsert_model_catalogue_entry(updated)
+    repository.append_lifecycle_event(transition)
+    return ModelLifecycleTransitionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=updated,
+        transition=transition,
+    )
+
+
+def build_model_catalogue_entry_detail(entry_id: str) -> ModelCatalogueEntryDetailResponse:
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(entry_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No model-catalogue entry exists for `{entry_id}`.",
+        )
+    return ModelCatalogueEntryDetailResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=entry,
+        lifecycle_events=repository.list_lifecycle_events(entry_id),
+    )
 
 
 def build_model_catalogue_response() -> ModelCatalogueResponse:

--- a/tests/integration/test_model_catalogue_api_contract.py
+++ b/tests/integration/test_model_catalogue_api_contract.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 
 from app.main import app
 from app.services.model_catalogue_store import reset_model_catalogue_store_cache
@@ -110,3 +111,114 @@ def test_model_catalogue_survives_a_store_restart_in_sqlalchemy_mode(
         assert second_body["entries"][0]["created_at"] == first_body["entries"][0]["created_at"], (
             "a restart must re-read the catalogued row, not re-create it"
         )
+
+
+def test_operator_deprecation_refuses_live_execution_end_to_end(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """The lifecycle producer chain: an operator transition to DEPRECATED must
+    refuse the next live execution at the gateway with the bounded category and
+    a recorded rejection."""
+
+    database_url = f"sqlite:///{tmp_path / 'catalogue-deprecation.db'}"
+    upgrade_database_to_head(database_url)
+
+    class _LiveAdapter:
+        def execute(self, request: object) -> object:
+            return type(
+                "Response",
+                (),
+                {
+                    "provider_id": "text.openai",
+                    "provider_mode": "openai",
+                    "adapter_kind": None,
+                    "failure_category": None,
+                    "timeout_ms": 4000,
+                    "retry_count": 0,
+                    "max_output_tokens": 512,
+                    "model_id": "gpt-5.4",
+                    "provider_request_id": "req_lc_1",
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "total_tokens": 2,
+                    "estimated_cost_usd": None,
+                    "stubbed": False,
+                    "message": "live response",
+                    "structured_output": {},
+                },
+            )()
+
+    monkeypatch.setattr(
+        "app.services.provider_gateway.resolve_text_generation_adapter",
+        lambda mode: _LiveAdapter(),
+    )
+
+    with override_runtime_settings(
+        model_catalogue_store_mode="sqlalchemy",
+        database_url=database_url,
+        provider_mode="openai",
+        provider_rollout_state="CANARY_ENABLED",
+        live_text_provider_id="text.openai",
+        live_text_model_id="gpt-5.4",
+        live_text_model_version=None,
+        live_text_provider_api_key="secret",
+        live_text_allowed_task_ids="explain.v1",
+        live_text_quota_enforced=False,
+        live_text_budget_enforced=False,
+        live_text_degradation_enforced=False,
+        workflow_run_model_risk_inventory_json="[]",
+    ):
+        with TestClient(app) as client:
+            execute_payload = {
+                "task_id": "explain.v1",
+                "input_mode": "STRUCTURED_CONTEXT",
+                "caller": {
+                    "caller_app": "lotus-manage",
+                    "correlation_id": "corr-lc-001",
+                    "requested_by": "ops.user@lotus",
+                    "tenant_id": "tenant-sg-001",
+                },
+                "context": {
+                    "summary": "Explain rebalance outcome",
+                    "payload": {"status": "BLOCKED"},
+                    "source_refs": ["lotus-manage:run:reb_lc_1"],
+                },
+                "expected_output_label": "EXPLANATION_ONLY",
+            }
+
+            before = client.post("/ai/tasks/execute", json=execute_payload)
+            assert before.status_code == 200
+
+            transitioned = client.post(
+                "/platform/models/catalogue/text.openai:gpt-5.4/lifecycle-transitions",
+                json={
+                    "caller_app": "lotus-platform",
+                    "to_state": "DEPRECATED",
+                    "reason": "Vendor end-of-life announced; retire from live service.",
+                    "requested_by": "ops.primary@lotus",
+                    "approved_by": "ops.secondary@lotus",
+                },
+                headers={"X-Caller-App": "lotus-platform"},
+            )
+            assert transitioned.status_code == 200
+            assert transitioned.json()["entry"]["lifecycle_state"] == "DEPRECATED"
+
+            refused = client.post("/ai/tasks/execute", json=execute_payload)
+            assert refused.status_code == 503
+            assert "MODEL_LIFECYCLE_INELIGIBLE" in refused.text
+
+            detail = client.get(
+                "/platform/models/catalogue/text.openai:gpt-5.4",
+                headers={"X-Caller-App": "lotus-platform"},
+            )
+            assert detail.status_code == 200
+            events = detail.json()["lifecycle_events"]
+            assert len(events) == 1
+            assert events[0]["from_state"] == "CATALOGUED"
+            assert events[0]["to_state"] == "DEPRECATED"
+
+            unknown = client.get(
+                "/platform/models/catalogue/text.unknown:nope",
+                headers={"X-Caller-App": "lotus-platform"},
+            )
+            assert unknown.status_code == 404

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -19,6 +19,7 @@ from app.contracts.model_catalogue import (
     ModelCatalogueSeedReport,
     ModelCatalogueSeedSource,
     ModelLifecycleState,
+    ModelLifecycleTransitionRequest,
     derive_model_catalogue_entry_id,
 )
 from app.contracts.providers import ProviderFailureCategory
@@ -304,3 +305,154 @@ def test_binding_refuses_an_execution_ineligible_lifecycle_state(
 
     assert excinfo.value.category is ProviderFailureCategory.MODEL_LIFECYCLE_INELIGIBLE
     assert "RETIRED" in excinfo.value.message
+
+
+def _transition_request(**overrides: object) -> ModelLifecycleTransitionRequest:
+    payload: dict[str, object] = {
+        "caller_app": "lotus-platform",
+        "to_state": ModelLifecycleState.EVALUATING,
+        "reason": "Begin evaluation for governed promotion.",
+        "requested_by": "ops.primary@lotus",
+        "approved_by": "ops.secondary@lotus",
+    }
+    payload.update(overrides)
+    return ModelLifecycleTransitionRequest.model_validate(payload)
+
+
+@pytest.fixture
+def _durable_catalogue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _local_unpinned_settings: None
+) -> str:
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    database_url = f"sqlite:///{tmp_path / 'catalogue-lifecycle.db'}"
+    upgrade_database_to_head(database_url)
+    monkeypatch.setattr(settings, "model_catalogue_store_mode", "sqlalchemy")
+    monkeypatch.setattr(settings, "database_url", database_url)
+    ensure_model_catalogue_seeded()
+    return "text.local:qwen3:8b"
+
+
+def test_lifecycle_transition_requires_authorization_and_durable_store(
+    monkeypatch: pytest.MonkeyPatch, _local_unpinned_settings: None
+) -> None:
+    from fastapi import HTTPException
+
+    from app.services.model_catalogue import apply_model_lifecycle_transition
+
+    with pytest.raises(HTTPException) as excinfo:
+        apply_model_lifecycle_transition(
+            "text.local:qwen3:8b", _transition_request(caller_app="lotus-manage")
+        )
+    assert excinfo.value.status_code == 403
+
+    with pytest.raises(HTTPException) as excinfo:
+        apply_model_lifecycle_transition("text.local:qwen3:8b", _transition_request())
+    assert excinfo.value.status_code == 409
+    assert "LOTUS_AI_MODEL_CATALOGUE_STORE_MODE" in str(excinfo.value.detail)
+
+
+def test_lifecycle_transition_walks_the_governed_edge_table(_durable_catalogue: str) -> None:
+    from fastapi import HTTPException
+
+    from app.services.model_catalogue import (
+        apply_model_lifecycle_transition,
+        build_model_catalogue_entry_detail,
+    )
+
+    entry_id = _durable_catalogue
+
+    with pytest.raises(HTTPException) as excinfo:
+        apply_model_lifecycle_transition(
+            entry_id, _transition_request(to_state=ModelLifecycleState.PRODUCTION)
+        )
+    assert excinfo.value.status_code == 422
+    assert "not allowed" in str(excinfo.value.detail)
+
+    apply_model_lifecycle_transition(entry_id, _transition_request())
+
+    with pytest.raises(HTTPException) as excinfo:
+        apply_model_lifecycle_transition(
+            entry_id, _transition_request(to_state=ModelLifecycleState.APPROVED)
+        )
+    assert excinfo.value.status_code == 422
+    assert "approval_evidence_ref" in str(excinfo.value.detail)
+
+    approved = apply_model_lifecycle_transition(
+        entry_id,
+        _transition_request(
+            to_state=ModelLifecycleState.APPROVED,
+            approval_evidence_ref="mrm-approval-2026-021",
+        ),
+    )
+    assert approved.entry.lifecycle_state is ModelLifecycleState.APPROVED
+    assert "mrm-approval-2026-021" in approved.entry.approval_evidence_refs
+
+    apply_model_lifecycle_transition(
+        entry_id, _transition_request(to_state=ModelLifecycleState.PRODUCTION)
+    )
+    apply_model_lifecycle_transition(
+        entry_id, _transition_request(to_state=ModelLifecycleState.DEPRECATED)
+    )
+    retired = apply_model_lifecycle_transition(
+        entry_id, _transition_request(to_state=ModelLifecycleState.RETIRED)
+    )
+    assert retired.entry.lifecycle_state is ModelLifecycleState.RETIRED
+
+    with pytest.raises(HTTPException) as excinfo:
+        apply_model_lifecycle_transition(
+            entry_id, _transition_request(to_state=ModelLifecycleState.CATALOGUED)
+        )
+    assert excinfo.value.status_code == 422
+    assert "terminal" in str(excinfo.value.detail)
+
+    detail = build_model_catalogue_entry_detail(entry_id)
+    assert [event.to_state for event in reversed(detail.lifecycle_events)] == [
+        ModelLifecycleState.EVALUATING,
+        ModelLifecycleState.APPROVED,
+        ModelLifecycleState.PRODUCTION,
+        ModelLifecycleState.DEPRECATED,
+        ModelLifecycleState.RETIRED,
+    ]
+    assert all(event.reason for event in detail.lifecycle_events)
+
+
+def test_seed_authority_change_never_resurrects_an_operator_terminal_state(
+    monkeypatch: pytest.MonkeyPatch, _local_unpinned_settings: None
+) -> None:
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    seeded = repository.get_entry("text.local:qwen3:8b")
+    assert seeded is not None
+    repository.upsert_entry(
+        seeded.model_copy(update={"lifecycle_state": ModelLifecycleState.RETIRED})
+    )
+
+    # The inventory now claims the same identity: a seeding-authority change
+    # that would normally re-assert APPROVED. Retirement must survive it.
+    monkeypatch.setattr(
+        settings,
+        "workflow_run_model_risk_inventory_json",
+        json.dumps(
+            [
+                {
+                    "provider_id": "text.local",
+                    "provider_mode": "local_openai_compatible",
+                    "model_id": "qwen3:8b",
+                    "model_version": "qwen3:8b",
+                    "workflow_pack_ids": ["advisor_brief.pack"],
+                    "approval_ref": "mrm-approval-2026-030",
+                    "approved_from_utc": "2026-08-01T00:00:00Z",
+                    "approved_until_utc": None,
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(settings, "live_text_model_version", "qwen3:8b")
+
+    ensure_model_catalogue_seeded()
+
+    resurrected = repository.get_entry("text.local:qwen3:8b")
+    assert resurrected is not None
+    assert resurrected.lifecycle_state is ModelLifecycleState.RETIRED
+    assert resurrected.seed_source is ModelCatalogueSeedSource.APPROVED_WORKFLOW_RUN_MODEL_INVENTORY


### PR DESCRIPTION
Part of #175 (slice 3 — do not close the issue on merge).

## What

The lifecycle vocabulary becomes **governable**, and the S2a execution fence gains its real producer:

- `ALLOWED_MODEL_LIFECYCLE_TRANSITIONS` is the policy — every reachable state change is an explicit operator action (`PROVIDER_CONTROL`, requester + approver + reason, the durable-store 409 rule shared with resets and kill switches). `RETIRED` is terminal. **Promotion to APPROVED requires approval evidence**, appended to the entry's evidence refs (charter §10: promotion requires evidence).
- Every transition writes a durable record (migration `0046`) **with a read path**: `GET /platform/models/catalogue/{entry_id}` returns the entry plus its ordered lifecycle history — no write-only evidence (the #167 lesson applied preemptively).
- **Seed hardening the transitions made necessary**: a seeding-authority change (inventory superseding a settings row) may re-assert lifecycle, but never *out of* an operator-terminal state — a retired model stays retired until an operator explicitly transitions it. Pinned against the exact resurrection scenario (operator retires; inventory still lists the model as approved; reseed).

## Evidence

- Unit: authz 403 / memory-store 409, illegal-edge 422 naming permitted targets, missing-evidence 422, the full governed walk `CATALOGUED→EVALUATING→APPROVED→PRODUCTION→DEPRECATED→RETIRED` with ordered history and terminality, the resurrection guard.
- Integration (the producer chain end to end): live execute 200 → operator POSTs a DEPRECATED transition → next execute **503 `MODEL_LIFECYCLE_INELIGIBLE`** (recorded as a routing rejection via #176) → detail shows exactly one transition event; unknown entry 404.
- 44 focused tests green across catalogue/gateway/kill-switch suites; lint, mypy (681 files), openapi-gate, migration contract check green.

## Remaining in #175

S4: revision-drift detection (compare provider echo to the pinned expectation; `revision_pinned=False` exposure is already surfaced for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)