### PR TITLE
fix(runs): publish the metric-grounded evidence refs the guardrail persists

### DIFF
--- a/src/app/contracts/workflow_pack_run_accepted_output.py
+++ b/src/app/contracts/workflow_pack_run_accepted_output.py
@@ -18,15 +18,34 @@ ACCEPTED_OUTPUT_SCHEMA_ADVISOR_BRIEF_V1 = (
 ACCEPTED_OUTPUT_CONTENT_HASH_ALGORITHM = "sha256"
 
 
-class AdvisorBriefAcceptedNarrativeItem(BaseModel):
-    """One bounded narrative element (talking point or risk/exception)."""
+class AdvisorBriefAcceptedEvidenceRef(BaseModel):
+    """One metric-grounded evidence reference, exactly as the generation
+    guardrail persisted it (advisor_brief_quality_guardrails)."""
 
-    headline: str = Field(description="Short reviewed statement for this element.")
-    detail: str = Field(description="Reviewed supporting detail for the headline.")
-    tone: str = Field(description="Bounded tone marker recorded with the element.")
-    evidence_refs: list[str] = Field(
+    metric_label: str = Field(description="Label of the grounding metric.")
+    metric_value: str = Field(description="Value of the grounding metric as generated.")
+    source_ref: str = Field(description="Source reference the metric was taken from.")
+
+
+class AdvisorBriefAcceptedNarrativeItem(BaseModel):
+    """One bounded narrative element (talking point or risk/exception).
+
+    Narrative strings are whitespace-collapsed plain text; markup is not
+    rejected at generation, so consumers must render them as text, never as
+    markup.
+    """
+
+    headline: str = Field(description="Short reviewed statement for this element (plain text).")
+    detail: str = Field(description="Reviewed supporting detail for the headline (plain text).")
+    tone: str = Field(
+        description=(
+            "Tone marker recorded with the element; the generation guardrail bounds it to "
+            "'positive', 'neutral', or 'warning'."
+        ),
+    )
+    evidence_refs: list[AdvisorBriefAcceptedEvidenceRef] = Field(
         default_factory=list,
-        description="Source references grounding this element, as recorded at generation.",
+        description="Metric-grounded evidence references recorded at generation.",
     )
 
 

--- a/src/app/services/workflow_pack_run_accepted_output.py
+++ b/src/app/services/workflow_pack_run_accepted_output.py
@@ -31,6 +31,7 @@ from app.contracts.workflow_pack_run_accepted_output import (
     ACCEPTED_OUTPUT_CONTENT_HASH_ALGORITHM,
     ACCEPTED_OUTPUT_SCHEMA_ADVISOR_BRIEF_V1,
     AdvisorBriefAcceptedContextIdentity,
+    AdvisorBriefAcceptedEvidenceRef,
     AdvisorBriefAcceptedNarrativeItem,
     AdvisorBriefAcceptedReviewIdentity,
     WorkflowPackRunAcceptedOutputResponse,
@@ -291,12 +292,42 @@ def _narrative_items(raw: Any) -> list[AdvisorBriefAcceptedNarrativeItem]:
                 headline=_required_string(entry, "headline"),
                 detail=_required_string(entry, "detail"),
                 tone=_required_string(entry, "tone"),
-                evidence_refs=[
-                    ref for ref in entry.get("evidence_refs", []) if isinstance(ref, str)
-                ],
+                evidence_refs=_evidence_refs(entry.get("evidence_refs")),
             )
         )
     return items
+
+
+def _evidence_refs(raw: Any) -> list[AdvisorBriefAcceptedEvidenceRef]:
+    """Project the guardrail's persisted evidence shape; corruption fails closed.
+
+    The generation guardrail persists refs as {metric_label, metric_value,
+    source_ref} dicts with all three non-empty. An accepted artifact carrying
+    anything else is a ledger inconsistency, not a projectable variant.
+    """
+
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_MALFORMED,
+            "The accepted output evidence references have an unexpected shape.",
+        )
+    refs: list[AdvisorBriefAcceptedEvidenceRef] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise AcceptedOutputNotAvailableError(
+                REASON_OUTPUT_ARTIFACT_MALFORMED,
+                "The accepted output evidence references have an unexpected shape.",
+            )
+        refs.append(
+            AdvisorBriefAcceptedEvidenceRef(
+                metric_label=_required_string(entry, "metric_label"),
+                metric_value=_required_string(entry, "metric_value"),
+                source_ref=_required_string(entry, "source_ref"),
+            )
+        )
+    return refs
 
 
 def _required_string(payload: dict[str, Any], key: str) -> str:

--- a/tests/integration/test_workflow_pack_run_accepted_output_api.py
+++ b/tests/integration/test_workflow_pack_run_accepted_output_api.py
@@ -65,6 +65,11 @@ def test_accepted_output_returns_the_exact_reviewed_narrative(client: TestClient
     assert body["review"]["reviewed_at"]
     assert body["grounded_summary"]
     assert body["talking_points"], "the reviewed talking points must be published"
+    first_refs = body["talking_points"][0]["evidence_refs"]
+    assert first_refs, "projected narrative items must keep their metric grounding"
+    assert first_refs[0]["metric_label"]
+    assert first_refs[0]["metric_value"]
+    assert first_refs[0]["source_ref"] == "lotus-gateway:performance-summary:YTD"
     assert body["context"]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
     assert body["context"]["period"] == "YTD"
     assert body["source_refs"] == ["lotus-gateway:performance-summary:YTD"]

--- a/tests/unit/test_workflow_pack_run_accepted_output.py
+++ b/tests/unit/test_workflow_pack_run_accepted_output.py
@@ -100,7 +100,13 @@ def _artifact_payload(**overrides: Any) -> dict[str, Any]:
                     "headline": "Active return was -6.68%.",
                     "detail": "Portfolio 1.25% versus benchmark 7.93%.",
                     "tone": "warning",
-                    "evidence_refs": ["lotus-gateway:performance-summary:YTD"],
+                    "evidence_refs": [
+                        {
+                            "metric_label": "Active Return",
+                            "metric_value": "-6.68%",
+                            "source_ref": "lotus-gateway:performance-summary:YTD",
+                        }
+                    ],
                 }
             ],
             "risks_and_exceptions": [],
@@ -314,3 +320,43 @@ def test_content_hash_is_deterministic_and_sensitive(_wired: WireCallable) -> No
         run_id="wfr-accepted-001", caller_tenant_id=TENANT
     )
     assert context_changed.content_hash != first.content_hash
+
+
+def test_projected_evidence_refs_carry_the_metric_grounding(_wired: WireCallable) -> None:
+    """Regression for the silent grounding loss: the guardrail persists refs as
+    metric dicts, and the projection must publish them - not filter them out."""
+
+    _wired(_record(), _artifact_payload())
+    response = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+    refs = response.talking_points[0].evidence_refs
+    assert len(refs) == 1
+    assert refs[0].metric_label == "Active Return"
+    assert refs[0].metric_value == "-6.68%"
+    assert refs[0].source_ref == "lotus-gateway:performance-summary:YTD"
+
+
+def test_malformed_evidence_reference_entries_fail_closed(_wired: WireCallable) -> None:
+    payload = _artifact_payload()
+    payload["structured_output"]["talking_points"][0]["evidence_refs"] = ["a-bare-string"]
+    _wired(_record(), payload)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+    payload = _artifact_payload()
+    payload["structured_output"]["talking_points"][0]["evidence_refs"] = [
+        {"metric_label": "Active Return", "metric_value": "", "source_ref": "x"}
+    ]
+    _wired(_record(), payload)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"
+
+    payload = _artifact_payload()
+    payload["structured_output"]["talking_points"][0]["evidence_refs"] = "not-a-list"
+    _wired(_record(), payload)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_artifact_malformed"


### PR DESCRIPTION
## The defect (found by the lotus-report consumer, confirmed by probe)

The accepted-output projection **silently dropped every narrative evidence reference**. The generation guardrail persists refs as `{metric_label, metric_value, source_ref}` dicts (`advisor_brief_quality_guardrails._normalize_evidence_refs`), but the projector kept only `isinstance(ref, str)` entries — consumers received grounding-free talking points from a projection whose stated purpose is groundedness.

**Probe against a real persisted artifact** (stub flow, execute → accept → project): artifact stores `[{'metric_label': 'Active Return', 'metric_value': '-6.68%', 'source_ref': 'lotus-gateway:performance-summary:YTD'}]`; projection returned `[]`. The unit fixtures used string refs **no producer ever writes** — the fixture-reality divergence that let this pass review.

## The fix

- `AdvisorBriefAcceptedEvidenceRef` publishes the exact persisted shape (structure preserved; lotus-report passes refs through verbatim and handles this shape).
- The projector **fails closed** (`output_artifact_malformed`) on any other shape — bare strings, missing/empty fields, non-list. The guardrail guarantees the shape; an accepted artifact carrying anything else is a ledger inconsistency, not a projectable variant.
- Fixtures corrected to the real shape; the end-to-end test now asserts projected refs carry the metric grounding.

## Contract truths the consumers asked for (same review, documentation-only)

- `tone` names its guardrail-bounded literals: `positive` / `neutral` / `warning` (verified at `advisor_brief_quality_guardrails` L202-203).
- Narrative strings are declared **whitespace-collapsed plain text with markup NOT rejected** — the truthful statement (`_clean_text` collapses whitespace only), so consumers keep rendering as text. A hard no-markup guarantee would be a generation-side behavior change and is deliberately not claimed here.

Hash note: `content_hash` covers published fields, so future retrievals of runs whose refs were previously dropped will hash differently than their empty-refs projections — correct, since the published content genuinely changed.

28 focused tests green; lint, mypy (681 files), openapi-gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)