### PR TITLE
feat(models): detect provider revision drift per live execution (#175 slice 4)

### DIFF
--- a/alembic/versions/0047_add_model_revision_drift.py
+++ b/alembic/versions/0047_add_model_revision_drift.py
@@ -1,0 +1,54 @@
+"""add model revision drift observations
+
+Revision ID: 0047_add_model_revision_drift
+Revises: 0046_add_model_lifecycle_events
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0047_add_model_revision_drift"
+down_revision = "0046_add_model_lifecycle_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_revision_drift_observations",
+        sa.Column("observation_id", sa.String(length=128), nullable=False),
+        sa.Column("entry_id", sa.String(length=256), nullable=False),
+        sa.Column("expected_identity", sa.String(length=256), nullable=False),
+        sa.Column("observed_model_id", sa.String(length=256), nullable=False),
+        sa.Column("revision_pinned_at_observation", sa.Boolean(), nullable=False),
+        sa.Column("first_observed_at", sa.String(length=64), nullable=False),
+        sa.Column("last_observed_at", sa.String(length=64), nullable=False),
+        sa.Column("observation_count", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("observation_id"),
+    )
+    op.create_index(
+        "ix_model_revision_drift_observations_entry_id",
+        "model_revision_drift_observations",
+        ["entry_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_model_revision_drift_observations_last_observed_at",
+        "model_revision_drift_observations",
+        ["last_observed_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_model_revision_drift_observations_last_observed_at",
+        table_name="model_revision_drift_observations",
+    )
+    op.drop_index(
+        "ix_model_revision_drift_observations_entry_id",
+        table_name="model_revision_drift_observations",
+    )
+    op.drop_table("model_revision_drift_observations")

--- a/src/app/contracts/model_catalogue.py
+++ b/src/app/contracts/model_catalogue.py
@@ -284,3 +284,35 @@ class ModelCatalogueEntryDetailResponse(BaseModel):
     lifecycle_events: list[ModelLifecycleTransitionRecord] = Field(
         description="Every recorded lifecycle transition for this entry, newest first.",
     )
+    revision_drift_observations: list[ModelRevisionDriftObservation] = Field(
+        description=(
+            "Deduplicated observations of the provider serving a model identity other than "
+            "this entry's expectation, most recently observed first."
+        ),
+    )
+
+
+class ModelRevisionDriftObservation(BaseModel):
+    """One deduplicated observation that a provider served a model identity
+    other than the catalogue expectation (issue #175, slice 4).
+
+    Observations are keyed by (entry, observed identifier): repeated identical
+    drift updates last_observed_at and the count instead of flooding the store.
+    """
+
+    observation_id: str = Field(min_length=1, description="Deterministic observation identity.")
+    entry_id: str = Field(min_length=1, description="Catalogue entry the execution was bound to.")
+    expected_identity: str = Field(
+        min_length=1,
+        description="What the catalogue expected: the pinned revision, or the family identity.",
+    )
+    observed_model_id: str = Field(
+        min_length=1,
+        description="Model identifier the provider actually echoed for the execution.",
+    )
+    revision_pinned_at_observation: bool = Field(
+        description="Whether the entry pinned an exact revision when this drift was observed.",
+    )
+    first_observed_at: str = Field(description="First instant this drift was observed (UTC).")
+    last_observed_at: str = Field(description="Most recent instant this drift was observed (UTC).")
+    observation_count: int = Field(ge=1, description="How many executions observed this drift.")

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -682,6 +682,19 @@ class ModelCatalogueLifecycleEventModel(Base):
     recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
 
 
+class ModelRevisionDriftObservationModel(Base):
+    __tablename__ = "model_revision_drift_observations"
+
+    observation_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    entry_id: Mapped[str] = mapped_column(String(256), nullable=False, index=True)
+    expected_identity: Mapped[str] = mapped_column(String(256), nullable=False)
+    observed_model_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    revision_pinned_at_observation: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    first_observed_at: Mapped[str] = mapped_column(String(64), nullable=False)
+    last_observed_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    observation_count: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
 class ModelCatalogueEntryModel(Base):
     __tablename__ = "model_catalogue_entries"
 

--- a/src/app/repositories/memory_model_catalogue_repository.py
+++ b/src/app/repositories/memory_model_catalogue_repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.contracts.model_catalogue import (
     ModelCatalogueEntry,
     ModelLifecycleTransitionRecord,
+    ModelRevisionDriftObservation,
 )
 
 
@@ -10,6 +11,7 @@ class InMemoryModelCatalogueRepository:
     def __init__(self) -> None:
         self._entries: dict[str, ModelCatalogueEntry] = {}
         self._lifecycle_events: list[ModelLifecycleTransitionRecord] = []
+        self._drift_observations: dict[str, ModelRevisionDriftObservation] = {}
 
     def list_entries(self) -> list[ModelCatalogueEntry]:
         return [self._entries[entry_id].model_copy(deep=True) for entry_id in sorted(self._entries)]
@@ -32,5 +34,23 @@ class InMemoryModelCatalogueRepository:
                 if event.entry_id == entry_id
             ),
             key=lambda event: event.recorded_at,
+            reverse=True,
+        )
+
+    def get_drift_observation(self, observation_id: str) -> ModelRevisionDriftObservation | None:
+        observation = self._drift_observations.get(observation_id)
+        return observation.model_copy(deep=True) if observation is not None else None
+
+    def upsert_drift_observation(self, observation: ModelRevisionDriftObservation) -> None:
+        self._drift_observations[observation.observation_id] = observation.model_copy(deep=True)
+
+    def list_drift_observations(self, entry_id: str) -> list[ModelRevisionDriftObservation]:
+        return sorted(
+            (
+                observation.model_copy(deep=True)
+                for observation in self._drift_observations.values()
+                if observation.entry_id == entry_id
+            ),
+            key=lambda observation: observation.last_observed_at,
             reverse=True,
         )

--- a/src/app/repositories/model_catalogue_repository.py
+++ b/src/app/repositories/model_catalogue_repository.py
@@ -5,6 +5,7 @@ from typing import Protocol
 from app.contracts.model_catalogue import (
     ModelCatalogueEntry,
     ModelLifecycleTransitionRecord,
+    ModelRevisionDriftObservation,
 )
 
 
@@ -18,3 +19,11 @@ class ModelCatalogueRepository(Protocol):
     def append_lifecycle_event(self, event: ModelLifecycleTransitionRecord) -> None: ...
 
     def list_lifecycle_events(self, entry_id: str) -> list[ModelLifecycleTransitionRecord]: ...
+
+    def get_drift_observation(
+        self, observation_id: str
+    ) -> ModelRevisionDriftObservation | None: ...
+
+    def upsert_drift_observation(self, observation: ModelRevisionDriftObservation) -> None: ...
+
+    def list_drift_observations(self, entry_id: str) -> list[ModelRevisionDriftObservation]: ...

--- a/src/app/repositories/sqlalchemy_model_catalogue_repository.py
+++ b/src/app/repositories/sqlalchemy_model_catalogue_repository.py
@@ -9,8 +9,13 @@ from app.contracts.model_catalogue import (
     ModelCatalogueSeedSource,
     ModelLifecycleState,
     ModelLifecycleTransitionRecord,
+    ModelRevisionDriftObservation,
 )
-from app.db.models import ModelCatalogueEntryModel, ModelCatalogueLifecycleEventModel
+from app.db.models import (
+    ModelCatalogueEntryModel,
+    ModelCatalogueLifecycleEventModel,
+    ModelRevisionDriftObservationModel,
+)
 from app.repositories.sqlalchemy_repository_base import SqlAlchemyRepositoryBase
 
 
@@ -101,6 +106,53 @@ class SqlAlchemyModelCatalogueRepository(SqlAlchemyRepositoryBase):
                 )
                 for model in models
             ]
+
+    def get_drift_observation(self, observation_id: str) -> ModelRevisionDriftObservation | None:
+        with self._session_factory() as session:
+            model = session.get(ModelRevisionDriftObservationModel, observation_id)
+            if model is None:
+                return None
+            return self._to_drift_observation(model)
+
+    def upsert_drift_observation(self, observation: ModelRevisionDriftObservation) -> None:
+        with self._session_factory() as session:
+            model = session.get(ModelRevisionDriftObservationModel, observation.observation_id)
+            if model is None:
+                model = ModelRevisionDriftObservationModel(
+                    observation_id=observation.observation_id
+                )
+                session.add(model)
+            model.entry_id = observation.entry_id
+            model.expected_identity = observation.expected_identity
+            model.observed_model_id = observation.observed_model_id
+            model.revision_pinned_at_observation = observation.revision_pinned_at_observation
+            model.first_observed_at = observation.first_observed_at
+            model.last_observed_at = observation.last_observed_at
+            model.observation_count = observation.observation_count
+            session.commit()
+
+    def list_drift_observations(self, entry_id: str) -> list[ModelRevisionDriftObservation]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(ModelRevisionDriftObservationModel)
+                .where(ModelRevisionDriftObservationModel.entry_id == entry_id)
+                .order_by(ModelRevisionDriftObservationModel.last_observed_at.desc())
+            ).all()
+            return [self._to_drift_observation(model) for model in models]
+
+    def _to_drift_observation(
+        self, model: ModelRevisionDriftObservationModel
+    ) -> ModelRevisionDriftObservation:
+        return ModelRevisionDriftObservation(
+            observation_id=model.observation_id,
+            entry_id=model.entry_id,
+            expected_identity=model.expected_identity,
+            observed_model_id=model.observed_model_id,
+            revision_pinned_at_observation=model.revision_pinned_at_observation,
+            first_observed_at=model.first_observed_at,
+            last_observed_at=model.last_observed_at,
+            observation_count=model.observation_count,
+        )
 
     def _to_entry(self, model: ModelCatalogueEntryModel) -> ModelCatalogueEntry:
         return ModelCatalogueEntry(

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -33,6 +33,7 @@ from app.contracts.model_catalogue import (
     ModelLifecycleTransitionRecord,
     ModelLifecycleTransitionRequest,
     ModelLifecycleTransitionResponse,
+    ModelRevisionDriftObservation,
     derive_model_catalogue_entry_id,
 )
 from app.contracts.providers import ProviderExecutionMode, ProviderFailureCategory
@@ -328,6 +329,52 @@ def build_model_catalogue_entry_detail(entry_id: str) -> ModelCatalogueEntryDeta
         store_mode=settings.model_catalogue_store_mode,
         entry=entry,
         lifecycle_events=repository.list_lifecycle_events(entry_id),
+        revision_drift_observations=repository.list_drift_observations(entry_id),
+    )
+
+
+def record_model_revision_drift(
+    *,
+    entry: ModelCatalogueEntry,
+    observed_model_id: str | None,
+) -> None:
+    """Record that a provider served an identity other than the expectation.
+
+    Called by the gateway after every live execution with the bound entry and
+    the provider's echoed model id. An echo equal to the pinned revision or to
+    the family identity is agreement, not drift. Observations are deduplicated
+    per (entry, observed id): repetition updates last_observed_at and count.
+    """
+
+    if not observed_model_id:
+        return
+    if observed_model_id in {entry.model_revision, entry.model_family}:
+        return
+    observation_id = f"{entry.entry_id}::{observed_model_id}"
+    repository = get_model_catalogue_repository()
+    existing = repository.get_drift_observation(observation_id)
+    now = _utc_now_iso()
+    if existing is None:
+        repository.upsert_drift_observation(
+            ModelRevisionDriftObservation(
+                observation_id=observation_id,
+                entry_id=entry.entry_id,
+                expected_identity=entry.model_revision,
+                observed_model_id=observed_model_id,
+                revision_pinned_at_observation=entry.revision_pinned,
+                first_observed_at=now,
+                last_observed_at=now,
+                observation_count=1,
+            )
+        )
+        return
+    repository.upsert_drift_observation(
+        existing.model_copy(
+            update={
+                "last_observed_at": now,
+                "observation_count": existing.observation_count + 1,
+            }
+        )
     )
 
 

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -23,7 +23,10 @@ from app.services.access_control_authorization import authorize_request, require
 from app.config import settings
 from app.contracts.model_catalogue import derive_model_catalogue_entry_id
 from app.services.kill_switch_control import enforce_kill_switches
-from app.services.model_catalogue import bind_live_text_model_catalogue_entry
+from app.services.model_catalogue import (
+    bind_live_text_model_catalogue_entry,
+    record_model_revision_drift,
+)
 from app.services.provider_policy import require_supported_text_generation_mode
 from app.services.provider_budget_policy import enforce_provider_budget, record_provider_spend
 from app.services.provider_degradation_state import (
@@ -99,6 +102,10 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             response.model_revision_pinned = catalogue_entry.revision_pinned
             if getattr(response, "model_version", None) is None:
                 response.model_version = catalogue_entry.model_revision
+            record_model_revision_drift(
+                entry=catalogue_entry,
+                observed_model_id=getattr(response, "model_id", None),
+            )
         response.routing_decision = _build_fixed_routing_decision(
             mode_value=mode.value,
             selected_provider_id=response.provider_id,

--- a/tests/integration/test_audit_tenant_isolation.py
+++ b/tests/integration/test_audit_tenant_isolation.py
@@ -162,3 +162,17 @@ def test_platform_audit_read_fails_closed_when_access_evidence_cannot_be_saved(
     assert response.status_code == 500
     assert response.json()["error_code"] == "LOTUS_AI_INTERNAL_ERROR"
     assert "sentinel" not in response.text
+
+
+def test_audit_list_applies_the_category_filter_within_the_caller_scope(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/ai/audit",
+        params={"category": "explain"},
+        headers={"X-Caller-App": "lotus-idea"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["filters_applied"]["category"] == "explain"
+    assert all(record["category"] == "explain" for record in body["records"])

--- a/tests/integration/test_observability_api_contract.py
+++ b/tests/integration/test_observability_api_contract.py
@@ -344,3 +344,15 @@ def test_breakdowns_fail_closed_for_unknown_and_unprivileged_callers(
         headers={"X-Caller-App": "lotus-platform"},
     )
     assert header_only_privileged.status_code == 403
+
+
+def test_retrieval_observability_summary_route(client: TestClient) -> None:
+    response = client.get("/platform/observability/retrieval-summary")
+    assert response.status_code == 200
+    assert response.json()["service"] == "lotus-ai"
+
+
+def test_async_observability_summary_route(client: TestClient) -> None:
+    response = client.get("/platform/observability/async-summary")
+    assert response.status_code == 200
+    assert response.json()["service"] == "lotus-ai"

--- a/tests/unit/test_audit_read_authorization.py
+++ b/tests/unit/test_audit_read_authorization.py
@@ -151,3 +151,56 @@ def test_resolve_audit_read_scope_denies_empty_or_unknown_policy(caller_app: str
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Caller is not authorized to inspect lotus-ai audit records."
+
+
+def test_resolve_audit_read_scope_fails_closed_on_degenerate_policies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.contracts.access_control import (
+        CallerLifecycleStatus,
+        CallerPolicyDescriptor,
+        TenantPolicyMode,
+    )
+
+    def _policy(restricted: list[str]) -> CallerPolicyDescriptor:
+        return CallerPolicyDescriptor(
+            caller_app="lotus-degenerate",
+            lifecycle_status=CallerLifecycleStatus.ACTIVE,
+            description="degenerate policy for fail-closed proof",
+            allowed_task_ids=[],
+            allowed_retrieval_source_ids=[],
+            allow_live_provider=False,
+            allow_async_control=False,
+            allow_prompt_control=False,
+            allow_provider_control=False,
+            allow_audit_read_all_tenants=False,
+            tenant_policy_mode=TenantPolicyMode.RESTRICTED,
+            restricted_tenant_ids=restricted,
+        )
+
+    class _StubPolicies:
+        def __init__(self, policy: object) -> None:
+            self._policy = policy
+
+        def get_policy(self, caller_app: str) -> object:
+            return self._policy
+
+    caller = AuthenticatedCaller(caller_app="lotus-degenerate", trust_source="trusted_http_header")
+
+    # A restricted policy with NO tenants grants nothing - never everything.
+    monkeypatch.setattr(
+        "app.services.audit_read_authorization.get_caller_policy_repository",
+        lambda: _StubPolicies(_policy([])),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_audit_read_scope(caller)
+    assert exc_info.value.status_code == 403
+
+    # A malformed tenant id (surrounding whitespace) fails closed too.
+    monkeypatch.setattr(
+        "app.services.audit_read_authorization.get_caller_policy_repository",
+        lambda: _StubPolicies(_policy([" tenant-sg-001 "])),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_audit_read_scope(caller)
+    assert exc_info.value.status_code == 403

--- a/tests/unit/test_kill_switch_control.py
+++ b/tests/unit/test_kill_switch_control.py
@@ -300,3 +300,57 @@ def _record(**overrides: object) -> KillSwitchActivationRecord:
     }
     payload.update(overrides)
     return KillSwitchActivationRecord.model_validate(payload)
+
+
+def test_memory_repository_get_and_ordering() -> None:
+    repository = get_kill_switch_repository()
+    assert repository.get_activation("ksw_absent") is None
+    repository.upsert_activation(_record(switch_id="ksw_a", activated_at="2026-08-30T01:00:00Z"))
+    repository.upsert_activation(_record(switch_id="ksw_b", activated_at="2026-08-30T02:00:00Z"))
+    fetched = repository.get_activation("ksw_a")
+    assert fetched is not None and fetched.switch_id == "ksw_a"
+    assert [a.switch_id for a in repository.list_activations()] == ["ksw_b", "ksw_a"]
+
+
+def test_sqlalchemy_repository_prepares_each_sqlite_location_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.repositories.sqlalchemy_kill_switch_repository import SqlAlchemyKillSwitchRepository
+
+    SqlAlchemyKillSwitchRepository("sqlite:///:memory:").close()
+    monkeypatch.chdir(tmp_path)
+    SqlAlchemyKillSwitchRepository("sqlite:///data/nested/kill.db").close()
+    assert (tmp_path / "data" / "nested").is_dir()
+    SqlAlchemyKillSwitchRepository("postgresql+psycopg://user:secret@localhost:5432/db").close()
+
+
+def test_store_accessor_fails_closed_on_bad_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "kill_switch_store_mode", "sqlalchemy")
+    monkeypatch.setattr(settings, "database_url", None)
+    with pytest.raises(RuntimeError, match="LOTUS_AI_DATABASE_URL is required"):
+        get_kill_switch_repository()
+    monkeypatch.setattr(settings, "kill_switch_store_mode", "carrier-pigeon")
+    with pytest.raises(RuntimeError, match="Unsupported LOTUS_AI_KILL_SWITCH_STORE_MODE"):
+        get_kill_switch_repository()
+
+
+def test_scope_matcher_rejects_an_unknown_scope_object() -> None:
+    from app.services.kill_switch_control import _matches
+
+    bogus = KillSwitchActivationRecord.model_construct(
+        switch_id="ksw_bogus",
+        scope="NOT_A_SCOPE",
+        target=None,
+        reason="r",
+        requested_by="a",
+        approved_by="b",
+        activated_at="2026-08-30T00:00:00Z",
+        expires_at_utc=None,
+        cleared_at=None,
+        cleared_by=None,
+        clear_reason=None,
+    )
+    with pytest.raises(RuntimeError, match="Unsupported kill-switch scope"):
+        _matches(bogus, request=_provider_request())

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -456,3 +456,41 @@ def test_seed_authority_change_never_resurrects_an_operator_terminal_state(
     assert resurrected is not None
     assert resurrected.lifecycle_state is ModelLifecycleState.RETIRED
     assert resurrected.seed_source is ModelCatalogueSeedSource.APPROVED_WORKFLOW_RUN_MODEL_INVENTORY
+
+
+def test_drift_recording_distinguishes_agreement_reveal_and_repetition(
+    _local_unpinned_settings: None,
+) -> None:
+    from app.services.model_catalogue import record_model_revision_drift
+
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry("text.local:qwen3:8b")
+    assert entry is not None
+
+    # Agreement with the family/revision identity is not drift.
+    record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b")
+    record_model_revision_drift(entry=entry, observed_model_id=None)
+    assert repository.list_drift_observations(entry.entry_id) == []
+
+    # An unpinned entry whose provider reveals a concrete revision IS an
+    # observation - the exact exposure revision_pinned=False warns about.
+    record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b-q4-2026-03")
+    observations = repository.list_drift_observations(entry.entry_id)
+    assert len(observations) == 1
+    first = observations[0]
+    assert first.observed_model_id == "qwen3:8b-q4-2026-03"
+    assert first.expected_identity == "qwen3:8b"
+    assert first.revision_pinned_at_observation is False
+    assert first.observation_count == 1
+
+    # Repetition deduplicates: same observation, count and last_observed move.
+    record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b-q4-2026-03")
+    repeated = repository.list_drift_observations(entry.entry_id)[0]
+    assert repeated.observation_count == 2
+    assert repeated.first_observed_at == first.first_observed_at
+    assert repeated.last_observed_at >= first.last_observed_at
+
+    # A different observed identity is its own observation.
+    record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b-q5-2026-06")
+    assert len(repository.list_drift_observations(entry.entry_id)) == 2

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -494,3 +494,56 @@ def test_drift_recording_distinguishes_agreement_reveal_and_repetition(
     # A different observed identity is its own observation.
     record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b-q5-2026-06")
     assert len(repository.list_drift_observations(entry.entry_id)) == 2
+
+
+def test_memory_lifecycle_events_append_and_list() -> None:
+    from app.contracts.model_catalogue import ModelLifecycleTransitionRecord
+
+    repository = get_model_catalogue_repository()
+    for index, instant in enumerate(["2026-08-30T01:00:00Z", "2026-08-30T02:00:00Z"]):
+        repository.append_lifecycle_event(
+            ModelLifecycleTransitionRecord(
+                event_id=f"mlc_mem_{index}",
+                entry_id="text.local:qwen3:8b",
+                from_state=ModelLifecycleState.CATALOGUED,
+                to_state=ModelLifecycleState.EVALUATING,
+                reason="memory round trip",
+                requested_by="ops.primary@lotus",
+                approved_by="ops.secondary@lotus",
+                recorded_at=instant,
+            )
+        )
+    events = repository.list_lifecycle_events("text.local:qwen3:8b")
+    assert [event.event_id for event in events] == ["mlc_mem_1", "mlc_mem_0"]
+    assert repository.list_lifecycle_events("other:entry") == []
+
+
+def test_lifecycle_transition_on_an_unknown_entry_is_404(_durable_catalogue: str) -> None:
+    from fastapi import HTTPException
+
+    from app.services.model_catalogue import apply_model_lifecycle_transition
+
+    with pytest.raises(HTTPException) as excinfo:
+        apply_model_lifecycle_transition("text.unknown:nope", _transition_request())
+    assert excinfo.value.status_code == 404
+
+
+def test_drift_observations_survive_a_store_restart_in_sqlalchemy_mode(
+    _durable_catalogue: str,
+) -> None:
+    from app.services.model_catalogue import record_model_revision_drift
+
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(_durable_catalogue)
+    assert entry is not None
+    record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b-q4-2026-03")
+    record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b-q4-2026-03")
+    record_model_revision_drift(entry=entry, observed_model_id="qwen3:8b-q5-2026-06")
+
+    # Restart: drop every in-process handle; observations must come back from SQL.
+    reset_model_catalogue_store_cache()
+    observations = get_model_catalogue_repository().list_drift_observations(_durable_catalogue)
+    by_observed = {o.observed_model_id: o for o in observations}
+    assert set(by_observed) == {"qwen3:8b-q4-2026-03", "qwen3:8b-q5-2026-06"}
+    assert by_observed["qwen3:8b-q4-2026-03"].observation_count == 2
+    assert by_observed["qwen3:8b-q5-2026-06"].observation_count == 1

--- a/tests/unit/test_provider_gateway.py
+++ b/tests/unit/test_provider_gateway.py
@@ -589,3 +589,67 @@ def test_execute_text_generation_refuses_a_retired_catalogue_model(
         is ProviderFailureCategory.MODEL_LIFECYCLE_INELIGIBLE
     )
     reset_model_catalogue_store_cache()
+
+
+def test_live_execution_records_revision_drift_from_the_provider_echo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The transport asks for the configured model id; the provider echoes a
+    concrete revision. The gateway must record that observation on the bound
+    catalogue entry."""
+
+    from app.services.model_catalogue_store import (
+        get_model_catalogue_repository,
+        reset_model_catalogue_store_cache,
+    )
+
+    reset_model_catalogue_store_cache()
+
+    class _EchoingAdapter:
+        def execute(self, request: ProviderExecutionRequest) -> object:
+            return type(
+                "Response",
+                (),
+                {
+                    "provider_id": "text.openai",
+                    "provider_mode": "openai",
+                    "adapter_kind": ProviderAdapterKind.OPENAI_LIVE,
+                    "failure_category": None,
+                    "timeout_ms": request.timeout_ms,
+                    "retry_count": 0,
+                    "max_output_tokens": request.max_output_tokens,
+                    "model_id": "gpt-5.4-2026-07-15",
+                    "provider_request_id": "req_drift_1",
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "total_tokens": 30,
+                    "estimated_cost_usd": None,
+                    "stubbed": False,
+                    "message": "live response",
+                    "structured_output": {},
+                },
+            )()
+
+    monkeypatch.setattr(settings, "provider_mode", "openai")
+    monkeypatch.setattr(settings, "provider_rollout_state", "CANARY_ENABLED")
+    monkeypatch.setattr(settings, "live_text_provider_id", "text.openai")
+    monkeypatch.setattr(settings, "live_text_model_id", "gpt-5.4")
+    monkeypatch.setattr(settings, "live_text_model_version", None)
+    monkeypatch.setattr(settings, "live_text_provider_api_key", "secret")
+    monkeypatch.setattr(settings, "live_text_allowed_task_ids", "explain.v1")
+    monkeypatch.setattr(settings, "live_text_quota_enforced", False)
+    monkeypatch.setattr(settings, "live_text_budget_enforced", False)
+    monkeypatch.setattr(settings, "live_text_degradation_enforced", False)
+    monkeypatch.setattr(settings, "workflow_run_model_risk_inventory_json", "[]")
+    monkeypatch.setattr(
+        "app.services.provider_gateway.resolve_text_generation_adapter",
+        lambda mode: _EchoingAdapter(),
+    )
+
+    execute_text_generation(_request())
+
+    observations = get_model_catalogue_repository().list_drift_observations("text.openai:gpt-5.4")
+    assert len(observations) == 1
+    assert observations[0].observed_model_id == "gpt-5.4-2026-07-15"
+    assert observations[0].revision_pinned_at_observation is False
+    reset_model_catalogue_store_cache()

--- a/tests/unit/test_task_execution_mapping.py
+++ b/tests/unit/test_task_execution_mapping.py
@@ -91,3 +91,20 @@ def test_map_audit_record_carries_governed_model_identity() -> None:
     assert audit_record.routing_decision == response.audit.routing_decision
     assert audit_record.routing_decision.selected_provider_id == "text.stub"
     assert audit_record.routing_decision.policy_id == "fixed_configured_mode"
+
+
+def test_failure_detail_and_category_inference_fallbacks() -> None:
+    from fastapi import HTTPException
+
+    from app.services.task_execution_pipeline import (
+        _http_exception_detail,
+        _infer_failure_category,
+    )
+
+    assert (
+        _http_exception_detail(HTTPException(status_code=503, detail={"not": "a-string"}))
+        == "Workflow-pack execution failed before lotus-ai could produce a completed task result."
+    )
+    assert _http_exception_detail(HTTPException(status_code=503, detail="  padded  ")) == "padded"
+    assert _infer_failure_category("QUOTA_EXCEEDED: limit reached") == "QUOTA_EXCEEDED"
+    assert _infer_failure_category("not a known prefix") is None

--- a/tests/unit/test_workflow_pack_run_accepted_output.py
+++ b/tests/unit/test_workflow_pack_run_accepted_output.py
@@ -360,3 +360,13 @@ def test_malformed_evidence_reference_entries_fail_closed(_wired: WireCallable) 
     with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
         build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
     assert _reason(excinfo) == "output_artifact_malformed"
+
+
+def test_absent_evidence_refs_key_projects_as_empty(_wired: WireCallable) -> None:
+    payload = _artifact_payload()
+    del payload["structured_output"]["talking_points"][0]["evidence_refs"]
+    _wired(_record(), payload)
+    response = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+    assert response.talking_points[0].evidence_refs == []


### PR DESCRIPTION
Closes #175 — this is the final slice of the model-identity programme.

## What

`record_model_revision_drift` runs in the gateway after the catalogue binding (#181), comparing the provider's echoed `model_id` against the bound entry's expectation:

- Echo equal to the **pinned revision** or the **family identity** = agreement, nothing recorded.
- Anything else = a durable observation (migration `0047`), including the unpinned-entry case where the provider reveals a concrete revision — exactly the exposure `revision_pinned=False` (#180) has been surfacing since slice 1.
- **Deduplicated** per (entry, observed id): repetition updates `last_observed_at` + `observation_count` rather than flooding the store; `first_observed_at` is stable.
- **Read path included**: `GET /platform/models/catalogue/{entry_id}` now carries `revision_drift_observations`, newest first — no write-only evidence.

## #175 across its four slices (for the closure audit)

S1 #180: identity contracts + governed catalogue + seed + read surface. S2a #181: execution binding + lifecycle fences. S2b #182: first-class identity columns on audit records. S3 #188: governed lifecycle transitions with durable history + the resurrection guard. S4 (this PR): drift detection. Acceptance criteria will be verified item-by-item on the issue after merge + gate.

## Evidence

39 focused tests green (drift semantics matrix, gateway echo recording end to end, catalogue/lifecycle suites unaffected); lint, mypy (681 files), openapi-gate, migration contract check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)