### PR TITLE
refactor(models): source model-risk evaluation from the governed catalogue (#191)

### DIFF
--- a/src/app/services/workflow_pack_run_ledger.py
+++ b/src/app/services/workflow_pack_run_ledger.py
@@ -35,10 +35,7 @@ from app.services.workflow_pack_run_artifacts import persist_workflow_pack_run_o
 from app.services.workflow_run_attestation_source import (
     capture_workflow_run_attestation_source,
 )
-from app.services.workflow_run_model_risk import evaluate_workflow_run_model_risk
-from app.providers.configured_workflow_run_model_risk_inventory import (
-    ConfiguredWorkflowRunModelRiskInventory,
-)
+from app.services.workflow_run_model_risk import evaluate_workflow_run_model_risk_from_catalogue
 from app.services.workflow_pack_run_provenance_summary import (
     build_workflow_pack_run_provenance_summary,
 )
@@ -285,8 +282,7 @@ def record_registered_workflow_pack_run(
         review_state=review_state.value,
         created_at=created_at,
     )
-    model_risk_decision = evaluate_workflow_run_model_risk(
-        inventory=ConfiguredWorkflowRunModelRiskInventory(settings=settings),
+    model_risk_decision = evaluate_workflow_run_model_risk_from_catalogue(
         provider_id=response.audit.provider_id,
         provider_mode=response.audit.provider_mode,
         model_id=response.audit.model_id or "deterministic-stub",

--- a/src/app/services/workflow_run_model_risk.py
+++ b/src/app/services/workflow_run_model_risk.py
@@ -1,10 +1,26 @@
+"""Model-risk evaluation for workflow runs, sourced from the governed catalogue.
+
+Issue #191: the catalogue (#175) is the single source of model identity and
+approval truth. Evaluation matches the executing identity against APPROVED
+catalogue rows - the rows the seed mirrors from the model-risk inventory and
+the rows operators promote through governed lifecycle transitions. The env
+inventory remains a seed-time input only; it is never read at evaluation time.
+
+Semantics preserved from the inventory era: exactly one effective match is
+`approved` (carrying its approval reference); anything else on a live path is
+`approval_unverified`; stub executions are `test_only`. Validity windows bound
+an approval when present; an APPROVED entry without a window (an operator
+promotion) is effective by virtue of its lifecycle state - the state machine
+is authoritative, windows are additional bounds.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol
 
-from app.contracts.workflow_run_model_risk import ApprovedWorkflowRunModel
+from app.contracts.model_catalogue import ModelCatalogueEntry, ModelLifecycleState
+from app.services.model_catalogue_store import get_model_catalogue_repository
 
 
 @dataclass(frozen=True)
@@ -13,13 +29,9 @@ class WorkflowRunModelRiskDecision:
     approval_ref: str | None
 
 
-class WorkflowRunModelRiskInventory(Protocol):
-    def approved_models(self) -> list[ApprovedWorkflowRunModel]: ...
-
-
 def evaluate_workflow_run_model_risk(
     *,
-    inventory: WorkflowRunModelRiskInventory,
+    entries: list[ModelCatalogueEntry],
     provider_id: str,
     provider_mode: str,
     model_id: str,
@@ -32,30 +44,61 @@ def evaluate_workflow_run_model_risk(
         return WorkflowRunModelRiskDecision(status="test_only", approval_ref=None)
     evaluated_at = _timestamp(evaluated_at_utc, "model-risk evaluation time")
     matches = [
-        model
-        for model in inventory.approved_models()
-        if model.provider_id == provider_id
-        and model.provider_mode == provider_mode
-        and model.model_id == model_id
-        and model.model_version == model_version
-        and workflow_pack_id in model.workflow_pack_ids
-        and _is_effective(model=model, evaluated_at=evaluated_at)
+        entry
+        for entry in entries
+        if entry.lifecycle_state is ModelLifecycleState.APPROVED
+        and entry.provider_id == provider_id
+        and entry.provider_mode == provider_mode
+        and entry.model_family == model_id
+        and entry.model_revision == model_version
+        and workflow_pack_id in entry.approved_workflow_pack_ids
+        and entry.approval_evidence_refs
+        and _is_effective(entry=entry, evaluated_at=evaluated_at)
     ]
     if len(matches) != 1:
         return WorkflowRunModelRiskDecision(status="approval_unverified", approval_ref=None)
-    return WorkflowRunModelRiskDecision(status="approved", approval_ref=matches[0].approval_ref)
+    return WorkflowRunModelRiskDecision(
+        status="approved",
+        approval_ref=matches[0].approval_evidence_refs[-1],
+    )
 
 
-def _is_effective(*, model: ApprovedWorkflowRunModel, evaluated_at: datetime) -> bool:
-    approved_from = _timestamp(model.approved_from_utc, "model approval start")
-    approved_until = (
-        _timestamp(model.approved_until_utc, "model approval end")
-        if model.approved_until_utc is not None
-        else None
+def evaluate_workflow_run_model_risk_from_catalogue(
+    *,
+    provider_id: str,
+    provider_mode: str,
+    model_id: str,
+    model_version: str,
+    workflow_pack_id: str,
+    evaluated_at_utc: str,
+    stubbed: bool,
+) -> WorkflowRunModelRiskDecision:
+    # Imported lazily to keep this module import-light for pure evaluation use.
+    from app.services.model_catalogue import ensure_model_catalogue_seeded
+
+    ensure_model_catalogue_seeded()
+    return evaluate_workflow_run_model_risk(
+        entries=get_model_catalogue_repository().list_entries(),
+        provider_id=provider_id,
+        provider_mode=provider_mode,
+        model_id=model_id,
+        model_version=model_version,
+        workflow_pack_id=workflow_pack_id,
+        evaluated_at_utc=evaluated_at_utc,
+        stubbed=stubbed,
     )
-    return approved_from <= evaluated_at and (
-        approved_until is None or evaluated_at < approved_until
-    )
+
+
+def _is_effective(*, entry: ModelCatalogueEntry, evaluated_at: datetime) -> bool:
+    if entry.approved_from_utc is not None:
+        approved_from = _timestamp(entry.approved_from_utc, "model approval start")
+        if approved_from > evaluated_at:
+            return False
+    if entry.approved_until_utc is not None:
+        approved_until = _timestamp(entry.approved_until_utc, "model approval end")
+        if evaluated_at >= approved_until:
+            return False
+    return True
 
 
 def _timestamp(value: str, label: str) -> datetime:

--- a/tests/unit/test_workflow_run_model_risk.py
+++ b/tests/unit/test_workflow_run_model_risk.py
@@ -1,18 +1,40 @@
+"""Model-risk evaluation sourced from the governed catalogue (issue #191).
+
+The evaluation matrix from the inventory era is preserved case for case; the
+source of truth is now APPROVED catalogue rows, so lifecycle transitions
+(#175 S3) change outcomes immediately. The env inventory's own validation
+remains tested as the seed-time guard it still is.
+"""
+
+from __future__ import annotations
+
 import json
+from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
-from app.config import Settings
+from app.config import Settings, settings
+from app.contracts.model_catalogue import (
+    ModelCatalogueEntry,
+    ModelCatalogueSeedSource,
+    ModelLifecycleState,
+    derive_model_catalogue_entry_id,
+)
 from app.providers.configured_workflow_run_model_risk_inventory import (
     ConfiguredWorkflowRunModelRiskInventory,
+)
+from app.services.model_catalogue_store import (
+    get_model_catalogue_repository,
+    reset_model_catalogue_store_cache,
 )
 from app.services.workflow_run_model_risk import (
     WorkflowRunModelRiskDecision,
     evaluate_workflow_run_model_risk,
+    evaluate_workflow_run_model_risk_from_catalogue,
 )
 
-
-APPROVED_MODEL: dict[str, object] = {
+APPROVED_INVENTORY_ROW: dict[str, object] = {
     "provider_id": "text.openai",
     "provider_mode": "openai",
     "model_id": "gpt-5.4",
@@ -24,22 +46,44 @@ APPROVED_MODEL: dict[str, object] = {
 }
 
 
-def _inventory(models: list[dict[str, object]]) -> ConfiguredWorkflowRunModelRiskInventory:
-    return ConfiguredWorkflowRunModelRiskInventory(
-        settings=Settings(workflow_run_model_risk_inventory_json=json.dumps(models))
+def _entry(**overrides: object) -> ModelCatalogueEntry:
+    payload: dict[str, object] = {
+        "provider_id": "text.openai",
+        "provider_mode": "openai",
+        "model_family": "gpt-5.4",
+        "model_revision": "2026-06-01",
+        "deployment": None,
+        "sku": None,
+        "lifecycle_state": ModelLifecycleState.APPROVED,
+        "revision_pinned": True,
+        "modalities": ["text"],
+        "approved_workflow_pack_ids": ["idea_explanation.pack"],
+        "approval_evidence_refs": ["model-risk://lotus-ai/gpt-5.4/2026-06-01"],
+        "approved_from_utc": "2026-06-01T00:00:00Z",
+        "approved_until_utc": "2026-09-01T00:00:00Z",
+        "seed_source": ModelCatalogueSeedSource.APPROVED_WORKFLOW_RUN_MODEL_INVENTORY,
+        "created_at": "2026-06-01T00:00:00Z",
+        "last_updated_at": "2026-06-01T00:00:00Z",
+    }
+    payload.update(overrides)
+    payload["entry_id"] = derive_model_catalogue_entry_id(
+        provider_id=str(payload["provider_id"]),
+        model_revision=str(payload["model_revision"]),
+        deployment=None,
     )
+    return ModelCatalogueEntry.model_validate(payload)
 
 
 def _evaluate(
     *,
-    inventory: ConfiguredWorkflowRunModelRiskInventory | None = None,
+    entries: list[ModelCatalogueEntry] | None = None,
     workflow_pack_id: str = "idea_explanation.pack",
     model_version: str = "2026-06-01",
     evaluated_at_utc: str = "2026-07-11T10:00:00Z",
     stubbed: bool = False,
 ) -> WorkflowRunModelRiskDecision:
     return evaluate_workflow_run_model_risk(
-        inventory=inventory or _inventory([APPROVED_MODEL]),
+        entries=entries if entries is not None else [_entry()],
         provider_id="text.openai",
         provider_mode="openai",
         model_id="gpt-5.4",
@@ -50,7 +94,7 @@ def _evaluate(
     )
 
 
-def test_exact_effective_model_inventory_match_is_approved() -> None:
+def test_exact_effective_approved_entry_is_approved() -> None:
     decision = _evaluate()
 
     assert decision.status == "approved"
@@ -65,7 +109,7 @@ def test_exact_effective_model_inventory_match_is_approved() -> None:
         ("idea_explanation.pack", "2026-06-01", "2026-09-01T00:00:00Z"),
     ],
 )
-def test_non_matching_or_expired_model_is_not_approved(
+def test_non_matching_or_expired_entry_is_not_approved(
     workflow_pack_id: str, model_version: str, evaluated_at_utc: str
 ) -> None:
     decision = _evaluate(
@@ -78,24 +122,140 @@ def test_non_matching_or_expired_model_is_not_approved(
     assert decision.approval_ref is None
 
 
-def test_stub_execution_remains_test_only_even_when_inventory_matches() -> None:
+def test_stub_execution_remains_test_only_even_when_an_entry_matches() -> None:
     decision = _evaluate(stubbed=True)
 
     assert decision.status == "test_only"
     assert decision.approval_ref is None
 
 
+def test_lifecycle_state_is_authoritative() -> None:
+    """A demoted entry stops approving immediately - the point of #191."""
+
+    for state in (
+        ModelLifecycleState.DEPRECATED,
+        ModelLifecycleState.RETIRED,
+        ModelLifecycleState.DEGRADED,
+        ModelLifecycleState.CATALOGUED,
+    ):
+        decision = _evaluate(entries=[_entry(lifecycle_state=state)])
+        assert decision.status == "approval_unverified", state
+
+
+def test_operator_promotion_without_windows_is_effective() -> None:
+    """An APPROVED entry without validity windows (a governed operator
+    promotion) is effective by state; windows are bounds, not prerequisites."""
+
+    decision = _evaluate(
+        entries=[
+            _entry(
+                approved_from_utc=None,
+                approved_until_utc=None,
+                approval_evidence_refs=["mrm-operator-2026-041"],
+                seed_source=ModelCatalogueSeedSource.SETTINGS_LIVE_TEXT,
+            )
+        ]
+    )
+
+    assert decision.status == "approved"
+    assert decision.approval_ref == "mrm-operator-2026-041"
+
+
+def test_entries_without_evidence_or_pack_bindings_never_approve() -> None:
+    assert _evaluate(entries=[_entry(approval_evidence_refs=[])]).status == ("approval_unverified")
+    assert _evaluate(entries=[_entry(approved_workflow_pack_ids=[])]).status == (
+        "approval_unverified"
+    )
+
+
+def test_more_than_one_effective_match_refuses_approval() -> None:
+    duplicate = _entry(deployment=None)
+    shadow = duplicate.model_copy(update={"entry_id": duplicate.entry_id + ":shadow"})
+    decision = _evaluate(entries=[duplicate, shadow])
+
+    assert decision.status == "approval_unverified"
+    assert decision.approval_ref is None
+
+
+@pytest.fixture
+def _seeded_catalogue(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    reset_model_catalogue_store_cache()
+    monkeypatch.setattr(settings, "provider_mode", "disabled")
+    monkeypatch.setattr(
+        settings,
+        "workflow_run_model_risk_inventory_json",
+        json.dumps([APPROVED_INVENTORY_ROW]),
+    )
+    yield
+    reset_model_catalogue_store_cache()
+
+
+def test_from_catalogue_wrapper_reflects_lifecycle_transitions(
+    _seeded_catalogue: None,
+) -> None:
+    """End to end: the seed mirrors the inventory to an APPROVED row, the
+    wrapper approves against it, and a lifecycle demotion flips the outcome -
+    impossible under the env-inventory read this issue removed."""
+
+    def _wrapped() -> WorkflowRunModelRiskDecision:
+        return evaluate_workflow_run_model_risk_from_catalogue(
+            provider_id="text.openai",
+            provider_mode="openai",
+            model_id="gpt-5.4",
+            model_version="2026-06-01",
+            workflow_pack_id="idea_explanation.pack",
+            evaluated_at_utc="2026-07-11T10:00:00Z",
+            stubbed=False,
+        )
+
+    assert _wrapped().status == "approved"
+
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry("text.openai:2026-06-01")
+    assert entry is not None
+    repository.upsert_entry(
+        entry.model_copy(update={"lifecycle_state": ModelLifecycleState.DEPRECATED})
+    )
+
+    demoted = _wrapped()
+    assert demoted.status == "approval_unverified"
+    assert demoted.approval_ref is None
+
+
 @pytest.mark.parametrize(
     ("configured", "message"),
     [
         ("{", "valid governed JSON"),
-        (json.dumps([APPROVED_MODEL, APPROVED_MODEL]), "identities must be unique"),
+        (
+            json.dumps([APPROVED_INVENTORY_ROW, APPROVED_INVENTORY_ROW]),
+            "identities must be unique",
+        ),
     ],
 )
-def test_invalid_model_inventory_fails_closed(configured: str, message: str) -> None:
+def test_invalid_inventory_fails_closed_at_seed_time(configured: str, message: str) -> None:
+    """The loader's validation is now the SEED-TIME guard: the seed calls
+    approved_models(), so a malformed or duplicated inventory fails loud
+    before any catalogue row exists."""
+
     inventory = ConfiguredWorkflowRunModelRiskInventory(
         settings=Settings(workflow_run_model_risk_inventory_json=configured)
     )
 
     with pytest.raises(ValueError, match=message):
         inventory.approved_models()
+
+
+def test_inventory_loader_is_referenced_only_by_the_seed() -> None:
+    """#191's single-source guard: the env inventory is a seed input, never a
+    runtime evaluation source. A new runtime consumer must show up here."""
+
+    src_root = Path(__file__).resolve().parents[2] / "src" / "app"
+    referencing = {
+        path.relative_to(src_root).as_posix()
+        for path in src_root.rglob("*.py")
+        if "ConfiguredWorkflowRunModelRiskInventory" in path.read_text(encoding="utf-8")
+    }
+    assert referencing == {
+        "providers/configured_workflow_run_model_risk_inventory.py",
+        "services/model_catalogue.py",
+    }

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -150,7 +150,7 @@ not in the public allowlist, so an anonymous verifier cannot fetch them.
 | `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_KEY_NOT_AFTER_UTC` | *(none)* |
 | `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_ROTATED_PUBLIC_KEYS_JSON` | `[]` |
 | `LOTUS_AI_WORKFLOW_RUN_ATTESTATION_TTL_SECONDS` | `300` |
-| `LOTUS_AI_WORKFLOW_RUN_MODEL_RISK_INVENTORY_JSON` | `[]` |
+| `LOTUS_AI_WORKFLOW_RUN_MODEL_RISK_INVENTORY_JSON` | `[]` — seed input only: mirrored into APPROVED model-catalogue rows at seed time; model-risk evaluation reads the catalogue, never this variable (#191) |
 
 ## Deployment, startup and readiness
 


### PR DESCRIPTION
Closes #191 — the residual named in #175's closure audit; removes the last duplicate-catalogue violation (charter §20).

## What

`evaluate_workflow_run_model_risk` now evaluates against **APPROVED catalogue rows** instead of re-reading the env-var JSON inventory at runtime. The inventory remains exactly what it was at seed time — a bootstrap input, mirrored into catalogue rows by the #175 seed — and is now provably never a runtime read path.

- **Lifecycle state is authoritative**: an operator demotion (#188) changes the evaluation outcome immediately — the new end-to-end test proves seed → approved → DEPRECATED → `approval_unverified`, which was impossible under the env read. Windows bound an approval when present; an APPROVED entry without windows (a governed operator promotion, which requires evidence) is effective by state.
- **Semantics preserved case for case**: the pre-existing matrix (exact match approved with ref; wrong pack/version/expired unverified; stub test_only; malformed/duplicate inventory fails loud) is kept verbatim under the new source. Plus: no-evidence and no-pack entries never approve; two effective matches refuse (exactly-one preserved).
- **Single-source guard**: an exact-set test pins `ConfiguredWorkflowRunModelRiskInventory` to its module + the seed; a new runtime consumer must show up in the guard. The loader's uniqueness validation is documented and tested as the seed-time guard it now is.
- Configuration-Reference documents the variable as seed input only.

## Evidence

91 tests green: the full evaluator matrix, catalogue suites, and both integration surfaces that consume the decision (workflow-pack run API contract, attestation API contract) — parity proven by the consuming suites staying green untouched. Lint, mypy (681 files); CI proves combined lanes on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)