### PR TITLE
feat(routing): operator routing-posture inspection (#176 slice 4)

### DIFF
--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -125,6 +125,49 @@ class RoutingDecisionDescriptor(BaseModel):
     )
 
 
+class RoutingPostureCandidateDescriptor(BaseModel):
+    provider_id: str | None = Field(
+        default=None,
+        description="Configured live provider identity; null when no live identity is set.",
+    )
+    provider_mode: str = Field(description="Configured provider execution mode.")
+    model_catalogue_entry_id: str | None = Field(
+        default=None,
+        description="Governed catalogue entry the live identity resolves to, when configured.",
+    )
+    model_family: str | None = Field(default=None, description="Model family of the candidate.")
+    model_revision: str | None = Field(
+        default=None, description="Exact (or fallback) revision of the candidate."
+    )
+    revision_pinned: bool | None = Field(
+        default=None, description="Whether the catalogue entry pins an exact revision."
+    )
+    lifecycle_state: str | None = Field(
+        default=None, description="Lifecycle state of the catalogue entry."
+    )
+
+
+class RoutingPostureResponse(BaseModel):
+    service: str = Field(description="Service name emitting the routing posture.")
+    version: str = Field(description="Current lotus-ai service version.")
+    policy_id: str = Field(description="Routing policy currently in force.")
+    policy_version: str = Field(description="Version of the routing policy.")
+    strategy: RoutingStrategy = Field(description="Routing strategy the policy applies.")
+    candidate: RoutingPostureCandidateDescriptor = Field(
+        description="The single candidate the fixed policy would consider right now.",
+    )
+    degradation: "ProviderDegradationStatusDescriptor" = Field(
+        description="Current circuit-breaker posture for the live provider path.",
+    )
+    quota_enforced: bool = Field(description="Whether live-text quota enforcement is on.")
+    budget_enforced: bool = Field(description="Whether live-text budget enforcement is on.")
+    enforcing_kill_switch_count: int = Field(
+        ge=0,
+        description="Currently enforcing kill-switch activations (any scope).",
+    )
+    notes: list[str] = Field(description="Boundary statements this posture ships with.")
+
+
 class ProviderCredentialStatus(str, Enum):
     NOT_CONFIGURED = "NOT_CONFIGURED"
     CONFIGURED = "CONFIGURED"

--- a/src/app/routers/providers.py
+++ b/src/app/routers/providers.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from app.contracts.providers import (
     ProviderActivationReadinessResponse,
+    RoutingPostureResponse,
     ProviderBudgetPolicyResponse,
     ProviderCatalogResponse,
     ProviderEvidenceReadinessResponse,
@@ -32,8 +33,30 @@ from app.services.provider_operator_profile import build_provider_operator_profi
 from app.services.provider_policy import build_provider_policy
 from app.services.provider_quota_policy import build_provider_quota_policy
 from app.services.provider_runbook_readiness import build_provider_runbook_readiness
+from app.services.routing_posture import build_routing_posture
 
 router = APIRouter(prefix="/platform/providers", tags=["platform"])
+
+
+@router.get(
+    "/routing-posture",
+    response_model=RoutingPostureResponse,
+    operation_id="getRoutingPosture",
+    summary="Get the current routing posture",
+    description=(
+        "Returns the routing policy currently in force, the single candidate the fixed policy "
+        "would bind for the next live execution (with its governed catalogue identity, "
+        "lifecycle state and pinning), the circuit-breaker posture, enforcement flags, and the "
+        "count of currently enforcing kill switches. Per-request gates are evaluated per "
+        "execution and recorded on its routing decision."
+    ),
+    responses={
+        200: {"description": "Routing posture returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_routing_posture_route() -> RoutingPostureResponse:
+    return build_routing_posture()
 
 
 @router.get(

--- a/src/app/services/routing_posture.py
+++ b/src/app/services/routing_posture.py
@@ -1,0 +1,75 @@
+"""Operator routing-posture inspection (issue #176, slice 4).
+
+Answers the charter's operator question - "which model is currently serving,
+under which policy, and what would stop it" - by composing the surfaces that
+already exist: the fixed routing policy identity, the single configured
+candidate with its governed catalogue binding, the circuit-breaker status,
+the enforcement flags, and the currently enforcing kill switches. Nothing here
+re-derives eligibility logic; a posture read must never disagree with what the
+gateway would actually do.
+
+Policy-artifact versioning deliberately does not exist yet: there is one
+policy (fixed_configured_mode v1) and its registry arrives with the second
+policy (ordered_fallback, slice 3 of #176).
+"""
+
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.model_catalogue import ModelCatalogueEntry, derive_model_catalogue_entry_id
+from app.contracts.providers import (
+    ROUTING_POLICY_FIXED_CONFIGURED_MODE,
+    ROUTING_POLICY_VERSION_V1,
+    RoutingPostureCandidateDescriptor,
+    RoutingPostureResponse,
+    RoutingStrategy,
+)
+from app.services.kill_switch_control import build_kill_switch_status
+from app.services.model_catalogue import ensure_model_catalogue_seeded
+from app.services.model_catalogue_store import get_model_catalogue_repository
+from app.services.provider_degradation_state import build_provider_degradation_status
+
+
+def build_routing_posture() -> RoutingPostureResponse:
+    candidate = _resolve_candidate()
+    return RoutingPostureResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        policy_id=ROUTING_POLICY_FIXED_CONFIGURED_MODE,
+        policy_version=ROUTING_POLICY_VERSION_V1,
+        strategy=RoutingStrategy.FIXED,
+        candidate=candidate,
+        degradation=build_provider_degradation_status(),
+        quota_enforced=settings.live_text_quota_enforced,
+        budget_enforced=settings.live_text_budget_enforced,
+        enforcing_kill_switch_count=build_kill_switch_status().active_count,
+        notes=[
+            "The fixed policy maps the configured provider mode to exactly one adapter; "
+            "this posture is the candidate the next live execution would bind.",
+            "Per-request gates (caller authorization, task/tenant/caller kill-switch scopes, "
+            "quota counters) are evaluated per execution and recorded on its routing decision.",
+        ],
+    )
+
+
+def _resolve_candidate() -> RoutingPostureCandidateDescriptor:
+    provider_id = settings.live_text_provider_id
+    model_id = settings.live_text_model_id
+    entry: ModelCatalogueEntry | None = None
+    if provider_id and model_id:
+        ensure_model_catalogue_seeded()
+        entry_id = derive_model_catalogue_entry_id(
+            provider_id=provider_id,
+            model_revision=settings.live_text_model_version or model_id,
+            deployment=None,
+        )
+        entry = get_model_catalogue_repository().get_entry(entry_id)
+    return RoutingPostureCandidateDescriptor(
+        provider_id=provider_id,
+        provider_mode=settings.provider_mode,
+        model_catalogue_entry_id=entry.entry_id if entry is not None else None,
+        model_family=entry.model_family if entry is not None else None,
+        model_revision=entry.model_revision if entry is not None else None,
+        revision_pinned=entry.revision_pinned if entry is not None else None,
+        lifecycle_state=entry.lifecycle_state.value if entry is not None else None,
+    )

--- a/tests/integration/test_provider_api_contract.py
+++ b/tests/integration/test_provider_api_contract.py
@@ -459,3 +459,16 @@ def test_provider_evidence_readiness_route_reports_partial_runtime_coverage(
     body = response.json()
     assert body["approval_gate"]["evidence_state"] == "RUNTIME_PARTIAL"
     assert body["approval_gate"]["approval_ready"] is False
+
+
+def test_routing_posture_route_reports_the_fixed_policy(client: TestClient) -> None:
+    response = client.get("/platform/providers/routing-posture")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["policy_id"] == "fixed_configured_mode"
+    assert body["policy_version"] == "v1"
+    assert body["strategy"] == "FIXED"
+    assert body["candidate"]["provider_mode"] == "disabled"
+    assert body["enforcing_kill_switch_count"] == 0
+    assert body["degradation"]["status"]

--- a/tests/unit/test_routing_posture.py
+++ b/tests/unit/test_routing_posture.py
@@ -1,0 +1,90 @@
+"""Operator routing-posture inspection (issue #176, slice 4)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from app.config import settings
+from app.contracts.kill_switches import KillSwitchActivationRecord, KillSwitchScope
+from app.services.kill_switch_store import (
+    get_kill_switch_repository,
+    reset_kill_switch_store_cache,
+)
+from app.services.model_catalogue_store import reset_model_catalogue_store_cache
+from app.services.routing_posture import build_routing_posture
+
+
+@pytest.fixture(autouse=True)
+def _fresh_stores() -> Iterator[None]:
+    reset_model_catalogue_store_cache()
+    reset_kill_switch_store_cache()
+    yield
+    reset_model_catalogue_store_cache()
+    reset_kill_switch_store_cache()
+
+
+def test_unconfigured_posture_reports_the_policy_and_null_candidate() -> None:
+    posture = build_routing_posture()
+
+    assert posture.policy_id == "fixed_configured_mode"
+    assert posture.policy_version == "v1"
+    assert posture.strategy.value == "FIXED"
+    assert posture.candidate.provider_id is None
+    assert posture.candidate.model_catalogue_entry_id is None
+    assert posture.candidate.provider_mode == settings.provider_mode
+    assert posture.enforcing_kill_switch_count == 0
+    assert posture.notes
+
+
+def test_configured_posture_carries_the_governed_candidate_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "provider_mode", "local_openai_compatible")
+    monkeypatch.setattr(settings, "live_text_provider_id", "text.local")
+    monkeypatch.setattr(settings, "live_text_model_id", "qwen3:8b")
+    monkeypatch.setattr(settings, "live_text_model_version", None)
+    monkeypatch.setattr(settings, "workflow_run_model_risk_inventory_json", "[]")
+
+    posture = build_routing_posture()
+
+    assert posture.candidate.provider_id == "text.local"
+    assert posture.candidate.model_catalogue_entry_id == "text.local:qwen3:8b"
+    assert posture.candidate.model_family == "qwen3:8b"
+    assert posture.candidate.revision_pinned is False
+    assert posture.candidate.lifecycle_state == "CATALOGUED"
+    assert posture.degradation.status
+    assert posture.quota_enforced is False
+    assert posture.budget_enforced is False
+
+
+def test_posture_counts_enforcing_kill_switches_and_ignores_cleared_ones() -> None:
+    repository = get_kill_switch_repository()
+    repository.upsert_activation(
+        KillSwitchActivationRecord(
+            switch_id="ksw_posture_active",
+            scope=KillSwitchScope.ALL_LIVE_TEXT,
+            target=None,
+            reason="posture probe",
+            requested_by="ops.primary@lotus",
+            approved_by="ops.secondary@lotus",
+            activated_at="2026-08-30T00:00:00Z",
+        )
+    )
+    repository.upsert_activation(
+        KillSwitchActivationRecord(
+            switch_id="ksw_posture_cleared",
+            scope=KillSwitchScope.TASK,
+            target="explain.v1",
+            reason="posture probe",
+            requested_by="ops.primary@lotus",
+            approved_by="ops.secondary@lotus",
+            activated_at="2026-08-30T00:00:00Z",
+            cleared_at="2026-08-30T01:00:00Z",
+            cleared_by="ops.secondary@lotus",
+            clear_reason="done",
+        )
+    )
+
+    assert build_routing_posture().enforcing_kill_switch_count == 1


### PR DESCRIPTION
Part of #176 (slice 4 — operator read; slice 3 `ordered_fallback` remains, pending the alternate-candidate design; do not close the issue on merge).

## What

`GET /platform/providers/routing-posture` — the charter §15 'inspect current routing posture' surface. It **composes, never re-derives**: policy identity (`fixed_configured_mode` v1), the single candidate the policy would bind next (governed catalogue entry id, family, revision, `revision_pinned`, lifecycle state — the same resolution the gateway binding uses), the circuit-breaker descriptor from its own builder, quota/budget enforcement flags, and the enforcing kill-switch count from the kill-switch status builder. A posture read that disagreed with gateway behavior would be worse than none; sharing the builders makes disagreement structurally impossible.

**Deliberately absent** (producers rule): a routing-policy artifact registry — exactly one policy exists today; the registry ships with the second policy (S3). Per-request gates are documented on the response as per-execution concerns recorded on each routing decision.

## Evidence

26 focused tests green: null-candidate posture, governed-identity posture (incl. unpinned exposure), enforcing-vs-cleared kill-switch counting, API contract; lint, mypy (688 files), openapi-gate green. CI proves combined lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)