### PR TITLE
fix(reproducibility): send sampling on the managed-OpenAI live path

### DIFF
--- a/src/app/providers/openai_live_text_provider.py
+++ b/src/app/providers/openai_live_text_provider.py
@@ -5,13 +5,7 @@ from app.contracts.providers import ProviderExecutionRequest, ProviderExecutionR
 from app.providers.base import TextGenerationProviderAdapter
 from app.providers.openai_compatible_text_transport import (
     OPENAI_MANAGED_TEXT_DESCRIPTOR,
-    as_str as _as_str,
-    build_structured_output as _build_structured_output,
-    build_user_message as _build_user_message,
-    extract_output_text as _extract_output_text,
-    extract_retry_count as _extract_retry_count,
-    extract_usage as _extract_usage,
-    post_openai_compatible_response as _post_openai_response_transport,
+    execute_openai_compatible_text_request,
 )
 
 
@@ -19,78 +13,10 @@ class OpenAILiveTextProvider(TextGenerationProviderAdapter):
     descriptor = OPENAI_MANAGED_TEXT_DESCRIPTOR
 
     def execute(self, request: ProviderExecutionRequest) -> ProviderExecutionResponse:
-        payload: dict[str, object] = {
-            "model": settings.live_text_model_id,
-            "input": [
-                {
-                    "role": "system",
-                    "content": [
-                        {
-                            "type": "input_text",
-                            "text": (
-                                f"{request.system_instructions}\n\n"
-                                f"Output contract notes:\n{request.output_contract_notes}"
-                            ),
-                        }
-                    ],
-                },
-                {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": _build_user_message(request)}],
-                },
-            ],
-            "max_output_tokens": request.max_output_tokens,
-        }
-        response_payload = _post_openai_response(
-            api_base=settings.live_text_api_base,
-            api_key=settings.live_text_provider_api_key,
-            payload=payload,
-            timeout_seconds=max(request.timeout_ms / 1000.0, 1.0),
-            retry_limit=request.retry_limit,
-        )
-        output_message = _extract_output_text(response_payload)
-        message, structured_output = _build_structured_output(
+        return execute_openai_compatible_text_request(
             descriptor=self.descriptor,
             request=request,
-            response_payload=response_payload,
-            output_message=output_message,
+            api_base=settings.live_text_api_base,
+            api_key=settings.live_text_provider_api_key,
+            require_api_key=True,
         )
-        input_tokens, output_tokens, total_tokens = _extract_usage(response_payload)
-        return ProviderExecutionResponse(
-            provider_id=self.descriptor.provider_id,
-            provider_mode=self.descriptor.runtime_mode.value,
-            adapter_kind=self.descriptor.adapter_kind,
-            failure_category=None,
-            timeout_ms=request.timeout_ms,
-            retry_count=_extract_retry_count(response_payload),
-            max_output_tokens=request.max_output_tokens,
-            model_id=_as_str(response_payload.get("model")) or settings.live_text_model_id,
-            model_version=settings.live_text_model_version,
-            provider_request_id=_as_str(response_payload.get("id")),
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            total_tokens=total_tokens,
-            estimated_cost_usd=structured_output.get("estimated_cost_usd"),
-            stubbed=False,
-            message=message,
-            structured_output=structured_output,
-        )
-
-
-def _post_openai_response(
-    *,
-    api_base: str,
-    api_key: str | None,
-    payload: dict[str, object],
-    timeout_seconds: float,
-    retry_limit: int = 0,
-) -> dict[str, object]:
-    return _post_openai_response_transport(
-        api_base=api_base,
-        api_key=api_key,
-        payload=payload,
-        timeout_seconds=timeout_seconds,
-        provider_display_name="OpenAI provider",
-        require_api_key=True,
-        retry_limit=retry_limit,
-    )

--- a/tests/integration/test_task_api_contract.py
+++ b/tests/integration/test_task_api_contract.py
@@ -764,7 +764,7 @@ def test_task_execute_contract_blocks_live_provider_for_caller_without_live_perm
     settings.live_text_input_cost_per_1k_tokens = 0.01
     settings.live_text_output_cost_per_1k_tokens = 0.03
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_live_unauthorized",
             "model": "gpt-5.4",
@@ -811,7 +811,7 @@ def test_task_execute_contract_allows_lotus_gateway_live_advisor_brief(
     settings.live_text_input_cost_per_1k_tokens = 0.01
     settings.live_text_output_cost_per_1k_tokens = 0.03
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_gateway_advisor_brief",
             "model": "gpt-5.4",

--- a/tests/unit/test_openai_live_text_provider.py
+++ b/tests/unit/test_openai_live_text_provider.py
@@ -15,11 +15,31 @@ from app.providers.openai_compatible_text_transport import (
     extract_output_text,
     extract_usage,
     parse_json_object,
+    post_openai_compatible_response,
     strip_json_code_fence,
 )
 from app.providers.local_openai_compatible_text_provider import LocalOpenAICompatibleTextProvider
-from app.providers.openai_live_text_provider import OpenAILiveTextProvider, _post_openai_response
+from app.providers.openai_live_text_provider import OpenAILiveTextProvider
 from tests.unit.test_provider_gateway import _request
+
+
+def _post_openai_response(
+    *,
+    api_base: str,
+    api_key: str | None,
+    payload: dict[str, object],
+    timeout_seconds: float,
+    retry_limit: int = 0,
+) -> dict[str, Any]:
+    return post_openai_compatible_response(
+        api_base=api_base,
+        api_key=api_key,
+        payload=payload,
+        timeout_seconds=timeout_seconds,
+        provider_display_name="OpenAI Managed Text Provider",
+        require_api_key=True,
+        retry_limit=retry_limit,
+    )
 
 
 class _OpenAICompatibleResponse:
@@ -43,7 +63,7 @@ def test_openai_live_text_provider_returns_usage_and_cost(monkeypatch: MonkeyPat
     settings.live_text_output_cost_per_1k_tokens = 0.03
 
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_123",
             "model": "gpt-5.4",
@@ -75,7 +95,7 @@ def test_openai_live_text_provider_parses_advisor_brief_structured_output(
     settings.live_text_output_cost_per_1k_tokens = 0.03
 
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_advisor_123",
             "model": "gpt-5.4",
@@ -133,7 +153,7 @@ def test_openai_live_text_provider_parses_fenced_advisor_brief_json(
 ) -> None:
     settings.live_text_model_id = "gpt-5.4"
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_advisor_fenced",
             "model": "gpt-5.4",
@@ -177,7 +197,7 @@ def test_openai_live_text_provider_parses_advisor_json_with_trailing_text(
 ) -> None:
     settings.live_text_model_id = "gpt-5.4"
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_advisor_trailing_text",
             "model": "gpt-5.4",
@@ -216,7 +236,7 @@ def test_openai_live_text_provider_extracts_summary_from_truncated_advisor_json(
 ) -> None:
     settings.live_text_model_id = "gpt-5.4"
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_advisor_truncated",
             "model": "gpt-5.4",
@@ -296,7 +316,7 @@ def test_openai_live_text_provider_falls_back_when_advisor_summary_leaks_contrac
 ) -> None:
     settings.live_text_model_id = "gpt-5.4"
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_advisor_bad_summary",
             "model": "gpt-5.4",
@@ -388,7 +408,7 @@ def test_openai_live_text_provider_maps_rate_limit_errors(monkeypatch: MonkeyPat
         )
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_RATE_LIMITED
-        assert exc.message == "OpenAI provider rate limit exceeded."
+        assert exc.message == "OpenAI Managed Text Provider rate limit exceeded."
         assert "Rate limit hit" not in exc.message
     else:
         raise AssertionError("Expected ProviderExecutionError for rate-limited provider response")
@@ -415,7 +435,10 @@ def test_openai_live_text_provider_maps_upstream_http_errors(monkeypatch: Monkey
         )
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR
-        assert exc.message == "OpenAI provider request failed at the upstream provider boundary."
+        assert (
+            exc.message
+            == "OpenAI Managed Text Provider request failed at the upstream provider boundary."
+        )
         assert "Transient upstream failure" not in exc.message
     else:
         raise AssertionError("Expected ProviderExecutionError for upstream provider response")
@@ -437,7 +460,7 @@ def test_openai_live_text_provider_maps_timeout_errors(monkeypatch: MonkeyPatch)
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_TIMEOUT
         assert exc.message == (
-            "OpenAI provider request did not complete within the configured timeout."
+            "OpenAI Managed Text Provider request did not complete within the configured timeout."
         )
     else:
         raise AssertionError("Expected ProviderExecutionError for provider timeout")
@@ -459,7 +482,7 @@ def test_openai_live_text_provider_maps_url_errors(monkeypatch: MonkeyPatch) -> 
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_TIMEOUT
         assert exc.message == (
-            "OpenAI provider request did not complete within the configured timeout."
+            "OpenAI Managed Text Provider request did not complete within the configured timeout."
         )
         assert "connection refused" not in exc.message
     else:
@@ -483,9 +506,8 @@ def test_openai_live_text_provider_posts_successfully_through_urlopen(
         timeout_seconds=4.0,
     )
 
-    payload_dict = cast(dict[str, Any], payload)
-    assert payload_dict["id"] == "resp_ok"
-    assert payload_dict["_lotus_retry_count"] == 0
+    assert payload["id"] == "resp_ok"
+    assert payload["_lotus_retry_count"] == 0
 
 
 def test_openai_live_text_provider_retries_managed_transient_failure_then_success(
@@ -568,7 +590,7 @@ def test_openai_compatible_transport_preserves_category_when_retries_exhaust(
     except ProviderExecutionError as exc:
         assert attempts["count"] == 3
         assert exc.category == ProviderFailureCategory.PROVIDER_RATE_LIMITED
-        assert exc.message == "OpenAI provider rate limit exceeded."
+        assert exc.message == "OpenAI Managed Text Provider rate limit exceeded."
         assert "raw account detail" not in exc.message
     else:
         raise AssertionError("Expected ProviderExecutionError after exhausted retries")
@@ -647,7 +669,10 @@ def test_openai_live_text_provider_handles_non_json_error_bodies(monkeypatch: Mo
         )
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR
-        assert exc.message == "OpenAI provider request failed at the upstream provider boundary."
+        assert (
+            exc.message
+            == "OpenAI Managed Text Provider request failed at the upstream provider boundary."
+        )
     else:
         raise AssertionError("Expected ProviderExecutionError for invalid JSON error body")
 

--- a/tests/unit/test_reproducibility_identity.py
+++ b/tests/unit/test_reproducibility_identity.py
@@ -162,6 +162,25 @@ def test_transport_sends_explicit_default_sampling(monkeypatch: MonkeyPatch) -> 
     assert "seed" not in captured
 
 
+def test_openai_live_provider_sends_explicit_sampling(monkeypatch: MonkeyPatch) -> None:
+    from app.providers.openai_live_text_provider import OpenAILiveTextProvider
+
+    captured = _capture_transport_payload(monkeypatch)
+
+    with override_runtime_settings(
+        live_text_provider_api_key="test-key", live_text_model_id="gpt-5.4"
+    ):
+        response = OpenAILiveTextProvider().execute(_provider_request())
+
+    # The managed-OpenAI path shares the payload builder with the local
+    # path, so recorded sampling is truthful for both live providers.
+    assert response.message == "OK"
+    assert captured["model"] == "gpt-5.4"
+    assert captured["temperature"] == 0.0
+    assert "top_p" not in captured
+    assert "seed" not in captured
+
+
 def test_transport_sends_configured_sampling_parameters(monkeypatch: MonkeyPatch) -> None:
     captured = _capture_transport_payload(monkeypatch)
 

--- a/tests/unit/test_task_executor.py
+++ b/tests/unit/test_task_executor.py
@@ -644,7 +644,7 @@ def test_execute_task_routes_allowlisted_task_through_live_provider(
     settings.live_text_output_cost_per_1k_tokens = 0.03
 
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_live_001",
             "model": "gpt-5.4",
@@ -753,7 +753,7 @@ def test_execute_task_blocks_live_provider_for_caller_without_live_permission(
     settings.live_text_input_cost_per_1k_tokens = 0.01
     settings.live_text_output_cost_per_1k_tokens = 0.03
     monkeypatch.setattr(
-        "app.providers.openai_live_text_provider._post_openai_response",
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
         lambda **_: {
             "id": "resp_live_unauthorized",
             "model": "gpt-5.4",


### PR DESCRIPTION
Follow-up to #151 (residual recorded in the closure audit there).

## Defect

`OpenAILiveTextProvider.execute` built its own request payload **without** the sampling fields, so the managed-OpenAI live path never sent the explicit `temperature` that #151's audit records now claim was sent — only the local-compatible path (which uses the shared transport builder) was truthful. The two payload builders were duplicates of the same Responses-API shape.

## Fix

The provider now delegates to the shared `execute_openai_compatible_text_request` with `require_api_key=True` — one payload builder for both live text paths, explicit sampling included. Net **−30 lines** (~60 duplicated lines deleted).

Behavior notes:
- Cost estimation unchanged: both paths already resolved through `estimate_live_text_cost_usd`.
- Provider-boundary error messages now carry the descriptor display name (`OpenAI Managed Text Provider`) instead of the hand-written `OpenAI provider` — the descriptor is the naming authority; messages stay bounded (no upstream detail leak, unchanged assertions).
- The module-private `_post_openai_response` seam is deleted; tests that monkeypatched it now patch the single real transport seam (`post_openai_compatible_response`), the same seam the eval-hermeticity work on #148 will formalize.

## Verification

- New parity test proves the managed path sends `model` + explicit `temperature` and omits unset `top_p`/`seed` (`tests/unit/test_reproducibility_identity.py`).
- 65 tests across the provider/executor/reproducibility files pass; provider-gateway, structured-logging, local-provider, eval-runtime suites pass; `make eval-run-gate`, `make lint`, `make typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)