### PR TITLE
refactor(evals): hermetic case execution without test tooling in src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint monetary-float-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply runtime-mode-smoke test test-unit test-integration test-e2e test-coverage coverage-gate security-audit check ci docker-build clean
+.PHONY: install lint monetary-float-guard runtime-purity-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply runtime-mode-smoke test test-unit test-integration test-e2e test-coverage coverage-gate security-audit check ci docker-build clean
 
 install:
 	python -m pip install --upgrade pip
@@ -7,9 +7,13 @@ install:
 lint:
 	python -m ruff check .
 	python -m ruff format --check .
+	python scripts/check_runtime_purity.py
 
 monetary-float-guard:
 	python scripts/check_monetary_float_usage.py
+
+runtime-purity-guard:
+	python scripts/check_runtime_purity.py
 
 verify-dependencies:
 	python scripts/dependency_health_check.py --skip-audit

--- a/scripts/check_runtime_purity.py
+++ b/scripts/check_runtime_purity.py
@@ -1,0 +1,69 @@
+"""Production-source purity guard (issue #148).
+
+Fails when production code under src/ imports test tooling (unittest, mock,
+pytest) or references pytest's monkeypatch, and when a string literal that
+is not a self-describing credential reference is assigned to an api-key
+attribute. Production code must never depend on test-harness mechanics, and
+credentials must come from configuration or fixtures, never from literals.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+FORBIDDEN_IMPORT_ROOTS = {"unittest", "mock", "pytest"}
+ALLOWED_API_KEY_LITERAL_PREFIXES = ("credential-ref:",)
+
+
+def _is_api_key_target(target: ast.expr) -> bool:
+    if isinstance(target, ast.Name):
+        return target.id.endswith("api_key")
+    if isinstance(target, ast.Attribute):
+        return target.attr.endswith("api_key")
+    return False
+
+
+def _violations_for_file(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] in FORBIDDEN_IMPORT_ROOTS:
+                    violations.append(f"{path}:{node.lineno}: test-tooling import '{alias.name}'")
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and (node.module or "").split(".")[0] in FORBIDDEN_IMPORT_ROOTS:
+                violations.append(f"{path}:{node.lineno}: test-tooling import 'from {node.module}'")
+        elif isinstance(node, ast.Name) and node.id == "monkeypatch":
+            violations.append(f"{path}:{node.lineno}: test-tooling reference 'monkeypatch'")
+        elif isinstance(node, ast.arg) and node.arg == "monkeypatch":
+            violations.append(f"{path}:{node.lineno}: test-tooling reference 'monkeypatch'")
+        elif isinstance(node, ast.Assign) or isinstance(node, ast.AnnAssign):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            value = node.value
+            if (
+                isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+                and value.value
+                and not value.value.startswith(ALLOWED_API_KEY_LITERAL_PREFIXES)
+                and any(_is_api_key_target(target) for target in targets)
+            ):
+                violations.append(f"{path}:{node.lineno}: secret-shaped api-key literal assignment")
+    return violations
+
+
+def main(root: str = "src") -> int:
+    violations: list[str] = []
+    for path in sorted(Path(root).rglob("*.py")):
+        violations.extend(_violations_for_file(path))
+    if violations:
+        print("\n".join(violations))
+        return 1
+    print("Runtime purity guard passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "src"))

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -16,6 +16,10 @@ from app.contracts.providers import (
     ProviderFailureCategory,
 )
 from app.providers.base import ProviderAdapterDescriptor, ProviderExecutionError
+from app.services.provider_execution_overrides import (
+    ensure_network_execution_permitted,
+    get_text_transport_post_override,
+)
 from app.services.provider_metrics import record_provider_attempt
 from app.services.structured_logging import correlation_id_var, log_event
 from app.providers.advisor_brief_quality_guardrails import (
@@ -133,11 +137,25 @@ def post_openai_compatible_response(
     require_api_key: bool,
     retry_limit: int = 0,
 ) -> dict[str, Any]:
+    override = get_text_transport_post_override()
+    if override is not None:
+        return override(
+            api_base=api_base,
+            api_key=api_key,
+            payload=payload,
+            timeout_seconds=timeout_seconds,
+            provider_display_name=provider_display_name,
+            require_api_key=require_api_key,
+            retry_limit=retry_limit,
+        )
     if require_api_key and api_key is None:
         raise ProviderExecutionError(
             category=ProviderFailureCategory.INVALID_LIVE_CONFIGURATION,
             message=f"Live provider credentials are not configured for {provider_display_name}.",
         )
+    ensure_network_execution_permitted(
+        seam="openai_compatible_text_transport.post_openai_compatible_response"
+    )
     endpoint = api_base.rstrip("/") + "/responses"
     body = json.dumps(payload).encode("utf-8")
     headers = {"Content-Type": "application/json"}

--- a/src/app/providers/openai_live_embedding_provider.py
+++ b/src/app/providers/openai_live_embedding_provider.py
@@ -14,6 +14,7 @@ from app.contracts.providers import (
     ProviderFailureCategory,
 )
 from app.providers.base import ProviderAdapterDescriptor, ProviderExecutionError
+from app.services.provider_execution_overrides import ensure_network_execution_permitted
 from app.providers.openai_compatible_text_transport import (
     failure_category_for_http_status,
     safe_provider_error_message,
@@ -74,6 +75,7 @@ def _post_openai_embedding(
             category=ProviderFailureCategory.INVALID_LIVE_CONFIGURATION,
             message="Live embedding provider credentials are not configured for OpenAI execution.",
         )
+    ensure_network_execution_permitted(seam="openai_live_embedding_provider._post_openai_embedding")
     endpoint = api_base.rstrip("/") + "/embeddings"
     body = json.dumps(payload).encode("utf-8")
     request = urllib_request.Request(

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -45,9 +45,17 @@ from app.services.artifact_payloads import persist_json_artifact
 from app.services.embedding_live_execution_state import build_embedding_live_execution_state
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 from app.services.prompt_rollout_models import PromptRolloutEventRecord, PromptRolloutStateRecord
+from app.services.local_openai_compatible_endpoint_probe import (
+    LocalOpenAICompatibleEndpointStatus,
+)
 from app.services.prompt_store import get_prompt_repository
 from app.services.prompt_store import reset_prompt_store_cache
 from app.services.provider_budget_policy import build_provider_budget_policy
+from app.services.provider_execution_overrides import (
+    hermetic_provider_execution,
+    override_local_probe_status,
+    override_text_transport_post,
+)
 from app.services.provider_catalog import build_provider_catalog
 from app.services.provider_configuration_status import build_embedding_configuration_status
 from app.services.provider_degradation_state import (
@@ -946,6 +954,13 @@ def _default_eval_tenant_id(*, caller_app: str, case_tenant_id: object | None) -
     return None
 
 
+# A self-describing non-credential reference (issue #148): it satisfies the
+# key-presence validation for hermetic openai-mode cases, and because every
+# case runs under hermetic_provider_execution() it can never reach a real
+# network call. It is not a secret and must never be shaped like one.
+EVAL_HERMETIC_CREDENTIAL_REF = "credential-ref:eval-hermetic"
+
+
 @contextmanager
 def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None]:
     original_values = {
@@ -978,6 +993,9 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
     }
     try:
         with ExitStack() as stack:
+            # Every case runs hermetically: the live network seams fail
+            # closed unless the case installs an explicit override below.
+            stack.enter_context(hermetic_provider_execution())
             reset_prompt_store_cache()
             reset_retrieval_repository()
             reset_provider_operations_store_cache()
@@ -1047,7 +1065,7 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                     settings.provider_rollout_state = "CANARY_ENABLED"
                 settings.live_text_provider_id = "text.openai"
                 settings.live_text_model_id = "gpt-5.4"
-                settings.live_text_provider_api_key = "eval-secret"
+                settings.live_text_provider_api_key = EVAL_HERMETIC_CREDENTIAL_REF
                 settings.live_text_allowed_task_ids = str(input_payload.get("task_id", ""))
             if settings.provider_mode == "local_openai_compatible":
                 if "rollout_state" not in input_payload:
@@ -1068,30 +1086,25 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                 local_probe_status = input_payload.get("local_probe_status")
                 if isinstance(local_probe_status, dict):
                     stack.enter_context(
-                        _patch_target(
-                            "app.services.provider_live_execution_state.build_local_openai_compatible_endpoint_status",
-                            lambda: type(
-                                "ProbeStatus",
-                                (),
-                                {
-                                    "endpoint_reachable": bool(
-                                        local_probe_status.get("endpoint_reachable", False)
-                                    ),
-                                    "model_available": bool(
-                                        local_probe_status.get("model_available", False)
-                                    ),
-                                    "blocking_reason": local_probe_status.get("blocking_reason"),
-                                },
-                            )(),
+                        override_local_probe_status(
+                            LocalOpenAICompatibleEndpointStatus(
+                                endpoint_reachable=bool(
+                                    local_probe_status.get("endpoint_reachable", False)
+                                ),
+                                model_available=bool(
+                                    local_probe_status.get("model_available", False)
+                                ),
+                                configured_model_id=settings.live_text_model_id,
+                                blocking_reason=cast(
+                                    str | None, local_probe_status.get("blocking_reason")
+                                ),
+                            )
                         )
                     )
                 local_provider_response = input_payload.get("local_provider_response")
                 if isinstance(local_provider_response, dict):
                     stack.enter_context(
-                        _patch_target(
-                            "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
-                            lambda **_: local_provider_response,
-                        )
+                        override_text_transport_post(lambda **_: local_provider_response)
                     )
                 local_provider_error = input_payload.get("local_provider_error")
                 if isinstance(local_provider_error, dict):
@@ -1099,12 +1112,11 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                         str(local_provider_error["failure_category"])
                     )
                     stack.enter_context(
-                        _patch_target(
-                            "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
+                        override_text_transport_post(
                             lambda **_: _raise_provider_execution_error(
                                 category=failure_category,
                                 message=str(local_provider_error["message"]),
-                            ),
+                            )
                         )
                     )
             if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
@@ -1192,14 +1204,6 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
         reset_provider_operations_store_cache()
         reset_provider_quota_counters()
         reset_provider_degradation_state()
-
-
-@contextmanager
-def _patch_target(target: str, replacement: object) -> Iterator[None]:
-    from unittest.mock import patch
-
-    with patch(target, replacement):
-        yield
 
 
 def _raise_provider_execution_error(*, category: ProviderFailureCategory, message: str) -> Any:

--- a/src/app/services/local_openai_compatible_endpoint_probe.py
+++ b/src/app/services/local_openai_compatible_endpoint_probe.py
@@ -7,6 +7,10 @@ from typing import Any, cast
 from urllib import error, request as urllib_request
 
 from app.config import settings
+from app.services.provider_execution_overrides import (
+    ensure_network_execution_permitted,
+    get_local_probe_status_override,
+)
 
 
 @dataclass(frozen=True)
@@ -33,6 +37,12 @@ def reset_local_openai_compatible_endpoint_probe_cache() -> None:
 
 
 def build_local_openai_compatible_endpoint_status() -> LocalOpenAICompatibleEndpointStatus:
+    probe_override = get_local_probe_status_override()
+    if probe_override is not None:
+        return probe_override
+    ensure_network_execution_permitted(
+        seam="local_openai_compatible_endpoint_probe.build_local_openai_compatible_endpoint_status"
+    )
     api_base = settings.live_text_api_base.strip().rstrip("/")
     configured_model_id = settings.live_text_model_id
     api_key = settings.live_text_provider_api_key

--- a/src/app/services/provider_execution_overrides.py
+++ b/src/app/services/provider_execution_overrides.py
@@ -1,0 +1,98 @@
+"""Execution-scoped provider overrides (issue #148).
+
+The evaluation runtime executes governed cases against the production task
+pipeline. Provider behaviour for a case - a fake transport response, a
+simulated provider failure, a probe posture - is injected here through
+contextvars, so an override is visible only to the execution that installed
+it: concurrent requests in the same process never observe another
+execution's override. This replaces module-global patching, which
+reconfigured the entire process for the lifetime of a case.
+
+Hermetic execution: the evaluation runtime wraps every case in
+``hermetic_provider_execution()``. Under that context the live network
+seams refuse to perform real I/O unless an explicit override is installed,
+so an evaluation case can never reach a real provider endpoint, whatever
+its configuration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Type-only: the probe module imports the hermetic guard from here at
+    # runtime, so a runtime import back into the probe would be circular.
+    from app.services.local_openai_compatible_endpoint_probe import (
+        LocalOpenAICompatibleEndpointStatus,
+    )
+
+TransportPostOverride = Callable[..., dict[str, Any]]
+
+_text_transport_post_override: ContextVar[TransportPostOverride | None] = ContextVar(
+    "lotus_ai_text_transport_post_override", default=None
+)
+_local_probe_status_override: ContextVar[LocalOpenAICompatibleEndpointStatus | None] = ContextVar(
+    "lotus_ai_local_probe_status_override", default=None
+)
+_hermetic_provider_execution: ContextVar[bool] = ContextVar(
+    "lotus_ai_hermetic_provider_execution", default=False
+)
+
+
+@contextmanager
+def override_text_transport_post(replacement: TransportPostOverride) -> Iterator[None]:
+    token = _text_transport_post_override.set(replacement)
+    try:
+        yield
+    finally:
+        _text_transport_post_override.reset(token)
+
+
+def get_text_transport_post_override() -> TransportPostOverride | None:
+    return _text_transport_post_override.get()
+
+
+@contextmanager
+def override_local_probe_status(status: LocalOpenAICompatibleEndpointStatus) -> Iterator[None]:
+    token = _local_probe_status_override.set(status)
+    try:
+        yield
+    finally:
+        _local_probe_status_override.reset(token)
+
+
+def get_local_probe_status_override() -> LocalOpenAICompatibleEndpointStatus | None:
+    return _local_probe_status_override.get()
+
+
+@contextmanager
+def hermetic_provider_execution() -> Iterator[None]:
+    token = _hermetic_provider_execution.set(True)
+    try:
+        yield
+    finally:
+        _hermetic_provider_execution.reset(token)
+
+
+def is_hermetic_provider_execution() -> bool:
+    return _hermetic_provider_execution.get()
+
+
+def ensure_network_execution_permitted(*, seam: str) -> None:
+    """Fail closed when a hermetic execution reaches a live network seam.
+
+    Raising (rather than returning a synthetic failure) is deliberate: a
+    hermetic case that reaches a network seam without an injected response
+    is a defect in the case or the runtime, not a provider condition, and
+    must surface as an error rather than as fabricated provider telemetry.
+    """
+
+    if _hermetic_provider_execution.get():
+        raise RuntimeError(
+            f"Hermetic evaluation execution reached the live network seam '{seam}' "
+            "without an injected response; evaluation cases must never perform "
+            "real provider I/O."
+        )

--- a/tests/unit/test_check_runtime_purity.py
+++ b/tests/unit/test_check_runtime_purity.py
@@ -1,0 +1,54 @@
+"""Runtime purity guard behaviour (issue #148)."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_guard() -> ModuleType:
+    script_path = Path("scripts") / "check_runtime_purity.py"
+    spec = importlib.util.spec_from_file_location("check_runtime_purity", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runtime_purity_guard_passes_on_current_src() -> None:
+    guard = _load_guard()
+    assert guard.main("src") == 0
+
+
+def test_runtime_purity_guard_flags_test_tooling_and_secret_literals(tmp_path: Path) -> None:
+    guard = _load_guard()
+    (tmp_path / "violations.py").write_text(
+        "import unittest\n"
+        "from unittest.mock import patch\n"
+        "import mock\n"
+        "def use(monkeypatch):\n"
+        "    monkeypatch.setattr('a', 'b')\n"
+        "live_text_provider_api_key = 'sk-secret'\n"
+        "settings_api_key: str = 'raw-secret'\n",
+        encoding="utf-8",
+    )
+
+    violations = guard._violations_for_file(tmp_path / "violations.py")
+
+    assert len(violations) == 7
+    assert sum("test-tooling import" in item for item in violations) == 3
+    assert sum("'monkeypatch'" in item for item in violations) == 2
+    assert sum("secret-shaped api-key literal" in item for item in violations) == 2
+    assert guard.main(str(tmp_path)) == 1
+
+
+def test_runtime_purity_guard_allows_credential_references(tmp_path: Path) -> None:
+    guard = _load_guard()
+    (tmp_path / "clean.py").write_text(
+        "from contextlib import contextmanager\n"
+        "live_text_provider_api_key = 'credential-ref:eval-hermetic'\n"
+        "provider_api_key = None\n",
+        encoding="utf-8",
+    )
+
+    assert guard._violations_for_file(tmp_path / "clean.py") == []
+    assert guard.main(str(tmp_path)) == 0

--- a/tests/unit/test_provider_execution_overrides.py
+++ b/tests/unit/test_provider_execution_overrides.py
@@ -1,0 +1,102 @@
+"""Execution-scoped provider overrides and hermetic enforcement (issue #148)."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+from pytest import raises
+
+from app.providers.openai_compatible_text_transport import post_openai_compatible_response
+from app.providers.openai_live_embedding_provider import _post_openai_embedding
+from app.services.local_openai_compatible_endpoint_probe import (
+    LocalOpenAICompatibleEndpointStatus,
+    build_local_openai_compatible_endpoint_status,
+    reset_local_openai_compatible_endpoint_probe_cache,
+)
+from app.services.provider_execution_overrides import (
+    get_local_probe_status_override,
+    get_text_transport_post_override,
+    hermetic_provider_execution,
+    is_hermetic_provider_execution,
+    override_local_probe_status,
+    override_text_transport_post,
+)
+
+
+def _probe_status(*, reachable: bool = True) -> LocalOpenAICompatibleEndpointStatus:
+    return LocalOpenAICompatibleEndpointStatus(
+        endpoint_reachable=reachable,
+        model_available=reachable,
+        configured_model_id="qwen3:8b",
+        blocking_reason=None if reachable else "Endpoint is not reachable.",
+    )
+
+
+def test_transport_override_applies_only_inside_the_installing_execution() -> None:
+    fake_payload = {"id": "resp_override", "output_text": "OK"}
+
+    with override_text_transport_post(lambda **_: fake_payload):
+        assert get_text_transport_post_override() is not None
+        # The override is contextvar-scoped: another thread (a concurrent
+        # production request) must not observe it. This is the regression
+        # test for the process-wide bleed that unittest.mock.patch caused.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            assert executor.submit(get_text_transport_post_override).result() is None
+
+        response = post_openai_compatible_response(
+            api_base="https://api.openai.com/v1",
+            api_key=None,
+            payload={"model": "gpt-5.4"},
+            timeout_seconds=1.0,
+            provider_display_name="OpenAI Managed Text Provider",
+            require_api_key=True,
+            retry_limit=0,
+        )
+        assert response == fake_payload
+
+    assert get_text_transport_post_override() is None
+
+
+def test_hermetic_execution_blocks_text_transport_without_override() -> None:
+    assert is_hermetic_provider_execution() is False
+    with hermetic_provider_execution():
+        assert is_hermetic_provider_execution() is True
+        with raises(RuntimeError) as exc_info:
+            post_openai_compatible_response(
+                api_base="https://api.openai.com/v1",
+                api_key="credential-ref:test",
+                payload={"model": "gpt-5.4"},
+                timeout_seconds=1.0,
+                provider_display_name="OpenAI Managed Text Provider",
+                require_api_key=True,
+                retry_limit=0,
+            )
+        assert "post_openai_compatible_response" in str(exc_info.value)
+        assert "never perform real provider I/O" in str(exc_info.value)
+    assert is_hermetic_provider_execution() is False
+
+
+def test_hermetic_execution_blocks_embedding_post() -> None:
+    with hermetic_provider_execution():
+        with raises(RuntimeError) as exc_info:
+            _post_openai_embedding(
+                api_base="https://api.openai.com/v1",
+                api_key="credential-ref:test",
+                payload={"model": "text-embedding-3-large", "input": ["text"]},
+            )
+    assert "_post_openai_embedding" in str(exc_info.value)
+
+
+def test_hermetic_execution_blocks_local_probe_without_override() -> None:
+    reset_local_openai_compatible_endpoint_probe_cache()
+    with hermetic_provider_execution():
+        with raises(RuntimeError) as exc_info:
+            build_local_openai_compatible_endpoint_status()
+    assert "build_local_openai_compatible_endpoint_status" in str(exc_info.value)
+
+
+def test_probe_override_supplies_status_without_network() -> None:
+    reset_local_openai_compatible_endpoint_probe_cache()
+    status = _probe_status(reachable=True)
+    with hermetic_provider_execution():
+        with override_local_probe_status(status):
+            assert build_local_openai_compatible_endpoint_status() is status
+    assert get_local_probe_status_override() is None

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -37,6 +37,14 @@ The baseline rules are:
 5. full correlation and audit metadata for every AI execution.
 6. provider retention/deletion outcomes are recorded only by AI provider operations and signed for
    bounded consumers; domain consumers cannot self-assert provider deletion.
+7. evaluation cases execute hermetically: every case runs under
+   `hermetic_provider_execution()`, so the live network seams (text transport,
+   embedding transport, local endpoint probe) fail closed unless the case
+   installs an explicit execution-scoped override. An eval case can never
+   reach a real provider endpoint, and its overrides are contextvar-scoped so
+   concurrent production requests never observe them. Production source is
+   guarded against test tooling and secret-shaped api-key literals by the
+   runtime-purity guard in `make lint`.
 
 Provider retention confirmation for Idea explanation runs is currently `not_certified`. The
 implementation binds provider/model/tenant identity to the durable workflow run, signs source-safe

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -49,7 +49,9 @@ relying on the lanes to repeat it.
 
 `make check` is the fast local gate. It currently covers:
 
-1. lint,
+1. lint (ruff check, ruff format, and the runtime-purity guard —
+   `scripts/check_runtime_purity.py` fails when production code under `src/`
+   imports test tooling or assigns a secret-shaped api-key literal),
 2. typecheck,
 3. OpenAPI quality,
 4. evaluation manifest validation,


### PR DESCRIPTION
Part of #148 — S1 of the [execution plan posted on the issue](https://github.com/sgajbi/lotus-ai/issues/148#issuecomment-5467533822).

## What this does

1. **Contextvar-scoped overrides replace `unittest.mock.patch`.** New `provider_execution_overrides` service: the eval runtime injects a case's provider behaviour (fake text-transport response, simulated failure, local-probe posture) through execution-scoped contextvars. An override is visible only to the execution that installed it — a concurrent production request can never observe an eval case's transport override. That cross-request bleed was the core hazard: mock.patch swapped module globals for the whole process. Regression-tested with a second thread.
2. **Hermetic case execution.** Every eval case now runs under `hermetic_provider_execution()`: the three live network seams (compatible text transport — which the managed-OpenAI path also uses after #198; the OpenAI embedding post; the local endpoint probe) fail closed with a `RuntimeError` naming the seam unless the case installed an explicit override. Evidence in the plan comment: every openai-mode fixture case expects a structured rejection or posture check, so this is behaviour-preserving for passing cases and strictly safer for misconfigured ones — previously a misconfigured case would really POST to `api.openai.com` with the fake key.
3. **`eval-secret` deleted.** Replaced by `EVAL_HERMETIC_CREDENTIAL_REF = "credential-ref:eval-hermetic"` — a self-describing non-credential reference that satisfies key-presence validation and can never be sent anywhere (hermetic enforcement). Raising (not synthesizing provider telemetry) on a hermeticity violation is deliberate: that state is a defect in the case or runtime, not a provider condition.
4. **Runtime-purity guard.** `scripts/check_runtime_purity.py` (AST-based) fails on `unittest`/`mock`/`pytest` imports, `monkeypatch` references (names and parameters), and secret-shaped `*api_key = "..."` literal assignments under `src/` (a `credential-ref:` prefix is the one allowed form). Wired into `make lint`, which both CI lanes already run — per the issue's AC. `src/` passes today: the only `unittest.mock` usage is gone with this PR.

Settings-group mutations in `_apply_case_configuration` remain — they are S2–S4 of the plan (per-request execution config threading). This slice removes the test tooling, the secret literal, and the network exposure.

## Verification

- New `tests/unit/test_provider_execution_overrides.py`: thread-isolation regression test, hermetic fail-closed at all three seams (with seam-named errors), override pass-through, contextvar cleanup.
- New `tests/unit/test_check_runtime_purity.py`: guard passes on current src; flags 7 violations across imports/monkeypatch/api-key literals in a fixture file; allows credential-ref literals.
- Full suite **1953 passed**; combined coverage 99% (20829 statements, 287 missed — margin unchanged). `make lint` (now including the guard), `make typecheck`, `make eval-run-gate`, integration eval contract suite all green.
- Docs: Validation-and-CI (lint now includes the guard), Security-and-Governance (hermetic eval execution as core rule 7).

Related finding filed while wiring the guard: #199 (monetary-float-guard is a dead gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)