### PR TITLE
refactor(providers): enforcement thresholds on the execution config

### DIFF
--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -968,15 +968,6 @@ EVAL_HERMETIC_CREDENTIAL_REF = "credential-ref:eval-hermetic"
 @contextmanager
 def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None]:
     original_values = {
-        "live_text_quota_enforced": settings.live_text_quota_enforced,
-        "live_text_default_quota_limit": settings.live_text_default_quota_limit,
-        "live_text_task_quota_limits": settings.live_text_task_quota_limits,
-        "live_text_budget_enforced": settings.live_text_budget_enforced,
-        "live_text_soft_budget_usd": settings.live_text_soft_budget_usd,
-        "live_text_degraded_failure_count_threshold": settings.live_text_degraded_failure_count_threshold,
-        "live_text_circuit_open_failure_count_threshold": settings.live_text_circuit_open_failure_count_threshold,
-        "live_text_circuit_open_seconds": settings.live_text_circuit_open_seconds,
-        "live_text_hard_budget_usd": settings.live_text_hard_budget_usd,
         "live_text_input_cost_per_1k_tokens": settings.live_text_input_cost_per_1k_tokens,
         "live_text_output_cost_per_1k_tokens": settings.live_text_output_cost_per_1k_tokens,
         "live_text_degradation_enforced": settings.live_text_degradation_enforced,
@@ -1090,6 +1081,72 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                     ),
                     allowed_task_ids=str(input_payload.get("task_id", "")),
                 )
+            enforcement = case_config.enforcement
+            if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
+                enforcement = replace(
+                    enforcement,
+                    quota_enforced=True,
+                    task_quota_limits=(
+                        f"{input_payload['task_id']}="
+                        f"{int(cast(int | str, input_payload['request_limit']))}"
+                    ),
+                )
+            if "hard_budget_usd" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    budget_enforced=True,
+                    hard_budget_usd=float(
+                        cast(int | float | str, input_payload["hard_budget_usd"])
+                    ),
+                    soft_budget_usd=float(
+                        cast(
+                            int | float | str,
+                            input_payload.get(
+                                "recorded_spend_usd", input_payload.get("tracked_spend_usd", 0.5)
+                            ),
+                        )
+                    ),
+                )
+            if "degraded_failure_count_threshold" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    degradation_enforced=True,
+                    degraded_failure_count_threshold=int(
+                        cast(int | str, input_payload["degraded_failure_count_threshold"])
+                    ),
+                )
+            if "circuit_open_failure_count_threshold" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    circuit_open_failure_count_threshold=int(
+                        cast(int | str, input_payload["circuit_open_failure_count_threshold"])
+                    ),
+                )
+            if "circuit_open_seconds" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    circuit_open_seconds=int(
+                        cast(int | str, input_payload["circuit_open_seconds"])
+                    ),
+                )
+                if "degraded_failure_count_threshold" not in input_payload:
+                    # A circuit-posture case without explicit thresholds trips
+                    # the breaker on the single recorded failure below.
+                    enforcement = replace(
+                        enforcement,
+                        degradation_enforced=True,
+                        degraded_failure_count_threshold=1,
+                        circuit_open_failure_count_threshold=1,
+                    )
+            elif any(
+                key in input_payload
+                for key in (
+                    "degraded_failure_count_threshold",
+                    "circuit_open_failure_count_threshold",
+                )
+            ):
+                enforcement = replace(enforcement, circuit_open_seconds=60)
+            case_config = replace(case_config, enforcement=enforcement)
             stack.enter_context(override_provider_execution_config(case_config))
             if case_mode == "local_openai_compatible":
                 local_probe_status = input_payload.get("local_probe_status")
@@ -1129,8 +1186,6 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                         )
                     )
             if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
-                settings.live_text_quota_enforced = True
-                settings.live_text_task_quota_limits = f"{input_payload['task_id']}={int(cast(int | str, input_payload['request_limit']))}"
                 get_provider_operations_store().increment_quota_state(
                     scope=ProviderQuotaScope.TASK,
                     scope_key=str(input_payload["task_id"]),
@@ -1138,18 +1193,6 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                     updated_at=_utcnow_iso(),
                 )
             if "hard_budget_usd" in input_payload:
-                settings.live_text_budget_enforced = True
-                settings.live_text_hard_budget_usd = float(
-                    cast(int | float | str, input_payload["hard_budget_usd"])
-                )
-                settings.live_text_soft_budget_usd = float(
-                    cast(
-                        int | float | str,
-                        input_payload.get(
-                            "recorded_spend_usd", input_payload.get("tracked_spend_usd", 0.5)
-                        ),
-                    )
-                )
                 settings.live_text_input_cost_per_1k_tokens = 0.01
                 settings.live_text_output_cost_per_1k_tokens = 0.03
                 tracked_spend = float(
@@ -1169,27 +1212,6 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                     if settings.provider_operations_store_mode == "sqlalchemy":
                         reset_provider_operations_store_cache()
             if "degraded_failure_count_threshold" in input_payload:
-                settings.live_text_degradation_enforced = True
-                settings.live_text_degraded_failure_count_threshold = int(
-                    cast(int | str, input_payload["degraded_failure_count_threshold"])
-                )
-            if "circuit_open_failure_count_threshold" in input_payload:
-                settings.live_text_circuit_open_failure_count_threshold = int(
-                    cast(int | str, input_payload["circuit_open_failure_count_threshold"])
-                )
-            if "circuit_open_seconds" in input_payload:
-                settings.live_text_circuit_open_seconds = int(
-                    cast(int | str, input_payload["circuit_open_seconds"])
-                )
-            elif any(
-                key in input_payload
-                for key in (
-                    "degraded_failure_count_threshold",
-                    "circuit_open_failure_count_threshold",
-                )
-            ):
-                settings.live_text_circuit_open_seconds = 60
-            if "degraded_failure_count_threshold" in input_payload:
                 failure_count = int(
                     cast(int | str, input_payload["degraded_failure_count_threshold"])
                 )
@@ -1198,9 +1220,6 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                 if settings.provider_operations_store_mode == "sqlalchemy":
                     reset_provider_operations_store_cache()
             elif "circuit_open_seconds" in input_payload:
-                settings.live_text_degradation_enforced = True
-                settings.live_text_degraded_failure_count_threshold = 1
-                settings.live_text_circuit_open_failure_count_threshold = 1
                 record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
                 if settings.provider_operations_store_mode == "sqlalchemy":
                     reset_provider_operations_store_cache()

--- a/src/app/services/provider_budget_policy.py
+++ b/src/app/services/provider_budget_policy.py
@@ -12,6 +12,7 @@ from app.contracts.providers import (
 )
 from app.providers.base import ProviderExecutionError
 from app.services.provider_operations_store import get_provider_operations_store
+from app.services.provider_execution_config import resolve_provider_execution_config
 
 _BUDGET_KEY = "live_text_generation"
 
@@ -34,7 +35,7 @@ def build_provider_budget_policy() -> ProviderBudgetPolicyResponse:
     return ProviderBudgetPolicyResponse(
         service=settings.service_name,
         version=settings.service_version,
-        provider_mode=settings.provider_mode,
+        provider_mode=resolve_provider_execution_config().provider_mode,
         budget_enforced=parsed.budget_enforced,
         configuration_valid=parsed.configuration_valid,
         budget_state=parsed.budget_state,
@@ -51,8 +52,9 @@ def parse_provider_budget_policy() -> ParsedProviderBudgetPolicy:
     findings: list[str] = []
     configuration_valid = True
     current_spend_usd = _load_current_spend_usd()
-    soft_budget_usd = settings.live_text_soft_budget_usd
-    hard_budget_usd = settings.live_text_hard_budget_usd
+    enforcement = resolve_provider_execution_config().enforcement
+    soft_budget_usd = enforcement.soft_budget_usd
+    hard_budget_usd = enforcement.hard_budget_usd
 
     if soft_budget_usd is not None and soft_budget_usd <= 0:
         configuration_valid = False
@@ -67,12 +69,12 @@ def parse_provider_budget_policy() -> ParsedProviderBudgetPolicy:
     ):
         configuration_valid = False
         findings.append("Soft provider budget must not exceed the hard provider budget.")
-    if settings.live_text_budget_enforced and hard_budget_usd is None:
+    if enforcement.budget_enforced and hard_budget_usd is None:
         configuration_valid = False
         findings.append(
             "Live-provider budget enforcement requires a configured hard budget threshold."
         )
-    if settings.live_text_budget_enforced and resolve_effective_live_text_card() is None:
+    if enforcement.budget_enforced and resolve_effective_live_text_card() is None:
         configuration_valid = False
         findings.append(
             "Live-provider budget enforcement requires an effective live-text rate card "
@@ -84,7 +86,7 @@ def parse_provider_budget_policy() -> ParsedProviderBudgetPolicy:
         remaining_budget_usd = round(max(hard_budget_usd - current_spend_usd, 0.0), 8)
 
     budget_state = _resolve_budget_state(
-        budget_enforced=settings.live_text_budget_enforced,
+        budget_enforced=enforcement.budget_enforced,
         configuration_valid=configuration_valid,
         current_spend_usd=current_spend_usd,
         soft_budget_usd=soft_budget_usd,
@@ -95,7 +97,7 @@ def parse_provider_budget_policy() -> ParsedProviderBudgetPolicy:
         findings.append("Provider budget posture is internally consistent for the current phase.")
 
     return ParsedProviderBudgetPolicy(
-        budget_enforced=settings.live_text_budget_enforced,
+        budget_enforced=enforcement.budget_enforced,
         configuration_valid=configuration_valid,
         budget_state=budget_state,
         current_spend_usd=current_spend_usd,

--- a/src/app/services/provider_degradation_state.py
+++ b/src/app/services/provider_degradation_state.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from app.config import settings
 from app.contracts.providers import (
     ProviderDegradationStatusDescriptor,
     ProviderFailureCategory,
@@ -11,6 +10,7 @@ from app.contracts.providers import (
 from app.providers.base import ProviderExecutionError
 from app.repositories.provider_operations_repository import ProviderDegradationStateRecord
 from app.services.provider_operations_store import get_provider_operations_store
+from app.services.provider_execution_config import resolve_provider_execution_config
 
 _DEGRADATION_KEY = "live_text_generation"
 
@@ -104,10 +104,11 @@ def reset_provider_degradation_state() -> None:
 def _resolve_provider_degradation_state() -> ProviderDegradationState:
     findings: list[str] = []
     state_record = _load_degradation_record()
-    enforcement_enabled = settings.live_text_degradation_enforced
-    degraded_threshold = settings.live_text_degraded_failure_count_threshold
-    circuit_threshold = settings.live_text_circuit_open_failure_count_threshold
-    circuit_open_seconds = settings.live_text_circuit_open_seconds
+    enforcement = resolve_provider_execution_config().enforcement
+    enforcement_enabled = enforcement.degradation_enforced
+    degraded_threshold = enforcement.degraded_failure_count_threshold
+    circuit_threshold = enforcement.circuit_open_failure_count_threshold
+    circuit_open_seconds = enforcement.circuit_open_seconds
     configuration_valid = True
 
     if not enforcement_enabled:
@@ -250,7 +251,7 @@ def _remaining_circuit_open_seconds(circuit_open_until: str | None) -> int | Non
 
 def _open_circuit() -> None:
     state_record = _load_degradation_record()
-    cooldown_seconds = settings.live_text_circuit_open_seconds or 0
+    cooldown_seconds = resolve_provider_execution_config().enforcement.circuit_open_seconds or 0
     _save_degradation_record(
         consecutive_failure_count=state_record.consecutive_failure_count,
         last_failure_category=state_record.last_failure_category,

--- a/src/app/services/provider_execution_config.py
+++ b/src/app/services/provider_execution_config.py
@@ -32,6 +32,29 @@ from app.config import settings
 
 
 @dataclass(frozen=True)
+class ProviderEnforcementThresholds:
+    """Quota/budget/degradation enforcement posture for one execution (S3).
+
+    Grouped rather than flattened onto the config: these are the operator's
+    protection thresholds, not the model identity, and the config digest
+    deliberately excludes them.
+    """
+
+    quota_enforced: bool
+    default_quota_limit: int | None
+    task_quota_limits: str
+    caller_quota_limits: str
+    tenant_quota_limits: str
+    budget_enforced: bool
+    soft_budget_usd: float | None
+    hard_budget_usd: float | None
+    degradation_enforced: bool
+    degraded_failure_count_threshold: int | None
+    circuit_open_failure_count_threshold: int | None
+    circuit_open_seconds: int | None
+
+
+@dataclass(frozen=True)
 class ProviderExecutionConfig:
     provider_mode: str
     rollout_state: str
@@ -47,6 +70,7 @@ class ProviderExecutionConfig:
     temperature: float
     top_p: float | None
     seed: int | None
+    enforcement: ProviderEnforcementThresholds
 
 
 _provider_execution_config_override: ContextVar[ProviderExecutionConfig | None] = ContextVar(
@@ -86,6 +110,22 @@ def resolve_provider_execution_config() -> ProviderExecutionConfig:
         temperature=settings.live_text_temperature,
         top_p=settings.live_text_top_p,
         seed=settings.live_text_seed,
+        enforcement=ProviderEnforcementThresholds(
+            quota_enforced=settings.live_text_quota_enforced,
+            default_quota_limit=settings.live_text_default_quota_limit,
+            task_quota_limits=settings.live_text_task_quota_limits,
+            caller_quota_limits=settings.live_text_caller_quota_limits,
+            tenant_quota_limits=settings.live_text_tenant_quota_limits,
+            budget_enforced=settings.live_text_budget_enforced,
+            soft_budget_usd=settings.live_text_soft_budget_usd,
+            hard_budget_usd=settings.live_text_hard_budget_usd,
+            degradation_enforced=settings.live_text_degradation_enforced,
+            degraded_failure_count_threshold=settings.live_text_degraded_failure_count_threshold,
+            circuit_open_failure_count_threshold=(
+                settings.live_text_circuit_open_failure_count_threshold
+            ),
+            circuit_open_seconds=settings.live_text_circuit_open_seconds,
+        ),
     )
 
 

--- a/src/app/services/provider_quota_policy.py
+++ b/src/app/services/provider_quota_policy.py
@@ -14,6 +14,7 @@ from app.contracts.providers import (
 )
 from app.providers.base import ProviderExecutionError
 from app.services.capability_catalog import get_capability_by_task_id
+from app.services.provider_execution_config import resolve_provider_execution_config
 from app.services.provider_operations_store import get_provider_operations_store
 
 _MATCHING_ORDER = [
@@ -37,7 +38,7 @@ def build_provider_quota_policy() -> ProviderQuotaPolicyResponse:
     return ProviderQuotaPolicyResponse(
         service=settings.service_name,
         version=settings.service_version,
-        provider_mode=settings.provider_mode,
+        provider_mode=resolve_provider_execution_config().provider_mode,
         quota_enforced=parsed.quota_enforced,
         configuration_valid=parsed.configuration_valid,
         findings=parsed.findings,
@@ -52,23 +53,24 @@ def parse_provider_quota_policy() -> ParsedProviderQuotaPolicy:
     quotas: list[ProviderQuotaDescriptor] = []
     current_counts = _load_quota_counts()
 
+    enforcement = resolve_provider_execution_config().enforcement
     task_entries, task_findings = _parse_quota_mapping(
-        settings.live_text_task_quota_limits,
+        enforcement.task_quota_limits,
         scope=ProviderQuotaScope.TASK,
         current_counts=current_counts,
     )
     caller_entries, caller_findings = _parse_quota_mapping(
-        settings.live_text_caller_quota_limits,
+        enforcement.caller_quota_limits,
         scope=ProviderQuotaScope.CALLER_APP,
         current_counts=current_counts,
     )
     tenant_entries, tenant_findings = _parse_quota_mapping(
-        settings.live_text_tenant_quota_limits,
+        enforcement.tenant_quota_limits,
         scope=ProviderQuotaScope.TENANT,
         current_counts=current_counts,
     )
     default_quota, default_findings = _parse_default_quota(
-        settings.live_text_default_quota_limit,
+        enforcement.default_quota_limit,
         current_counts=current_counts,
     )
 
@@ -98,7 +100,7 @@ def parse_provider_quota_policy() -> ParsedProviderQuotaPolicy:
     if findings:
         configuration_valid = False
 
-    if settings.live_text_quota_enforced and not quotas:
+    if enforcement.quota_enforced and not quotas:
         configuration_valid = False
         findings.append(
             "Live-provider quota enforcement is enabled but no valid quota scopes are configured."
@@ -108,7 +110,7 @@ def parse_provider_quota_policy() -> ParsedProviderQuotaPolicy:
         findings.append("Provider quota posture is internally consistent for the current phase.")
 
     return ParsedProviderQuotaPolicy(
-        quota_enforced=settings.live_text_quota_enforced,
+        quota_enforced=enforcement.quota_enforced,
         configuration_valid=configuration_valid,
         findings=findings,
         quotas=quotas,

--- a/src/app/services/routing_posture.py
+++ b/src/app/services/routing_posture.py
@@ -32,6 +32,7 @@ from app.services.provider_degradation_state import build_provider_degradation_s
 
 
 def build_routing_posture() -> RoutingPostureResponse:
+    config = resolve_provider_execution_config()
     candidate = _resolve_candidate()
     return RoutingPostureResponse(
         service=settings.service_name,
@@ -41,8 +42,8 @@ def build_routing_posture() -> RoutingPostureResponse:
         strategy=RoutingStrategy.FIXED,
         candidate=candidate,
         degradation=build_provider_degradation_status(),
-        quota_enforced=settings.live_text_quota_enforced,
-        budget_enforced=settings.live_text_budget_enforced,
+        quota_enforced=config.enforcement.quota_enforced,
+        budget_enforced=config.enforcement.budget_enforced,
         enforcing_kill_switch_count=build_kill_switch_status().active_count,
         notes=[
             "The fixed policy maps the configured provider mode to exactly one adapter; "

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from fastapi import HTTPException
 
+from app.services.provider_execution_config import resolve_provider_execution_config
 from app.config import settings
 from app.contracts.access_control import (
     AuthorizationCapabilityType,
@@ -601,8 +602,17 @@ def test_apply_case_configuration_supports_sqlalchemy_budget_and_degradation_pat
         }
     ):
         assert settings.provider_operations_store_mode == "sqlalchemy"
-        assert settings.live_text_budget_enforced is True
-        assert settings.live_text_degradation_enforced is True
+        # Enforcement posture rides on the case's config override (issue
+        # #148 S3); the process settings are never mutated for it.
+        enforcement = resolve_provider_execution_config().enforcement
+        assert enforcement.budget_enforced is True
+        assert enforcement.hard_budget_usd == 5.0
+        assert enforcement.soft_budget_usd == 1.25
+        assert enforcement.degradation_enforced is True
+        assert enforcement.degraded_failure_count_threshold == 1
+        assert enforcement.circuit_open_seconds == 60
+        assert settings.live_text_budget_enforced is False
+        assert settings.live_text_degradation_enforced is False
 
     reset_provider_operations_store_cache()
 
@@ -618,7 +628,12 @@ def test_apply_case_configuration_supports_sqlalchemy_circuit_open_path(tmp_path
         }
     ):
         assert settings.provider_operations_store_mode == "sqlalchemy"
-        assert settings.live_text_circuit_open_seconds == 30
+        enforcement = resolve_provider_execution_config().enforcement
+        assert enforcement.circuit_open_seconds == 30
+        assert enforcement.degradation_enforced is True
+        assert enforcement.degraded_failure_count_threshold == 1
+        assert enforcement.circuit_open_failure_count_threshold == 1
+        assert settings.live_text_circuit_open_seconds is None
 
     reset_provider_operations_store_cache()
 

--- a/tests/unit/test_provider_execution_config.py
+++ b/tests/unit/test_provider_execution_config.py
@@ -32,6 +32,39 @@ def test_resolve_reflects_settings_and_override_wins() -> None:
     assert get_provider_execution_config_override() is None
 
 
+def test_enforcement_thresholds_resolve_from_override_not_settings() -> None:
+    from app.services.provider_budget_policy import build_provider_budget_policy
+    from app.services.provider_quota_policy import parse_provider_quota_policy
+
+    base = resolve_provider_execution_config()
+    assert base.enforcement.quota_enforced is settings.live_text_quota_enforced
+    assert base.enforcement.hard_budget_usd == settings.live_text_hard_budget_usd
+
+    case_config = replace(
+        base,
+        enforcement=replace(
+            base.enforcement,
+            quota_enforced=True,
+            task_quota_limits="explain.v1=5",
+            budget_enforced=True,
+            hard_budget_usd=2.0,
+            soft_budget_usd=0.5,
+        ),
+    )
+    with override_provider_execution_config(case_config):
+        parsed = parse_provider_quota_policy()
+        assert parsed.quota_enforced is True
+        assert any(quota.scope_key == "explain.v1" for quota in parsed.quotas)
+        budget = build_provider_budget_policy()
+        assert budget.budget_enforced is True
+        assert budget.hard_budget_usd == 2.0
+
+    # The override never touched process settings.
+    assert settings.live_text_quota_enforced is False
+    assert settings.live_text_budget_enforced is False
+    assert parse_provider_quota_policy().quota_enforced is False
+
+
 def test_concurrent_executions_use_independent_configs() -> None:
     """The issue #148 evaluation condition, at the task-executor boundary:
 


### PR DESCRIPTION
Part of #148 — S3 of the [execution plan](https://github.com/sgajbi/lotus-ai/issues/148#issuecomment-5467533822).

## What this does

1. **`ProviderEnforcementThresholds`** — a frozen group nested on `ProviderExecutionConfig` carrying quota flags/limits, budget flags/limits, and degradation thresholds/cooldown. Grouped rather than flattened: these are the operator's protection posture, not the model identity, and the #151 config digest deliberately excludes them (digests unchanged).
2. `provider_quota_policy`, `provider_budget_policy`, `provider_degradation_state`, and the routing-posture surface read the resolved enforcement group instead of settings — behavior-identical in production (`resolve()` without an override IS the settings snapshot).
3. **Nine more eval settings writes deleted.** The runtime computes a case's enforcement posture into its config override before installing it; the store-seeding operations (quota pre-increment, budget spend, failure records) stay where they were and now read the override through `resolve()`. Fixture semantics preserved exactly, including the circuit-only case's implicit 1/1 thresholds and the implicit 60s cooldown when only failure thresholds are given.
4. Remaining `settings` writes in the eval runtime after this PR: the rate-card cost scalars (deferred to the #178 S3 coordination — they seed the rate-card store, so their removal is a fixture-seeded rate card, not a config field) and the S4 retrieval/safety/embedding groups.

## Verification

- Full suite: **1956 passed**, combined coverage 99% (20881 statements, 286 missed — margin improved again).
- New test: quota/budget policies consume an override's thresholds while process settings stay untouched (asserted both inside and after the override).
- The two sqlalchemy case-configuration tests were rewritten to assert the new mechanism — enforcement rides the override, settings are provably unmutated (stronger than before, which asserted the mutation).
- `make lint` (purity guard included), `make typecheck` (700 files) green; no contract or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)