### PR TITLE
refactor(runtime): execution-scoped runtime-mode and store-mode config

### DIFF
--- a/src/app/providers/openai_live_embedding_provider.py
+++ b/src/app/providers/openai_live_embedding_provider.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 from urllib import error, request as urllib_request
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import (
     EmbeddingExecutionRequest,
     EmbeddingExecutionResponse,
@@ -40,14 +41,17 @@ class OpenAILiveEmbeddingProvider:
     def embed(self, request: EmbeddingExecutionRequest) -> EmbeddingExecutionResponse:
         response_payload = _post_openai_embedding(
             api_base=settings.live_text_api_base,
-            api_key=settings.live_embedding_provider_api_key,
+            api_key=resolve_runtime_mode_config().embedding_api_key,
             payload={
-                "model": settings.live_embedding_model_id,
+                "model": resolve_runtime_mode_config().embedding_model_id,
                 "input": request.content,
             },
         )
         embedding = _extract_embedding(response_payload)
-        model_id = _as_str(response_payload.get("model")) or settings.live_embedding_model_id
+        model_id = (
+            _as_str(response_payload.get("model"))
+            or resolve_runtime_mode_config().embedding_model_id
+        )
         return EmbeddingExecutionResponse(
             provider_id=self.descriptor.provider_id,
             provider_mode=self.descriptor.runtime_mode.value,

--- a/src/app/retrieval/document_governance.py
+++ b/src/app/retrieval/document_governance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.retrieval import (
     RetrievalDocumentVersionDescriptor,
     RetrievalIngestionJobDescriptor,
@@ -69,7 +70,7 @@ def build_retrieval_document_governance(
     documents.sort(key=lambda item: (item.source_id, item.document_id))
     return RetrievalDocumentGovernanceResponse(
         service=settings.service_name,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         vector_store=VECTOR_STORE_STRATEGY,
         searchable_document_count=sum(1 for document in documents if document.search_enabled),
         index_pending_document_count=sum(

--- a/src/app/retrieval/document_registry.py
+++ b/src/app/retrieval/document_registry.py
@@ -7,6 +7,7 @@ from app.contracts.retrieval import (
     RetrievalSourceStatusDescriptor,
 )
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.retrieval.inventory_summary import summarize_retrieval_source_inventory
 from app.retrieval.policy import VECTOR_STORE_STRATEGY
 from app.services.retrieval_store import get_retrieval_repository
@@ -49,7 +50,7 @@ def build_retrieval_index_status() -> RetrievalIndexStatusResponse:
 
     return RetrievalIndexStatusResponse(
         service=settings.service_name,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         vector_store=VECTOR_STORE_STRATEGY,
         sources=source_statuses,
     )

--- a/src/app/retrieval/job_registry.py
+++ b/src/app/retrieval/job_registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import HTTPException, status
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.repositories.async_runtime_repository import AsyncRuntimeJobRecord
 from app.contracts.retrieval import (
     RetrievalIndexJobCatalogResponse,
@@ -78,7 +79,7 @@ def get_retrieval_job_detail(job_id: str) -> RetrievalIndexJobDetailResponse:
             return RetrievalIndexJobDetailResponse(
                 service=settings.service_name,
                 vector_store=VECTOR_STORE_STRATEGY,
-                embedding_provider_mode=settings.embedding_provider_mode,
+                embedding_provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
                 job=descriptor,
                 steps=[
                     RetrievalIndexJobStepDescriptor(
@@ -167,9 +168,9 @@ def build_retrieval_indexing_policy() -> RetrievalIndexingPolicyResponse:
     return RetrievalIndexingPolicyResponse(
         service=settings.service_name,
         vector_store=VECTOR_STORE_STRATEGY,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         retrieval_store_mode=settings.retrieval_store_mode,
-        embedding_provider_mode=settings.embedding_provider_mode,
+        embedding_provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
         embedding_execution_enabled=embedding_runtime.embedding_execution_enabled,
         embedding_provider_id=embedding_runtime.embedding_provider_id,
         embedding_model_id=embedding_runtime.embedding_model_id,
@@ -205,7 +206,7 @@ def build_retrieval_runtime_status() -> RetrievalRuntimeStatusResponse:
     return RetrievalRuntimeStatusResponse(
         service=settings.service_name,
         delivery_phase=settings.delivery_phase,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         retrieval_store_mode=settings.retrieval_store_mode,
         retrieval_store_status=store_status.status,
         retrieval_store_detail=store_status.detail,

--- a/src/app/retrieval/source_governance.py
+++ b/src/app/retrieval/source_governance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.retrieval import (
     RetrievalDocumentDescriptor,
     RetrievalDocumentVersionDescriptor,
@@ -39,7 +40,7 @@ def build_retrieval_source_governance() -> RetrievalSourceGovernanceResponse:
     ]
     return RetrievalSourceGovernanceResponse(
         service=settings.service_name,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         vector_store=VECTOR_STORE_STRATEGY,
         searchable_source_count=sum(1 for source in governance_sources if source.search_enabled),
         index_pending_source_count=sum(

--- a/src/app/retrieval/source_registry.py
+++ b/src/app/retrieval/source_registry.py
@@ -4,6 +4,7 @@ from app.contracts.retrieval import (
     RetrievalSourceCatalogResponse,
 )
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.retrieval.policy import VECTOR_STORE_STRATEGY
 from app.services.retrieval_store import get_retrieval_repository
 
@@ -13,7 +14,7 @@ __all__ = ["VECTOR_STORE_STRATEGY", "list_retrieval_sources"]
 def list_retrieval_sources() -> RetrievalSourceCatalogResponse:
     return RetrievalSourceCatalogResponse(
         service=settings.service_name,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         vector_store=VECTOR_STORE_STRATEGY,
         sources=get_retrieval_repository().list_sources(),
     )

--- a/src/app/services/embedding_live_execution_state.py
+++ b/src/app/services/embedding_live_execution_state.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import ProviderCredentialStatus, ProviderExecutionMode
 from app.services.provider_configuration_status import build_embedding_configuration_status
 
@@ -22,12 +22,14 @@ class EmbeddingLiveExecutionState:
 
 def build_embedding_live_execution_state() -> EmbeddingLiveExecutionState:
     configuration = build_embedding_configuration_status()
-    mode_supported = settings.embedding_provider_mode in {
+    mode_supported = resolve_runtime_mode_config().embedding_provider_mode in {
         ProviderExecutionMode.DISABLED.value,
         ProviderExecutionMode.STUB.value,
         ProviderExecutionMode.ENABLED.value,
     }
-    live_mode_requested = settings.embedding_provider_mode == ProviderExecutionMode.ENABLED.value
+    live_mode_requested = (
+        resolve_runtime_mode_config().embedding_provider_mode == ProviderExecutionMode.ENABLED.value
+    )
     credentials_configured = configuration.credential_status == ProviderCredentialStatus.CONFIGURED
 
     blocking_reason: str | None = None
@@ -45,7 +47,7 @@ def build_embedding_live_execution_state() -> EmbeddingLiveExecutionState:
         blocking_reason = "Live embedding provider credentials are not fully configured."
 
     return EmbeddingLiveExecutionState(
-        provider_mode=settings.embedding_provider_mode,
+        provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
         configuration_valid=configuration.configuration_valid,
         credentials_configured=credentials_configured,
         mode_supported=mode_supported,

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -51,6 +51,10 @@ from app.services.local_openai_compatible_endpoint_probe import (
 from app.services.prompt_store import get_prompt_repository
 from app.services.prompt_store import reset_prompt_store_cache
 from app.services.provider_budget_policy import build_provider_budget_policy
+from app.services.runtime_mode_config import (
+    override_runtime_mode_config,
+    resolve_runtime_mode_config,
+)
 from app.services.provider_execution_config import (
     override_provider_execution_config,
     resolve_provider_execution_config,
@@ -69,6 +73,8 @@ from app.services.provider_degradation_state import (
 from app.services.provider_operations_status import build_provider_operations_status
 from app.services.provider_policy import build_provider_policy
 from app.services.provider_operations_store import (
+    override_provider_operations_store_mode,
+    resolved_provider_operations_store_mode,
     get_provider_operations_store,
     reset_provider_operations_store_cache,
 )
@@ -970,14 +976,6 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
     original_values = {
         "live_text_input_cost_per_1k_tokens": settings.live_text_input_cost_per_1k_tokens,
         "live_text_output_cost_per_1k_tokens": settings.live_text_output_cost_per_1k_tokens,
-        "live_text_degradation_enforced": settings.live_text_degradation_enforced,
-        "provider_operations_store_mode": settings.provider_operations_store_mode,
-        "retrieval_mode": settings.retrieval_mode,
-        "safety_mode": settings.safety_mode,
-        "embedding_provider_mode": settings.embedding_provider_mode,
-        "live_embedding_provider_id": settings.live_embedding_provider_id,
-        "live_embedding_model_id": settings.live_embedding_model_id,
-        "live_embedding_provider_api_key": settings.live_embedding_provider_api_key,
     }
     try:
         with ExitStack() as stack:
@@ -989,30 +987,48 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
             reset_provider_operations_store_cache()
             reset_provider_quota_counters()
             reset_provider_degradation_state()
+            runtime_modes = resolve_runtime_mode_config()
             if "retrieval_mode" in input_payload:
-                settings.retrieval_mode = str(input_payload["retrieval_mode"])
+                runtime_modes = replace(
+                    runtime_modes, retrieval_mode=str(input_payload["retrieval_mode"])
+                )
             if "safety_mode" in input_payload:
-                settings.safety_mode = str(input_payload["safety_mode"])
+                runtime_modes = replace(
+                    runtime_modes, safety_mode=str(input_payload["safety_mode"])
+                )
             if "embedding_provider_mode" in input_payload:
-                settings.embedding_provider_mode = str(input_payload["embedding_provider_mode"])
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_provider_mode=str(input_payload["embedding_provider_mode"]),
+                )
             if "live_embedding_provider_id" in input_payload:
-                settings.live_embedding_provider_id = (
-                    str(input_payload["live_embedding_provider_id"])
-                    if input_payload["live_embedding_provider_id"] is not None
-                    else None
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_provider_id=(
+                        str(input_payload["live_embedding_provider_id"])
+                        if input_payload["live_embedding_provider_id"] is not None
+                        else None
+                    ),
                 )
             if "live_embedding_model_id" in input_payload:
-                settings.live_embedding_model_id = (
-                    str(input_payload["live_embedding_model_id"])
-                    if input_payload["live_embedding_model_id"] is not None
-                    else None
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_model_id=(
+                        str(input_payload["live_embedding_model_id"])
+                        if input_payload["live_embedding_model_id"] is not None
+                        else None
+                    ),
                 )
             if "live_embedding_provider_api_key" in input_payload:
-                settings.live_embedding_provider_api_key = (
-                    str(input_payload["live_embedding_provider_api_key"])
-                    if input_payload["live_embedding_provider_api_key"] is not None
-                    else None
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_api_key=(
+                        str(input_payload["live_embedding_provider_api_key"])
+                        if input_payload["live_embedding_provider_api_key"] is not None
+                        else None
+                    ),
                 )
+            stack.enter_context(override_runtime_mode_config(runtime_modes))
             indexed_sources = input_payload.get("index_sources", [])
             if isinstance(indexed_sources, list):
                 repository = get_retrieval_repository()
@@ -1033,7 +1049,7 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                 input_payload.get("provider_operations_store_mode") == "sqlalchemy"
                 and settings.database_url
             ):
-                settings.provider_operations_store_mode = "sqlalchemy"
+                stack.enter_context(override_provider_operations_store_mode("sqlalchemy"))
                 reset_provider_operations_store_cache()
             live_execution_signals = any(
                 key in input_payload
@@ -1209,7 +1225,7 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                         amount_usd=tracked_spend,
                         updated_at=_utcnow_iso(),
                     )
-                    if settings.provider_operations_store_mode == "sqlalchemy":
+                    if resolved_provider_operations_store_mode() == "sqlalchemy":
                         reset_provider_operations_store_cache()
             if "degraded_failure_count_threshold" in input_payload:
                 failure_count = int(
@@ -1217,11 +1233,11 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                 )
                 for _ in range(failure_count):
                     record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
-                if settings.provider_operations_store_mode == "sqlalchemy":
+                if resolved_provider_operations_store_mode() == "sqlalchemy":
                     reset_provider_operations_store_cache()
             elif "circuit_open_seconds" in input_payload:
                 record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
-                if settings.provider_operations_store_mode == "sqlalchemy":
+                if resolved_provider_operations_store_mode() == "sqlalchemy":
                     reset_provider_operations_store_cache()
             yield
     finally:

--- a/src/app/services/platform_status.py
+++ b/src/app/services/platform_status.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.platform import PlatformRuntimeStatusResponse
 from app.services.app_capability_rollout_catalog import (
     build_app_capability_rollout_catalog,
@@ -183,9 +184,9 @@ def build_platform_runtime_status(app_state: object | None = None) -> PlatformRu
         readiness_probe_policy=settings.readiness_probe_policy,
         local_header_caller_identity_enabled=settings.local_header_caller_identity_enabled,
         provider_mode=settings.provider_mode,
-        retrieval_mode=settings.retrieval_mode,
-        embedding_provider_mode=settings.embedding_provider_mode,
-        safety_mode=settings.safety_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
+        embedding_provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
+        safety_mode=resolve_runtime_mode_config().safety_mode,
         prompt_store_mode=settings.prompt_store_mode,
         access_control_store_mode=settings.access_control_store_mode,
         workflow_pack_registry_store_mode=settings.workflow_pack_registry_store_mode,

--- a/src/app/services/production_go_live_runtime.py
+++ b/src/app/services/production_go_live_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.production_go_live import (
     ProductionGoLiveDomainDescriptor,
     ProductionGoLiveDomainStatus,
@@ -59,9 +60,9 @@ def build_production_go_live_runtime_status(
     )
     live_provider_inventory = build_live_provider_inventory()
     live_provider_required = live_provider_inventory.execution_requested
-    retrieval_required = settings.retrieval_mode == "enabled"
+    retrieval_required = resolve_runtime_mode_config().retrieval_mode == "enabled"
     prompt_governance_required = _live_prompt_activation_required()
-    safety_governance_required = settings.safety_mode == "runtime_enforced"
+    safety_governance_required = resolve_runtime_mode_config().safety_mode == "runtime_enforced"
     prompt_governance = _resolve_prompt_governance(
         prompt_governance=prompt_governance,
         required_for_platform_approval=prompt_governance_required,
@@ -106,7 +107,7 @@ def build_production_go_live_runtime_status(
                 required_for_platform_approval=retrieval_required,
             ),
             required_for_platform_approval=retrieval_required,
-            configured_mode=settings.retrieval_mode,
+            configured_mode=resolve_runtime_mode_config().retrieval_mode,
             review_surface="/platform/retrieval/governance-status",
             detail=(
                 "Retrieval governance is currently approved for active retrieval execution."
@@ -139,7 +140,7 @@ def build_production_go_live_runtime_status(
                 required_for_platform_approval=safety_governance_required,
             ),
             required_for_platform_approval=safety_governance_required,
-            configured_mode=settings.safety_mode,
+            configured_mode=resolve_runtime_mode_config().safety_mode,
             review_surface="/platform/safety/governance-status",
             detail=_safety_governance_domain_detail(
                 governance_ready=safety_governance_ready,

--- a/src/app/services/production_live_provider_inventory.py
+++ b/src/app/services/production_live_provider_inventory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import ProviderExecutionMode
 
 
@@ -60,9 +61,9 @@ def build_live_provider_inventory() -> LiveProviderInventory:
             LiveProviderCapability(
                 capability_id="embeddings",
                 label="embeddings",
-                configured_mode=settings.embedding_provider_mode,
-                secret_configured=bool(settings.live_embedding_provider_api_key),
-                execution_requested=settings.embedding_provider_mode
+                configured_mode=resolve_runtime_mode_config().embedding_provider_mode,
+                secret_configured=bool(resolve_runtime_mode_config().embedding_api_key),
+                execution_requested=resolve_runtime_mode_config().embedding_provider_mode
                 == ProviderExecutionMode.ENABLED.value,
             ),
         )

--- a/src/app/services/provider_activation_readiness.py
+++ b/src/app/services/provider_activation_readiness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import (
     ProviderActivationReadinessResponse,
     ProviderBudgetState,
@@ -86,7 +87,7 @@ def build_provider_activation_readiness() -> ProviderActivationReadinessResponse
         service=settings.service_name,
         version=settings.service_version,
         provider_mode=settings.provider_mode,
-        embedding_provider_mode=settings.embedding_provider_mode,
+        embedding_provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
         text_generation_configuration=configuration,
         embedding_configuration=embedding_configuration,
         activation_ready=activation_ready,

--- a/src/app/services/provider_catalog.py
+++ b/src/app/services/provider_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import (
     ProviderCapability,
     ProviderCatalogResponse,
@@ -60,7 +61,7 @@ def build_provider_catalog() -> ProviderCatalogResponse:
         service=settings.service_name,
         version=settings.service_version,
         provider_mode=settings.provider_mode,
-        embedding_provider_mode=settings.embedding_provider_mode,
+        embedding_provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
         text_generation_configuration=text_generation_configuration,
         embedding_configuration=embedding_configuration,
         runtime_execution_enabled=text_generation_runtime_execution_enabled

--- a/src/app/services/provider_configuration_status.py
+++ b/src/app/services/provider_configuration_status.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import (
     ProviderCapability,
     ProviderConfigurationStatusDescriptor,
@@ -114,10 +114,10 @@ def build_text_generation_configuration_status() -> ProviderConfigurationStatusD
 
 
 def build_embedding_configuration_status() -> ProviderConfigurationStatusDescriptor:
-    configured_mode = settings.embedding_provider_mode
-    configured_live_provider_id = settings.live_embedding_provider_id
-    configured_live_model_id = settings.live_embedding_model_id
-    api_key = settings.live_embedding_provider_api_key
+    configured_mode = resolve_runtime_mode_config().embedding_provider_mode
+    configured_live_provider_id = resolve_runtime_mode_config().embedding_provider_id
+    configured_live_model_id = resolve_runtime_mode_config().embedding_model_id
+    api_key = resolve_runtime_mode_config().embedding_api_key
     findings: list[str] = []
     configuration_valid = True
     allowlisted_task_ids: list[str] = []

--- a/src/app/services/provider_operations_store.py
+++ b/src/app/services/provider_operations_store.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 from app.config import settings
 from app.repositories.memory_provider_operations_repository import (
     InMemoryProviderOperationsRepository,
@@ -12,14 +16,38 @@ from app.repositories.sqlalchemy_provider_operations_repository import (
 _memory_repository: InMemoryProviderOperationsRepository | None = None
 _sqlalchemy_repository: SqlAlchemyProviderOperationsRepository | None = None
 
+_store_mode_override: ContextVar[str | None] = ContextVar(
+    "lotus_ai_provider_operations_store_mode_override", default=None
+)
+
+
+@contextmanager
+def override_provider_operations_store_mode(mode: str) -> Iterator[None]:
+    """Execution-scoped store-mode override (issue #148, S4).
+
+    Used by the evaluation runtime to run a case against the durable store
+    without mutating process settings; both backend caches coexist, so a
+    concurrent production request keeps its configured backend.
+    """
+
+    token = _store_mode_override.set(mode)
+    try:
+        yield
+    finally:
+        _store_mode_override.reset(token)
+
+
+def resolved_provider_operations_store_mode() -> str:
+    return _store_mode_override.get() or settings.provider_operations_store_mode
+
 
 def get_provider_operations_store() -> ProviderOperationsRepository:
-    if settings.provider_operations_store_mode == "memory":
+    if resolved_provider_operations_store_mode() == "memory":
         global _memory_repository
         if _memory_repository is None:
             _memory_repository = InMemoryProviderOperationsRepository()
         return _memory_repository
-    if settings.provider_operations_store_mode == "sqlalchemy":
+    if resolved_provider_operations_store_mode() == "sqlalchemy":
         if not settings.database_url:
             raise RuntimeError(
                 "LOTUS_AI_DATABASE_URL is required when LOTUS_AI_PROVIDER_OPERATIONS_STORE_MODE=sqlalchemy."

--- a/src/app/services/provider_policy.py
+++ b/src/app/services/provider_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import HTTPException, status
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import (
     ProviderAdapterKind,
     ProviderCapability,
@@ -34,7 +35,7 @@ def build_provider_policy() -> ProviderPolicyResponse:
         rejection_category = ProviderFailureCategory.LIVE_EXECUTION_NOT_ENABLED
     else:
         rejection_category = ProviderFailureCategory.UNSUPPORTED_MODE
-    if settings.embedding_provider_mode == ProviderExecutionMode.ENABLED.value:
+    if resolve_runtime_mode_config().embedding_provider_mode == ProviderExecutionMode.ENABLED.value:
         embedding_rejection_category = ProviderFailureCategory.LIVE_EXECUTION_NOT_ENABLED
     else:
         embedding_rejection_category = ProviderFailureCategory.UNSUPPORTED_MODE
@@ -65,7 +66,7 @@ def build_provider_policy() -> ProviderPolicyResponse:
             ),
             ProviderPolicyDescriptor(
                 capability=ProviderCapability.EMBEDDINGS,
-                configured_mode=settings.embedding_provider_mode,
+                configured_mode=resolve_runtime_mode_config().embedding_provider_mode,
                 allowed_modes=[
                     ProviderExecutionMode.DISABLED,
                     ProviderExecutionMode.STUB,
@@ -110,7 +111,7 @@ def require_supported_embedding_mode() -> ProviderExecutionMode:
         ProviderExecutionMode.STUB.value: ProviderExecutionMode.STUB,
         ProviderExecutionMode.ENABLED.value: ProviderExecutionMode.ENABLED,
     }
-    configured_mode = settings.embedding_provider_mode
+    configured_mode = resolve_runtime_mode_config().embedding_provider_mode
     if configured_mode not in supported_modes:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -136,7 +137,7 @@ def _resolve_selected_text_provider() -> tuple[str, ProviderAdapterKind]:
 
 
 def _resolve_selected_embedding_provider() -> tuple[str, ProviderAdapterKind]:
-    configured_mode = settings.embedding_provider_mode
+    configured_mode = resolve_runtime_mode_config().embedding_provider_mode
     supported_modes = {
         ProviderExecutionMode.DISABLED.value,
         ProviderExecutionMode.STUB.value,

--- a/src/app/services/retrieval_activation_readiness.py
+++ b/src/app/services/retrieval_activation_readiness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.retrieval import RetrievalActivationReadinessResponse
 from app.retrieval.document_governance import build_retrieval_document_governance
 from app.services.retrieval_evidence_readiness import build_retrieval_evidence_readiness
@@ -21,7 +22,7 @@ def build_retrieval_activation_readiness() -> RetrievalActivationReadinessRespon
     )
 
     blocking_findings: list[str] = []
-    if settings.retrieval_mode != "enabled":
+    if resolve_runtime_mode_config().retrieval_mode != "enabled":
         blocking_findings.append(
             "Retrieval mode is not enabled, so the live indexed-search path is not in active rollout."
         )
@@ -68,7 +69,7 @@ def build_retrieval_activation_readiness() -> RetrievalActivationReadinessRespon
         )
 
     activation_ready = (
-        settings.retrieval_mode == "enabled"
+        resolve_runtime_mode_config().retrieval_mode == "enabled"
         and store_status.status == "READY"
         and document_governance is not None
         and document_governance.searchable_document_count > 0
@@ -87,8 +88,8 @@ def build_retrieval_activation_readiness() -> RetrievalActivationReadinessRespon
     return RetrievalActivationReadinessResponse(
         service=settings.service_name,
         delivery_phase=settings.delivery_phase,
-        retrieval_mode=settings.retrieval_mode,
-        embedding_provider_mode=settings.embedding_provider_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
+        embedding_provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
         embedding_execution_enabled=embedding_runtime.embedding_execution_enabled,
         ingestion_execution_enabled=ingestion_status.live_ingestion_enabled,
         activation_ready=activation_ready,

--- a/src/app/services/retrieval_embedding_runtime.py
+++ b/src/app/services/retrieval_embedding_runtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.services.embedding_live_execution_state import build_embedding_live_execution_state
 from app.services.provider_policy import _resolve_selected_embedding_provider
 
@@ -25,7 +25,7 @@ def build_retrieval_embedding_runtime() -> RetrievalEmbeddingRuntimeDescriptor:
         findings = [
             "Retrieval indexing can use the bounded live embedding provider path for governed corpus growth."
         ]
-    elif settings.embedding_provider_mode == "stub":
+    elif resolve_runtime_mode_config().embedding_provider_mode == "stub":
         embedding_strategy = "provider-stub"
         findings = [
             "Retrieval indexing remains on the stub embedding path until live embedding rollout is enabled."
@@ -38,7 +38,7 @@ def build_retrieval_embedding_runtime() -> RetrievalEmbeddingRuntimeDescriptor:
         if live_execution_state.blocking_reason is not None:
             findings.append(live_execution_state.blocking_reason)
     return RetrievalEmbeddingRuntimeDescriptor(
-        embedding_provider_mode=settings.embedding_provider_mode,
+        embedding_provider_mode=resolve_runtime_mode_config().embedding_provider_mode,
         embedding_execution_enabled=live_execution_state.live_execution_enabled,
         embedding_provider_id=embedding_provider_id,
         embedding_model_id=live_execution_state.configured_model_id,

--- a/src/app/services/retrieval_execution_status.py
+++ b/src/app/services/retrieval_execution_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.retrieval import (
     RetrievalExecutionStage,
     RetrievalExecutionStatusResponse,
@@ -20,11 +21,11 @@ def build_retrieval_execution_status() -> RetrievalExecutionStatusResponse:
         effective_stage=posture.effective_stage,
         degraded_findings=posture.retrieval_degraded_findings,
     )
-    if settings.retrieval_mode != "enabled":
+    if resolve_runtime_mode_config().retrieval_mode != "enabled":
         return RetrievalExecutionStatusResponse(
             service=settings.service_name,
             delivery_phase=settings.delivery_phase,
-            retrieval_mode=settings.retrieval_mode,
+            retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
             execution_stage=RetrievalExecutionStage.SEARCH_DISABLED,
             vector_store=VECTOR_STORE_STRATEGY,
             live_search_enabled=False,
@@ -50,7 +51,7 @@ def build_retrieval_execution_status() -> RetrievalExecutionStatusResponse:
         return RetrievalExecutionStatusResponse(
             service=settings.service_name,
             delivery_phase=settings.delivery_phase,
-            retrieval_mode=settings.retrieval_mode,
+            retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
             execution_stage=RetrievalExecutionStage.INDEXING_DISABLED,
             vector_store=VECTOR_STORE_STRATEGY,
             live_search_enabled=False,
@@ -115,7 +116,7 @@ def build_retrieval_execution_status() -> RetrievalExecutionStatusResponse:
     return RetrievalExecutionStatusResponse(
         service=settings.service_name,
         delivery_phase=settings.delivery_phase,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         execution_stage=RetrievalExecutionStage.LIVE_SEARCH,
         vector_store=VECTOR_STORE_STRATEGY,
         live_search_enabled=True,

--- a/src/app/services/retrieval_gateway.py
+++ b/src/app/services/retrieval_gateway.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.retrieval import (
     RetrievalDocumentGovernanceResponse,
     RetrievalExecutionRequest,
@@ -19,7 +19,7 @@ from app.services.retrieval_store import get_retrieval_repository
 
 def execute_retrieval_search(request: RetrievalExecutionRequest) -> RetrievalExecutionResponse:
     repository = get_retrieval_repository()
-    if settings.retrieval_mode != "enabled":
+    if resolve_runtime_mode_config().retrieval_mode != "enabled":
         catalog_hits = _build_catalog_only_hits(request, repository=repository)
         if catalog_hits:
             return RetrievalExecutionResponse(

--- a/src/app/services/retrieval_ingestion_status.py
+++ b/src/app/services/retrieval_ingestion_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.retrieval import (
     RetrievalDocumentVersionLifecycleStatus,
     RetrievalIngestionDeliveryStage,
@@ -21,7 +22,7 @@ def build_retrieval_ingestion_status() -> RetrievalIngestionStatusResponse:
         return RetrievalIngestionStatusResponse(
             service=settings.service_name,
             delivery_phase=settings.delivery_phase,
-            retrieval_mode=settings.retrieval_mode,
+            retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
             retrieval_store_mode=settings.retrieval_store_mode,
             ingestion_delivery_stage=RetrievalIngestionDeliveryStage.CATALOG_ONLY,
             live_ingestion_enabled=False,
@@ -125,7 +126,7 @@ def build_retrieval_ingestion_status() -> RetrievalIngestionStatusResponse:
     return RetrievalIngestionStatusResponse(
         service=settings.service_name,
         delivery_phase=settings.delivery_phase,
-        retrieval_mode=settings.retrieval_mode,
+        retrieval_mode=resolve_runtime_mode_config().retrieval_mode,
         retrieval_store_mode=settings.retrieval_store_mode,
         ingestion_delivery_stage=(
             RetrievalIngestionDeliveryStage.OPERATIONALLY_HARDENED

--- a/src/app/services/retrieval_service.py
+++ b/src/app/services/retrieval_service.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from fastapi import HTTPException, status
 
-from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.audit import AuditRecordResponse
 from app.contracts.access_control import AuthorizationCapabilityType, AuthorizationDecision
 from app.contracts.evidence import ExecutionEvidenceBundle, ExecutionEvidenceDescriptor
@@ -137,7 +137,7 @@ def _record_direct_search_audit(
             provider_id="retrieval-store",
             adapter_kind=None,
             model_id=None,
-            safety_mode=settings.safety_mode,
+            safety_mode=resolve_runtime_mode_config().safety_mode,
             redaction_posture=RedactionPosture.MINIMIZATION_REQUIRED,
             enforced_safety_controls=[
                 "correlation_and_audit",
@@ -145,7 +145,7 @@ def _record_direct_search_audit(
                 "no_raw_retrieval_payload_audit",
             ],
             safety_outcome=SafetyExecutionOutcome(
-                safety_mode=settings.safety_mode,
+                safety_mode=resolve_runtime_mode_config().safety_mode,
                 output_label=OutputLabel.RETRIEVAL_ANSWER.value,
                 redaction_posture=RedactionPosture.MINIMIZATION_REQUIRED,
                 disposition=SafetyExecutionDisposition.ENFORCED_PASSTHROUGH,

--- a/src/app/services/runtime_mode_config.py
+++ b/src/app/services/runtime_mode_config.py
@@ -1,0 +1,61 @@
+"""Per-execution runtime mode configuration (issue #148, S4).
+
+The retrieval, safety, and embedding subsystems read their operating modes
+mid-request the same way the text-generation path once read its provider
+settings. This module gives them the same shape S2 gave the provider path:
+one frozen snapshot resolved from ``settings`` unless an execution-scoped
+override is installed. The evaluation runtime installs a per-case override
+instead of mutating process settings, so a concurrent production request
+always runs under the deployed modes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from app.config import settings
+
+
+@dataclass(frozen=True)
+class RuntimeModeConfig:
+    retrieval_mode: str
+    safety_mode: str
+    embedding_provider_mode: str
+    embedding_provider_id: str | None
+    embedding_model_id: str | None
+    embedding_api_key: str | None
+
+
+_runtime_mode_config_override: ContextVar[RuntimeModeConfig | None] = ContextVar(
+    "lotus_ai_runtime_mode_config_override", default=None
+)
+
+
+@contextmanager
+def override_runtime_mode_config(config: RuntimeModeConfig) -> Iterator[None]:
+    token = _runtime_mode_config_override.set(config)
+    try:
+        yield
+    finally:
+        _runtime_mode_config_override.reset(token)
+
+
+def get_runtime_mode_config_override() -> RuntimeModeConfig | None:
+    return _runtime_mode_config_override.get()
+
+
+def resolve_runtime_mode_config() -> RuntimeModeConfig:
+    override = _runtime_mode_config_override.get()
+    if override is not None:
+        return override
+    return RuntimeModeConfig(
+        retrieval_mode=settings.retrieval_mode,
+        safety_mode=settings.safety_mode,
+        embedding_provider_mode=settings.embedding_provider_mode,
+        embedding_provider_id=settings.live_embedding_provider_id,
+        embedding_model_id=settings.live_embedding_model_id,
+        embedding_api_key=settings.live_embedding_provider_api_key,
+    )

--- a/src/app/services/safety_enforcement.py
+++ b/src/app/services/safety_enforcement.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.providers import ProviderExecutionResponse
 from app.contracts.safety import (
     RedactionPosture,
@@ -50,7 +50,7 @@ def resolve_safety_execution_outcome(
     *,
     safety_mode: str | None = None,
 ) -> SafetyExecutionOutcome:
-    resolved_safety_mode = safety_mode or settings.safety_mode
+    resolved_safety_mode = safety_mode or resolve_runtime_mode_config().safety_mode
     if resolved_safety_mode == "runtime_enforced":
         return _build_enforced_safety_outcome(policy, safety_mode=resolved_safety_mode)
     return SafetyExecutionOutcome(
@@ -100,7 +100,7 @@ def apply_safety_enforcement(
     policy: ResolvedSafetyPolicy,
     provider_execution: ProviderExecutionResponse,
 ) -> tuple[ProviderExecutionResponse, SafetyExecutionOutcome]:
-    if settings.safety_mode != "runtime_enforced":
+    if resolve_runtime_mode_config().safety_mode != "runtime_enforced":
         return provider_execution, resolve_safety_execution_outcome(policy)
 
     if policy.redaction_posture == RedactionPosture.DOCUMENTED_ONLY:
@@ -108,7 +108,7 @@ def apply_safety_enforcement(
             provider_execution,
             _build_enforced_safety_outcome(
                 policy,
-                safety_mode=settings.safety_mode,
+                safety_mode=resolve_runtime_mode_config().safety_mode,
                 disposition=SafetyExecutionDisposition.ENFORCED_PASSTHROUGH,
                 decision_summary=(
                     "Runtime safety enforcement is active and no redaction was required for "
@@ -125,7 +125,7 @@ def apply_safety_enforcement(
     if blocked_keys:
         blocked_outcome = _build_enforced_safety_outcome(
             policy,
-            safety_mode=settings.safety_mode,
+            safety_mode=resolve_runtime_mode_config().safety_mode,
             disposition=SafetyExecutionDisposition.BLOCKED,
             decision_summary=(
                 "Runtime safety enforcement blocked execution because the provider payload "
@@ -168,7 +168,7 @@ def apply_safety_enforcement(
         )
         outcome = _build_enforced_safety_outcome(
             policy,
-            safety_mode=settings.safety_mode,
+            safety_mode=resolve_runtime_mode_config().safety_mode,
             disposition=disposition,
             decision_summary=summary,
         )
@@ -187,7 +187,7 @@ def apply_safety_enforcement(
     degraded_message = "Safety-minimized output generated for bounded Lotus task execution."
     degraded_outcome = _build_enforced_safety_outcome(
         policy,
-        safety_mode=settings.safety_mode,
+        safety_mode=resolve_runtime_mode_config().safety_mode,
         disposition=SafetyExecutionDisposition.DEGRADED,
         decision_summary=(
             "Runtime safety enforcement produced a conservative fallback message because the "

--- a/src/app/services/safety_policy.py
+++ b/src/app/services/safety_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.safety import (
     RedactionPosture,
     SafetyControlDescriptor,
@@ -17,7 +18,7 @@ def build_safety_policy() -> SafetyPolicyResponse:
     return SafetyPolicyResponse(
         service=settings.service_name,
         version=settings.service_version,
-        safety_mode=settings.safety_mode,
+        safety_mode=resolve_runtime_mode_config().safety_mode,
         controls=[
             SafetyControlDescriptor(
                 control_id="context_minimization",
@@ -46,12 +47,12 @@ def build_safety_policy() -> SafetyPolicyResponse:
                 control_id="runtime_redaction_engine",
                 status=(
                     SafetyControlStatus.ENFORCED
-                    if settings.safety_mode == "runtime_enforced"
+                    if resolve_runtime_mode_config().safety_mode == "runtime_enforced"
                     else SafetyControlStatus.DOCUMENTED
                 ),
                 description=(
                     "Deterministic runtime safety enforcement is active for bounded task outputs."
-                    if settings.safety_mode == "runtime_enforced"
+                    if resolve_runtime_mode_config().safety_mode == "runtime_enforced"
                     else (
                         "Runtime safety outcomes are now typed and reviewable, but deterministic "
                         "redaction remains documented-only and is not yet active in the current "

--- a/src/app/services/safety_status.py
+++ b/src/app/services/safety_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_mode_config import resolve_runtime_mode_config
 from app.contracts.safety import (
     SafetyControlStatus,
     SafetyExecutionDisposition,
@@ -24,11 +25,11 @@ def build_safety_runtime_status() -> SafetyRuntimeStatusResponse:
     return SafetyRuntimeStatusResponse(
         service=settings.service_name,
         version=settings.service_version,
-        safety_mode=settings.safety_mode,
-        runtime_redaction_active=settings.safety_mode == "runtime_enforced",
+        safety_mode=resolve_runtime_mode_config().safety_mode,
+        runtime_redaction_active=resolve_runtime_mode_config().safety_mode == "runtime_enforced",
         runtime_redaction_disposition=(
             SafetyExecutionDisposition.ENFORCED_PASSTHROUGH
-            if settings.safety_mode == "runtime_enforced"
+            if resolve_runtime_mode_config().safety_mode == "runtime_enforced"
             else SafetyExecutionDisposition.DOCUMENTED_ONLY
         ),
         enforced_control_ids=enforced_control_ids,
@@ -40,7 +41,7 @@ def build_safety_runtime_status() -> SafetyRuntimeStatusResponse:
                 SafetyExecutionDisposition.BLOCKED,
                 SafetyExecutionDisposition.DEGRADED,
             ]
-            if settings.safety_mode == "runtime_enforced"
+            if resolve_runtime_mode_config().safety_mode == "runtime_enforced"
             else [SafetyExecutionDisposition.DOCUMENTED_ONLY]
         ),
         task_policy_count=len(policy.task_policies),

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -24,7 +24,10 @@ from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 from app.services.prompt_rollout_control import apply_prompt_control_action
 from app.services.prompt_rollout_models import PromptRolloutEventRecord, PromptRolloutStateRecord
 from app.services.prompt_store import get_prompt_repository
-from app.services.provider_operations_store import reset_provider_operations_store_cache
+from app.services.provider_operations_store import (
+    reset_provider_operations_store_cache,
+    resolved_provider_operations_store_mode,
+)
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
 
@@ -601,7 +604,8 @@ def test_apply_case_configuration_supports_sqlalchemy_budget_and_degradation_pat
             "degraded_failure_count_threshold": 1,
         }
     ):
-        assert settings.provider_operations_store_mode == "sqlalchemy"
+        assert resolved_provider_operations_store_mode() == "sqlalchemy"
+        assert settings.provider_operations_store_mode == "memory"
         # Enforcement posture rides on the case's config override (issue
         # #148 S3); the process settings are never mutated for it.
         enforcement = resolve_provider_execution_config().enforcement
@@ -627,7 +631,8 @@ def test_apply_case_configuration_supports_sqlalchemy_circuit_open_path(tmp_path
             "circuit_open_seconds": 30,
         }
     ):
-        assert settings.provider_operations_store_mode == "sqlalchemy"
+        assert resolved_provider_operations_store_mode() == "sqlalchemy"
+        assert settings.provider_operations_store_mode == "memory"
         enforcement = resolve_provider_execution_config().enforcement
         assert enforcement.circuit_open_seconds == 30
         assert enforcement.degradation_enforced is True

--- a/tests/unit/test_runtime_mode_config.py
+++ b/tests/unit/test_runtime_mode_config.py
@@ -1,0 +1,49 @@
+"""Per-execution runtime-mode config and store-mode override (issue #148, S4)."""
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
+from app.config import settings
+from app.services.provider_operations_store import (
+    override_provider_operations_store_mode,
+    resolved_provider_operations_store_mode,
+)
+from app.services.runtime_mode_config import (
+    get_runtime_mode_config_override,
+    override_runtime_mode_config,
+    resolve_runtime_mode_config,
+)
+
+
+def test_runtime_modes_resolve_from_settings_and_override_wins() -> None:
+    base = resolve_runtime_mode_config()
+    assert base.retrieval_mode == settings.retrieval_mode
+    assert base.safety_mode == settings.safety_mode
+    assert base.embedding_provider_mode == settings.embedding_provider_mode
+    assert get_runtime_mode_config_override() is None
+
+    case_modes = replace(base, retrieval_mode="enabled", safety_mode="runtime_enforced")
+    with override_runtime_mode_config(case_modes):
+        assert resolve_runtime_mode_config() is case_modes
+        # Execution-scoped: a concurrent request on another thread still
+        # resolves the settings-derived modes.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            other = executor.submit(resolve_runtime_mode_config).result()
+        assert other.retrieval_mode == settings.retrieval_mode
+        assert other.safety_mode == settings.safety_mode
+
+    assert get_runtime_mode_config_override() is None
+    assert settings.retrieval_mode == "disabled"
+
+
+def test_store_mode_override_is_execution_scoped() -> None:
+    assert resolved_provider_operations_store_mode() == settings.provider_operations_store_mode
+
+    with override_provider_operations_store_mode("sqlalchemy"):
+        assert resolved_provider_operations_store_mode() == "sqlalchemy"
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            other = executor.submit(resolved_provider_operations_store_mode).result()
+        assert other == settings.provider_operations_store_mode
+        assert settings.provider_operations_store_mode == "memory"
+
+    assert resolved_provider_operations_store_mode() == settings.provider_operations_store_mode

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -127,8 +127,10 @@ does not require editing the execution path.
 Stage 4 resolves one frozen `ProviderExecutionConfig` (mode, rollout, model identity, endpoint,
 credential, task allowlist, and the recorded sampling controls) at the gateway entry and threads it
 through policy checks, catalogue binding, kill-switch scope matching, and the provider adapters —
-mid-request `settings` reads on this path are gone. The evaluation runtime installs a per-case
-config through an execution-scoped override instead of mutating process settings, so a concurrent
+mid-request `settings` reads on this path are gone. Quota/budget/degradation thresholds ride the
+same config as a frozen enforcement group, and the retrieval/safety/embedding operating modes
+resolve through a parallel `RuntimeModeConfig` snapshot. The evaluation runtime installs per-case
+configs through execution-scoped overrides instead of mutating process settings, so a concurrent
 production request always executes under the deployed configuration (issue #148).
 
 ## Caller identity and tenant scope


### PR DESCRIPTION
Part of #148 — S4 of the [execution plan](https://github.com/sgajbi/lotus-ai/issues/148#issuecomment-5467533822).

## What this does

1. **`RuntimeModeConfig`** — the S2 pattern applied to the remaining subsystems: retrieval mode, safety mode, and embedding mode/identity/credential resolve as one frozen snapshot (settings unless an execution-scoped override is installed). **62 read sites across 23 files** converted; a guard in the conversion script refused any module-level read (all 62 are inside functions, so override-awareness is real).
2. **Store-mode override** — `get_provider_operations_store()` honours an execution-scoped mode override; both backend caches coexist, so an eval case running against the durable store never flips a concurrent request's backend. The resolved mode is exposed (`resolved_provider_operations_store_mode`) and the eval's cache-reset logic uses it.
3. **Seven more eval settings writes deleted** (retrieval/safety/embedding groups + the store-mode write). After this PR the only `settings.<attr> = ` sites in all of `src/` are the two rate-card cost scalars — removed by the closing slice together with rate-card fixture seeding (coordinating #178 S3), which then lands the settings-assignment guard.

## Verification

- Full suite: **1956 passed**, combined coverage 99% (20941 statements, 287 missed).
- New thread-isolation tests for both overrides; the sqlalchemy case-configuration tests now assert the resolved store mode rides the override while `settings.provider_operations_store_mode` provably stays `memory`.
- Every eval fixture family passes unchanged; `make lint` (purity guard), `make typecheck` (702 files), `make eval-run-gate` green. No contract or migration changes.
- Docs: Architecture stage-4 paragraph extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)