### PR TITLE
refactor(evals): rate-card fixture seeding, case config digests, settings-write guard

### DIFF
--- a/alembic/versions/0050_add_eval_case_config_digest.py
+++ b/alembic/versions/0050_add_eval_case_config_digest.py
@@ -1,0 +1,26 @@
+"""add provider config digest to evaluation case results
+
+Revision ID: 0050_add_eval_case_config_digest
+Revises: 0049_add_reproducibility_identity
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0050_add_eval_case_config_digest"
+down_revision = "0049_add_reproducibility_identity"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "evaluation_case_results",
+        sa.Column("provider_config_sha256", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("evaluation_case_results", "provider_config_sha256")

--- a/scripts/check_runtime_purity.py
+++ b/scripts/check_runtime_purity.py
@@ -1,10 +1,11 @@
 """Production-source purity guard (issue #148).
 
 Fails when production code under src/ imports test tooling (unittest, mock,
-pytest) or references pytest's monkeypatch, and when a string literal that
-is not a self-describing credential reference is assigned to an api-key
-attribute. Production code must never depend on test-harness mechanics, and
-credentials must come from configuration or fixtures, never from literals.
+pytest) or references pytest's monkeypatch, when a string literal that is
+not a self-describing credential reference is assigned to an api-key
+attribute, and when anything assigns to a ``settings`` attribute (process
+configuration is immutable after startup - issue #148; per-execution
+variation goes through the execution-scoped config overrides).
 """
 
 from __future__ import annotations
@@ -29,6 +30,16 @@ def _violations_for_file(path: Path) -> list[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     violations: list[str] = []
     for node in ast.walk(tree):
+        if isinstance(node, ast.AugAssign):
+            target = node.target
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "settings"
+            ):
+                violations.append(
+                    f"{path}:{node.lineno}: settings attribute assignment 'settings.{target.attr}'"
+                )
         if isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name.split(".")[0] in FORBIDDEN_IMPORT_ROOTS:
@@ -42,6 +53,16 @@ def _violations_for_file(path: Path) -> list[str]:
             violations.append(f"{path}:{node.lineno}: test-tooling reference 'monkeypatch'")
         elif isinstance(node, ast.Assign) or isinstance(node, ast.AnnAssign):
             targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "settings"
+                ):
+                    violations.append(
+                        f"{path}:{node.lineno}: settings attribute assignment "
+                        f"'settings.{target.attr}'"
+                    )
             value = node.value
             if (
                 isinstance(value, ast.Constant)

--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -250,6 +250,11 @@ class EvaluationCaseResultDescriptor(BaseModel):
         default_factory=list,
         description="Governed artifact descriptors attached to the persisted case outcome.",
     )
+    provider_config_sha256: str | None = Field(
+        default=None,
+        description="Digest of the provider execution configuration the case ran under "
+        "(issue #148); the reproducibility key shared with audit records.",
+    )
     recorded_at: str = Field(description="UTC timestamp when the case outcome was recorded.")
 
 

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -425,6 +425,7 @@ class EvaluationCaseResultModel(Base):
     summary: Mapped[str] = mapped_column(Text, nullable=False)
     evidence_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False)
     artifact_ids: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    provider_config_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
     recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
 
     run: Mapped["EvaluationRunModel"] = relationship(back_populates="case_results")

--- a/src/app/repositories/evaluation_runtime_repository.py
+++ b/src/app/repositories/evaluation_runtime_repository.py
@@ -43,6 +43,7 @@ class EvaluationCaseResultRecord:
     summary: str
     evidence_refs: list[str]
     artifact_ids: list[str]
+    provider_config_sha256: str | None
     recorded_at: str
 
 

--- a/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
@@ -104,6 +104,7 @@ class SqlAlchemyEvaluationRuntimeRepository(SqlAlchemyRepositoryBase, Evaluation
             summary=record.summary,
             evidence_refs=record.evidence_refs,
             artifact_ids=record.artifact_ids,
+            provider_config_sha256=record.provider_config_sha256,
             recorded_at=record.recorded_at,
         )
         with self._session_factory() as session:
@@ -151,6 +152,7 @@ class SqlAlchemyEvaluationRuntimeRepository(SqlAlchemyRepositoryBase, Evaluation
             summary=model.summary,
             evidence_refs=list(model.evidence_refs),
             artifact_ids=list(model.artifact_ids),
+            provider_config_sha256=model.provider_config_sha256,
             recorded_at=model.recorded_at,
         )
 

--- a/src/app/services/eval_run_service.py
+++ b/src/app/services/eval_run_service.py
@@ -150,5 +150,6 @@ def _map_runtime_case_result(record: EvaluationCaseResultRecord) -> EvaluationCa
         summary=record.summary,
         evidence_refs=record.evidence_refs,
         artifact_refs=load_artifact_descriptors(artifact_ids=record.artifact_ids),
+        provider_config_sha256=record.provider_config_sha256,
         recorded_at=record.recorded_at,
     )

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -51,11 +51,17 @@ from app.services.local_openai_compatible_endpoint_probe import (
 from app.services.prompt_store import get_prompt_repository
 from app.services.prompt_store import reset_prompt_store_cache
 from app.services.provider_budget_policy import build_provider_budget_policy
+from app.contracts.rate_cards import RateCard, RateCardScopeKind
+from app.services.rate_card_store import (
+    get_rate_card_repository,
+    reset_rate_card_store_cache,
+)
 from app.services.runtime_mode_config import (
     override_runtime_mode_config,
     resolve_runtime_mode_config,
 )
 from app.services.provider_execution_config import (
+    compute_provider_config_sha256,
     override_provider_execution_config,
     resolve_provider_execution_config,
 )
@@ -221,6 +227,17 @@ def _evaluate_case(
     case: EvaluationFixtureRuntimeCase,
 ) -> EvaluationCaseResultRecord:
     with _apply_case_configuration(case.input_payload):
+        case_provider_config = resolve_provider_execution_config()
+        provider_config_sha256 = compute_provider_config_sha256(
+            provider_mode=case_provider_config.provider_mode,
+            provider_id=case_provider_config.provider_id,
+            model_id=case_provider_config.model_id,
+            model_version=case_provider_config.model_version,
+            temperature=case_provider_config.temperature,
+            top_p=case_provider_config.top_p,
+            seed=case_provider_config.seed,
+            max_output_tokens=case_provider_config.max_output_tokens,
+        )
         summary, outcome, evidence_refs = _execute_fixture_case(
             fixture_id=run.fixture_id,
             fixture_task_id=fixture_task_id,
@@ -243,6 +260,7 @@ def _evaluate_case(
                 "outcome": outcome.value,
                 "summary": summary,
                 "evidence_refs": evidence_refs,
+                "provider_config_sha256": provider_config_sha256,
             },
             sort_keys=True,
         ).encode("utf-8"),
@@ -257,6 +275,7 @@ def _evaluate_case(
         summary=summary,
         evidence_refs=evidence_refs,
         artifact_ids=[artifact.artifact_id],
+        provider_config_sha256=provider_config_sha256,
         recorded_at=_utcnow_iso(),
     )
 
@@ -973,10 +992,6 @@ EVAL_HERMETIC_CREDENTIAL_REF = "credential-ref:eval-hermetic"
 
 @contextmanager
 def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None]:
-    original_values = {
-        "live_text_input_cost_per_1k_tokens": settings.live_text_input_cost_per_1k_tokens,
-        "live_text_output_cost_per_1k_tokens": settings.live_text_output_cost_per_1k_tokens,
-    }
     try:
         with ExitStack() as stack:
             # Every case runs hermetically: the live network seams fail
@@ -987,6 +1002,7 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
             reset_provider_operations_store_cache()
             reset_provider_quota_counters()
             reset_provider_degradation_state()
+            reset_rate_card_store_cache()
             runtime_modes = resolve_runtime_mode_config()
             if "retrieval_mode" in input_payload:
                 runtime_modes = replace(
@@ -1209,8 +1225,20 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                     updated_at=_utcnow_iso(),
                 )
             if "hard_budget_usd" in input_payload:
-                settings.live_text_input_cost_per_1k_tokens = 0.01
-                settings.live_text_output_cost_per_1k_tokens = 0.03
+                seeded_at = _utcnow_iso()
+                get_rate_card_repository().upsert_card(
+                    RateCard(
+                        card_id="eval-hermetic-live-text",
+                        scope_kind=RateCardScopeKind.DEFAULT_LIVE_TEXT,
+                        currency="USD",
+                        input_cost_per_1k_tokens=0.01,
+                        output_cost_per_1k_tokens=0.03,
+                        effective_from_utc=None,
+                        effective_to_utc=None,
+                        created_at=seeded_at,
+                        last_updated_at=seeded_at,
+                    )
+                )
                 tracked_spend = float(
                     cast(
                         int | float | str,
@@ -1241,13 +1269,12 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                     reset_provider_operations_store_cache()
             yield
     finally:
-        for key, value in original_values.items():
-            setattr(settings, key, value)
         reset_retrieval_repository()
         reset_prompt_store_cache()
         reset_provider_operations_store_cache()
         reset_provider_quota_counters()
         reset_provider_degradation_state()
+        reset_rate_card_store_cache()
 
 
 def _raise_provider_execution_error(*, category: ProviderFailureCategory, message: str) -> Any:

--- a/tests/integration/test_eval_api_contract.py
+++ b/tests/integration/test_eval_api_contract.py
@@ -339,6 +339,12 @@ def test_evaluation_run_detail_route_exposes_runtime_attempt_and_case_history(
     assert len(body["case_results"]) == 2
     assert body["case_results"][0]["outcome"] == "PASS"
     assert len(body["case_results"][0]["artifact_refs"]) == 1
+    # Every case result records the digest of the provider execution
+    # configuration it ran under (issue #148) - the reproducibility key
+    # shared with audit records.
+    for case_result in body["case_results"]:
+        digest = case_result["provider_config_sha256"]
+        assert isinstance(digest, str) and len(digest) == 64
 
 
 def test_evaluation_run_submit_route_rejects_staged_only_fixture(client: TestClient) -> None:

--- a/tests/unit/test_check_runtime_purity.py
+++ b/tests/unit/test_check_runtime_purity.py
@@ -28,16 +28,20 @@ def test_runtime_purity_guard_flags_test_tooling_and_secret_literals(tmp_path: P
         "def use(monkeypatch):\n"
         "    monkeypatch.setattr('a', 'b')\n"
         "live_text_provider_api_key = 'sk-secret'\n"
-        "settings_api_key: str = 'raw-secret'\n",
+        "settings_api_key: str = 'raw-secret'\n"
+        "settings.provider_mode = 'openai'\n"
+        "settings.live_text_seed = 7\n"
+        "settings.retry_count += 1\n",
         encoding="utf-8",
     )
 
     violations = guard._violations_for_file(tmp_path / "violations.py")
 
-    assert len(violations) == 7
+    assert len(violations) == 10
     assert sum("test-tooling import" in item for item in violations) == 3
     assert sum("'monkeypatch'" in item for item in violations) == 2
     assert sum("secret-shaped api-key literal" in item for item in violations) == 2
+    assert sum("settings attribute assignment" in item for item in violations) == 3
     assert guard.main(str(tmp_path)) == 1
 
 

--- a/tests/unit/test_memory_evaluation_runtime_repository.py
+++ b/tests/unit/test_memory_evaluation_runtime_repository.py
@@ -49,6 +49,7 @@ def test_memory_evaluation_runtime_repository_round_trip() -> None:
             summary="Citations remained bounded and grounded.",
             evidence_refs=["evidence://retrieval.answer.case_001"],
             artifact_ids=[],
+            provider_config_sha256="d" * 64,
             recorded_at="2026-03-23T00:05:00Z",
         )
     )
@@ -116,6 +117,7 @@ def test_memory_evaluation_runtime_repository_replaces_attempt_and_case_result_r
             summary="Initial outcome.",
             evidence_refs=["evidence://old"],
             artifact_ids=[],
+            provider_config_sha256="d" * 64,
             recorded_at="2026-03-23T00:01:00Z",
         )
     )
@@ -130,6 +132,7 @@ def test_memory_evaluation_runtime_repository_replaces_attempt_and_case_result_r
             summary="Updated outcome.",
             evidence_refs=["evidence://new"],
             artifact_ids=[],
+            provider_config_sha256="d" * 64,
             recorded_at="2026-03-23T00:02:00Z",
         )
     )

--- a/tests/unit/test_rate_cards.py
+++ b/tests/unit/test_rate_cards.py
@@ -148,9 +148,12 @@ def test_sqlalchemy_repository_prepares_each_sqlite_location_shape(
 
 
 def test_cost_scalars_are_read_only_by_config_and_the_seed() -> None:
-    """#178's single-source guard: the legacy scalars are seed inputs. A new
-    runtime reader must show up here (eval_runtime_execution still WRITES them
-    - the mutation #148 owns - and is listed until that issue lands)."""
+    """#178's single-source guard: the legacy scalars are seed inputs only.
+
+    #148's closing slice removed the last writer (the eval runtime now
+    seeds a rate card instead of mutating the scalars), so exactly the
+    definition and the seed reference them. A new reader or writer must
+    justify itself here."""
 
     pattern = re.compile(r"live_text_(?:input|output)_cost_per_1k_tokens")
     referencing = {
@@ -161,5 +164,4 @@ def test_cost_scalars_are_read_only_by_config_and_the_seed() -> None:
     assert referencing == {
         "config.py",
         "services/provider_usage_accounting.py",
-        "services/eval_runtime_execution.py",
     }

--- a/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
+++ b/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
@@ -57,6 +57,7 @@ def test_sqlalchemy_evaluation_runtime_repository_round_trip(tmp_path: Path) -> 
             summary="Citations remained bounded and grounded.",
             evidence_refs=["evidence://retrieval.answer.case_001"],
             artifact_ids=[],
+            provider_config_sha256="d" * 64,
             recorded_at="2026-03-23T00:05:00Z",
         )
     )
@@ -144,6 +145,7 @@ def test_sqlalchemy_evaluation_runtime_repository_replaces_attempt_and_case_resu
             summary="Initial outcome.",
             evidence_refs=["evidence://old"],
             artifact_ids=[],
+            provider_config_sha256="d" * 64,
             recorded_at="2026-03-23T00:01:00Z",
         )
     )
@@ -158,6 +160,7 @@ def test_sqlalchemy_evaluation_runtime_repository_replaces_attempt_and_case_resu
             summary="Updated outcome.",
             evidence_refs=["evidence://new"],
             artifact_ids=[],
+            provider_config_sha256="d" * 64,
             recorded_at="2026-03-23T00:02:00Z",
         )
     )

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -42,9 +42,11 @@ The baseline rules are:
    embedding transport, local endpoint probe) fail closed unless the case
    installs an explicit execution-scoped override. An eval case can never
    reach a real provider endpoint, and its overrides are contextvar-scoped so
-   concurrent production requests never observe them. Production source is
-   guarded against test tooling and secret-shaped api-key literals by the
-   runtime-purity guard in `make lint`.
+   concurrent production requests never observe them. Process configuration
+   is immutable after startup: nothing in `src/` assigns to a `settings`
+   attribute (per-execution variation goes through the execution-scoped
+   config overrides), and the runtime-purity guard in `make lint` enforces
+   this alongside the test-tooling and secret-literal rules.
 
 Provider retention confirmation for Idea explanation runs is currently `not_certified`. The
 implementation binds provider/model/tenant identity to the durable workflow run, signs source-safe

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -51,7 +51,10 @@ relying on the lanes to repeat it.
 
 1. lint (ruff check, ruff format, and the runtime-purity guard —
    `scripts/check_runtime_purity.py` fails when production code under `src/`
-   imports test tooling or assigns a secret-shaped api-key literal),
+   imports test tooling, assigns a secret-shaped api-key literal, or assigns
+   to any `settings` attribute: process configuration is immutable after
+   startup, and per-execution variation goes through the execution-scoped
+   config overrides),
 2. typecheck,
 3. OpenAPI quality,
 4. evaluation manifest validation,


### PR DESCRIPTION
**Closes #148** — the closing slice of the [execution plan](https://github.com/sgajbi/lotus-ai/issues/148#issuecomment-5467533822), after S1 #200, S2 #201, S3 #202, S4 #203 (each merged tree-proven with Main Releasability Gate success on the exact merge SHA).

## What this does

1. **The last settings writes are gone.** Eval budget cases seed a `DEFAULT_LIVE_TEXT` rate card through the rate-card store instead of writing the legacy cost scalars; the per-case reset now includes the rate-card store, so a case's card can never leak into the next case's cost estimation (the leak class we hit in #196). The `original_values` snapshot/restore machinery is deleted — there is nothing left to restore. The #178 single-source ratchet tightens to exactly {definition, seed} — its docstring had listed the eval writer "until #148 lands"; it landed.
2. **`provider_config_sha256` on evaluation case results** (issue expected-direction item 4, eval side — the audit side shipped in #151/#197): computed inside the case's configuration context, persisted on the record (column + migration 0050 + both repositories), the case artifact bundle, and the API contract; the run-detail contract test asserts every case result carries a 64-hex digest.
3. **Settings-assignment guard**: `check_runtime_purity.py` now fails on ANY assignment to a `settings` attribute under `src/` (Assign/AnnAssign/AugAssign). src/ passes with zero such sites. Three new violation classes covered in the guard tests.

## #148 acceptance criteria after this PR

- `grep -n "settings\.\w\+ = " src/app/services/eval_runtime_execution.py` → **nothing** (true for all of src/); `unittest.mock` absent with an enforcing guard ✅ (S1 + this PR's guard extension)
- Concurrency test: production request + eval-style override execute concurrently, each audit record carries its own identity/config, settings untouched ✅ (S2)
- `eval-secret` removed; guard covers secret-shaped api-key literals ✅ (S1)
- Gates green; context and eval docs updated ✅ (per-slice + this PR)

## Verification

- Full suite on this tree: 1957 passed with the one remaining failure being the #178 ratchet firing **in the intended direction** (writer removed) — tightened and green; combined coverage 99% (20947 statements, 286 missed).
- `make lint` (extended purity guard), `make typecheck`, `make openapi-gate` (new contract field), `make migration-smoke` (0050), `make eval-run-gate` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)