### PR TITLE
fix(safety): report runtime redaction truthfully as documented-only

### DIFF
--- a/docs/evals/fixtures/safety.policy/basic_cases.json
+++ b/docs/evals/fixtures/safety.policy/basic_cases.json
@@ -28,6 +28,7 @@
         ],
         "documented_only_control_ids": [
           "context_minimization",
+          "structured_output_key_minimization",
           "runtime_redaction_engine"
         ],
         "runtime_redaction_active": false

--- a/docs/evals/fixtures/safety.runtime/basic_cases.json
+++ b/docs/evals/fixtures/safety.runtime/basic_cases.json
@@ -4,7 +4,7 @@
   "cases": [
     {
       "case_id": "runtime_safety_pass_through_for_draft_output",
-      "summary": "Runtime safety remains active but does not redact draft outputs that do not require minimization.",
+      "summary": "Runtime safety remains active but does not minimize draft outputs that do not require it; no redaction engine exists (issue #150).",
       "input": {
         "task_id": "summarize.v1",
         "safety_mode": "runtime_enforced"
@@ -12,12 +12,12 @@
       "expected": {
         "task_status": "COMPLETED",
         "disposition": "ENFORCED_PASSTHROUGH",
-        "runtime_redaction_active": true
+        "runtime_redaction_active": false
       }
     },
     {
       "case_id": "runtime_safety_redacts_explanation_output",
-      "summary": "Runtime safety deterministically redacts explanation output before task response and audit persistence.",
+      "summary": "Runtime safety deterministically minimizes explanation output keys before task response and audit persistence; content redaction remains documented-only.",
       "input": {
         "task_id": "explain.v1",
         "safety_mode": "runtime_enforced"
@@ -25,7 +25,7 @@
       "expected": {
         "task_status": "COMPLETED",
         "disposition": "ENFORCED_REDACTED",
-        "runtime_redaction_active": true,
+        "runtime_redaction_active": false,
         "caller_app_redacted": true
       }
     },
@@ -44,7 +44,7 @@
       },
       "expected": {
         "disposition": "BLOCKED",
-        "runtime_redaction_active": true
+        "runtime_redaction_active": false
       }
     },
     {
@@ -60,7 +60,7 @@
       },
       "expected": {
         "disposition": "DEGRADED",
-        "runtime_redaction_active": true
+        "runtime_redaction_active": false
       }
     }
   ]

--- a/src/app/services/retrieval_service.py
+++ b/src/app/services/retrieval_service.py
@@ -149,7 +149,7 @@ def _record_direct_search_audit(
                 output_label=OutputLabel.RETRIEVAL_ANSWER.value,
                 redaction_posture=RedactionPosture.MINIMIZATION_REQUIRED,
                 disposition=SafetyExecutionDisposition.ENFORCED_PASSTHROUGH,
-                runtime_redaction_active=True,
+                runtime_redaction_active=False,
                 enforced_controls=[
                     "correlation_and_audit",
                     "retrieval_citation_lineage",

--- a/src/app/services/safety_enforcement.py
+++ b/src/app/services/safety_enforcement.py
@@ -80,17 +80,25 @@ def resolve_safety_execution_outcome(
                 summary="Correlation metadata and audit capture are enforced on every execution.",
             ),
             SafetyControlExecutionResult(
+                control_id="structured_output_key_minimization",
+                execution_state=SafetyControlExecutionState.DOCUMENTED_ONLY,
+                summary=(
+                    "Deterministic structured-output key minimization runs only under "
+                    "runtime-enforced safety mode."
+                ),
+            ),
+            SafetyControlExecutionResult(
                 control_id="runtime_redaction_engine",
                 execution_state=SafetyControlExecutionState.DOCUMENTED_ONLY,
                 summary=(
-                    "Runtime redaction is typed and inspectable but not yet active in the current "
-                    "slice."
+                    "A runtime redaction engine (content screening for PII, account and card "
+                    "identifiers) is not implemented; redaction remains documented-only."
                 ),
             ),
         ],
         decision_summary=(
-            "Safety posture is typed and reviewable, but runtime redaction remains "
-            "documented-only in the current slice."
+            "Safety posture is typed and reviewable, but content redaction remains "
+            "documented-only: no runtime redaction engine exists."
         ),
     )
 
@@ -217,10 +225,13 @@ def _build_enforced_safety_outcome(
         output_label=policy.output_label.value,
         redaction_posture=policy.redaction_posture,
         disposition=disposition,
-        runtime_redaction_active=True,
+        # No runtime redaction engine exists (issue #150): what runs under
+        # runtime-enforced mode is deterministic key minimization and
+        # identity-echo truncation, reported under its own honest control id.
+        runtime_redaction_active=False,
         enforced_controls=[
             *_ENFORCED_CONTROL_IDS,
-            "runtime_redaction_engine",
+            "structured_output_key_minimization",
         ],
         control_results=[
             SafetyControlExecutionResult(
@@ -239,9 +250,20 @@ def _build_enforced_safety_outcome(
                 summary="Correlation metadata and audit capture are enforced on every execution.",
             ),
             SafetyControlExecutionResult(
-                control_id="runtime_redaction_engine",
+                control_id="structured_output_key_minimization",
                 execution_state=SafetyControlExecutionState.ENFORCED,
-                summary="Deterministic runtime safety enforcement is active for this execution.",
+                summary=(
+                    "Deterministic structured-output key minimization and identity-echo "
+                    "truncation ran for this execution."
+                ),
+            ),
+            SafetyControlExecutionResult(
+                control_id="runtime_redaction_engine",
+                execution_state=SafetyControlExecutionState.DOCUMENTED_ONLY,
+                summary=(
+                    "A runtime redaction engine (content screening for PII, account and card "
+                    "identifiers) is not implemented; redaction remains documented-only."
+                ),
             ),
         ],
         decision_summary=decision_summary

--- a/src/app/services/safety_policy.py
+++ b/src/app/services/safety_policy.py
@@ -44,20 +44,24 @@ def build_safety_policy() -> SafetyPolicyResponse:
                 ),
             ),
             SafetyControlDescriptor(
-                control_id="runtime_redaction_engine",
+                control_id="structured_output_key_minimization",
                 status=(
                     SafetyControlStatus.ENFORCED
                     if resolve_runtime_mode_config().safety_mode == "runtime_enforced"
                     else SafetyControlStatus.DOCUMENTED
                 ),
                 description=(
-                    "Deterministic runtime safety enforcement is active for bounded task outputs."
-                    if resolve_runtime_mode_config().safety_mode == "runtime_enforced"
-                    else (
-                        "Runtime safety outcomes are now typed and reviewable, but deterministic "
-                        "redaction remains documented-only and is not yet active in the current "
-                        "slice."
-                    )
+                    "Deterministic structured-output key minimization and identity-echo "
+                    "truncation run on bounded task outputs under runtime-enforced safety mode."
+                ),
+            ),
+            SafetyControlDescriptor(
+                control_id="runtime_redaction_engine",
+                status=SafetyControlStatus.DOCUMENTED,
+                description=(
+                    "A runtime redaction engine (content screening for PII, account and card "
+                    "identifiers before persistence and egress) is not implemented; redaction "
+                    "remains documented-only (issue #150)."
                 ),
             ),
         ],

--- a/src/app/services/safety_status.py
+++ b/src/app/services/safety_status.py
@@ -26,12 +26,11 @@ def build_safety_runtime_status() -> SafetyRuntimeStatusResponse:
         service=settings.service_name,
         version=settings.service_version,
         safety_mode=resolve_runtime_mode_config().safety_mode,
-        runtime_redaction_active=resolve_runtime_mode_config().safety_mode == "runtime_enforced",
-        runtime_redaction_disposition=(
-            SafetyExecutionDisposition.ENFORCED_PASSTHROUGH
-            if resolve_runtime_mode_config().safety_mode == "runtime_enforced"
-            else SafetyExecutionDisposition.DOCUMENTED_ONLY
-        ),
+        # No runtime redaction engine exists (issue #150): the redaction
+        # posture is documented-only in every safety mode; key minimization
+        # is reported under its own control id in the policy catalogue.
+        runtime_redaction_active=False,
+        runtime_redaction_disposition=SafetyExecutionDisposition.DOCUMENTED_ONLY,
         enforced_control_ids=enforced_control_ids,
         documented_only_control_ids=documented_only_control_ids,
         supported_execution_dispositions=(

--- a/src/app/services/task_execution_mapping.py
+++ b/src/app/services/task_execution_mapping.py
@@ -87,8 +87,12 @@ def build_task_result_payload(
         **resolved.provider_execution.structured_output,
         "input_mode": context.request.input_mode,
     }
+    # Caller identity is echoed only when deterministic key minimization did
+    # NOT run for this output. Keyed to the control that actually executed,
+    # not to runtime_redaction_active - that flag now truthfully reports the
+    # (absent) content-redaction engine (issue #150), not minimization.
     if not (
-        resolved.safety_outcome.runtime_redaction_active
+        "structured_output_key_minimization" in resolved.safety_outcome.enforced_controls
         and resolved.safety_outcome.redaction_posture == RedactionPosture.MINIMIZATION_REQUIRED
     ):
         payload["caller_app"] = context.request.caller.caller_app

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -654,7 +654,7 @@ def test_execute_fixture_case_reports_pass_for_runtime_safety_redaction_case() -
         expected_payload={
             "task_status": "COMPLETED",
             "disposition": "ENFORCED_REDACTED",
-            "runtime_redaction_active": True,
+            "runtime_redaction_active": False,
             "caller_app_redacted": True,
         },
     )
@@ -686,7 +686,7 @@ def test_execute_fixture_case_reports_pass_for_blocked_runtime_safety_case() -> 
         },
         expected_payload={
             "disposition": "BLOCKED",
-            "runtime_redaction_active": True,
+            "runtime_redaction_active": False,
         },
     )
 

--- a/tests/unit/test_safety_enforcement.py
+++ b/tests/unit/test_safety_enforcement.py
@@ -50,7 +50,11 @@ def test_safety_enforcement_redacts_bounded_output_when_runtime_enforced() -> No
     )
 
     assert outcome.disposition == "ENFORCED_REDACTED"
-    assert outcome.runtime_redaction_active is True
+    # No runtime redaction engine exists (issue #150): the enforced
+    # mechanism is key minimization, reported under its own control id.
+    assert outcome.runtime_redaction_active is False
+    assert "structured_output_key_minimization" in outcome.enforced_controls
+    assert "runtime_redaction_engine" not in outcome.enforced_controls
     assert (
         safe_execution.message == "Stub execution completed for foundation-phase task explain.v1."
     )
@@ -79,7 +83,11 @@ def test_safety_enforcement_blocks_unsupported_raw_context_echo() -> None:
     )
 
     assert outcome.disposition == "BLOCKED"
-    assert outcome.runtime_redaction_active is True
+    # No runtime redaction engine exists (issue #150): the enforced
+    # mechanism is key minimization, reported under its own control id.
+    assert outcome.runtime_redaction_active is False
+    assert "structured_output_key_minimization" in outcome.enforced_controls
+    assert "runtime_redaction_engine" not in outcome.enforced_controls
     assert "unsupported raw context echo fields" in outcome.decision_summary
     assert (
         safe_execution.message == "Task output blocked by deterministic runtime safety enforcement."

--- a/tests/unit/test_safety_policy.py
+++ b/tests/unit/test_safety_policy.py
@@ -22,7 +22,13 @@ def test_safety_policy_reports_runtime_redaction_control_as_enforced_when_activa
     )
 
     assert response.safety_mode == "runtime_enforced"
-    assert runtime_redaction.status == SafetyControlStatus.ENFORCED
-    assert "active" in runtime_redaction.description.lower()
+    assert runtime_redaction.status == SafetyControlStatus.DOCUMENTED
+    minimization = next(
+        control
+        for control in response.controls
+        if control.control_id == "structured_output_key_minimization"
+    )
+    assert minimization.status == SafetyControlStatus.ENFORCED
+    assert "not implemented" in runtime_redaction.description.lower()
 
     settings.safety_mode = "documented_only"

--- a/tests/unit/test_safety_status.py
+++ b/tests/unit/test_safety_status.py
@@ -1,4 +1,6 @@
 from app.config import settings
+from app.contracts.safety import SafetyExecutionDisposition
+
 from app.services.safety_status import build_safety_runtime_status
 
 
@@ -21,9 +23,12 @@ def test_safety_runtime_status_reports_active_redaction_when_runtime_enforced() 
     status = build_safety_runtime_status()
 
     assert status.safety_mode == "runtime_enforced"
-    assert status.runtime_redaction_active is True
-    assert status.runtime_redaction_disposition == "ENFORCED_PASSTHROUGH"
-    assert "runtime_redaction_engine" in status.enforced_control_ids
+    # Truthful posture (issue #150): no redaction engine exists, so the
+    # redaction fields stay documented-only even under runtime_enforced.
+    assert status.runtime_redaction_active is False
+    assert status.runtime_redaction_disposition == SafetyExecutionDisposition.DOCUMENTED_ONLY
+    assert "structured_output_key_minimization" in status.enforced_control_ids
+    assert "runtime_redaction_engine" in status.documented_only_control_ids
     assert "ENFORCED_REDACTED" in status.supported_execution_dispositions
 
     settings.safety_mode = "documented_only"

--- a/tests/unit/test_task_executor.py
+++ b/tests/unit/test_task_executor.py
@@ -106,7 +106,10 @@ def test_execute_task_enforces_runtime_redaction_for_provider_backed_output() ->
 
     assert response.audit.safety.safety_mode == "runtime_enforced"
     assert response.audit.safety.disposition == "ENFORCED_REDACTED"
-    assert response.audit.safety.runtime_redaction_active is True
+    # Truthful posture (issue #150): key minimization runs, but no
+    # runtime redaction engine exists.
+    assert response.audit.safety.runtime_redaction_active is False
+    assert "structured_output_key_minimization" in response.audit.safety.enforced_controls
     assert (
         response.result.message == "Stub execution completed for foundation-phase task explain.v1."
     )
@@ -535,7 +538,10 @@ def test_execute_task_enforces_runtime_redaction_for_retrieval_backed_output(
     )
 
     assert response.audit.safety.safety_mode == "runtime_enforced"
-    assert response.audit.safety.runtime_redaction_active is True
+    # Truthful posture (issue #150): key minimization runs, but no
+    # runtime redaction engine exists.
+    assert response.audit.safety.runtime_redaction_active is False
+    assert "structured_output_key_minimization" in response.audit.safety.enforced_controls
     assert "caller_app" not in response.result.structured_output
     assert response.result.structured_output["citation_count"] >= 1
     assert response.result.structured_output["hits"][0]["source_id"] == "lotus-platform-rfcs"

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -149,6 +149,15 @@ Current runtime nuance from the deeper security docs:
 3. redaction posture is declared per task,
 4. callers still remain responsible for context minimization.
 
+Read the redaction posture precisely (issue #150): under runtime-enforced safety
+mode the service applies **deterministic structured-output key minimization and
+identity-echo truncation** — reported under the `structured_output_key_minimization`
+control. A **runtime redaction engine** (content screening of generated text for
+PII, account and card identifiers before persistence and egress) is **not
+implemented**; `runtime_redaction_engine` reports `DOCUMENTED_ONLY` and
+`runtime_redaction_active` is `false` in every safety mode until a real engine
+lands.
+
 ## Runtime Governance Surfaces
 
 The key governance surfaces are grouped by domain:


### PR DESCRIPTION
Part of #150 — slice 1 of the [plan posted on the issue](https://github.com/sgajbi/lotus-ai/issues/150#issuecomment-5469059280).

## The untruth

The enforced-mode safety outcome claimed `runtime_redaction_active=True` and listed `runtime_redaction_engine: ENFORCED`, while `resolve_safety_policy_for_output` hard-coded `runtime_redaction_available=False` — the module contradicted itself, and what actually runs is fixed-key structured-output minimization plus identity-echo truncation, not content redaction. Three more surfaces asserted the engine active from safety mode alone (runtime status route, direct-retrieval audit record, policy catalogue).

## The truth pass

1. The real mechanism gets its honest control id — **`structured_output_key_minimization`** — ENFORCED under runtime-enforced mode, DOCUMENTED_ONLY otherwise, listed in both outcome branches and in the policy catalogue.
2. **`runtime_redaction_engine` reports `DOCUMENTED_ONLY` everywhere**, described as *not implemented*; `runtime_redaction_active` is `False` in every safety mode. Supportability/governance/observability surfaces now derive the degraded state they were designed to report.
3. **Load-bearing discovery**: the flag wasn't just misreported — `task_execution_mapping` used it as the switch deciding whether to re-echo `caller_app` into result payloads. Re-keyed to `structured_output_key_minimization ∈ enforced_controls`; minimization behaviour preserved exactly (the issue's non-goal), decoupled from the truth-telling field. Proven by the executor tests: `caller_app` still stripped under runtime-enforced minimization.
4. **Eval governance surfaces corrected**: `safety_runtime_examples` expectations (4 cases → `runtime_redaction_active: false`, honest summaries) and `safety_policy_examples`' exact control-id list; the safety approval gate passes end-to-end against the corrected fixtures (RUNTIME_PASS with truthful evidence, not with a fabricated control).
5. Security-and-Governance documents the precise posture: key minimization enforced; a content-redaction engine (PII/account/PAN screening before persistence and egress) does not exist until slice 2.

## Verification

- Full suite: **1958 passed**, combined coverage 99% (20947 statements, 288 missed).
- `make lint` / `make typecheck` / `make openapi-gate` / `make eval-manifest-gate` / `make eval-run-gate` green.
- Slice 2 (the real deterministic `RedactionEngine`) follows per the issue plan; `runtime_redaction_active` becomes `True` only where that engine actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)