### PR TITLE
feat(kill-switches): drain semantics with their async-runtime producer

### DIFF
--- a/alembic/versions/0051_add_kill_switch_semantics.py
+++ b/alembic/versions/0051_add_kill_switch_semantics.py
@@ -1,0 +1,31 @@
+"""add drain/hard-kill semantics to kill-switch activations
+
+Revision ID: 0051_add_kill_switch_semantics
+Revises: 0050_add_eval_case_config_digest
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0051_add_kill_switch_semantics"
+down_revision = "0050_add_eval_case_config_digest"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "kill_switch_activations",
+        sa.Column(
+            "semantics",
+            sa.String(length=16),
+            nullable=False,
+            server_default="HARD_KILL",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("kill_switch_activations", "semantics")

--- a/src/app/contracts/kill_switches.py
+++ b/src/app/contracts/kill_switches.py
@@ -7,9 +7,12 @@ are durable, attributable, optionally time-bounded, and enforced at the
 provider gateway preflight, where a hit becomes a recorded routing rejection
 (issue #176) with the bounded KILL_SWITCH_ACTIVE category.
 
-Slice 1 ships hard-kill semantics only: new live executions in scope are
-refused immediately. Drain semantics arrive with their async-runtime producer
-in a later slice.
+Two semantics exist (issue #177 S3). HARD_KILL refuses everything in scope
+immediately - new synchronous executions, new async intake, and the execution
+of already-queued work. DRAIN stops intake (new synchronous executions and new
+async submissions are refused) while already-claimed async workflow-pack jobs
+are allowed to complete safely; synchronous requests are never drained - they
+refuse immediately under either semantics.
 """
 
 from __future__ import annotations
@@ -17,6 +20,11 @@ from __future__ import annotations
 from enum import Enum
 
 from pydantic import BaseModel, Field
+
+
+class KillSwitchSemantics(str, Enum):
+    HARD_KILL = "HARD_KILL"
+    DRAIN = "DRAIN"
 
 
 class KillSwitchScope(str, Enum):
@@ -36,6 +44,11 @@ class KillSwitchActivationRecord(BaseModel):
 
     switch_id: str = Field(min_length=1, description="Server-assigned activation identity.")
     scope: KillSwitchScope = Field(description="What kind of target this switch disables.")
+    semantics: KillSwitchSemantics = Field(
+        default=KillSwitchSemantics.HARD_KILL,
+        description="HARD_KILL refuses all in-scope execution immediately; DRAIN refuses "
+        "new intake while already-claimed async work completes safely.",
+    )
     target: str | None = Field(
         default=None,
         description="Scope target (provider id, model revision, task id, tenant id, or "
@@ -66,6 +79,11 @@ class KillSwitchActivationRecord(BaseModel):
 class KillSwitchActivationRequest(BaseModel):
     caller_app: str = Field(min_length=1, description="Calling application identity.")
     scope: KillSwitchScope = Field(description="What kind of target to disable.")
+    semantics: KillSwitchSemantics = Field(
+        default=KillSwitchSemantics.HARD_KILL,
+        description="HARD_KILL (default) refuses all in-scope execution immediately; "
+        "DRAIN refuses new intake while already-claimed async work completes.",
+    )
     target: str | None = Field(
         default=None,
         description="Scope target; required for every scope except targetless ones.",

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -677,6 +677,9 @@ class KillSwitchActivationModel(Base):
 
     switch_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     scope: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    semantics: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="HARD_KILL", server_default="HARD_KILL"
+    )
     target: Mapped[str | None] = mapped_column(String(256), nullable=True, index=True)
     reason: Mapped[str] = mapped_column(Text, nullable=False)
     requested_by: Mapped[str] = mapped_column(String(128), nullable=False)

--- a/src/app/repositories/sqlalchemy_kill_switch_repository.py
+++ b/src/app/repositories/sqlalchemy_kill_switch_repository.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 from sqlalchemy import select
 
-from app.contracts.kill_switches import KillSwitchActivationRecord, KillSwitchScope
+from app.contracts.kill_switches import (
+    KillSwitchActivationRecord,
+    KillSwitchScope,
+    KillSwitchSemantics,
+)
 from app.db.models import KillSwitchActivationModel
 from app.repositories.sqlalchemy_repository_base import SqlAlchemyRepositoryBase
 
@@ -38,6 +42,7 @@ class SqlAlchemyKillSwitchRepository(SqlAlchemyRepositoryBase):
                 model = KillSwitchActivationModel(switch_id=activation.switch_id)
                 session.add(model)
             model.scope = activation.scope.value
+            model.semantics = activation.semantics.value
             model.target = activation.target
             model.reason = activation.reason
             model.requested_by = activation.requested_by
@@ -53,6 +58,7 @@ class SqlAlchemyKillSwitchRepository(SqlAlchemyRepositoryBase):
         return KillSwitchActivationRecord(
             switch_id=model.switch_id,
             scope=KillSwitchScope(model.scope),
+            semantics=KillSwitchSemantics(model.semantics),
             target=model.target,
             reason=model.reason,
             requested_by=model.requested_by,

--- a/src/app/routers/kill_switches.py
+++ b/src/app/routers/kill_switches.py
@@ -41,10 +41,12 @@ async def get_kill_switch_status_route() -> KillSwitchStatusResponse:
     operation_id="activateKillSwitch",
     summary="Activate a kill switch",
     description=(
-        "Activates a scoped hard-kill switch: new live text executions matching the scope are "
-        "refused immediately with the bounded KILL_SWITCH_ACTIVE category and a recorded "
-        "routing rejection. Requires provider-control authorization, requester and approver "
-        "identity, an operator reason, and the durable kill-switch store."
+        "Activates a scoped kill switch. HARD_KILL (default) refuses all matching live "
+        "execution immediately; DRAIN refuses new synchronous executions and new async "
+        "intake while already-claimed async workflow-pack jobs complete safely. Refusals "
+        "carry the bounded KILL_SWITCH_ACTIVE category and a recorded routing rejection. "
+        "Requires provider-control authorization, requester and approver identity, an "
+        "operator reason, and the durable kill-switch store."
     ),
     responses={
         200: {"description": "Kill switch activated."},

--- a/src/app/services/kill_switch_control.py
+++ b/src/app/services/kill_switch_control.py
@@ -11,6 +11,10 @@ KILL_SWITCH_ACTIVE category (issue #176).
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -19,6 +23,7 @@ from fastapi import HTTPException, status
 from app.config import settings
 from app.contracts.access_control import AuthorizationCapabilityType
 from app.contracts.kill_switches import (
+    KillSwitchSemantics,
     TARGETLESS_KILL_SWITCH_SCOPES,
     KillSwitchActionResponse,
     KillSwitchActivationRecord,
@@ -59,6 +64,7 @@ def activate_kill_switch(request: KillSwitchActivationRequest) -> KillSwitchActi
     activation = KillSwitchActivationRecord(
         switch_id=f"ksw_{uuid4().hex[:16]}",
         scope=request.scope,
+        semantics=request.semantics,
         target=request.target,
         reason=request.reason,
         requested_by=request.requested_by,
@@ -134,6 +140,62 @@ def build_kill_switch_status() -> KillSwitchStatusResponse:
     )
 
 
+_drain_completion_permitted: ContextVar[bool] = ContextVar(
+    "lotus_ai_kill_switch_drain_completion_permitted", default=False
+)
+
+
+@contextmanager
+def drain_completion_permit() -> Iterator[None]:
+    """Mark this execution as the safe completion of already-claimed async work.
+
+    Under the permit, DRAIN activations do not refuse execution - that is the
+    entire meaning of drain. HARD_KILL refuses regardless.
+    """
+
+    token = _drain_completion_permitted.set(True)
+    try:
+        yield
+    finally:
+        _drain_completion_permitted.reset(token)
+
+
+def enforce_kill_switch_intake(
+    *,
+    task_id: str,
+    tenant_id: str | None,
+    caller_app: str,
+) -> None:
+    """Refuse new async intake in scope of any enforcing activation.
+
+    Intake stops under BOTH semantics: draining means no new work enters the
+    queue while claimed work completes. Provider/model scopes match the
+    currently configured live identity, exactly as the sync preflight does.
+    """
+
+    probe = ProviderExecutionRequest.model_construct(
+        task_id=task_id,
+        tenant_id=tenant_id,
+        caller_app=caller_app,
+    )
+    now = _utc_now_iso()
+    for activation in get_kill_switch_repository().list_activations():
+        if not _is_enforcing(activation, now=now):
+            continue
+        if not _matches(activation, request=probe):
+            continue
+        target_note = f" target `{activation.target}`" if activation.target else ""
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                f"{ProviderFailureCategory.KILL_SWITCH_ACTIVE.value}: kill switch "
+                f"`{activation.switch_id}` ({activation.semantics.value}) is active for "
+                f"scope `{activation.scope.value}`{target_note}; new async intake is "
+                "refused until it clears."
+            ),
+        )
+
+
 def enforce_kill_switches(request: ProviderExecutionRequest) -> None:
     """Refuse live execution when any enforcing activation matches the request.
 
@@ -148,6 +210,12 @@ def enforce_kill_switches(request: ProviderExecutionRequest) -> None:
         if not _is_enforcing(activation, now=now):
             continue
         if _matches(activation, request=request):
+            if (
+                activation.semantics is KillSwitchSemantics.DRAIN
+                and _drain_completion_permitted.get()
+            ):
+                # Draining: already-claimed async work completes safely.
+                continue
             target_note = f" target `{activation.target}`" if activation.target else ""
             raise ProviderExecutionError(
                 category=ProviderFailureCategory.KILL_SWITCH_ACTIVE,

--- a/src/app/services/workflow_pack_async_execution.py
+++ b/src/app/services/workflow_pack_async_execution.py
@@ -9,6 +9,10 @@ from uuid import uuid4
 
 from fastapi import HTTPException, status
 
+from app.services.kill_switch_control import (
+    drain_completion_permit,
+    enforce_kill_switch_intake,
+)
 from app.config import settings
 from app.contracts.artifacts import ArtifactDescriptor
 from app.contracts.async_runtime import AsyncJobStatus
@@ -268,6 +272,11 @@ def _preflight_workflow_pack_execution_request(
             detail=f"Unknown workflow-pack registration: {request.pack_id}@{request.version}",
         )
     workflow_surface = request.workflow_surface or resolved_binding.binding.default_workflow_surface
+    enforce_kill_switch_intake(
+        task_id=request.task_request.task_id,
+        tenant_id=request.task_request.caller.tenant_id,
+        caller_app=request.task_request.caller.caller_app,
+    )
     eligibility = evaluate_workflow_pack_eligibility(
         WorkflowPackEligibilityEvaluationRequest(
             pack_id=request.pack_id,
@@ -490,6 +499,15 @@ def _canonical_json(payload: object) -> bytes:
 
 
 def _execute_claimed_workflow_pack_job(
+    *,
+    claim: AsyncWorkerClaimResult,
+    worker_id: str,
+) -> WorkflowPackAsyncExecutionResult | None:
+    with drain_completion_permit():
+        return _execute_claimed_workflow_pack_job_inner(claim=claim, worker_id=worker_id)
+
+
+def _execute_claimed_workflow_pack_job_inner(
     *,
     claim: AsyncWorkerClaimResult,
     worker_id: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         "http_hsts_enabled": settings.http_hsts_enabled,
         "http_hsts_max_age_seconds": settings.http_hsts_max_age_seconds,
         "http_max_request_body_bytes": settings.http_max_request_body_bytes,
+        "kill_switch_store_mode": settings.kill_switch_store_mode,
         "database_url": settings.database_url,
     }
     try:

--- a/tests/unit/test_kill_switch_drain.py
+++ b/tests/unit/test_kill_switch_drain.py
@@ -126,7 +126,11 @@ def test_async_submission_intake_checks_kill_switches(monkeypatch: MonkeyPatch) 
     from app.services.workflow_pack_async_execution import (
         _preflight_workflow_pack_execution_request,
     )
-    from app.contracts.workflow_packs import WorkflowPackExecutionRequest
+    from app.contracts.workflow_packs import (
+        WorkflowPackCallerIdentityClass,
+        WorkflowPackEnvironment,
+        WorkflowPackExecutionRequest,
+    )
     from app.contracts.tasks import (
         CallerMetadata,
         TaskContextEnvelope,
@@ -137,8 +141,8 @@ def test_async_submission_intake_checks_kill_switches(monkeypatch: MonkeyPatch) 
     request = WorkflowPackExecutionRequest(
         pack_id="advisor_brief.pack",
         version="v1",
-        environment="PRODUCTION",
-        caller_identity_class="INTERNAL_SERVICE",
+        environment=WorkflowPackEnvironment.PRODUCTION,
+        caller_identity_class=WorkflowPackCallerIdentityClass.INTERNAL_SERVICE,
         task_request=TaskExecutionRequest(
             task_id="explain.v1",
             input_mode=TaskInputMode.STRUCTURED_CONTEXT,

--- a/tests/unit/test_kill_switch_drain.py
+++ b/tests/unit/test_kill_switch_drain.py
@@ -1,0 +1,161 @@
+"""Drain semantics for kill switches (issue #177, S3)."""
+
+from pathlib import Path
+
+from fastapi import HTTPException
+from pytest import MonkeyPatch, raises
+
+from app.config import settings
+from app.contracts.kill_switches import (
+    KillSwitchActivationRequest,
+    KillSwitchScope,
+    KillSwitchSemantics,
+)
+from app.providers.base import ProviderExecutionError
+from app.services.kill_switch_control import (
+    activate_kill_switch,
+    drain_completion_permit,
+    enforce_kill_switch_intake,
+    enforce_kill_switches,
+)
+from app.services.kill_switch_store import get_kill_switch_repository
+from tests.support.migration_runner import upgrade_database_to_head
+from tests.unit.test_provider_gateway import _request
+
+
+def _activate(
+    scope: KillSwitchScope,
+    *,
+    semantics: KillSwitchSemantics,
+    target: str | None,
+) -> str:
+    response = activate_kill_switch(
+        KillSwitchActivationRequest(
+            caller_app="lotus-platform",
+            scope=scope,
+            semantics=semantics,
+            target=target,
+            reason="Drain-semantics test activation.",
+            requested_by="alice@lotus.test",
+            approved_by="bob@lotus.test",
+        )
+    )
+    return response.activation.switch_id
+
+
+def _use_durable_store(tmp_path: Path) -> None:
+    settings.kill_switch_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'kill-switch-drain.db'}"
+    upgrade_database_to_head(settings.database_url)
+
+
+def test_drain_refuses_sync_execution_but_permits_claimed_completion(
+    tmp_path: Path,
+) -> None:
+    _use_durable_store(tmp_path)
+    _activate(KillSwitchScope.TASK, semantics=KillSwitchSemantics.DRAIN, target="explain.v1")
+
+    # Sync requests are never drained: they refuse immediately.
+    with raises(ProviderExecutionError) as exc_info:
+        enforce_kill_switches(_request())
+    assert exc_info.value.category.value == "KILL_SWITCH_ACTIVE"
+
+    # Already-claimed async work completes under the drain permit.
+    with drain_completion_permit():
+        enforce_kill_switches(_request())
+
+
+def test_hard_kill_refuses_even_under_the_completion_permit(tmp_path: Path) -> None:
+    _use_durable_store(tmp_path)
+    _activate(KillSwitchScope.TASK, semantics=KillSwitchSemantics.HARD_KILL, target="explain.v1")
+
+    with drain_completion_permit():
+        with raises(ProviderExecutionError):
+            enforce_kill_switches(_request())
+
+
+def test_intake_is_refused_under_both_semantics(tmp_path: Path) -> None:
+    _use_durable_store(tmp_path)
+    _activate(KillSwitchScope.TENANT, semantics=KillSwitchSemantics.DRAIN, target="tenant-sg-001")
+
+    with raises(HTTPException) as exc_info:
+        enforce_kill_switch_intake(
+            task_id="explain.v1", tenant_id="tenant-sg-001", caller_app="lotus-manage"
+        )
+    assert exc_info.value.status_code == 503
+    assert "KILL_SWITCH_ACTIVE" in str(exc_info.value.detail)
+    assert "DRAIN" in str(exc_info.value.detail)
+
+    # Out-of-scope intake proceeds.
+    enforce_kill_switch_intake(
+        task_id="explain.v1", tenant_id="tenant-us-002", caller_app="lotus-manage"
+    )
+
+
+def test_semantics_round_trip_through_the_durable_store(tmp_path: Path) -> None:
+    _use_durable_store(tmp_path)
+    switch_id = _activate(
+        KillSwitchScope.CALLER_APP, semantics=KillSwitchSemantics.DRAIN, target="lotus-manage"
+    )
+
+    stored = get_kill_switch_repository().get_activation(switch_id)
+    assert stored is not None
+    assert stored.semantics is KillSwitchSemantics.DRAIN
+
+    # Default remains hard kill - the safe interpretation.
+    default_id = _activate(
+        KillSwitchScope.PROVIDER, semantics=KillSwitchSemantics.HARD_KILL, target="text.openai"
+    )
+    default_stored = get_kill_switch_repository().get_activation(default_id)
+    assert default_stored is not None
+    assert default_stored.semantics is KillSwitchSemantics.HARD_KILL
+
+
+def test_async_submission_intake_checks_kill_switches(monkeypatch: MonkeyPatch) -> None:
+    """The workflow-pack async submission preflight calls the intake check."""
+
+    calls: list[tuple[str, str | None, str]] = []
+
+    def _spy(*, task_id: str, tenant_id: str | None, caller_app: str) -> None:
+        calls.append((task_id, tenant_id, caller_app))
+
+    monkeypatch.setattr(
+        "app.services.workflow_pack_async_execution.enforce_kill_switch_intake",
+        _spy,
+    )
+    from app.services.workflow_pack_async_execution import (
+        _preflight_workflow_pack_execution_request,
+    )
+    from app.contracts.workflow_packs import WorkflowPackExecutionRequest
+    from app.contracts.tasks import (
+        CallerMetadata,
+        TaskContextEnvelope,
+        TaskExecutionRequest,
+        TaskInputMode,
+    )
+
+    request = WorkflowPackExecutionRequest(
+        pack_id="advisor_brief.pack",
+        version="v1",
+        environment="PRODUCTION",
+        caller_identity_class="INTERNAL_SERVICE",
+        task_request=TaskExecutionRequest(
+            task_id="explain.v1",
+            input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+            caller=CallerMetadata(
+                caller_app="lotus-gateway",
+                correlation_id="corr-drain-intake",
+                tenant_id="tenant-sg-001",
+            ),
+            context=TaskContextEnvelope(
+                summary="Drain intake probe",
+                payload={"status": "OK"},
+                source_refs=[],
+            ),
+        ),
+    )
+    try:
+        _preflight_workflow_pack_execution_request(request=request)
+    except HTTPException:
+        pass
+    assert calls == [("explain.v1", "tenant-sg-001", "lotus-gateway")]

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -92,11 +92,15 @@ platform programs.
      identity as a first-class entry (provider, family, exact revision, deployment, SKU,
      lifecycle state, approval evidence, pinning posture), reconciled on read from the
      live-text settings and the approved model-risk inventory (issue #175 slice 1)
-2. kill switches (issue #177 slice 1)
+2. kill switches (issue #177 slices 1 and 3)
    - `/platform/providers/kill-switches` — list activations and the enforcing count; POST
-     activates a scoped hard kill (provider, model revision, task, tenant, caller app, or
+     activates a scoped switch (provider, model revision, task, tenant, caller app, or
      all live text); `/{switch_id}/clear` clears one. Enforced first at the gateway
      preflight; a hit is a recorded routing rejection with `KILL_SWITCH_ACTIVE`.
+   - Semantics per activation: `HARD_KILL` (default) refuses everything in scope
+     immediately; `DRAIN` refuses new synchronous executions and new async workflow-pack
+     intake while already-claimed async jobs complete safely. Synchronous requests are
+     never drained — they refuse immediately under either semantics.
 3. app-capability rollout governance
    - `/platform/app-capability-rollouts`
    - `/platform/app-capability-rollouts/governance-status`


### PR DESCRIPTION
Part of #177 — S3. (S2's operator API was already delivered by S1's over-delivery: activate, clear, and a status listing that includes cleared and expired activations as the durable history — recorded on the issue.)

## What this does

`KillSwitchSemantics` ships with both its producer and its consumers, honouring the producers-rule deferral the S1 contract docstring recorded ("drain semantics arrive with their async-runtime producer"):

1. **`HARD_KILL`** (default — the safe interpretation) refuses everything in scope immediately: new sync executions, new async intake, and already-claimed async work.
2. **`DRAIN`** stops intake while claimed work completes safely:
   - The workflow-pack async submission preflight refuses matching new submissions under **both** semantics — draining means nothing new enters the queue (`enforce_kill_switch_intake`, matching task/tenant/caller/all-live-text plus the resolved provider/model identity exactly as the sync preflight does).
   - The claimed-job execution path runs under a **drain-completion permit** (execution-scoped contextvar — consistent with the #148 override architecture), which the gateway's kill-switch enforcement honours for DRAIN activations only.
   - **Synchronous requests are never drained** — they refuse immediately under either semantics (contract + Platform-Surfaces documentation).
3. **Durable**: `semantics` column with `server_default='HARD_KILL'` backfilling existing rows (migration 0051); both repository directions; activation request/record contracts; route description updated.
4. `tests/conftest.py` snapshot gains `kill_switch_store_mode` — the same explicit-key leak class as `redaction_mode` in #206, caught when the drain tests leaked sqlalchemy mode into the neighbouring suite.

## Verification

- Full suite **1975 passed**, combined coverage 99% (21148 statements, 292 missed); lint (purity guard), typecheck, OpenAPI gate, migration smoke all green.
- Tests: drain permits claimed completion while refusing sync; hard kill refuses even under the permit; intake refused under both semantics with out-of-scope intake proceeding; semantics round-trips the durable store with the hard-kill default; the async submission preflight provably calls the intake check with the request's identity.

Remaining on #177 after this: S4 — TTL expiry sweep with expiry events, activation/refusal counters (coordinate with #152), and the platform-status kill posture (routing posture already shows the enforcing count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)