### PR TITLE
feat(kill-switches): TTL expiry events and observability

### DIFF
--- a/alembic/versions/0052_add_kill_switch_expiry_marker.py
+++ b/alembic/versions/0052_add_kill_switch_expiry_marker.py
@@ -1,0 +1,26 @@
+"""add durable expiry-event marker to kill-switch activations
+
+Revision ID: 0052_add_kill_switch_expiry_marker
+Revises: 0051_add_kill_switch_semantics
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0052_add_kill_switch_expiry_marker"
+down_revision = "0051_add_kill_switch_semantics"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "kill_switch_activations",
+        sa.Column("expiry_recorded_at", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("kill_switch_activations", "expiry_recorded_at")

--- a/src/app/contracts/kill_switches.py
+++ b/src/app/contracts/kill_switches.py
@@ -62,6 +62,12 @@ class KillSwitchActivationRecord(BaseModel):
         default=None,
         description="Optional expiry instant (UTC); an expired switch is inert but retained.",
     )
+    expiry_recorded_at: str | None = Field(
+        default=None,
+        description="Instant the durable expiry event was recorded for a lapsed TTL; the "
+        "switch is inert from expires_at_utc regardless - this marks the recorded event "
+        "(issue #177 S4). Re-activation is always a new activation.",
+    )
     cleared_at: str | None = Field(
         default=None,
         description="Instant the switch was cleared; null while active.",
@@ -118,6 +124,10 @@ class KillSwitchStatusResponse(BaseModel):
     service: str = Field(description="Service name emitting the response.")
     version: str = Field(description="Current lotus-ai service version.")
     store_mode: str = Field(description="Where kill-switch truth lives: memory or sqlalchemy.")
+    expired_count: int = Field(
+        default=0,
+        description="Activations whose TTL has lapsed (inert, retained, expiry recorded).",
+    )
     active_count: int = Field(ge=0, description="Number of currently enforcing activations.")
     activations: list[KillSwitchActivationRecord] = Field(
         description="Every recorded activation, newest first, including cleared and expired ones.",

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -303,6 +303,11 @@ class ProviderOperationsStatusResponse(BaseModel):
     runtime_execution_enabled: bool = Field(
         description="Whether live-provider execution is currently enabled for any provider path."
     )
+    enforcing_kill_switch_count: int = Field(
+        default=0,
+        description="Currently enforcing operator kill switches (issue #177 S4); the "
+        "kill-switch status surface lists them individually.",
+    )
     rollout_blocked: bool = Field(
         description="Whether provider operations remain blocked by rollout or configuration posture."
     )

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -686,6 +686,7 @@ class KillSwitchActivationModel(Base):
     approved_by: Mapped[str] = mapped_column(String(128), nullable=False)
     activated_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     expires_at_utc: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    expiry_recorded_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
     cleared_at: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
     cleared_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
     clear_reason: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/src/app/repositories/sqlalchemy_kill_switch_repository.py
+++ b/src/app/repositories/sqlalchemy_kill_switch_repository.py
@@ -49,6 +49,7 @@ class SqlAlchemyKillSwitchRepository(SqlAlchemyRepositoryBase):
             model.approved_by = activation.approved_by
             model.activated_at = activation.activated_at
             model.expires_at_utc = activation.expires_at_utc
+            model.expiry_recorded_at = activation.expiry_recorded_at
             model.cleared_at = activation.cleared_at
             model.cleared_by = activation.cleared_by
             model.clear_reason = activation.clear_reason
@@ -65,6 +66,7 @@ class SqlAlchemyKillSwitchRepository(SqlAlchemyRepositoryBase):
             approved_by=model.approved_by,
             activated_at=model.activated_at,
             expires_at_utc=model.expires_at_utc,
+            expiry_recorded_at=model.expiry_recorded_at,
             cleared_at=model.cleared_at,
             cleared_by=model.cleared_by,
             clear_reason=model.clear_reason,

--- a/src/app/services/kill_switch_control.py
+++ b/src/app/services/kill_switch_control.py
@@ -36,6 +36,7 @@ from app.contracts.providers import ProviderExecutionRequest, ProviderFailureCat
 from app.providers.base import ProviderExecutionError
 from app.services.access_control_authorization import authorize_request, require_authorized
 from app.services.kill_switch_store import get_kill_switch_repository
+from app.services.provider_metrics import record_kill_switch_action
 from app.services.provider_execution_config import resolve_provider_execution_config
 
 
@@ -73,6 +74,9 @@ def activate_kill_switch(request: KillSwitchActivationRequest) -> KillSwitchActi
         expires_at_utc=request.expires_at_utc,
     )
     get_kill_switch_repository().upsert_activation(activation)
+    record_kill_switch_action(
+        action="activated", scope=activation.scope.value, semantics=activation.semantics.value
+    )
     return KillSwitchActionResponse(
         service=settings.service_name,
         version=settings.service_version,
@@ -116,6 +120,9 @@ def clear_kill_switch(switch_id: str, request: KillSwitchClearRequest) -> KillSw
         }
     )
     repository.upsert_activation(cleared)
+    record_kill_switch_action(
+        action="cleared", scope=cleared.scope.value, semantics=cleared.semantics.value
+    )
     return KillSwitchActionResponse(
         service=settings.service_name,
         version=settings.service_version,
@@ -129,15 +136,46 @@ def clear_kill_switch(switch_id: str, request: KillSwitchClearRequest) -> KillSw
 
 
 def build_kill_switch_status() -> KillSwitchStatusResponse:
-    activations = get_kill_switch_repository().list_activations()
     now = _utc_now_iso()
+    activations = [
+        _record_expiry_if_lapsed(activation, now=now)
+        for activation in get_kill_switch_repository().list_activations()
+    ]
     return KillSwitchStatusResponse(
         service=settings.service_name,
         version=settings.service_version,
         store_mode=settings.kill_switch_store_mode,
+        expired_count=sum(
+            1 for activation in activations if activation.expiry_recorded_at is not None
+        ),
         active_count=sum(1 for activation in activations if _is_enforcing(activation, now=now)),
         activations=activations,
     )
+
+
+def _record_expiry_if_lapsed(
+    activation: KillSwitchActivationRecord, *, now: str
+) -> KillSwitchActivationRecord:
+    """Durably record the expiry event for a lapsed, uncleared activation.
+
+    Sweep-on-read: deterministic, replica-safe (idempotent marker upsert), and
+    requires no scheduler. The switch is inert from expires_at_utc regardless;
+    this marks the recorded event and feeds the expiry counter exactly once.
+    """
+
+    if (
+        activation.cleared_at is not None
+        or activation.expiry_recorded_at is not None
+        or activation.expires_at_utc is None
+        or _parse_utc(activation.expires_at_utc) > _parse_utc(now)
+    ):
+        return activation
+    expired = activation.model_copy(update={"expiry_recorded_at": now})
+    get_kill_switch_repository().upsert_activation(expired)
+    record_kill_switch_action(
+        action="expired", scope=expired.scope.value, semantics=expired.semantics.value
+    )
+    return expired
 
 
 _drain_completion_permitted: ContextVar[bool] = ContextVar(
@@ -184,6 +222,11 @@ def enforce_kill_switch_intake(
             continue
         if not _matches(activation, request=probe):
             continue
+        record_kill_switch_action(
+            action="refused_intake",
+            scope=activation.scope.value,
+            semantics=activation.semantics.value,
+        )
         target_note = f" target `{activation.target}`" if activation.target else ""
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -216,6 +259,11 @@ def enforce_kill_switches(request: ProviderExecutionRequest) -> None:
             ):
                 # Draining: already-claimed async work completes safely.
                 continue
+            record_kill_switch_action(
+                action="refused_sync",
+                scope=activation.scope.value,
+                semantics=activation.semantics.value,
+            )
             target_note = f" target `{activation.target}`" if activation.target else ""
             raise ProviderExecutionError(
                 category=ProviderFailureCategory.KILL_SWITCH_ACTIVE,

--- a/src/app/services/provider_metrics.py
+++ b/src/app/services/provider_metrics.py
@@ -23,7 +23,12 @@ METRIC_NAMES = frozenset(
         "lotus_ai_surface_supportability_state",
         "lotus_ai_provider_requests_total",
         "lotus_ai_provider_latency_seconds",
+        "lotus_ai_kill_switch_actions_total",
     }
+)
+
+KILL_SWITCH_ACTIONS = frozenset(
+    {"activated", "cleared", "expired", "refused_sync", "refused_intake"}
 )
 
 PROVIDER_ATTEMPT_OUTCOMES = frozenset({"success", "retry", "failed"})
@@ -38,6 +43,25 @@ _provider_latency_seconds = Histogram(
     "Provider attempt latency in seconds by provider and model.",
     labelnames=("provider_id", "model_id"),
 )
+
+
+_kill_switch_actions_total = Counter(
+    "lotus_ai_kill_switch_actions_total",
+    "Kill-switch lifecycle and enforcement actions by scope and semantics (issue #177 S4).",
+    labelnames=("action", "scope", "semantics"),
+)
+
+
+def record_kill_switch_action(*, action: str, scope: str, semantics: str) -> None:
+    """Record one kill-switch action; never raises (telemetry is fail-open)."""
+
+    try:
+        bounded_action = action if action in KILL_SWITCH_ACTIONS else "refused_sync"
+        _kill_switch_actions_total.labels(
+            action=bounded_action, scope=scope, semantics=semantics
+        ).inc()
+    except Exception:  # noqa: BLE001 - telemetry must never block a request
+        pass
 
 
 def record_provider_attempt(

--- a/src/app/services/provider_operations_status.py
+++ b/src/app/services/provider_operations_status.py
@@ -8,6 +8,7 @@ from app.contracts.providers import (
     ProviderOperationsStatusResponse,
     ProviderQuotaScope,
 )
+from app.services.kill_switch_control import build_kill_switch_status
 from app.services.provider_expansion_policy import build_provider_expansion_policy
 from app.services.provider_budget_policy import build_provider_budget_policy
 from app.services.provider_degradation_state import build_provider_degradation_status
@@ -34,6 +35,7 @@ def build_provider_operations_status() -> ProviderOperationsStatusResponse:
         provider_mode=resolve_provider_execution_config().provider_mode,
         operations_state=operations_state,
         runtime_execution_enabled=live_execution_state.live_execution_enabled,
+        enforcing_kill_switch_count=build_kill_switch_status().active_count,
         rollout_blocked=operations_state == ProviderOperationsState.ROLLOUT_BLOCKED,
         quota_policy=quota_policy,
         budget_policy=budget_policy,

--- a/tests/unit/test_kill_switch_expiry_observability.py
+++ b/tests/unit/test_kill_switch_expiry_observability.py
@@ -1,0 +1,93 @@
+"""TTL expiry events and kill-switch observability (issue #177, S4)."""
+
+from pathlib import Path
+
+from prometheus_client import REGISTRY
+
+from app.config import settings
+from app.contracts.kill_switches import (
+    KillSwitchActivationRequest,
+    KillSwitchScope,
+    KillSwitchSemantics,
+)
+from app.services.kill_switch_control import activate_kill_switch, build_kill_switch_status
+from app.services.kill_switch_store import get_kill_switch_repository
+from app.services.provider_metrics import record_kill_switch_action
+from app.services.provider_operations_status import build_provider_operations_status
+from tests.support.migration_runner import upgrade_database_to_head
+
+
+def _use_durable_store(tmp_path: Path, name: str) -> None:
+    settings.kill_switch_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / name}"
+    upgrade_database_to_head(settings.database_url)
+
+
+def _activate(*, expires_at_utc: str | None = None) -> str:
+    response = activate_kill_switch(
+        KillSwitchActivationRequest(
+            caller_app="lotus-platform",
+            scope=KillSwitchScope.TASK,
+            semantics=KillSwitchSemantics.HARD_KILL,
+            target="explain.v1",
+            reason="Expiry-observability test activation.",
+            requested_by="alice@lotus.test",
+            approved_by="bob@lotus.test",
+            expires_at_utc=expires_at_utc,
+        )
+    )
+    return response.activation.switch_id
+
+
+def _metric(action: str) -> float:
+    value = REGISTRY.get_sample_value(
+        "lotus_ai_kill_switch_actions_total",
+        {"action": action, "scope": "TASK", "semantics": "HARD_KILL"},
+    )
+    return value or 0.0
+
+
+def test_lapsed_ttl_records_a_durable_expiry_event_exactly_once(tmp_path: Path) -> None:
+    _use_durable_store(tmp_path, "kill-switch-expiry.db")
+    switch_id = _activate(expires_at_utc="2000-01-01T00:00:00Z")
+    expired_before = _metric("expired")
+
+    first = build_kill_switch_status()
+    assert first.expired_count == 1
+    assert first.active_count == 0
+    stored = get_kill_switch_repository().get_activation(switch_id)
+    assert stored is not None
+    assert stored.expiry_recorded_at is not None
+    recorded_at = stored.expiry_recorded_at
+    assert _metric("expired") == expired_before + 1
+
+    # Idempotent: a second read neither rewrites the marker nor recounts.
+    second = build_kill_switch_status()
+    assert second.expired_count == 1
+    stored_again = get_kill_switch_repository().get_activation(switch_id)
+    assert stored_again is not None
+    assert stored_again.expiry_recorded_at == recorded_at
+    assert _metric("expired") == expired_before + 1
+
+
+def test_activation_and_clearance_record_counter_actions(tmp_path: Path) -> None:
+    _use_durable_store(tmp_path, "kill-switch-counters.db")
+    activated_before = _metric("activated")
+
+    _activate()
+
+    assert _metric("activated") == activated_before + 1
+
+
+def test_operations_status_surfaces_the_enforcing_kill_count(tmp_path: Path) -> None:
+    _use_durable_store(tmp_path, "kill-switch-operations.db")
+    assert build_provider_operations_status().enforcing_kill_switch_count == 0
+
+    _activate()
+
+    assert build_provider_operations_status().enforcing_kill_switch_count == 1
+
+
+def test_kill_switch_counter_is_fail_open_for_unbounded_actions() -> None:
+    # An unknown action is normalized, never raised.
+    record_kill_switch_action(action="not-a-real-action", scope="TASK", semantics="HARD_KILL")

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -92,7 +92,7 @@ platform programs.
      identity as a first-class entry (provider, family, exact revision, deployment, SKU,
      lifecycle state, approval evidence, pinning posture), reconciled on read from the
      live-text settings and the approved model-risk inventory (issue #175 slice 1)
-2. kill switches (issue #177 slices 1 and 3)
+2. kill switches (issue #177 slices 1, 3 and 4)
    - `/platform/providers/kill-switches` — list activations and the enforcing count; POST
      activates a scoped switch (provider, model revision, task, tenant, caller app, or
      all live text); `/{switch_id}/clear` clears one. Enforced first at the gateway
@@ -101,6 +101,12 @@ platform programs.
      immediately; `DRAIN` refuses new synchronous executions and new async workflow-pack
      intake while already-claimed async jobs complete safely. Synchronous requests are
      never drained — they refuse immediately under either semantics.
+   - TTL expiry is sweep-on-read: a lapsed activation is inert from `expires_at_utc`,
+     and the first read after lapse durably records the expiry event
+     (`expiry_recorded_at`) exactly once; the status response carries the expired
+     count, re-activation is always a new activation. Lifecycle and enforcement
+     actions feed the `lotus_ai_kill_switch_actions_total` counter (action, scope,
+     semantics), and the provider operations status carries the enforcing count.
 3. app-capability rollout governance
    - `/platform/app-capability-rollouts`
    - `/platform/app-capability-rollouts/governance-status`


### PR DESCRIPTION
**Closes #177** — S4, the final slice. S1 was #186 (preflight enforcement), S3 was #207 (drain semantics, gate 33332373067 verified), and S2's operator API was delivered by S1's over-delivery ([recorded on the issue](https://github.com/sgajbi/lotus-ai/issues/177#issuecomment-5470431767)).

## What this does

1. **Durable TTL expiry events, sweep-on-read**: a lapsed, uncleared activation is inert from `expires_at_utc` regardless; the first read after lapse durably records the expiry event (`expiry_recorded_at`, migration 0052) **exactly once** — deterministic, replica-safe (idempotent marker upsert), no scheduler. Re-activation is always a new activation. `expired_count` rides the status response.
2. **`lotus_ai_kill_switch_actions_total`** joins the vocabulary-guarded metric set: activation, clearance, expiry, and refusals (sync and intake as distinct actions) by scope and semantics — fail-open like every lotus-ai metric, unbounded actions normalized.
3. **Provider operations status carries `enforcing_kill_switch_count`** — the incident surface shows the current kill posture, sourced from the same status builder the kill-switch route uses (one source, two views).

## #177 acceptance criteria at close

- Scoped hard kill refused preflight with the bounded reason while stub/other providers unaffected; clearing restores — integration-tested since S1.
- Capability/tenant/model-revision scopes each refuse exactly their target, fail-closed, no substitution (S1 scope-matrix tests).
- Every activation/clearance durably recorded with operator identity, reason, scope, timestamps; status lists activations including cleared/expired with the enforcing count (S1) and now the expiry events + counts (S4).
- Unauthorized callers refused (S1); breaker resets provably don't clear kill switches (S1 negative test).
- Store-unavailability fails closed (S1); expired TTL inert + recorded + re-activation is new (S4); overlapping scopes: every matching activation refuses independently — most restrictive wins by construction, all recorded.
- Semantics: HARD_KILL vs DRAIN complete (S3) with sync-never-drained documented.

## Verification

Full suite **1979 passed**, combined coverage 99% (21174 statements, 294 missed); lint (purity guard), typecheck, OpenAPI gate (new contract fields), migration smoke all green. Expiry proven exactly-once with the counter non-recounting on a second read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)