### PR TITLE
feat(observability): OpenTelemetry tracing behind a flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ LOTUS_AI_LIVE_EMBEDDING_PROVIDER_API_KEY=
 LOTUS_AI_LIVE_TEXT_MODEL_VERSION=
 LOTUS_AI_LIVE_TEXT_TEMPERATURE=0.0
 LOTUS_AI_REDACTION_MODE=enforce
+# Tracing is off by default; enabling requires the OTLP endpoint.
+# LOTUS_AI_TRACING_ENABLED=true
+# LOTUS_AI_TRACING_OTLP_ENDPOINT=http://otel-collector:4318/v1/traces
 # Optional sampling bounds; leave unset (commented) to omit from provider calls.
 # LOTUS_AI_LIVE_TEXT_TOP_P=1.0
 # LOTUS_AI_LIVE_TEXT_SEED=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
   # across 7.x/8.x (see its comment) and the full suite exercises it.
   "prometheus-fastapi-instrumentator>=7.1.0",
   "prometheus-client>=0.20.0",
+  "opentelemetry-api>=1.25",
+  "opentelemetry-sdk>=1.25",
+  "opentelemetry-exporter-otlp-proto-http>=1.25",
   "redis>=6.4.0",
   "sqlalchemy>=2.0.44"
 ]

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -42,6 +42,8 @@ class Settings(BaseSettings):
     live_text_top_p: float | None = None
     live_text_seed: int | None = None
     redaction_mode: str = "enforce"
+    tracing_enabled: bool = False
+    tracing_otlp_endpoint: str | None = None
     retrieval_mode: str = "disabled"
     embedding_provider_mode: str = "disabled"
     safety_mode: str = "documented_only"

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -15,6 +15,7 @@ from app.config import settings
 from app.contracts.api_errors import COMMON_PROBLEM_RESPONSES, ProblemDetails
 from app.http.authenticated_caller import require_authenticated_caller
 from app.middleware.correlation import CorrelationIdMiddleware
+from app.services.tracing_runtime import configure_tracing
 from app.middleware.http_boundary import HttpBoundaryMiddleware
 from app.routers.access_control import router as access_control_router
 from app.routers.artifacts import router as artifacts_router
@@ -196,6 +197,7 @@ app = FastAPI(
     responses=COMMON_PROBLEM_RESPONSES,
 )
 install_problem_detail_handlers(app)
+configure_tracing()
 app.add_middleware(HttpBoundaryMiddleware)
 app.add_middleware(CorrelationIdMiddleware, service_name=SERVICE_NAME)
 _install_fastapi_included_router_prometheus_patch()

--- a/src/app/middleware/correlation.py
+++ b/src/app/middleware/correlation.py
@@ -10,6 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
 from app.services.structured_logging import bind_correlation_context, log_event
+from app.services.tracing_runtime import server_request_span
 
 _logger = logging.getLogger("app.http")
 
@@ -32,12 +33,22 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
             source="provided" if provided else "generated",
         )
         start = time.perf_counter()
-        response = await call_next(request)
+        with server_request_span(
+            method=request.method,
+            headers=dict(request.headers),
+            correlation_id=correlation_id,
+        ) as span_handle:
+            response = await call_next(request)
+            route = request.scope.get("route")
+            span_handle.finish(
+                method=request.method,
+                route=getattr(route, "path", request.url.path),
+                status_code=response.status_code,
+            )
         duration_ms = (time.perf_counter() - start) * 1000.0
         response.headers["X-Correlation-Id"] = correlation_id
         response.headers["X-Service-Name"] = self._service_name
         response.headers["X-Request-Duration-Ms"] = f"{duration_ms:.3f}"
-        route = request.scope.get("route")
         log_event(
             _logger,
             "http_request",

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -20,6 +20,11 @@ from app.services.provider_execution_overrides import (
     get_text_transport_post_override,
 )
 from app.services.provider_metrics import record_provider_attempt
+from app.services.tracing_runtime import (
+    inject_trace_context,
+    provider_attempt_span,
+    record_provider_span_outcome,
+)
 from app.services.structured_logging import correlation_id_var, log_event
 from app.providers.advisor_brief_quality_guardrails import (
     build_advisor_brief_user_message,
@@ -166,6 +171,7 @@ def post_openai_compatible_response(
     correlation_id = correlation_id_var.get()
     if correlation_id is not None:
         headers["X-Correlation-Id"] = correlation_id
+    inject_trace_context(headers)
     model_identity = payload.get("model")
     bounded_retry_limit = max(retry_limit, 0)
     for attempt_index in range(bounded_retry_limit + 1):
@@ -177,7 +183,15 @@ def post_openai_compatible_response(
         )
         attempt_started = time.perf_counter()
         try:
-            with urllib_request.urlopen(provider_request, timeout=timeout_seconds) as response:
+            with (
+                provider_attempt_span(
+                    provider_id=provider_display_name,
+                    model_id=model_identity if isinstance(model_identity, str) else None,
+                    attempt=attempt_index,
+                ) as attempt_span,
+                urllib_request.urlopen(provider_request, timeout=timeout_seconds) as response,
+            ):
+                record_provider_span_outcome(attempt_span, outcome="success")
                 response_payload = cast(dict[str, Any], json.loads(response.read().decode("utf-8")))
                 response_payload["_lotus_retry_count"] = attempt_index
                 usage = response_payload.get("usage")

--- a/src/app/services/tracing_runtime.py
+++ b/src/app/services/tracing_runtime.py
@@ -1,0 +1,174 @@
+"""OpenTelemetry tracing behind a flag (issue #152, S4-slice).
+
+Spans are hand-rolled at the two seams lotus-ai owns - the HTTP server
+boundary and the provider transport attempt - rather than through framework
+auto-instrumentation, so span names and attributes stay under this
+repository's control and the no-content telemetry rule holds by
+construction (bounded attributes only; never prompt or output text).
+
+Naming, recorded for alignment with the lotus-core #569 programme:
+- server spans: ``{METHOD} {route_template}`` (OTel HTTP semantic style)
+- provider client spans: ``lotus_ai.provider.request``
+- attributes beyond OTel semconv use the ``lotus_ai.`` namespace, mirroring
+  the metric prefix.
+
+The module holds its own ``TracerProvider`` instead of the process-global
+one, so tests can configure and reset it freely; W3C ``traceparent`` is
+extracted on ingress and injected on provider egress through the explicit
+propagator API. Tracing is telemetry: once configured, failures never block
+a request. Configuration itself is validated fail-closed - enabling tracing
+without an endpoint (and without an injected exporter) refuses startup
+rather than silently exporting nowhere.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+from app.config import settings
+
+_tracer_provider: TracerProvider | None = None
+_propagator = TraceContextTextMapPropagator()
+
+
+def configure_tracing(*, span_exporter: SpanExporter | None = None) -> None:
+    """Configure the lotus-ai tracer provider from settings.
+
+    ``span_exporter`` is the explicit injection seam (tests pass an
+    in-memory exporter); by default the OTLP HTTP exporter targets
+    ``LOTUS_AI_TRACING_OTLP_ENDPOINT``, which is required when tracing is
+    enabled - enabling tracing that exports nowhere would be a silently
+    broken control.
+    """
+
+    global _tracer_provider
+    if not settings.tracing_enabled:
+        _tracer_provider = None
+        return
+    exporter = span_exporter
+    if exporter is None:
+        if not settings.tracing_otlp_endpoint:
+            raise RuntimeError(
+                "LOTUS_AI_TRACING_OTLP_ENDPOINT is required when LOTUS_AI_TRACING_ENABLED=true."
+            )
+        exporter = OTLPSpanExporter(endpoint=settings.tracing_otlp_endpoint)
+    provider = TracerProvider(
+        resource=Resource.create(
+            {
+                "service.name": settings.service_name,
+                "service.version": settings.service_version,
+            }
+        )
+    )
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    _tracer_provider = provider
+
+
+def force_flush_tracing() -> None:
+    """Flush buffered spans (batch export is asynchronous by design)."""
+
+    if _tracer_provider is not None:
+        _tracer_provider.force_flush()
+
+
+def reset_tracing_for_tests() -> None:
+    global _tracer_provider
+    if _tracer_provider is not None:
+        _tracer_provider.shutdown()
+    _tracer_provider = None
+
+
+def is_tracing_active() -> bool:
+    return _tracer_provider is not None
+
+
+def _tracer() -> trace.Tracer | None:
+    if _tracer_provider is None:
+        return None
+    return _tracer_provider.get_tracer("lotus-ai")
+
+
+@contextmanager
+def server_request_span(
+    *,
+    method: str,
+    headers: dict[str, str],
+    correlation_id: str | None,
+) -> Iterator["_ServerSpanHandle"]:
+    """One server span per HTTP request; a no-op handle when tracing is off."""
+
+    tracer = _tracer()
+    if tracer is None:
+        yield _ServerSpanHandle(span=None)
+        return
+    parent = _propagator.extract(carrier=headers)
+    token = otel_context.attach(parent)
+    span = tracer.start_span(method, context=parent, kind=trace.SpanKind.SERVER)
+    handle = _ServerSpanHandle(span=span)
+    try:
+        with trace.use_span(span, end_on_exit=False):
+            span.set_attribute("http.request.method", method)
+            if correlation_id is not None:
+                span.set_attribute("lotus_ai.correlation_id", correlation_id)
+            yield handle
+    finally:
+        span.end()
+        otel_context.detach(token)
+
+
+class _ServerSpanHandle:
+    def __init__(self, *, span: trace.Span | None) -> None:
+        self._span = span
+
+    def finish(self, *, method: str, route: str, status_code: int) -> None:
+        if self._span is None:
+            return
+        self._span.update_name(f"{method} {route}")
+        self._span.set_attribute("http.route", route)
+        self._span.set_attribute("http.response.status_code", status_code)
+
+
+@contextmanager
+def provider_attempt_span(
+    *,
+    provider_id: str,
+    model_id: str | None,
+    attempt: int,
+) -> Iterator[trace.Span | None]:
+    """One client span per provider attempt; no-op when tracing is off."""
+
+    tracer = _tracer()
+    if tracer is None:
+        yield None
+        return
+    with tracer.start_as_current_span(
+        "lotus_ai.provider.request", kind=trace.SpanKind.CLIENT
+    ) as span:
+        span.set_attribute("lotus_ai.provider_id", provider_id)
+        span.set_attribute("lotus_ai.model_id", model_id or "unknown")
+        span.set_attribute("lotus_ai.attempt", attempt)
+        yield span
+
+
+def record_provider_span_outcome(span: trace.Span | None, *, outcome: str) -> None:
+    if span is None:
+        return
+    span.set_attribute("lotus_ai.outcome", outcome)
+
+
+def inject_trace_context(headers: dict[str, Any]) -> None:
+    """Inject W3C traceparent into egress headers when a span is recording."""
+
+    if _tracer_provider is None:
+        return
+    _propagator.inject(carrier=headers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,8 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         "embedding_provider_mode": settings.embedding_provider_mode,
         "safety_mode": settings.safety_mode,
         "redaction_mode": settings.redaction_mode,
+        "tracing_enabled": settings.tracing_enabled,
+        "tracing_otlp_endpoint": settings.tracing_otlp_endpoint,
         "audit_store_mode": settings.audit_store_mode,
         "prompt_store_mode": settings.prompt_store_mode,
         "retrieval_store_mode": settings.retrieval_store_mode,

--- a/tests/unit/test_tracing_runtime.py
+++ b/tests/unit/test_tracing_runtime.py
@@ -1,0 +1,131 @@
+"""OpenTelemetry tracing behind a flag (issue #152)."""
+
+from collections.abc import Iterator
+
+from fastapi.testclient import TestClient
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pytest import MonkeyPatch, fixture, raises
+
+from app.config import settings
+from app.main import app
+from app.services.tracing_runtime import (
+    configure_tracing,
+    force_flush_tracing,
+    inject_trace_context,
+    is_tracing_active,
+    provider_attempt_span,
+    record_provider_span_outcome,
+    reset_tracing_for_tests,
+)
+
+
+@fixture(autouse=True)
+def _reset_tracing() -> Iterator[None]:
+    yield
+    reset_tracing_for_tests()
+
+
+def _enable(exporter: InMemorySpanExporter) -> None:
+    settings.tracing_enabled = True
+    configure_tracing(span_exporter=exporter)
+
+
+def test_tracing_is_off_by_default_and_configures_to_noop() -> None:
+    configure_tracing()
+    assert is_tracing_active() is False
+    with provider_attempt_span(provider_id="p", model_id="m", attempt=0) as span:
+        assert span is None
+    headers: dict[str, object] = {}
+    inject_trace_context(headers)
+    assert headers == {}
+
+
+def test_enabling_without_an_endpoint_refuses_startup() -> None:
+    settings.tracing_enabled = True
+    settings.tracing_otlp_endpoint = None
+    with raises(RuntimeError) as exc_info:
+        configure_tracing()
+    assert "LOTUS_AI_TRACING_OTLP_ENDPOINT" in str(exc_info.value)
+
+
+def test_server_span_carries_route_status_and_inbound_traceparent() -> None:
+    exporter = InMemorySpanExporter()
+    _enable(exporter)
+
+    client = TestClient(app)
+    response = client.get(
+        "/health/live",
+        headers={"traceparent": "00-11111111111111111111111111111111-2222222222222222-01"},
+    )
+    assert response.status_code == 200
+
+    force_flush_tracing()
+    spans = exporter.get_finished_spans()
+    server_spans = [span for span in spans if span.kind.name == "SERVER"]
+    assert len(server_spans) == 1
+    span = server_spans[0]
+    assert span.name == "GET /health/live"
+    assert span.attributes is not None
+    assert span.attributes["http.route"] == "/health/live"
+    assert span.attributes["http.response.status_code"] == 200
+    assert "lotus_ai.correlation_id" in span.attributes
+    # The gateway-propagated W3C trace continues through lotus-ai.
+    assert format(span.context.trace_id, "032x") == "11111111111111111111111111111111"
+
+
+def test_provider_attempt_span_records_identity_and_outcome() -> None:
+    exporter = InMemorySpanExporter()
+    _enable(exporter)
+
+    with provider_attempt_span(provider_id="text.local", model_id="qwen3:8b", attempt=1) as span:
+        record_provider_span_outcome(span, outcome="success")
+
+    force_flush_tracing()
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert attributes is not None
+    assert spans[0].name == "lotus_ai.provider.request"
+    assert attributes["lotus_ai.provider_id"] == "text.local"
+    assert attributes["lotus_ai.model_id"] == "qwen3:8b"
+    assert attributes["lotus_ai.attempt"] == 1
+    assert attributes["lotus_ai.outcome"] == "success"
+
+
+def test_traceparent_is_injected_on_provider_egress(monkeypatch: MonkeyPatch) -> None:
+    exporter = InMemorySpanExporter()
+    _enable(exporter)
+
+    captured_headers: dict[str, str] = {}
+
+    class _Response:
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b'{"id": "resp_trace", "output_text": "OK"}'
+
+    def _urlopen(request: object, timeout: float) -> _Response:
+        captured_headers.update(
+            {key.lower(): value for key, value in getattr(request, "headers", {}).items()}
+        )
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+    from app.providers.openai_compatible_text_transport import post_openai_compatible_response
+
+    with provider_attempt_span(provider_id="p", model_id="m", attempt=0):
+        post_openai_compatible_response(
+            api_base="http://localhost:1234/v1",
+            api_key=None,
+            payload={"model": "m"},
+            timeout_seconds=1.0,
+            provider_display_name="Local OpenAI-Compatible Text Provider",
+            require_api_key=False,
+            retry_limit=0,
+        )
+
+    assert "traceparent" in captured_headers

--- a/wiki/Configuration-Reference.md
+++ b/wiki/Configuration-Reference.md
@@ -92,6 +92,8 @@ startup — smoke-test a route that uses the store after changing one.
 | `LOTUS_AI_LIVE_TEXT_TEMPERATURE` | `0.0` — always sent explicitly; never left to provider defaults |
 | `LOTUS_AI_LIVE_TEXT_TOP_P` | *(none)* — omitted from provider calls when unset |
 | `LOTUS_AI_LIVE_TEXT_SEED` | *(none)* — omitted from provider calls when unset |
+| `LOTUS_AI_TRACING_ENABLED` | `false` — OpenTelemetry spans at the HTTP boundary and provider transport; enabling requires the OTLP endpoint (startup refuses otherwise) |
+| `LOTUS_AI_TRACING_OTLP_ENDPOINT` | *(none)* — OTLP/HTTP trace endpoint |
 | `LOTUS_AI_REDACTION_MODE` | `enforce` — the deterministic redaction engine redacts generated content before persistence and egress; `observe` counts findings without modifying content |
 
 Sampling parameters are part of the recorded reproducibility identity: every audit


### PR DESCRIPTION
**Closes #152** — the final slice (tracing); S1 structured logging was #193, S2 metrics #194.

## What this does

OTel spans behind `LOTUS_AI_TRACING_ENABLED` (default **off** — the tracer provider is `None` and every seam is an asserted no-op, so promoted behavior is unchanged until an operator enables it). Spans are hand-rolled at the two seams lotus-ai owns, not via framework auto-instrumentation — span names and attributes stay under this repository's control and the no-content telemetry rule holds by construction:

1. **Server span per HTTP request** (correlation middleware): named `{METHOD} {route_template}`, with `http.route`, status code, and the correlation id; the gateway-propagated W3C `traceparent` is extracted so the ecosystem trace continues through lotus-ai (proven: inbound trace id continues into the server span).
2. **Client span per provider transport attempt** (`lotus_ai.provider.request`): bounded `lotus_ai.*` attributes (provider, model, attempt, outcome), `traceparent` injected on provider egress (proven via captured urlopen headers).
3. **Fail-closed configuration**: enabling tracing without `LOTUS_AI_TRACING_OTLP_ENDPOINT` refuses startup — tracing that exports nowhere would be a silently broken control. The exporter is an explicit injection seam (tests use the in-memory exporter + force-flush; batch export is asynchronous by design).
4. Module-held `TracerProvider` (not the process-global singleton) so configuration is resettable; conftest snapshot gains the two tracing settings per the explicit-key rule.

**Span naming recorded for alignment with lotus-core #569** (which has not yet pinned conventions): OTel HTTP semantic style for server spans; `lotus_ai.` attribute namespace mirroring the metric prefix — noted on both issues at close.

## Verification

Full suite **1980 passed**, combined coverage 99% (21243 statements, 293 missed); verify-dependencies (three new `opentelemetry-*` runtime deps declared), lint (purity guard), typecheck, OpenAPI gate all green. Five tracing tests: default no-op, endpoint-refusal, server span naming + trace continuity, provider span attributes, egress injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)