### PR TITLE
feat(economics): accounting binds the rate-card catalogue by routed identity

### DIFF
--- a/alembic/versions/0053_add_rate_card_scope_target.py
+++ b/alembic/versions/0053_add_rate_card_scope_target.py
@@ -1,0 +1,28 @@
+"""add scope target to rate cards for model-revision pricing
+
+Revision ID: 0053_add_rate_card_scope_target
+Revises: 0052_add_kill_switch_expiry_marker
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0053_add_rate_card_scope_target"
+down_revision = "0052_add_kill_switch_expiry_marker"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "rate_cards",
+        sa.Column("scope_target", sa.String(length=256), nullable=True),
+    )
+    op.create_index("ix_rate_cards_scope_target", "rate_cards", ["scope_target"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_rate_cards_scope_target", table_name="rate_cards")
+    op.drop_column("rate_cards", "scope_target")

--- a/docs/evals/fixtures/providers.operations/basic_cases.json
+++ b/docs/evals/fixtures/providers.operations/basic_cases.json
@@ -24,6 +24,7 @@
         "task_id": "explain.v1",
         "configured_mode": "openai",
         "hard_budget_usd": 1.0,
+        "rate_card": { "input_cost_per_1k_tokens": 0.01, "output_cost_per_1k_tokens": 0.03 },
         "tracked_spend_usd": 1.0
       },
       "expected": {
@@ -40,7 +41,8 @@
         "configured_mode": "openai",
         "provider_operations_store_mode": "sqlalchemy",
         "recorded_spend_usd": 0.75,
-        "hard_budget_usd": 1.0
+        "hard_budget_usd": 1.0,
+        "rate_card": { "input_cost_per_1k_tokens": 0.01, "output_cost_per_1k_tokens": 0.03 }
       },
       "expected": {
         "budget_state": "SOFT_LIMIT_REACHED",

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -839,6 +839,11 @@ class ProviderExecutionResponse(BaseModel):
         default=None,
         description="Estimated USD cost for the provider execution when rate-card data is configured.",
     )
+    rate_card_ref: str | None = Field(
+        default=None,
+        description="Identity of the rate card that priced this execution (issue #178 S2); "
+        "null is the explicit cost-unknown posture.",
+    )
     stubbed: bool = Field(description="Whether execution was handled by a stub provider path.")
     message: str = Field(description="Human-readable execution message returned by the provider.")
     structured_output: dict[str, object] = Field(
@@ -864,6 +869,16 @@ class EmbeddingExecutionResponse(BaseModel):
     )
     stubbed: bool = Field(
         description="Whether embedding execution was handled by a stub provider path."
+    )
+    estimated_cost_usd: float | None = Field(
+        default=None,
+        description="Estimated embedding cost in USD when an EMBEDDING_DEFAULT rate card "
+        "is effective (issue #178 S2).",
+    )
+    rate_card_ref: str | None = Field(
+        default=None,
+        description="Identity of the rate card that priced this embedding execution; null "
+        "is the explicit cost-unknown posture.",
     )
     vector_dimension: int | None = Field(
         default=None,

--- a/src/app/contracts/rate_cards.py
+++ b/src/app/contracts/rate_cards.py
@@ -15,18 +15,32 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class RateCardScopeKind(str, Enum):
     DEFAULT_LIVE_TEXT = "DEFAULT_LIVE_TEXT"
+    MODEL_REVISION = "MODEL_REVISION"
+    EMBEDDING_DEFAULT = "EMBEDDING_DEFAULT"
+
+
+TARGETLESS_RATE_CARD_SCOPES = frozenset(
+    {RateCardScopeKind.DEFAULT_LIVE_TEXT, RateCardScopeKind.EMBEDDING_DEFAULT}
+)
 
 
 class RateCard(BaseModel):
     card_id: str = Field(min_length=1, description="Rate-card identity.")
     scope_kind: RateCardScopeKind = Field(
         description="What executions this card prices; DEFAULT_LIVE_TEXT prices every live "
-        "text execution, exactly as the legacy scalars did.",
+        "text execution (exactly as the legacy scalars did), MODEL_REVISION prices one "
+        "routed model revision and beats the default, EMBEDDING_DEFAULT prices embedding "
+        "executions.",
+    )
+    scope_target: str | None = Field(
+        default=None,
+        description="Scope key (the model revision for MODEL_REVISION); null for the "
+        "targetless default scopes.",
     )
     currency: str = Field(description="ISO currency of the prices.")
     input_cost_per_1k_tokens: float = Field(ge=0, description="Price per 1000 input tokens.")
@@ -40,6 +54,16 @@ class RateCard(BaseModel):
         description="Effective end (UTC), exclusive; null means no expiry.",
     )
     created_at: str = Field(description="Instant this card was first stored (UTC).")
+
+    @model_validator(mode="after")
+    def _validate_scope_target(self) -> "RateCard":
+        if self.scope_kind in TARGETLESS_RATE_CARD_SCOPES:
+            if self.scope_target is not None:
+                raise ValueError(f"Scope {self.scope_kind.value} is targetless.")
+        elif not self.scope_target:
+            raise ValueError(f"Scope {self.scope_kind.value} requires a scope_target.")
+        return self
+
     last_updated_at: str = Field(description="Instant this card last changed (UTC).")
 
 

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -663,6 +663,7 @@ class RateCardModel(Base):
 
     card_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     scope_kind: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    scope_target: Mapped[str | None] = mapped_column(String(256), nullable=True, index=True)
     currency: Mapped[str] = mapped_column(String(8), nullable=False)
     input_cost_per_1k_tokens: Mapped[float] = mapped_column(Float, nullable=False)
     output_cost_per_1k_tokens: Mapped[float] = mapped_column(Float, nullable=False)

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -30,7 +30,7 @@ from app.providers.advisor_brief_quality_guardrails import (
     build_advisor_brief_user_message,
     normalize_advisor_brief_output,
 )
-from app.services.provider_usage_accounting import estimate_live_text_cost_usd
+from app.services.provider_usage_accounting import estimate_live_text_cost
 
 
 def execute_openai_compatible_text_request(
@@ -88,6 +88,11 @@ def execute_openai_compatible_text_request(
         configured_model_id=model_id,
     )
     input_tokens, output_tokens, total_tokens = extract_usage(response_payload)
+    cost = estimate_live_text_cost(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        model_revision=model_version or model_id,
+    )
     return ProviderExecutionResponse(
         provider_id=descriptor.provider_id,
         provider_mode=descriptor.runtime_mode.value,
@@ -102,10 +107,8 @@ def execute_openai_compatible_text_request(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
-        estimated_cost_usd=estimate_live_text_cost_usd(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-        ),
+        estimated_cost_usd=cost.estimated_cost_usd,
+        rate_card_ref=cost.rate_card_ref,
         stubbed=False,
         message=message,
         structured_output=structured_output,
@@ -438,15 +441,19 @@ def build_structured_output(
         "retry_count": extract_retry_count(response_payload),
     }
     input_tokens, output_tokens, total_tokens = extract_usage(response_payload)
+    structured_cost = estimate_live_text_cost(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        model_revision=configured_model_id,
+    )
     structured_output.update(
         {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "total_tokens": total_tokens,
-            "estimated_cost_usd": estimate_live_text_cost_usd(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-            ),
+            "estimated_cost_usd": structured_cost.estimated_cost_usd,
+            "rate_card_ref": structured_cost.rate_card_ref,
+            "cost_posture": structured_cost.cost_posture,
         }
     )
     if not is_advisor_brief_payload(request.context_payload):

--- a/src/app/providers/openai_live_embedding_provider.py
+++ b/src/app/providers/openai_live_embedding_provider.py
@@ -16,6 +16,7 @@ from app.contracts.providers import (
 )
 from app.providers.base import ProviderAdapterDescriptor, ProviderExecutionError
 from app.services.provider_execution_overrides import ensure_network_execution_permitted
+from app.services.provider_usage_accounting import estimate_embedding_cost
 from app.providers.openai_compatible_text_transport import (
     failure_category_for_http_status,
     safe_provider_error_message,
@@ -48,6 +49,11 @@ class OpenAILiveEmbeddingProvider:
             },
         )
         embedding = _extract_embedding(response_payload)
+        usage = response_payload.get("usage")
+        raw_input_tokens = usage.get("prompt_tokens") if isinstance(usage, dict) else None
+        cost = estimate_embedding_cost(
+            input_tokens=raw_input_tokens if isinstance(raw_input_tokens, int) else None
+        )
         model_id = (
             _as_str(response_payload.get("model"))
             or resolve_runtime_mode_config().embedding_model_id
@@ -59,6 +65,8 @@ class OpenAILiveEmbeddingProvider:
             failure_category=None,
             model_id=model_id,
             stubbed=False,
+            estimated_cost_usd=cost.estimated_cost_usd,
+            rate_card_ref=cost.rate_card_ref,
             vector_dimension=len(embedding),
             embedding=embedding,
             message=(

--- a/src/app/repositories/sqlalchemy_rate_card_repository.py
+++ b/src/app/repositories/sqlalchemy_rate_card_repository.py
@@ -34,6 +34,7 @@ class SqlAlchemyRateCardRepository(SqlAlchemyRepositoryBase):
                 model = RateCardModel(card_id=card.card_id)
                 session.add(model)
             model.scope_kind = card.scope_kind.value
+            model.scope_target = card.scope_target
             model.currency = card.currency
             model.input_cost_per_1k_tokens = card.input_cost_per_1k_tokens
             model.output_cost_per_1k_tokens = card.output_cost_per_1k_tokens
@@ -47,6 +48,7 @@ class SqlAlchemyRateCardRepository(SqlAlchemyRepositoryBase):
         return RateCard(
             card_id=model.card_id,
             scope_kind=RateCardScopeKind(model.scope_kind),
+            scope_target=model.scope_target,
             currency=model.currency,
             input_cost_per_1k_tokens=model.input_cost_per_1k_tokens,
             output_cost_per_1k_tokens=model.output_cost_per_1k_tokens,

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -52,8 +52,8 @@ from app.services.prompt_store import get_prompt_repository
 from app.services.prompt_store import reset_prompt_store_cache
 from app.services.provider_budget_policy import build_provider_budget_policy
 from app.contracts.rate_cards import RateCard, RateCardScopeKind
+from app.services.provider_usage_accounting import save_rate_card
 from app.services.rate_card_store import (
-    get_rate_card_repository,
     reset_rate_card_store_cache,
 )
 from app.services.runtime_mode_config import (
@@ -1225,14 +1225,21 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                     updated_at=_utcnow_iso(),
                 )
             if "hard_budget_usd" in input_payload:
+                # The card is fixture data (issue #178 S3): budget cases
+                # declare their rates in the fixture payload.
+                fixture_rates = cast(dict[str, object], input_payload["rate_card"])
                 seeded_at = _utcnow_iso()
-                get_rate_card_repository().upsert_card(
+                save_rate_card(
                     RateCard(
                         card_id="eval-hermetic-live-text",
                         scope_kind=RateCardScopeKind.DEFAULT_LIVE_TEXT,
                         currency="USD",
-                        input_cost_per_1k_tokens=0.01,
-                        output_cost_per_1k_tokens=0.03,
+                        input_cost_per_1k_tokens=float(
+                            cast(int | float | str, fixture_rates["input_cost_per_1k_tokens"])
+                        ),
+                        output_cost_per_1k_tokens=float(
+                            cast(int | float | str, fixture_rates["output_cost_per_1k_tokens"])
+                        ),
                         effective_from_utc=None,
                         effective_to_utc=None,
                         created_at=seeded_at,

--- a/src/app/services/provider_usage_accounting.py
+++ b/src/app/services/provider_usage_accounting.py
@@ -1,14 +1,31 @@
-"""Live-text cost accounting, sourced from the rate-card catalogue (issue #178).
+"""Usage cost accounting, sourced from the rate-card catalogue (issue #178).
 
 The two legacy cost scalars are seed inputs only: the seed migrates them into
-the DEFAULT_LIVE_TEXT rate card, and estimation resolves the effective card.
-Behaviour is cutover-identical - the same numbers the scalars produced - with
-the source moved to governed, effective-dated data.
+the DEFAULT_LIVE_TEXT rate card, and estimation resolves the effective card
+for the routed identity at the execution instant (S2):
+
+- resolution precedence: a MODEL_REVISION card matching the routed revision
+  beats the DEFAULT_LIVE_TEXT card; among candidates the latest
+  effective_from wins (a new effective row changes costs only for
+  executions after its instant), ties broken by card_id for determinism.
+- every estimate carries the rate_card_ref of the card that priced it; no
+  applicable card is an explicit cost-unknown posture (estimate and ref are
+  both None) and never blocks execution - economics observe, policy decides.
+- embedding executions price through the EMBEDDING_DEFAULT scope the same
+  way; no seed exists for it, so pricing starts when an operator-supplied
+  card does.
+
+Writes go through save_rate_card, which refuses overlapping effective
+ranges for the same scope key - the write-side invariant every producer
+(seed, eval fixtures, tests, future operator API) shares.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
+
+from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.rate_cards import RateCard, RateCardScopeKind
@@ -18,6 +35,58 @@ DEFAULT_LIVE_TEXT_CARD_ID = "default-live-text"
 
 # Fields the seeder owns; provenance timestamps are managed by idempotency.
 _SEED_MANAGED_EXCLUDES = {"created_at", "last_updated_at"}
+
+
+@dataclass(frozen=True)
+class UsageCostEstimate:
+    estimated_cost_usd: float | None
+    rate_card_ref: str | None
+
+    @property
+    def cost_posture(self) -> str:
+        return "ESTIMATED" if self.rate_card_ref is not None else "UNKNOWN"
+
+
+UNKNOWN_COST = UsageCostEstimate(estimated_cost_usd=None, rate_card_ref=None)
+
+
+def save_rate_card(card: RateCard) -> None:
+    """Persist one rate card, refusing overlapping effective ranges.
+
+    Two cards for the same scope key may not have intersecting effective
+    windows (an open bound intersects everything on its side); replacing a
+    card under its own id is always allowed.
+    """
+
+    repository = get_rate_card_repository()
+    for existing in repository.list_cards():
+        if existing.card_id == card.card_id:
+            continue
+        if existing.scope_kind is not card.scope_kind or existing.scope_target != card.scope_target:
+            continue
+        if _windows_overlap(card, existing):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Rate card `{card.card_id}` overlaps the effective range of "
+                    f"`{existing.card_id}` for scope {card.scope_kind.value}"
+                    f"{f' target {card.scope_target}' if card.scope_target else ''}; "
+                    "close the existing window before adding a new one."
+                ),
+            )
+    repository.upsert_card(card)
+
+
+def _windows_overlap(first: RateCard, second: RateCard) -> bool:
+    first_from = _parse_utc(first.effective_from_utc) if first.effective_from_utc else None
+    first_to = _parse_utc(first.effective_to_utc) if first.effective_to_utc else None
+    second_from = _parse_utc(second.effective_from_utc) if second.effective_from_utc else None
+    second_to = _parse_utc(second.effective_to_utc) if second.effective_to_utc else None
+    if first_to is not None and second_from is not None and first_to <= second_from:
+        return False
+    if second_to is not None and first_from is not None and second_to <= first_from:
+        return False
+    return True
 
 
 def ensure_rate_cards_seeded() -> None:
@@ -43,7 +112,7 @@ def ensure_rate_cards_seeded() -> None:
     )
     existing = repository.get_card(DEFAULT_LIVE_TEXT_CARD_ID)
     if existing is None:
-        repository.upsert_card(desired)
+        save_rate_card(desired)
         return
     # Effective windows on the existing card are governed operator data; the
     # seed owns the prices, never the bounds (the #175 resurrection lesson).
@@ -61,28 +130,99 @@ def ensure_rate_cards_seeded() -> None:
     repository.upsert_card(candidate)
 
 
-def resolve_effective_live_text_card(*, at_utc: str | None = None) -> RateCard | None:
-    ensure_rate_cards_seeded()
-    instant = _parse_utc(at_utc) if at_utc is not None else datetime.now(UTC)
+def _effective_candidates(
+    *,
+    scope_kind: RateCardScopeKind,
+    scope_target: str | None,
+    instant: datetime,
+) -> list[RateCard]:
+    candidates = []
     for card in get_rate_card_repository().list_cards():
-        if card.scope_kind is not RateCardScopeKind.DEFAULT_LIVE_TEXT:
+        if card.scope_kind is not scope_kind or card.scope_target != scope_target:
             continue
         if card.effective_from_utc is not None and _parse_utc(card.effective_from_utc) > instant:
             continue
         if card.effective_to_utc is not None and instant >= _parse_utc(card.effective_to_utc):
             continue
-        return card
-    return None
+        candidates.append(card)
+    # Latest effective_from wins (None sorts earliest); card_id breaks ties
+    # deterministically.
+    return sorted(
+        candidates,
+        key=lambda card: (
+            _parse_utc(card.effective_from_utc)
+            if card.effective_from_utc
+            else datetime.min.replace(tzinfo=UTC),
+            card.card_id,
+        ),
+        reverse=True,
+    )
 
 
-def estimate_live_text_cost_usd(
-    *, input_tokens: int | None, output_tokens: int | None
-) -> float | None:
+def resolve_effective_live_text_card(
+    *,
+    model_revision: str | None = None,
+    at_utc: str | None = None,
+) -> RateCard | None:
+    ensure_rate_cards_seeded()
+    instant = _parse_utc(at_utc) if at_utc is not None else datetime.now(UTC)
+    if model_revision is not None:
+        scoped = _effective_candidates(
+            scope_kind=RateCardScopeKind.MODEL_REVISION,
+            scope_target=model_revision,
+            instant=instant,
+        )
+        if scoped:
+            return scoped[0]
+    defaults = _effective_candidates(
+        scope_kind=RateCardScopeKind.DEFAULT_LIVE_TEXT, scope_target=None, instant=instant
+    )
+    return defaults[0] if defaults else None
+
+
+def estimate_live_text_cost(
+    *,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    model_revision: str | None = None,
+    at_utc: str | None = None,
+) -> UsageCostEstimate:
     if input_tokens is None or output_tokens is None:
-        return None
-    card = resolve_effective_live_text_card()
+        return UNKNOWN_COST
+    card = resolve_effective_live_text_card(model_revision=model_revision, at_utc=at_utc)
     if card is None:
-        return None
+        return UNKNOWN_COST
+    return UsageCostEstimate(
+        estimated_cost_usd=_price(card, input_tokens=input_tokens, output_tokens=output_tokens),
+        rate_card_ref=card.card_id,
+    )
+
+
+def resolve_effective_embedding_card(*, at_utc: str | None = None) -> RateCard | None:
+    instant = _parse_utc(at_utc) if at_utc is not None else datetime.now(UTC)
+    candidates = _effective_candidates(
+        scope_kind=RateCardScopeKind.EMBEDDING_DEFAULT, scope_target=None, instant=instant
+    )
+    return candidates[0] if candidates else None
+
+
+def estimate_embedding_cost(
+    *,
+    input_tokens: int | None,
+    at_utc: str | None = None,
+) -> UsageCostEstimate:
+    if input_tokens is None:
+        return UNKNOWN_COST
+    card = resolve_effective_embedding_card(at_utc=at_utc)
+    if card is None:
+        return UNKNOWN_COST
+    return UsageCostEstimate(
+        estimated_cost_usd=_price(card, input_tokens=input_tokens, output_tokens=0),
+        rate_card_ref=card.card_id,
+    )
+
+
+def _price(card: RateCard, *, input_tokens: int, output_tokens: int) -> float:
     return round(
         (input_tokens / 1000.0) * card.input_cost_per_1k_tokens
         + (output_tokens / 1000.0) * card.output_cost_per_1k_tokens,

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -600,6 +600,10 @@ def test_apply_case_configuration_supports_sqlalchemy_budget_and_degradation_pat
         {
             "provider_operations_store_mode": "sqlalchemy",
             "hard_budget_usd": 5.0,
+            "rate_card": {
+                "input_cost_per_1k_tokens": 0.01,
+                "output_cost_per_1k_tokens": 0.03,
+            },
             "tracked_spend_usd": 1.25,
             "degraded_failure_count_threshold": 1,
         }

--- a/tests/unit/test_provider_usage_accounting.py
+++ b/tests/unit/test_provider_usage_accounting.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator
 import pytest
 
 from app.config import settings
-from app.services.provider_usage_accounting import estimate_live_text_cost_usd
+from app.services.provider_usage_accounting import estimate_live_text_cost
 from app.services.rate_card_store import reset_rate_card_store_cache
 
 
@@ -26,7 +26,7 @@ def _fresh_rate_cards(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 def test_estimate_live_text_cost_usd_returns_none_without_rate_card() -> None:
-    assert estimate_live_text_cost_usd(input_tokens=100, output_tokens=50) is None
+    assert estimate_live_text_cost(input_tokens=100, output_tokens=50).estimated_cost_usd is None
 
 
 def test_estimate_live_text_cost_usd_uses_the_seeded_rate_card(
@@ -35,7 +35,10 @@ def test_estimate_live_text_cost_usd_uses_the_seeded_rate_card(
     monkeypatch.setattr(settings, "live_text_input_cost_per_1k_tokens", 0.01)
     monkeypatch.setattr(settings, "live_text_output_cost_per_1k_tokens", 0.03)
 
-    assert estimate_live_text_cost_usd(input_tokens=500, output_tokens=250) == 0.0125
+    estimate = estimate_live_text_cost(input_tokens=500, output_tokens=250)
+    assert estimate.estimated_cost_usd == 0.0125
+    assert estimate.rate_card_ref == "default-live-text"
+    assert estimate.cost_posture == "ESTIMATED"
 
 
 def test_estimate_live_text_cost_usd_returns_none_for_missing_token_counts(
@@ -44,8 +47,8 @@ def test_estimate_live_text_cost_usd_returns_none_for_missing_token_counts(
     monkeypatch.setattr(settings, "live_text_input_cost_per_1k_tokens", 0.01)
     monkeypatch.setattr(settings, "live_text_output_cost_per_1k_tokens", 0.03)
 
-    assert estimate_live_text_cost_usd(input_tokens=None, output_tokens=250) is None
-    assert estimate_live_text_cost_usd(input_tokens=500, output_tokens=None) is None
+    assert estimate_live_text_cost(input_tokens=None, output_tokens=250).estimated_cost_usd is None
+    assert estimate_live_text_cost(input_tokens=500, output_tokens=None).estimated_cost_usd is None
 
 
 def test_estimate_live_text_cost_usd_returns_none_for_partial_rate_configuration(
@@ -55,4 +58,4 @@ def test_estimate_live_text_cost_usd_returns_none_for_partial_rate_configuration
     monkeypatch.setattr(settings, "live_text_output_cost_per_1k_tokens", None)
 
     # A partial configuration seeds no card, so nothing is priced.
-    assert estimate_live_text_cost_usd(input_tokens=500, output_tokens=250) is None
+    assert estimate_live_text_cost(input_tokens=500, output_tokens=250).estimated_cost_usd is None

--- a/tests/unit/test_rate_card_identity_binding.py
+++ b/tests/unit/test_rate_card_identity_binding.py
@@ -1,0 +1,140 @@
+"""Accounting binds the rate-card catalogue by routed identity (issue #178, S2)."""
+
+from fastapi import HTTPException
+from pytest import raises
+
+from app.contracts.rate_cards import RateCard, RateCardScopeKind
+from app.services.provider_usage_accounting import (
+    estimate_embedding_cost,
+    estimate_live_text_cost,
+    resolve_effective_live_text_card,
+    save_rate_card,
+)
+
+
+def _card(
+    card_id: str,
+    *,
+    scope_kind: RateCardScopeKind = RateCardScopeKind.DEFAULT_LIVE_TEXT,
+    scope_target: str | None = None,
+    input_rate: float = 0.01,
+    output_rate: float = 0.03,
+    effective_from: str | None = None,
+    effective_to: str | None = None,
+) -> RateCard:
+    return RateCard(
+        card_id=card_id,
+        scope_kind=scope_kind,
+        scope_target=scope_target,
+        currency="USD",
+        input_cost_per_1k_tokens=input_rate,
+        output_cost_per_1k_tokens=output_rate,
+        effective_from_utc=effective_from,
+        effective_to_utc=effective_to,
+        created_at="2026-08-31T00:00:00Z",
+        last_updated_at="2026-08-31T00:00:00Z",
+    )
+
+
+def test_model_scoped_card_beats_the_default_and_records_its_ref() -> None:
+    save_rate_card(_card("default"))
+    save_rate_card(
+        _card(
+            "premium-model",
+            scope_kind=RateCardScopeKind.MODEL_REVISION,
+            scope_target="gpt-5.4-2026-06-01",
+            input_rate=0.10,
+            output_rate=0.30,
+        )
+    )
+
+    premium = estimate_live_text_cost(
+        input_tokens=1000, output_tokens=1000, model_revision="gpt-5.4-2026-06-01"
+    )
+    assert premium.rate_card_ref == "premium-model"
+    assert premium.estimated_cost_usd == 0.40
+    assert premium.cost_posture == "ESTIMATED"
+
+    # Two catalogued models with different rates price correctly in the same
+    # process lifetime - the global-scalar model could not do this.
+    other = estimate_live_text_cost(
+        input_tokens=1000, output_tokens=1000, model_revision="qwen3:8b"
+    )
+    assert other.rate_card_ref == "default"
+    assert other.estimated_cost_usd == 0.04
+
+
+def test_new_effective_row_changes_costs_only_after_its_instant() -> None:
+    save_rate_card(_card("old-prices", effective_to="2026-09-01T00:00:00Z"))
+    save_rate_card(
+        _card(
+            "new-prices",
+            input_rate=0.02,
+            output_rate=0.06,
+            effective_from="2026-09-01T00:00:00Z",
+        )
+    )
+
+    before = estimate_live_text_cost(
+        input_tokens=1000, output_tokens=1000, at_utc="2026-08-31T23:59:59Z"
+    )
+    after = estimate_live_text_cost(
+        input_tokens=1000, output_tokens=1000, at_utc="2026-09-01T00:00:00Z"
+    )
+    assert before.rate_card_ref == "old-prices"
+    assert before.estimated_cost_usd == 0.04
+    assert after.rate_card_ref == "new-prices"
+    assert after.estimated_cost_usd == 0.08
+
+
+def test_overlapping_effective_ranges_are_refused_at_write() -> None:
+    save_rate_card(_card("open-ended"))
+
+    with raises(HTTPException) as exc_info:
+        save_rate_card(_card("competing", input_rate=0.02))
+    assert exc_info.value.status_code == 409
+    assert "overlaps" in str(exc_info.value.detail)
+
+    # A different scope key never conflicts.
+    save_rate_card(
+        _card(
+            "scoped",
+            scope_kind=RateCardScopeKind.MODEL_REVISION,
+            scope_target="gpt-5.4",
+            input_rate=0.02,
+        )
+    )
+    # Replacing a card under its own id is always allowed.
+    save_rate_card(_card("open-ended", input_rate=0.05))
+
+
+def test_missing_card_is_an_explicit_cost_unknown_posture() -> None:
+    estimate = estimate_live_text_cost(input_tokens=100, output_tokens=100)
+    assert estimate.estimated_cost_usd is None
+    assert estimate.rate_card_ref is None
+    assert estimate.cost_posture == "UNKNOWN"
+    assert resolve_effective_live_text_card() is None
+
+
+def test_embedding_executions_price_through_their_own_scope() -> None:
+    assert estimate_embedding_cost(input_tokens=1000).cost_posture == "UNKNOWN"
+
+    save_rate_card(
+        _card(
+            "embedding-default",
+            scope_kind=RateCardScopeKind.EMBEDDING_DEFAULT,
+            input_rate=0.001,
+            output_rate=0.0,
+        )
+    )
+
+    estimate = estimate_embedding_cost(input_tokens=2000)
+    assert estimate.rate_card_ref == "embedding-default"
+    assert estimate.estimated_cost_usd == 0.002
+
+
+def test_scope_target_validation_is_enforced_by_the_contract() -> None:
+    with raises(ValueError):
+        _card("bad", scope_kind=RateCardScopeKind.MODEL_REVISION, scope_target=None)
+    with raises(ValueError):
+        _card("bad2", scope_target="unexpected")

--- a/tests/unit/test_rate_cards.py
+++ b/tests/unit/test_rate_cards.py
@@ -13,7 +13,7 @@ from app.contracts.rate_cards import RateCardScopeKind
 from app.services.provider_usage_accounting import (
     DEFAULT_LIVE_TEXT_CARD_ID,
     ensure_rate_cards_seeded,
-    estimate_live_text_cost_usd,
+    estimate_live_text_cost,
     resolve_effective_live_text_card,
 )
 from app.services.rate_card_store import (
@@ -41,8 +41,8 @@ def test_seed_migrates_the_scalars_and_estimation_is_cutover_identical(
     _legacy_scalars: None,
 ) -> None:
     # The exact arithmetic the scalars produced, now sourced from the card.
-    assert estimate_live_text_cost_usd(input_tokens=1000, output_tokens=1000) == 0.04
-    assert estimate_live_text_cost_usd(input_tokens=500, output_tokens=100) == round(
+    assert estimate_live_text_cost(input_tokens=1000, output_tokens=1000).estimated_cost_usd == 0.04
+    assert estimate_live_text_cost(input_tokens=500, output_tokens=100).estimated_cost_usd == round(
         0.5 * 0.01 + 0.1 * 0.03, 8
     )
 
@@ -57,9 +57,9 @@ def test_no_scalars_means_no_card_and_no_cost(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(settings, "live_text_input_cost_per_1k_tokens", None)
     monkeypatch.setattr(settings, "live_text_output_cost_per_1k_tokens", None)
 
-    assert estimate_live_text_cost_usd(input_tokens=10, output_tokens=10) is None
+    assert estimate_live_text_cost(input_tokens=10, output_tokens=10).estimated_cost_usd is None
     assert get_rate_card_repository().list_cards() == []
-    assert estimate_live_text_cost_usd(input_tokens=None, output_tokens=10) is None
+    assert estimate_live_text_cost(input_tokens=None, output_tokens=10).estimated_cost_usd is None
 
 
 def test_seed_is_idempotent_and_follows_scalar_changes(
@@ -125,7 +125,7 @@ def test_sqlalchemy_round_trip_and_restart(
     monkeypatch.setattr(settings, "rate_card_store_mode", "sqlalchemy")
     monkeypatch.setattr(settings, "database_url", database_url)
 
-    assert estimate_live_text_cost_usd(input_tokens=1000, output_tokens=0) == 0.01
+    assert estimate_live_text_cost(input_tokens=1000, output_tokens=0).estimated_cost_usd == 0.01
 
     # Restart: truth must come back from SQL with provenance intact.
     seeded = get_rate_card_repository().get_card(DEFAULT_LIVE_TEXT_CARD_ID)


### PR DESCRIPTION
Part of #178 — S2, and it completes S3's **letter** (S3's spirit shipped in #204; the closure grep is now genuinely clean).

## What this does

1. **Identity-bound, effective-dated resolution**: `MODEL_REVISION` cards (new scope, validated `scope_target`, migration 0053) beat `DEFAULT_LIVE_TEXT`; among candidates the latest `effective_from` wins with deterministic tie-breaks. Proven: a new effective row changes costs **only after its instant** (time-controlled test), and two catalogued models price differently in the same process lifetime — the AC the global-scalar model could never satisfy.
2. **`rate_card_ref` beside every cost**: `UsageCostEstimate` flows into the provider response contract, structured output (with explicit `cost_posture: ESTIMATED|UNKNOWN`), and embedding responses. Missing card = explicit cost-unknown posture, never a block — economics observe, policy decides.
3. **Embedding pricing for the first time** via `EMBEDDING_DEFAULT`; honestly documented that no seed exists for it — pricing begins when an operator-supplied card does.
4. **Overlap refusal at write**: `save_rate_card` is the single governed write path (409 on intersecting windows for a scope key; same-id replacement allowed) shared by the seed, eval fixture seeding, and any future operator API.
5. **S3 letter**: budget eval cases declare `rate_card` rates as fixture data (required — a budget scenario without declared economics is a fixture defect); `grep -rn "0\.01\|0\.03" src/app/services/eval_runtime_execution.py` returns nothing.

**Boundary recorded**: budget spend is an aggregate accumulator per budget key, so the per-execution `rate_card_ref` lives on the response/evidence/audit trail rather than the aggregate row.

## Verification

Full suite **1990 passing** (1989 + the second budget fixture case corrected), combined coverage 99%; lint (purity guard), typecheck, OpenAPI gate (new contract fields), migration smoke (0053), eval manifest + run gates all green. Six new acceptance tests: model-beats-default with refs, time-window flip, overlap refusal (+scope isolation +same-id replace), cost-unknown posture, embedding scope pricing, contract scope-target validation.

Remaining on #178: S4 — cost observability on the tenant-scoped breakdowns (fields coordinated with the now-closed #152).

🤖 Generated with [Claude Code](https://claude.com/claude-code)