### PR TITLE
fix(quality): revive the monetary float guard as a live lint gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ lint:
 	python -m ruff check .
 	python -m ruff format --check .
 	python scripts/check_runtime_purity.py
+	python scripts/check_monetary_float_usage.py
 
 monetary-float-guard:
 	python scripts/check_monetary_float_usage.py

--- a/scripts/check_monetary_float_usage.py
+++ b/scripts/check_monetary_float_usage.py
@@ -1,8 +1,26 @@
+"""Monetary float-usage guard.
+
+Deterministic financial truth must not be computed with binary floats. This
+guard flags ``float(`` usage on lines that look monetary (by keyword hint)
+under ``src/``.
+
+A line that uses float legitimately - display formatting, leak-detection
+comparisons against caller-supplied values, embedding vectors that merely
+match a hint word - carries an inline waiver with a recorded reason::
+
+    allowed = [float(v) for v in values]  # monetary-float-ok: display-only comparison
+
+A waiver without a reason is itself a violation: every exception is
+review-visible at the site it excuses, never in a central list.
+"""
+
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 
 MONETARY_HINTS = ("amount", "value", "price", "cost", "pnl", "market_value", "fx_rate")
-ALLOWLIST = set()
+WAIVER_MARKER = "# monetary-float-ok:"
 
 
 def likely_monetary(line: str) -> bool:
@@ -10,19 +28,31 @@ def likely_monetary(line: str) -> bool:
     return any(token in low for token in MONETARY_HINTS)
 
 
-def main() -> int:
+def _line_violation(line: str) -> str | None:
+    if "float(" not in line or not likely_monetary(line):
+        return None
+    if WAIVER_MARKER in line:
+        reason = line.split(WAIVER_MARKER, 1)[1].strip()
+        if reason:
+            return None
+        return "monetary float waiver has no reason"
+    return "monetary float usage detected"
+
+
+def main(root: str = "src") -> int:
     violations: list[str] = []
-    for path in Path("src").rglob("*.py"):
+    for path in sorted(Path(root).rglob("*.py")):
         text = path.read_text(encoding="utf-8")
         for idx, line in enumerate(text.splitlines(), start=1):
-            if "float(" in line and likely_monetary(line) and f"{path}:{idx}" not in ALLOWLIST:
-                violations.append(f"{path}:{idx}: monetary float usage detected")
+            finding = _line_violation(line)
+            if finding is not None:
+                violations.append(f"{path}:{idx}: {finding}")
     if violations:
-        print("\\n".join(violations))
+        print("\n".join(violations))
         return 1
     print("Monetary float guard passed")
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "src"))

--- a/src/app/providers/advisor_brief_quality_guardrails.py
+++ b/src/app/providers/advisor_brief_quality_guardrails.py
@@ -273,7 +273,9 @@ def _has_numeric_consistency_mismatch(
     if not isinstance(performance, dict):
         return False
     allowed_percents = [
-        float(value)
+        float(
+            value
+        )  # monetary-float-ok: leak-detection comparison of caller-supplied display values
         for value in (
             performance.get("portfolio_return_pct"),
             performance.get("benchmark_return_pct"),
@@ -283,7 +285,9 @@ def _has_numeric_consistency_mismatch(
         if isinstance(value, int | float)
     ]
     allowed_currency_values = [
-        float(value)
+        float(
+            value
+        )  # monetary-float-ok: leak-detection comparison of caller-supplied display values
         for value in (
             performance.get("net_cash_flow"),
             performance.get("end_market_value"),

--- a/src/app/providers/advisor_brief_stub.py
+++ b/src/app/providers/advisor_brief_stub.py
@@ -377,13 +377,13 @@ def _pick_effect(value: Any) -> dict[str, str] | None:
 def _format_pct(value: Any) -> str:
     if not isinstance(value, int | float):
         return "N/A"
-    return f"{float(value):.2f}%"
+    return f"{float(value):.2f}%"  # monetary-float-ok: display formatting only
 
 
 def _format_currency(value: Any) -> str:
     if not isinstance(value, int | float):
         return "N/A"
-    return f"${float(value):,.0f}"
+    return f"${float(value):,.0f}"  # monetary-float-ok: display formatting only
 
 
 def _safe_dict(value: Any) -> dict[str, Any]:

--- a/src/app/providers/openai_live_embedding_provider.py
+++ b/src/app/providers/openai_live_embedding_provider.py
@@ -148,7 +148,10 @@ def _extract_embedding(payload: dict[str, Any]) -> list[float]:
             if isinstance(embedding, list) and all(
                 isinstance(value, int | float) for value in embedding
             ):
-                return [float(value) for value in embedding]
+                return [
+                    float(value)  # monetary-float-ok: embedding vector components, not money
+                    for value in embedding
+                ]
     raise ProviderExecutionError(
         category=ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR,
         message="OpenAI embedding provider response did not include an embedding vector.",

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -1234,10 +1234,12 @@ def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None
                         card_id="eval-hermetic-live-text",
                         scope_kind=RateCardScopeKind.DEFAULT_LIVE_TEXT,
                         currency="USD",
-                        input_cost_per_1k_tokens=float(
+                        # monetary-float-ok markers: rate-card contract rates
+                        # are float-typed by design (#178 S1).
+                        input_cost_per_1k_tokens=float(  # monetary-float-ok: rate-card contract field is float-typed
                             cast(int | float | str, fixture_rates["input_cost_per_1k_tokens"])
                         ),
-                        output_cost_per_1k_tokens=float(
+                        output_cost_per_1k_tokens=float(  # monetary-float-ok: rate-card contract field is float-typed
                             cast(int | float | str, fixture_rates["output_cost_per_1k_tokens"])
                         ),
                         effective_from_utc=None,

--- a/tests/unit/test_check_monetary_float_usage.py
+++ b/tests/unit/test_check_monetary_float_usage.py
@@ -1,0 +1,52 @@
+"""Monetary float guard behaviour (issue #199)."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_guard() -> ModuleType:
+    script_path = Path("scripts") / "check_monetary_float_usage.py"
+    spec = importlib.util.spec_from_file_location("check_monetary_float_usage", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_monetary_guard_passes_on_current_src() -> None:
+    guard = _load_guard()
+    assert guard.main("src") == 0
+
+
+def test_monetary_guard_flags_unwaived_usage_one_per_line(tmp_path: Path, capsys: object) -> None:
+    guard = _load_guard()
+    (tmp_path / "violations.py").write_text(
+        "amount = float(raw_amount)\nprice = float(raw_price)\nvector = float(component)\n",
+        encoding="utf-8",
+    )
+
+    assert guard.main(str(tmp_path)) == 1
+    captured = capsys.readouterr().out  # type: ignore[attr-defined]
+    lines = [line for line in captured.splitlines() if "monetary float" in line]
+    # One violation per line, newline-separated (the old guard printed a
+    # literal backslash-n); the non-monetary float is not flagged.
+    assert len(lines) == 2
+
+
+def test_monetary_guard_requires_a_reason_on_waivers(tmp_path: Path) -> None:
+    guard = _load_guard()
+    (tmp_path / "waivers.py").write_text(
+        "amount = float(raw)  # monetary-float-ok: display formatting only\n"
+        "price = float(raw)  # monetary-float-ok:\n",
+        encoding="utf-8",
+    )
+
+    violations = [
+        finding
+        for idx, line in enumerate(
+            (tmp_path / "waivers.py").read_text(encoding="utf-8").splitlines(), start=1
+        )
+        if (finding := guard._line_violation(line)) is not None
+    ]
+    assert violations == ["monetary float waiver has no reason"]


### PR DESCRIPTION
**Closes #199.**

## What this does

1. **The gate is alive**: `scripts/check_monetary_float_usage.py` now runs inside `make lint`, which both CI lanes execute — same wiring as the runtime-purity guard. It had a Makefile target referenced by nothing.
2. **Output fixed**: findings print one per line (the old `"\n".join` printed a literal backslash-n); `main(root)` is testable.
3. **Waivers are reviewable, never central**: a legitimate float use carries `# monetary-float-ok: <reason>` at the site it excuses; a waiver **without a reason is itself a violation**.
4. **The five standing hits triaged** — none was monetary arithmetic: leak-detection comparisons of caller-supplied display values (advisor-brief guardrails ×2), display-only formatting (advisor stub ×2), embedding vector components (embedding provider). Each carries its recorded reason.
5. **Liveness proof**: the revived guard immediately caught **three new hits from code merged this very cycle** (a comment-style waiver placed on the wrong line, and the #178 fixture-rate casts — waived as rate-card contract fields that are float-typed by design). Exactly what a dead gate hides.

## Verification

Full suite **1994 passed**, combined coverage 99% (21371 statements, 295 missed); `make lint` (now three guards), `make typecheck` green. Three behaviour tests: passes on src, flags unwaived usage newline-separated with non-monetary floats untouched, refuses reasonless waivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)