### PR TITLE
feat(resilience): retry backoff, jitter, and a total-attempt deadline

### DIFF
--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -20,6 +20,11 @@ from app.services.provider_execution_overrides import (
     get_text_transport_post_override,
 )
 from app.services.provider_metrics import record_provider_attempt
+from app.services.provider_retry_backoff import (
+    RetryBackoffPlan,
+    plan_retry,
+    wait_for_retry,
+)
 from app.services.tracing_runtime import (
     inject_trace_context,
     provider_attempt_span,
@@ -177,6 +182,10 @@ def post_openai_compatible_response(
     inject_trace_context(headers)
     model_identity = payload.get("model")
     bounded_retry_limit = max(retry_limit, 0)
+    backoff_plan = RetryBackoffPlan(
+        timeout_seconds=timeout_seconds, retry_limit=bounded_retry_limit
+    )
+    deadline_at = time.perf_counter() + backoff_plan.total_deadline_seconds
     for attempt_index in range(bounded_retry_limit + 1):
         provider_request = urllib_request.Request(
             endpoint,
@@ -223,7 +232,12 @@ def post_openai_compatible_response(
             load_error_payload(exc)
             category = failure_category_for_http_status(exc.code)
             retryable = is_retryable_provider_failure(category=category, http_status_code=exc.code)
-            will_retry = retryable and attempt_index < bounded_retry_limit
+            retry_decision = plan_retry(
+                backoff_plan, retry_index=attempt_index + 1, deadline_at=deadline_at
+            )
+            will_retry = (
+                retryable and attempt_index < bounded_retry_limit and retry_decision.permitted
+            )
             attempt_latency_ms = _attempt_latency_ms(attempt_started)
             record_provider_attempt(
                 provider_id=provider_display_name,
@@ -244,6 +258,7 @@ def post_openai_compatible_response(
                 latency_ms=attempt_latency_ms,
             )
             if will_retry:
+                wait_for_retry(retry_decision)
                 continue
             raise ProviderExecutionError(
                 category=category,
@@ -253,7 +268,10 @@ def post_openai_compatible_response(
                 ),
             ) from exc
         except TimeoutError as exc:
-            will_retry = attempt_index < bounded_retry_limit
+            retry_decision = plan_retry(
+                backoff_plan, retry_index=attempt_index + 1, deadline_at=deadline_at
+            )
+            will_retry = attempt_index < bounded_retry_limit and retry_decision.permitted
             attempt_latency_ms = _attempt_latency_ms(attempt_started)
             record_provider_attempt(
                 provider_id=provider_display_name,
@@ -273,6 +291,7 @@ def post_openai_compatible_response(
                 latency_ms=attempt_latency_ms,
             )
             if will_retry:
+                wait_for_retry(retry_decision)
                 continue
             raise ProviderExecutionError(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,
@@ -282,7 +301,10 @@ def post_openai_compatible_response(
                 ),
             ) from exc
         except error.URLError as exc:
-            will_retry = attempt_index < bounded_retry_limit
+            retry_decision = plan_retry(
+                backoff_plan, retry_index=attempt_index + 1, deadline_at=deadline_at
+            )
+            will_retry = attempt_index < bounded_retry_limit and retry_decision.permitted
             attempt_latency_ms = _attempt_latency_ms(attempt_started)
             record_provider_attempt(
                 provider_id=provider_display_name,
@@ -302,6 +324,7 @@ def post_openai_compatible_response(
                 latency_ms=attempt_latency_ms,
             )
             if will_retry:
+                wait_for_retry(retry_decision)
                 continue
             raise ProviderExecutionError(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,

--- a/src/app/services/provider_retry_backoff.py
+++ b/src/app/services/provider_retry_backoff.py
@@ -1,0 +1,72 @@
+"""Exponential backoff with jitter and a total-attempt deadline (issue #153, S1).
+
+Retryable provider attempts wait ``base * 2^(retry_index-1)`` seconds (capped
+per delay) plus proportional jitter before the next attempt, and the whole
+attempt sequence is bounded by a total deadline of
+``timeout_seconds * attempts`` plus the maximum backoff sum - a retry can
+never stretch the call beyond its declared budget: when the next delay would
+cross the deadline, the attempt sequence stops and the failure is final.
+
+The sleeper and jitter source are module seams (tests replace them for
+determinism; production uses ``time.sleep`` and ``random.random``).
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass
+
+BASE_DELAY_SECONDS = 0.25
+MAX_DELAY_SECONDS = 4.0
+JITTER_RATIO = 0.25
+
+_sleep = time.sleep
+_jitter_source = random.random
+
+
+@dataclass(frozen=True)
+class RetryBackoffPlan:
+    timeout_seconds: float
+    retry_limit: int
+
+    def delay_before_retry(self, retry_index: int, *, jitter: float) -> float:
+        """Delay before the retry with 1-based ``retry_index``; jitter in [0, 1)."""
+
+        base = min(BASE_DELAY_SECONDS * (2 ** (retry_index - 1)), MAX_DELAY_SECONDS)
+        return base * (1.0 + JITTER_RATIO * jitter)
+
+    @property
+    def total_deadline_seconds(self) -> float:
+        attempts = self.retry_limit + 1
+        max_backoff_sum = sum(
+            min(BASE_DELAY_SECONDS * (2**index), MAX_DELAY_SECONDS)
+            for index in range(self.retry_limit)
+        ) * (1.0 + JITTER_RATIO)
+        return self.timeout_seconds * attempts + max_backoff_sum
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    permitted: bool
+    delay_seconds: float
+
+
+def plan_retry(
+    plan: RetryBackoffPlan,
+    *,
+    retry_index: int,
+    deadline_at: float,
+    now: float | None = None,
+) -> RetryDecision:
+    """Decide whether the retry fits the deadline; the caller logs, then waits."""
+
+    delay = plan.delay_before_retry(retry_index, jitter=_jitter_source())
+    instant = time.perf_counter() if now is None else now
+    if instant + delay > deadline_at:
+        return RetryDecision(permitted=False, delay_seconds=delay)
+    return RetryDecision(permitted=True, delay_seconds=delay)
+
+
+def wait_for_retry(decision: RetryDecision) -> None:
+    _sleep(decision.delay_seconds)

--- a/src/app/services/provider_retry_backoff.py
+++ b/src/app/services/provider_retry_backoff.py
@@ -33,17 +33,17 @@ class RetryBackoffPlan:
     def delay_before_retry(self, retry_index: int, *, jitter: float) -> float:
         """Delay before the retry with 1-based ``retry_index``; jitter in [0, 1)."""
 
-        base = min(BASE_DELAY_SECONDS * (2 ** (retry_index - 1)), MAX_DELAY_SECONDS)
-        return base * (1.0 + JITTER_RATIO * jitter)
+        base = min(BASE_DELAY_SECONDS * float(2 ** (retry_index - 1)), MAX_DELAY_SECONDS)
+        return float(base * (1.0 + JITTER_RATIO * jitter))
 
     @property
     def total_deadline_seconds(self) -> float:
         attempts = self.retry_limit + 1
         max_backoff_sum = sum(
-            min(BASE_DELAY_SECONDS * (2**index), MAX_DELAY_SECONDS)
+            min(BASE_DELAY_SECONDS * float(2**index), MAX_DELAY_SECONDS)
             for index in range(self.retry_limit)
         ) * (1.0 + JITTER_RATIO)
-        return self.timeout_seconds * attempts + max_backoff_sum
+        return float(self.timeout_seconds * attempts + max_backoff_sum)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_provider_retry_backoff.py
+++ b/tests/unit/test_provider_retry_backoff.py
@@ -1,0 +1,131 @@
+"""Retry backoff, jitter, and total-attempt deadline (issue #153, S1)."""
+
+from email.message import Message
+from io import BytesIO
+from urllib import error
+
+from pytest import MonkeyPatch, raises
+
+from app.contracts.providers import ProviderFailureCategory
+from app.providers.base import ProviderExecutionError
+from app.providers.openai_compatible_text_transport import post_openai_compatible_response
+from app.services.provider_retry_backoff import (
+    BASE_DELAY_SECONDS,
+    JITTER_RATIO,
+    MAX_DELAY_SECONDS,
+    RetryBackoffPlan,
+    plan_retry,
+)
+
+
+def test_delays_grow_exponentially_with_proportional_jitter_and_a_cap() -> None:
+    plan = RetryBackoffPlan(timeout_seconds=4.0, retry_limit=6)
+
+    without_jitter = [plan.delay_before_retry(index, jitter=0.0) for index in range(1, 7)]
+    assert without_jitter == [0.25, 0.5, 1.0, 2.0, 4.0, 4.0]
+    assert without_jitter[-1] == MAX_DELAY_SECONDS
+
+    with_full_jitter = plan.delay_before_retry(1, jitter=1.0)
+    assert with_full_jitter == BASE_DELAY_SECONDS * (1.0 + JITTER_RATIO)
+
+
+def test_total_deadline_bounds_attempts_plus_maximum_backoff() -> None:
+    plan = RetryBackoffPlan(timeout_seconds=4.0, retry_limit=2)
+    # 3 attempts * 4s + (0.25 + 0.5) * 1.25 jitter headroom
+    assert plan.total_deadline_seconds == 4.0 * 3 + 0.75 * 1.25
+
+
+def test_plan_retry_refuses_when_the_delay_would_cross_the_deadline() -> None:
+    plan = RetryBackoffPlan(timeout_seconds=1.0, retry_limit=1)
+
+    inside = plan_retry(plan, retry_index=1, deadline_at=100.0, now=99.0)
+    assert inside.permitted is True
+
+    crossing = plan_retry(plan, retry_index=1, deadline_at=100.0, now=99.9)
+    assert crossing.permitted is False
+    assert crossing.delay_seconds > 0.0
+
+
+def test_transport_backs_off_between_retries_and_succeeds(monkeypatch: MonkeyPatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "app.services.provider_retry_backoff._sleep", lambda delay: sleeps.append(delay)
+    )
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+
+    attempts = {"count": 0}
+
+    class _Response:
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b'{"id": "resp_backoff", "output_text": "OK"}'
+
+    def _urlopen(request: object, timeout: float) -> _Response:
+        attempts["count"] += 1
+        if attempts["count"] <= 2:
+            raise error.HTTPError(
+                url="http://localhost/v1/responses",
+                code=503,
+                msg="unavailable",
+                hdrs=Message(),
+                fp=BytesIO(b"{}"),
+            )
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    payload = post_openai_compatible_response(
+        api_base="http://localhost:1234/v1",
+        api_key=None,
+        payload={"model": "m"},
+        timeout_seconds=4.0,
+        provider_display_name="Local OpenAI-Compatible Text Provider",
+        require_api_key=False,
+        retry_limit=2,
+    )
+
+    assert payload["_lotus_retry_count"] == 2
+    assert attempts["count"] == 3
+    # Exponential, jitter-free (injected): first retry 0.25s, second 0.5s.
+    assert sleeps == [0.25, 0.5]
+
+
+def test_deadline_exhaustion_converts_a_retryable_failure_into_a_final_one(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+    # Force every retry decision past the deadline.
+    monkeypatch.setattr(
+        "app.providers.openai_compatible_text_transport.plan_retry",
+        lambda plan, *, retry_index, deadline_at: __import__(
+            "app.services.provider_retry_backoff", fromlist=["RetryDecision"]
+        ).RetryDecision(permitted=False, delay_seconds=0.25),
+    )
+
+    attempts = {"count": 0}
+
+    def _urlopen(request: object, timeout: float) -> object:
+        attempts["count"] += 1
+        raise TimeoutError()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    with raises(ProviderExecutionError) as exc_info:
+        post_openai_compatible_response(
+            api_base="http://localhost:1234/v1",
+            api_key=None,
+            payload={"model": "m"},
+            timeout_seconds=1.0,
+            provider_display_name="Local OpenAI-Compatible Text Provider",
+            require_api_key=False,
+            retry_limit=5,
+        )
+
+    assert exc_info.value.category is ProviderFailureCategory.PROVIDER_TIMEOUT
+    # The deadline stopped the sequence on the first attempt despite retry_limit=5.
+    assert attempts["count"] == 1


### PR DESCRIPTION
Part of #153 — S1 of the [execution plan](https://github.com/sgajbi/lotus-ai/issues/153#issuecomment-5472124499).

## What this does

1. **Exponential backoff with jitter** between retryable provider attempts: `0.25s * 2^(n-1)` capped at 4s per delay, plus proportional jitter (`+0–25%`). The bare `continue` retry storm is gone.
2. **Total-attempt deadline**: the whole sequence is bounded by `timeout * attempts` plus the maximum backoff sum — when the next delay would cross the deadline, the retryable failure becomes **final** instead of stretching the call beyond its declared budget (never exceeding the issue's `provider_timeout_ms * (retries+1)` + backoff bound).
3. **Truthful telemetry**: the deadline decision is made *before* the retry/failed outcome is logged and counted, so a deadline-stopped attempt reports `failed`, never a phantom `retry`.
4. **Deterministic tests**: the sleeper and jitter source are module seams — the delay sequence `[0.25, 0.5]` is asserted exactly, deadline exhaustion is proven to stop a `retry_limit=5` sequence on attempt one, and no test sleeps. Attempt counts already flow to metrics/logs (#152), the response, and provider execution evidence — the audit-side AC was standing.

## Verification

Full suite **1996 passed**, combined coverage 99% (21413 statements, 295 missed); lint, typecheck green. Existing transport retry tests pass unchanged (each absorbs one real 0.25s backoff).

Remaining on #153: S2 runtime-profile defaults (the design-sensitive slice — profile sets only what the operator didn't set explicitly), S3 SQL admission leases, S4 the end-to-end evaluation condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)