### PR TITLE
feat(lookup): latest accepted run by portfolio context (#183)

### DIFF
--- a/src/app/contracts/workflow_pack_run_accepted_latest.py
+++ b/src/app/contracts/workflow_pack_run_accepted_latest.py
@@ -1,0 +1,65 @@
+"""Latest-accepted run lookup envelope for one pack family (issue #183).
+
+This contract answers the pre-order availability question the report ordering
+surface must answer truthfully - "does an accepted brief exist for this
+portfolio and context?" - with a bounded IDENTITY envelope only. It carries no
+narrative fields: the consumer fetches the narrative through the run_id-keyed
+accepted-output projection, so there is exactly one narrative-bearing surface.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from app.contracts.workflow_pack_run_accepted_output import (
+    AdvisorBriefAcceptedContextIdentity,
+    AdvisorBriefAcceptedReviewIdentity,
+)
+
+ACCEPTED_LATEST_SCHEMA_V1 = "lotus-ai.workflow_pack_run.accepted_latest.v1"
+
+
+class WorkflowPackRunAcceptedLatestResponse(BaseModel):
+    """Identity of the latest accepted run of one pack family for one portfolio.
+
+    "Latest" is deterministic: the run whose accepting review event is most
+    recent among completed, accepted, non-superseded runs of the pack family
+    whose accepted output asserts the requested portfolio (review-time ties
+    break on run_id, descending). Optional context filters compare only
+    against values the source asserted - an unasserted value never
+    wildcard-matches a caller filter. The response never contains narrative,
+    prompts, task payloads, object-store paths, storage references, provider
+    secrets, or artifact bodies.
+    """
+
+    schema_id: str = Field(description="Versioned schema discriminator for this lookup envelope.")
+    service: str = Field(description="Publishing service identity.")
+    version: str = Field(description="Publishing service version.")
+    run_id: str = Field(description="Latest accepted workflow-pack run identity.")
+    pack_id: str = Field(description="Workflow pack identity.")
+    pack_family: str = Field(description="Workflow pack family the lookup was scoped to.")
+    pack_version: str = Field(description="Workflow pack version.")
+    tenant_id: str = Field(description="Tenant the run belongs to and was retrieved for.")
+    workflow_authority_owner: str = Field(
+        description="Service that owns consequence-bearing workflow authority for this pack.",
+    )
+    context: AdvisorBriefAcceptedContextIdentity = Field(
+        description="Bounded report-context identity the accepted output asserted.",
+    )
+    review: AdvisorBriefAcceptedReviewIdentity = Field(
+        description="Accepting reviewer identity and time from the review event ledger.",
+    )
+    accepted_output_schema_id: str = Field(
+        description=(
+            "Schema of the run_id-keyed accepted-output projection the consumer must fetch "
+            "for the narrative content."
+        ),
+    )
+    content_hash: str = Field(
+        description=(
+            "Canonical hash of the accepted-output projection this envelope points at, so a "
+            "consumer can pin the exact accepted content before and after fetching it."
+        ),
+    )
+    content_hash_algorithm: str = Field(description="Algorithm of content_hash.")
+    notes: list[str] = Field(description="Boundary statements this lookup ships with.")

--- a/src/app/repositories/memory_workflow_pack_run_repository.py
+++ b/src/app/repositories/memory_workflow_pack_run_repository.py
@@ -29,6 +29,7 @@ class InMemoryWorkflowPackRunRepository(WorkflowPackRunRepository):
         *,
         registration_ref: str | None = None,
         pack_id: str | None = None,
+        pack_family: str | None = None,
         caller_app: str | None = None,
         tenant_id: str | None = None,
         workflow_surface: str | None = None,
@@ -42,6 +43,7 @@ class InMemoryWorkflowPackRunRepository(WorkflowPackRunRepository):
             for record in self._runs.values()
             if (registration_ref is None or record.registration_ref == registration_ref)
             and (pack_id is None or record.pack_id == pack_id)
+            and (pack_family is None or record.pack_family == pack_family)
             and (caller_app is None or record.caller_app == caller_app)
             and (tenant_id is None or record.tenant_id == tenant_id)
             and (workflow_surface is None or record.workflow_surface == workflow_surface)

--- a/src/app/repositories/sqlalchemy_workflow_pack_run_repository.py
+++ b/src/app/repositories/sqlalchemy_workflow_pack_run_repository.py
@@ -38,6 +38,7 @@ class SqlAlchemyWorkflowPackRunRepository(SqlAlchemyRepositoryBase, WorkflowPack
         *,
         registration_ref: str | None = None,
         pack_id: str | None = None,
+        pack_family: str | None = None,
         caller_app: str | None = None,
         tenant_id: str | None = None,
         workflow_surface: str | None = None,
@@ -51,6 +52,8 @@ class SqlAlchemyWorkflowPackRunRepository(SqlAlchemyRepositoryBase, WorkflowPack
             statement = statement.where(WorkflowPackRunModel.registration_ref == registration_ref)
         if pack_id is not None:
             statement = statement.where(WorkflowPackRunModel.pack_id == pack_id)
+        if pack_family is not None:
+            statement = statement.where(WorkflowPackRunModel.pack_family == pack_family)
         if caller_app is not None:
             statement = statement.where(WorkflowPackRunModel.caller_app == caller_app)
         if tenant_id is not None:

--- a/src/app/repositories/workflow_pack_run_repository.py
+++ b/src/app/repositories/workflow_pack_run_repository.py
@@ -77,6 +77,7 @@ class WorkflowPackRunRepository(Protocol):
         *,
         registration_ref: str | None = None,
         pack_id: str | None = None,
+        pack_family: str | None = None,
         caller_app: str | None = None,
         tenant_id: str | None = None,
         workflow_surface: str | None = None,

--- a/src/app/routers/workflow_packs.py
+++ b/src/app/routers/workflow_packs.py
@@ -64,6 +64,13 @@ from app.services.workflow_pack_run_accepted_output import (
     AcceptedOutputNotFoundError,
     build_workflow_pack_run_accepted_output,
 )
+from app.contracts.workflow_pack_run_accepted_latest import (
+    WorkflowPackRunAcceptedLatestResponse,
+)
+from app.services.workflow_pack_run_accepted_latest import (
+    AcceptedLatestNotFoundError,
+    build_workflow_pack_run_accepted_latest,
+)
 from app.services.workflow_pack_run_consumer_view import build_workflow_pack_run_consumer_view
 from app.services.workflow_pack_run_operator_profile import build_workflow_pack_run_operator_profile
 from app.services.workflow_pack_control import (
@@ -922,6 +929,93 @@ async def get_workflow_pack_task_flow_checkpoints_route(
     except WorkflowPackTaskFlowNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except WorkflowPackTaskFlowStoreNotReadyError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.get(
+    "/platform/workflow-packs/runs/accepted-latest",
+    response_model=WorkflowPackRunAcceptedLatestResponse,
+    operation_id="getWorkflowPackRunAcceptedLatest",
+    summary="Resolve the latest accepted run of one pack family for one portfolio",
+    description=(
+        "Answers the pre-order availability question - does an accepted run of this pack "
+        "family exist for this portfolio and context? - with a bounded identity envelope "
+        "only. `latest` is the run whose accepting review event is most recent among "
+        "completed, accepted, non-superseded runs whose accepted output asserts the "
+        "requested portfolio; optional `as_of_date` and `reporting_currency` filters "
+        "compare only against values the source asserted (an unasserted value never "
+        "wildcard-matches). The envelope carries no narrative: consumers fetch the "
+        "run_id-keyed accepted-output projection, keeping exactly one narrative-bearing "
+        "surface. Unknown tenants and unknown portfolios share one not-found reason - "
+        "this route is not an existence oracle."
+    ),
+    responses={
+        200: {"description": "Latest accepted run identity returned successfully."},
+        403: {"description": "Caller is not an active registered caller."},
+        404: {
+            "description": (
+                "No accepted run answers the lookup: no_accepted_run (none asserts the "
+                "portfolio - unknown tenants and portfolios share this shape) or "
+                "no_context_match (accepted portfolio runs exist, none assert the "
+                "requested filters)."
+            )
+        },
+        409: {
+            "description": (
+                "The lookup cannot be answered truthfully: pack_projection_unsupported, "
+                "lookup_scan_saturated, or an unresolvable accepted candidate "
+                "(output_artifact_missing or output_artifact_malformed) whose position "
+                "in the latest-accepted order cannot be proven."
+            )
+        },
+        422: {"description": "Required caller headers or query parameters are missing or invalid."},
+        503: {"description": "Run or artifact stores are not ready."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_workflow_pack_run_accepted_latest_route(
+    caller_app: Annotated[str, Header(alias="X-Caller-App", min_length=1)],
+    tenant_id: Annotated[str, Header(alias="X-Tenant-Id", min_length=1)],
+    pack_family: Annotated[str, Query(min_length=1)],
+    portfolio_id: Annotated[str, Query(min_length=1)],
+    as_of_date: Annotated[str | None, Query()] = None,
+    reporting_currency: Annotated[str | None, Query()] = None,
+) -> WorkflowPackRunAcceptedLatestResponse:
+    require_active_registered_caller(
+        caller_app.strip(),
+        blocked_summary="Caller is not authorized to resolve accepted workflow-pack runs.",
+    )
+    try:
+        return build_workflow_pack_run_accepted_latest(
+            pack_family=pack_family.strip(),
+            portfolio_id=portfolio_id.strip(),
+            caller_tenant_id=tenant_id.strip(),
+            as_of_date=as_of_date.strip() if as_of_date and as_of_date.strip() else None,
+            reporting_currency=(
+                reporting_currency.strip()
+                if reporting_currency and reporting_currency.strip()
+                else None
+            ),
+        )
+    except AcceptedLatestNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "detail": exc.message,
+                "error_code": f"LOTUS_AI_ACCEPTED_LATEST_{exc.reason_code.upper()}",
+                "metadata": {"reason_code": exc.reason_code},
+            },
+        ) from exc
+    except AcceptedOutputNotAvailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "detail": exc.message,
+                "error_code": f"LOTUS_AI_ACCEPTED_LATEST_{exc.reason_code.upper()}",
+                "metadata": {"reason_code": exc.reason_code},
+            },
+        ) from exc
+    except WorkflowPackRunStoreUnavailableError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 

--- a/src/app/services/workflow_pack_run_accepted_latest.py
+++ b/src/app/services/workflow_pack_run_accepted_latest.py
@@ -1,0 +1,226 @@
+"""Resolve the latest accepted run of one pack family for one portfolio.
+
+Issue #183: the report ordering surface must truthfully answer "does an
+accepted brief exist for this portfolio and context?" before an order is
+placed. The accepted-output projection is run_id-keyed by design; this lookup
+resolves the run_id and returns an identity envelope only - the narrative
+stays on the single run_id-keyed surface.
+
+Design decisions, deliberate:
+
+- "Latest" is ordered by ACCEPTING-REVIEW recency (ties break on run_id,
+  descending), not by run creation time: what governs staleness for a
+  consumer is when a human accepted content, not when generation started.
+- The lookup fails closed on ANY unresolvable candidate: a candidate whose
+  review identity, pack projection, or governed output artifact cannot be
+  resolved has an unknowable position in the "latest" order, so answering
+  around it could present stale commentary as current. Corrupt accepted
+  ledgers are an operations problem, never something to silently skip.
+- Optional context filters compare only against values the source asserted:
+  an unasserted as_of_date or reporting_currency never wildcard-matches a
+  caller filter, so a filtered "ready" answer is always a proven match.
+- Unknown tenants and unknown portfolios produce the same `no_accepted_run`
+  not-found reason - this route must not become an existence oracle.
+- The candidate scan is bounded and saturation fails closed: a truncated scan
+  cannot prove which run is latest, so it refuses instead of guessing.
+"""
+
+from __future__ import annotations
+
+from app.config import settings
+from app.contracts.workflow_pack_run_accepted_latest import (
+    ACCEPTED_LATEST_SCHEMA_V1,
+    WorkflowPackRunAcceptedLatestResponse,
+)
+from app.contracts.workflow_pack_run_accepted_output import (
+    WorkflowPackRunAcceptedOutputResponse,
+)
+from app.contracts.workflow_pack_runs import (
+    WorkflowPackRunReviewState,
+    WorkflowPackRunRuntimeState,
+)
+from app.repositories.workflow_pack_run_repository import (
+    WorkflowPackRunRecord,
+    WorkflowPackRunRepository,
+)
+from app.services.workflow_pack_run_accepted_output import (
+    REASON_OUTPUT_ARTIFACT_MALFORMED,
+    REASON_PACK_PROJECTION_UNSUPPORTED,
+    AcceptedOutputNotAvailableError,
+    build_workflow_pack_run_accepted_output,
+)
+from app.services.workflow_pack_run_ledger import ensure_workflow_pack_run_store_ready
+from app.services.workflow_pack_run_review_summary import (
+    build_workflow_pack_run_review_summary,
+)
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+
+REASON_NO_ACCEPTED_RUN = "no_accepted_run"
+REASON_NO_CONTEXT_MATCH = "no_context_match"
+REASON_LOOKUP_SCAN_SATURATED = "lookup_scan_saturated"
+
+ACCEPTED_LATEST_NOT_FOUND_REASON_CODES = frozenset(
+    {REASON_NO_ACCEPTED_RUN, REASON_NO_CONTEXT_MATCH}
+)
+
+# Pack families that may be discovered through this lookup: a family earns
+# discovery exactly when it ships a typed accepted-output projection, so the
+# lookup can never point at a run whose narrative is unretrievable.
+_SUPPORTED_PACK_FAMILIES = frozenset({"advisor_brief"})
+
+# Deliberate scan bound. One tenant's accepted, completed runs of one pack
+# family is a small governed set; if it ever saturates this bound the lookup
+# refuses (lookup_scan_saturated) rather than answering from a truncated scan.
+_CANDIDATE_SCAN_LIMIT = 1000
+
+_ACCEPTED_LATEST_NOTES = [
+    "This envelope identifies the latest accepted run for the requested portfolio and "
+    "context; it carries no narrative. Fetch the accepted-output projection by run_id "
+    "for the reviewed content.",
+    "A filtered match compares only against context values the source asserted; an "
+    "unasserted value never satisfies a caller filter.",
+    "Consequence-bearing workflow authority remains with the workflow authority owner; "
+    "lotus-ai remains the AI run, review and evidence system of record.",
+]
+
+
+class AcceptedLatestNotFoundError(LookupError):
+    """No accepted run answers the lookup - bounded reason, no existence leak."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+def build_workflow_pack_run_accepted_latest(
+    *,
+    pack_family: str,
+    portfolio_id: str,
+    caller_tenant_id: str,
+    as_of_date: str | None = None,
+    reporting_currency: str | None = None,
+) -> WorkflowPackRunAcceptedLatestResponse:
+    if pack_family not in _SUPPORTED_PACK_FAMILIES:
+        raise AcceptedOutputNotAvailableError(
+            REASON_PACK_PROJECTION_UNSUPPORTED,
+            "No typed accepted-output projection exists for this pack family.",
+        )
+
+    ensure_workflow_pack_run_store_ready()
+    store = get_workflow_pack_run_store()
+    candidates = [
+        record
+        for record in store.query_runs(
+            tenant_id=caller_tenant_id,
+            pack_family=pack_family,
+            runtime_state=WorkflowPackRunRuntimeState.COMPLETED.value,
+            review_state=WorkflowPackRunReviewState.ACCEPTED.value,
+            limit=_CANDIDATE_SCAN_LIMIT,
+        )
+        if not record.superseded_by_run_id
+    ]
+    if len(candidates) >= _CANDIDATE_SCAN_LIMIT:
+        raise AcceptedOutputNotAvailableError(
+            REASON_LOOKUP_SCAN_SATURATED,
+            "The candidate scan bound was reached; a truncated scan cannot prove which "
+            "accepted run is latest.",
+        )
+
+    portfolio_asserted = False
+    for record in _by_accepting_review_recency(store=store, candidates=candidates):
+        projection = _resolve_candidate(record=record, caller_tenant_id=caller_tenant_id)
+        if projection.context.portfolio_id != portfolio_id:
+            continue
+        portfolio_asserted = True
+        if as_of_date is not None and projection.context.as_of_date != as_of_date:
+            continue
+        if (
+            reporting_currency is not None
+            and projection.context.reporting_currency != reporting_currency
+        ):
+            continue
+        return _envelope(projection=projection, pack_family=pack_family)
+
+    if portfolio_asserted:
+        raise AcceptedLatestNotFoundError(
+            REASON_NO_CONTEXT_MATCH,
+            "Accepted runs exist for this portfolio, but none assert the requested "
+            "context filters.",
+        )
+    raise AcceptedLatestNotFoundError(
+        REASON_NO_ACCEPTED_RUN,
+        "No accepted run of this pack family asserts the requested portfolio.",
+    )
+
+
+def _by_accepting_review_recency(
+    *,
+    store: WorkflowPackRunRepository,
+    candidates: list[WorkflowPackRunRecord],
+) -> list[WorkflowPackRunRecord]:
+    """Order candidates newest-accepting-review first, run_id breaking ties.
+
+    An ACCEPTED run without a recorded review transition has an unknowable
+    position in this order; it fails the whole lookup closed rather than being
+    silently skipped past.
+    """
+
+    keyed: list[tuple[str, str, WorkflowPackRunRecord]] = []
+    for record in candidates:
+        summary = build_workflow_pack_run_review_summary(
+            events=store.list_events(run_id=record.run_id)
+        )
+        if not summary.latest_review_event_at:
+            raise AcceptedOutputNotAvailableError(
+                REASON_OUTPUT_ARTIFACT_MALFORMED,
+                "An accepted candidate run has no recorded accepting review event, so "
+                "the latest-accepted order cannot be proven.",
+            )
+        keyed.append((summary.latest_review_event_at, record.run_id, record))
+    keyed.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [record for _, _, record in keyed]
+
+
+def _resolve_candidate(
+    *,
+    record: WorkflowPackRunRecord,
+    caller_tenant_id: str,
+) -> WorkflowPackRunAcceptedOutputResponse:
+    """Resolve one candidate through the run_id projection - one code path
+    computes context, review identity and content hash for both surfaces.
+
+    Every projection failure (unsupported version, missing or malformed
+    artifact) propagates: an unresolvable candidate makes "latest for this
+    portfolio" unanswerable, because its context - and therefore its claim to
+    being the answer - cannot be proven.
+    """
+
+    return build_workflow_pack_run_accepted_output(
+        run_id=record.run_id,
+        caller_tenant_id=caller_tenant_id,
+    )
+
+
+def _envelope(
+    *,
+    projection: WorkflowPackRunAcceptedOutputResponse,
+    pack_family: str,
+) -> WorkflowPackRunAcceptedLatestResponse:
+    return WorkflowPackRunAcceptedLatestResponse(
+        schema_id=ACCEPTED_LATEST_SCHEMA_V1,
+        service=settings.service_name,
+        version=settings.service_version,
+        run_id=projection.run_id,
+        pack_id=projection.pack_id,
+        pack_family=pack_family,
+        pack_version=projection.pack_version,
+        tenant_id=projection.tenant_id,
+        workflow_authority_owner=projection.workflow_authority_owner,
+        context=projection.context,
+        review=projection.review,
+        accepted_output_schema_id=projection.schema_id,
+        content_hash=projection.content_hash,
+        content_hash_algorithm=projection.content_hash_algorithm,
+        notes=list(_ACCEPTED_LATEST_NOTES),
+    )

--- a/tests/integration/test_workflow_pack_run_accepted_latest_api.py
+++ b/tests/integration/test_workflow_pack_run_accepted_latest_api.py
@@ -1,0 +1,239 @@
+"""API contract for the latest-accepted lookup (issue #183).
+
+These tests prove the two-step consumer flow the report ordering surface
+depends on - resolve latest accepted identity, then fetch the narrative by
+run_id - plus the bounded not-found reasons, review-recency determinism,
+tenant isolation without an existence oracle, caller authorization, and that
+the literal `accepted-latest` path is never captured as a run id.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.support.workflow_pack_fixtures import advisor_brief_task_execution_request_json
+
+CALLER_HEADERS = {"X-Caller-App": "lotus-gateway", "X-Tenant-Id": "tenant-sg-001"}
+LOOKUP_PATH = "/platform/workflow-packs/runs/accepted-latest"
+
+
+def _execute_advisor_brief(
+    client: TestClient, *, correlation_id: str, portfolio_id: str = "PB_SG_GLOBAL_BAL_001"
+) -> str:
+    execute_response = client.post(
+        "/ai/tasks/execute",
+        json=advisor_brief_task_execution_request_json(
+            correlation_id=correlation_id, portfolio_id=portfolio_id
+        ),
+    )
+    assert execute_response.status_code == 200
+    runs = client.get("/platform/workflow-packs/runs").json()["runs"]
+    return str(next(run["run_id"] for run in runs if run["correlation_id"] == correlation_id))
+
+
+def _accept(client: TestClient, run_id: str, *, reviewed_by: str = "banker.sg.301") -> None:
+    review_response = client.post(
+        f"/platform/workflow-packs/runs/{run_id}/review-actions",
+        json={
+            "action_type": "ACCEPT",
+            "caller_app": "lotus-gateway",
+            "reviewed_by": reviewed_by,
+            "reason": "Accepted for latest-accepted lookup proof.",
+        },
+    )
+    assert review_response.status_code == 200
+
+
+def _lookup_params(**overrides: str) -> dict[str, str]:
+    params = {"pack_family": "advisor_brief", "portfolio_id": "PB_SG_GLOBAL_BAL_001"}
+    params.update(overrides)
+    return params
+
+
+def test_accepted_latest_resolves_the_most_recently_accepted_run(
+    client: TestClient,
+) -> None:
+    """Two accepted runs for one portfolio: the lookup answers with the run
+    accepted LAST, and the envelope chains to the run_id narrative surface."""
+
+    first_run = _execute_advisor_brief(client, correlation_id="corr-accepted-latest-001")
+    second_run = _execute_advisor_brief(client, correlation_id="corr-accepted-latest-002")
+    _accept(client, first_run, reviewed_by="banker.sg.301")
+    _accept(client, second_run, reviewed_by="banker.sg.302")
+
+    response = client.get(LOOKUP_PATH, params=_lookup_params(), headers=CALLER_HEADERS)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["schema_id"] == "lotus-ai.workflow_pack_run.accepted_latest.v1"
+    assert body["run_id"] == second_run
+    assert body["pack_id"] == "advisor_brief.pack"
+    assert body["pack_family"] == "advisor_brief"
+    assert body["pack_version"] == "v1"
+    assert body["tenant_id"] == "tenant-sg-001"
+    assert body["review"]["reviewed_by"] == "banker.sg.302"
+    assert body["context"]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert (
+        body["accepted_output_schema_id"]
+        == "lotus-ai.workflow_pack_run.accepted_output.advisor_brief.v1"
+    )
+
+    # Identity envelope only: none of the narrative fields leak here.
+    for narrative_field in (
+        "grounded_summary",
+        "talking_points",
+        "risks_and_exceptions",
+        "source_refs",
+    ):
+        assert narrative_field not in body
+
+    # The two-step consumer flow: the resolved run_id fetches the narrative,
+    # and the envelope's content hash pins exactly that content.
+    narrative = client.get(
+        f"/platform/workflow-packs/runs/{body['run_id']}/accepted-output",
+        headers=CALLER_HEADERS,
+    )
+    assert narrative.status_code == 200
+    assert narrative.json()["content_hash"] == body["content_hash"]
+    assert narrative.json()["grounded_summary"]
+
+
+def test_accepted_latest_ignores_unaccepted_and_foreign_portfolio_runs(
+    client: TestClient,
+) -> None:
+    """A completed-but-unreviewed run and an accepted run for another
+    portfolio both leave the requested portfolio unanswered: no_accepted_run."""
+
+    _execute_advisor_brief(
+        client, correlation_id="corr-accepted-latest-010", portfolio_id="PB_SG_TARGET_010"
+    )
+    other_portfolio_run = _execute_advisor_brief(
+        client, correlation_id="corr-accepted-latest-011", portfolio_id="PB_SG_OTHER_011"
+    )
+    _accept(client, other_portfolio_run)
+
+    response = client.get(
+        LOOKUP_PATH,
+        params=_lookup_params(portfolio_id="PB_SG_TARGET_010"),
+        headers=CALLER_HEADERS,
+    )
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error_code"] == "LOTUS_AI_ACCEPTED_LATEST_NO_ACCEPTED_RUN"
+    assert body["metadata"]["reason_code"] == "no_accepted_run"
+
+
+def test_accepted_latest_distinguishes_context_mismatch_from_absence(
+    client: TestClient,
+) -> None:
+    """The generated brief asserts no as_of_date, so an as_of_date filter can
+    never match it: no_context_match, proving unasserted context is not a
+    wildcard at the API boundary."""
+
+    run_id = _execute_advisor_brief(
+        client, correlation_id="corr-accepted-latest-020", portfolio_id="PB_SG_FILTERED_020"
+    )
+    _accept(client, run_id)
+
+    response = client.get(
+        LOOKUP_PATH,
+        params=_lookup_params(portfolio_id="PB_SG_FILTERED_020", as_of_date="2026-04-22"),
+        headers=CALLER_HEADERS,
+    )
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error_code"] == "LOTUS_AI_ACCEPTED_LATEST_NO_CONTEXT_MATCH"
+    assert body["metadata"]["reason_code"] == "no_context_match"
+
+
+def test_accepted_latest_does_not_leak_existence_across_tenants(
+    client: TestClient,
+) -> None:
+    run_id = _execute_advisor_brief(
+        client, correlation_id="corr-accepted-latest-030", portfolio_id="PB_SG_TENANT_030"
+    )
+    _accept(client, run_id)
+
+    response = client.get(
+        LOOKUP_PATH,
+        params=_lookup_params(portfolio_id="PB_SG_TENANT_030"),
+        headers={"X-Caller-App": "lotus-gateway", "X-Tenant-Id": "tenant-uk-999"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["metadata"]["reason_code"] == "no_accepted_run"
+
+
+def test_accepted_latest_refuses_unsupported_pack_family(client: TestClient) -> None:
+    response = client.get(
+        LOOKUP_PATH,
+        params=_lookup_params(pack_family="fund_teaser"),
+        headers=CALLER_HEADERS,
+    )
+
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error_code"] == "LOTUS_AI_ACCEPTED_LATEST_PACK_PROJECTION_UNSUPPORTED"
+    assert body["metadata"]["reason_code"] == "pack_projection_unsupported"
+
+
+def test_accepted_latest_requires_a_registered_caller(client: TestClient) -> None:
+    response = client.get(
+        LOOKUP_PATH,
+        params=_lookup_params(),
+        headers={"X-Caller-App": "unknown-app", "X-Tenant-Id": "tenant-sg-001"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_accepted_latest_literal_path_is_not_captured_as_a_run_id(
+    client: TestClient,
+) -> None:
+    """The literal segment must reach the lookup route: its bounded
+    problem-details shape proves the {run_id} detail route never captured it."""
+
+    response = client.get(LOOKUP_PATH, params=_lookup_params(), headers=CALLER_HEADERS)
+
+    assert response.status_code in {200, 404}
+    if response.status_code == 404:
+        assert response.json()["metadata"]["reason_code"] in {
+            "no_accepted_run",
+            "no_context_match",
+        }
+
+
+def test_accepted_latest_names_the_lookup_boundary(client: TestClient) -> None:
+    from app.main import app
+
+    schema = app.openapi()
+    operation = schema["paths"][LOOKUP_PATH]["get"]
+
+    assert operation["operationId"] == "getWorkflowPackRunAcceptedLatest"
+    description = operation["description"]
+    assert "accepting review" in description
+    assert "wildcard" in description
+    assert "existence oracle" in description
+    for status_code in ("200", "403", "404", "409", "422", "503"):
+        assert status_code in operation["responses"]
+
+
+def test_accepted_latest_store_unavailable_returns_503(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.workflow_pack_run_ledger import WorkflowPackRunStoreUnavailableError
+
+    def raise_store_unavailable() -> None:
+        raise WorkflowPackRunStoreUnavailableError("Workflow-pack run store is not ready.")
+
+    monkeypatch.setattr(
+        "app.services.workflow_pack_run_accepted_latest.ensure_workflow_pack_run_store_ready",
+        raise_store_unavailable,
+    )
+
+    response = client.get(LOOKUP_PATH, params=_lookup_params(), headers=CALLER_HEADERS)
+
+    assert response.status_code == 503

--- a/tests/support/workflow_pack_fixtures.py
+++ b/tests/support/workflow_pack_fixtures.py
@@ -12,12 +12,13 @@ from app.services.portfolio_memory_context_guardrails import PORTFOLIO_MEMORY_EV
 
 def advisor_brief_payload(
     *,
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001",
     portfolio_return_pct: float = 1.25,
     benchmark_return_pct: float = 7.93,
     active_return_pct: float = -6.68,
 ) -> dict[str, object]:
     return {
-        "portfolio": {"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+        "portfolio": {"portfolio_id": portfolio_id},
         "period": {"period": "YTD"},
         "performance": {
             "portfolio_return_pct": portfolio_return_pct,
@@ -69,6 +70,7 @@ def advisor_brief_task_execution_request_json(
     tenant_id: str | None = "tenant-sg-001",
     summary: str = "Draft advisor brief from source performance facts.",
     source_refs: list[str] | None = None,
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001",
     portfolio_return_pct: float = 1.25,
     benchmark_return_pct: float = 7.93,
     active_return_pct: float = -6.68,
@@ -84,6 +86,7 @@ def advisor_brief_task_execution_request_json(
         "context": {
             "summary": summary,
             "payload": advisor_brief_payload(
+                portfolio_id=portfolio_id,
                 portfolio_return_pct=portfolio_return_pct,
                 benchmark_return_pct=benchmark_return_pct,
                 active_return_pct=active_return_pct,

--- a/tests/unit/test_workflow_pack_run_accepted_latest.py
+++ b/tests/unit/test_workflow_pack_run_accepted_latest.py
@@ -1,0 +1,452 @@
+"""Service-level pins for the latest-accepted lookup (issue #183).
+
+The API contract tests prove the reachable postures end to end; these pin the
+determinism rules and the fail-closed postures only a corrupted or edited
+ledger can produce: accepting-review ordering with ties, filters that never
+wildcard unasserted context, scan saturation, unresolvable candidates, and
+tenant isolation without an existence oracle.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from app.contracts.artifacts import (
+    ArtifactDescriptor,
+    ArtifactLifecycleStatus,
+    ArtifactStorageBackend,
+)
+from app.contracts.workflow_pack_runs import WorkflowPackRunEventType
+from app.repositories.workflow_pack_run_repository import (
+    WorkflowPackRunEventRecord,
+    WorkflowPackRunRecord,
+)
+from app.services import workflow_pack_run_accepted_latest as module
+from app.services import workflow_pack_run_accepted_output as output_module
+from app.services.workflow_pack_run_accepted_latest import (
+    AcceptedLatestNotFoundError,
+    build_workflow_pack_run_accepted_latest,
+)
+from app.services.workflow_pack_run_accepted_output import AcceptedOutputNotAvailableError
+
+TENANT = "tenant-sg-001"
+PORTFOLIO = "PB_SG_GLOBAL_BAL_001"
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.runs: dict[str, WorkflowPackRunRecord] = {}
+        self.events: dict[str, list[WorkflowPackRunEventRecord]] = {}
+
+    def query_runs(self, *, limit: int, **filters: Any) -> list[WorkflowPackRunRecord]:
+        records = [
+            record
+            for record in self.runs.values()
+            if all(
+                value is None or getattr(record, field) == value for field, value in filters.items()
+            )
+        ]
+        records.sort(key=lambda record: record.created_at, reverse=True)
+        return records[: max(limit, 0)]
+
+    def get_run(self, *, run_id: str) -> WorkflowPackRunRecord | None:
+        return self.runs.get(run_id)
+
+    def list_events(self, *, run_id: str) -> list[WorkflowPackRunEventRecord]:
+        return sorted(self.events.get(run_id, []), key=lambda event: event.recorded_at)
+
+
+class _ObjectStore:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    def get_object(self, *, object_key: str) -> Any:
+        payload = self.objects.get(object_key)
+        if payload is None:
+            return None
+
+        class _Stored:
+            payload: bytes
+
+        stored = _Stored()
+        stored.payload = payload
+        return stored
+
+
+@pytest.fixture
+def _stores(monkeypatch: pytest.MonkeyPatch) -> tuple[_Store, _ObjectStore]:
+    store = _Store()
+    objects = _ObjectStore()
+    for target in (module, output_module):
+        monkeypatch.setattr(target, "ensure_workflow_pack_run_store_ready", lambda: None)
+        monkeypatch.setattr(target, "get_workflow_pack_run_store", lambda: store)
+    monkeypatch.setattr(output_module, "get_artifact_object_store", lambda: objects)
+    return store, objects
+
+
+def _seed_run(
+    stores: tuple[_Store, _ObjectStore],
+    *,
+    run_id: str,
+    created_at: str,
+    reviewed_at: str | None,
+    portfolio_id: str = PORTFOLIO,
+    as_of_date: str | None = None,
+    reporting_currency: str | None = None,
+    tenant_id: str | None = TENANT,
+    pack_version: str = "v1",
+    superseded_by_run_id: str | None = None,
+    artifact_intact: bool = True,
+) -> None:
+    store, objects = stores
+    store.runs[run_id] = WorkflowPackRunRecord(
+        run_id=run_id,
+        pack_id="advisor_brief.pack",
+        pack_family="advisor_brief",
+        pack_version=pack_version,
+        registration_ref=f"advisor_brief.pack@{pack_version}",
+        task_id="explain.v1",
+        request_id=f"req-{run_id}",
+        caller_app="lotus-gateway",
+        correlation_id=f"corr-{run_id}",
+        tenant_id=tenant_id,
+        workflow_surface="advisor-brief-workspace",
+        workflow_authority_owner="lotus-gateway",
+        runtime_state="COMPLETED",
+        review_state="ACCEPTED",
+        review_required=True,
+        provider_mode="stub",
+        stubbed=True,
+        output_preview="preview",
+        structured_output_keys=["grounded_summary"],
+        evidence_descriptors=[],
+        artifact_refs=[
+            ArtifactDescriptor(
+                artifact_id=f"art-{run_id}",
+                domain="workflow_pack",
+                artifact_type="run_output_summary",
+                source_object_kind="workflow_pack_run",
+                source_object_id=run_id,
+                lifecycle_status=ArtifactLifecycleStatus.RUNTIME_GENERATED,
+                retention_posture="retained_for_review",
+                media_type="application/json",
+                byte_size=512,
+                checksum_sha256="0" * 64,
+                storage_backend=ArtifactStorageBackend.MEMORY,
+                storage_reference=f"artifact://runs/{run_id}.json",
+                created_at=created_at,
+                created_by="lotus-ai.workflow-pack-run-ledger",
+            )
+        ],
+        supersedes_run_id=None,
+        superseded_by_run_id=superseded_by_run_id,
+        created_at=created_at,
+        completed_at=created_at,
+        last_updated_at=created_at,
+    )
+    if reviewed_at is not None:
+        store.events.setdefault(run_id, []).append(
+            WorkflowPackRunEventRecord(
+                event_id=f"evt-{run_id}",
+                run_id=run_id,
+                event_type=WorkflowPackRunEventType.REVIEW_STATE_UPDATED.value,
+                runtime_state="COMPLETED",
+                review_state="ACCEPTED",
+                actor="review:banker.sg.301",
+                message="Accepted.",
+                recorded_at=reviewed_at,
+            )
+        )
+    if artifact_intact:
+        structured: dict[str, Any] = {
+            "advisor_brief_status": "complete",
+            "coverage_state": "complete",
+            "portfolio_id": portfolio_id,
+            "period": "YTD",
+            "grounded_summary": f"Summary for {run_id}.",
+            "talking_points": [],
+            "risks_and_exceptions": [],
+        }
+        if as_of_date is not None:
+            structured["as_of_date"] = as_of_date
+        if reporting_currency is not None:
+            structured["reporting_currency"] = reporting_currency
+        objects.objects[f"runs/{run_id}.json"] = json.dumps(
+            {
+                "run_id": run_id,
+                "pack_id": "advisor_brief.pack",
+                "source_refs": [],
+                "evidence_types": [],
+                "structured_output": structured,
+            }
+        ).encode("utf-8")
+
+
+def _lookup(**overrides: Any) -> Any:
+    params: dict[str, Any] = {
+        "pack_family": "advisor_brief",
+        "portfolio_id": PORTFOLIO,
+        "caller_tenant_id": TENANT,
+    }
+    params.update(overrides)
+    return build_workflow_pack_run_accepted_latest(**params)
+
+
+def test_unsupported_pack_family_is_refused(_stores: tuple[_Store, _ObjectStore]) -> None:
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        _lookup(pack_family="fund_teaser")
+    assert excinfo.value.reason_code == "pack_projection_unsupported"
+
+
+def test_latest_is_ordered_by_accepting_review_not_creation(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    """The run created FIRST but accepted LAST is the latest accepted run."""
+
+    _seed_run(
+        _stores,
+        run_id="wfr-early",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T12:00:00Z",
+    )
+    _seed_run(
+        _stores,
+        run_id="wfr-late",
+        created_at="2026-08-30T09:00:00Z",
+        reviewed_at="2026-08-30T10:00:00Z",
+    )
+
+    envelope = _lookup()
+
+    assert envelope.run_id == "wfr-early"
+    assert envelope.review.reviewed_at == "2026-08-30T12:00:00Z"
+    assert envelope.review.reviewed_by == "banker.sg.301"
+
+
+def test_review_time_ties_break_on_run_id_descending(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    _seed_run(
+        _stores,
+        run_id="wfr-a",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T10:00:00Z",
+    )
+    _seed_run(
+        _stores,
+        run_id="wfr-b",
+        created_at="2026-08-30T08:30:00Z",
+        reviewed_at="2026-08-30T10:00:00Z",
+    )
+
+    assert _lookup().run_id == "wfr-b"
+
+
+def test_unknown_portfolio_and_unknown_tenant_share_no_accepted_run(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    _seed_run(
+        _stores,
+        run_id="wfr-001",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+    )
+
+    with pytest.raises(AcceptedLatestNotFoundError) as unknown_portfolio:
+        _lookup(portfolio_id="PB_UK_UNKNOWN_999")
+    with pytest.raises(AcceptedLatestNotFoundError) as unknown_tenant:
+        _lookup(caller_tenant_id="tenant-uk-999")
+
+    assert unknown_portfolio.value.reason_code == "no_accepted_run"
+    assert unknown_tenant.value.reason_code == "no_accepted_run"
+
+
+def test_context_filters_distinguish_no_context_match(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    _seed_run(
+        _stores,
+        run_id="wfr-001",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+        as_of_date="2026-04-22",
+    )
+
+    with pytest.raises(AcceptedLatestNotFoundError) as excinfo:
+        _lookup(as_of_date="2026-05-31")
+    assert excinfo.value.reason_code == "no_context_match"
+
+    assert _lookup(as_of_date="2026-04-22").run_id == "wfr-001"
+
+
+def test_unasserted_context_never_wildcard_matches_a_filter(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    _seed_run(
+        _stores,
+        run_id="wfr-001",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+    )
+
+    for filters in (
+        {"as_of_date": "2026-04-22"},
+        {"reporting_currency": "USD"},
+    ):
+        with pytest.raises(AcceptedLatestNotFoundError) as excinfo:
+            _lookup(**filters)
+        assert excinfo.value.reason_code == "no_context_match"
+
+
+def test_filters_select_an_older_matching_accepted_run(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    """A newer accepted run that fails the filters yields to the newest run
+    that asserts the requested context - never to a wildcard."""
+
+    _seed_run(
+        _stores,
+        run_id="wfr-old-usd",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+        reporting_currency="USD",
+    )
+    _seed_run(
+        _stores,
+        run_id="wfr-new-sgd",
+        created_at="2026-08-30T10:00:00Z",
+        reviewed_at="2026-08-30T11:00:00Z",
+        reporting_currency="SGD",
+    )
+
+    envelope = _lookup(reporting_currency="USD")
+
+    assert envelope.run_id == "wfr-old-usd"
+    assert envelope.context.reporting_currency == "USD"
+
+
+def test_superseded_accepted_runs_are_not_candidates(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    _seed_run(
+        _stores,
+        run_id="wfr-001",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+        superseded_by_run_id="wfr-002",
+    )
+
+    with pytest.raises(AcceptedLatestNotFoundError) as excinfo:
+        _lookup()
+    assert excinfo.value.reason_code == "no_accepted_run"
+
+
+def test_scan_saturation_fails_closed(
+    _stores: tuple[_Store, _ObjectStore], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_run(
+        _stores,
+        run_id="wfr-001",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+    )
+    _seed_run(
+        _stores,
+        run_id="wfr-002",
+        created_at="2026-08-30T08:30:00Z",
+        reviewed_at="2026-08-30T09:30:00Z",
+    )
+    monkeypatch.setattr(module, "_CANDIDATE_SCAN_LIMIT", 2)
+
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        _lookup()
+    assert excinfo.value.reason_code == "lookup_scan_saturated"
+
+
+def test_accepted_candidate_without_review_event_fails_the_lookup_closed(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    """An ACCEPTED run with no review transition has an unknowable position in
+    the latest-accepted order - even when an intact candidate also exists."""
+
+    _seed_run(
+        _stores,
+        run_id="wfr-intact",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+    )
+    _seed_run(_stores, run_id="wfr-no-review", created_at="2026-08-30T08:30:00Z", reviewed_at=None)
+
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        _lookup()
+    assert excinfo.value.reason_code == "output_artifact_malformed"
+
+
+def test_unresolvable_newer_candidate_fails_the_lookup_closed(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    """A corrupt candidate NEWER than an intact match could itself be the
+    answer; the lookup refuses rather than serving possibly-stale content."""
+
+    _seed_run(
+        _stores,
+        run_id="wfr-intact",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+    )
+    _seed_run(
+        _stores,
+        run_id="wfr-corrupt",
+        created_at="2026-08-30T08:30:00Z",
+        reviewed_at="2026-08-30T10:00:00Z",
+        artifact_intact=False,
+    )
+
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        _lookup()
+    assert excinfo.value.reason_code == "output_artifact_missing"
+
+
+def test_envelope_is_identity_only_and_pins_the_projection_hash(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    _seed_run(
+        _stores,
+        run_id="wfr-001",
+        created_at="2026-08-30T08:00:00Z",
+        reviewed_at="2026-08-30T09:00:00Z",
+        as_of_date="2026-04-22",
+        reporting_currency="USD",
+    )
+
+    envelope = _lookup()
+    projection = output_module.build_workflow_pack_run_accepted_output(
+        run_id="wfr-001", caller_tenant_id=TENANT
+    )
+
+    assert envelope.schema_id == "lotus-ai.workflow_pack_run.accepted_latest.v1"
+    assert envelope.accepted_output_schema_id == projection.schema_id
+    assert envelope.content_hash == projection.content_hash
+    assert envelope.content_hash_algorithm == "sha256"
+    assert envelope.context == projection.context
+    published_fields = set(envelope.model_dump())
+    assert published_fields == {
+        "schema_id",
+        "service",
+        "version",
+        "run_id",
+        "pack_id",
+        "pack_family",
+        "pack_version",
+        "tenant_id",
+        "workflow_authority_owner",
+        "context",
+        "review",
+        "accepted_output_schema_id",
+        "content_hash",
+        "content_hash_algorithm",
+        "notes",
+    }

--- a/tests/unit/test_workflow_pack_source_events.py
+++ b/tests/unit/test_workflow_pack_source_events.py
@@ -24,6 +24,7 @@ class _NoBroadListWorkflowPackRunRepository(InMemoryWorkflowPackRunRepository):
         *,
         registration_ref: str | None = None,
         pack_id: str | None = None,
+        pack_family: str | None = None,
         caller_app: str | None = None,
         tenant_id: str | None = None,
         workflow_surface: str | None = None,
@@ -36,6 +37,7 @@ class _NoBroadListWorkflowPackRunRepository(InMemoryWorkflowPackRunRepository):
         return super().query_runs(
             registration_ref=registration_ref,
             pack_id=pack_id,
+            pack_family=pack_family,
             caller_app=caller_app,
             tenant_id=tenant_id,
             workflow_surface=workflow_surface,

--- a/wiki/Platform-Surfaces.md
+++ b/wiki/Platform-Surfaces.md
@@ -145,6 +145,7 @@ platform programs.
    - `/platform/workflow-packs/runs/{run_id}/source-events`
    - `/platform/workflow-packs/runs/{run_id}/operator-profile`
    - `/platform/workflow-packs/runs/{run_id}/consumer-view`
+   - `/platform/workflow-packs/runs/accepted-latest`
    - `/platform/workflow-packs/runs/{run_id}/accepted-output`
    - `/platform/workflow-packs/runs/{run_id}/review-actions`
    - `/platform/workflow-packs/task-flows`
@@ -182,10 +183,19 @@ The workflow-pack run-ledger routes now add bounded runtime lineage for Phase-1 
    content hash, and never exposes prompts, raw payloads, storage references, or generic artifact
    bodies. Per-pack projectors are registered explicitly, so future structured-output keys never
    become implicitly retrievable,
-7. `/platform/workflow-packs/runs/{run_id}/review-actions` records bounded actor-attributed review transitions without taking consequence-bearing workflow authority,
-8. `lotus-gateway` now uses that same bounded ledger seam to record advisor-brief review actions and returns refreshed workflow-pack posture through its advisor-brief contract without turning `lotus-ai` into the business-workflow owner,
-9. `lotus-workbench` now has a typed client seam for the downstream advisor-brief review-action route, while UI-triggered business authorization remains a separate future slice,
-10. the current executable workflow-pack set includes `advisor_brief.pack`,
+7. `/platform/workflow-packs/runs/accepted-latest` resolves the latest accepted run of one
+   pack family for one portfolio (issue #183) as a bounded identity envelope only - run and
+   pack identity, asserted context, accepting reviewer, and the accepted-output content hash -
+   so the report ordering surface can answer "does an accepted brief exist?" truthfully before
+   an order is placed. "Latest" is deterministic by accepting-review recency; optional context
+   filters compare only against source-asserted values (an unasserted value never
+   wildcard-matches); `no_accepted_run` and `no_context_match` are distinguished while unknown
+   tenants and portfolios share one shape; unresolvable candidates and scan saturation fail
+   closed. The narrative itself stays on the single run_id-keyed accepted-output surface,
+8. `/platform/workflow-packs/runs/{run_id}/review-actions` records bounded actor-attributed review transitions without taking consequence-bearing workflow authority,
+9. `lotus-gateway` now uses that same bounded ledger seam to record advisor-brief review actions and returns refreshed workflow-pack posture through its advisor-brief contract without turning `lotus-ai` into the business-workflow owner,
+10. `lotus-workbench` now has a typed client seam for the downstream advisor-brief review-action route, while UI-triggered business authorization remains a separate future slice,
+11. the current executable workflow-pack set includes `advisor_brief.pack`,
    `workspace_rationale.pack`, `twr_inspection_support_brief.pack`, the review-gated
    RFC-0027 `advisory_copilot_*.pack` contracts for `lotus-advise` source-backed copilot
    evidence packets, the review-gated


### PR DESCRIPTION
## Summary

Implements #183: `GET /platform/workflow-packs/runs/accepted-latest?pack_family=&portfolio_id=` (optional `as_of_date`, `reporting_currency`), the lookup that unblocks the ordering-availability acceptance criterion of sgajbi/lotus-report#166.

### Contract, as agreed on the issue
- **Identity envelope only** — run/pack identity, asserted context, accepting reviewer, and the accepted-output `content_hash`. No narrative fields: consumers fetch the run_id-keyed accepted-output projection, keeping exactly one narrative-bearing surface.
- **Deterministic latest** — the run whose accepting review event is most recent among completed, accepted, non-superseded family runs asserting the portfolio; run_id breaks review-time ties.
- **Filters never wildcard** — `as_of_date` / `reporting_currency` compare only against values the source asserted.
- **Bounded not-found reasons** — `no_accepted_run` vs `no_context_match`; unknown tenants and unknown portfolios share one shape (no existence oracle).
- **Fail-closed postures** — unsupported pack family, unresolvable candidates (missing review event, unsupported version, missing/malformed governed artifact — an unresolvable candidate has an unknowable position in the latest-accepted order), and candidate-scan saturation all refuse with bounded 409 reasons.

### Implementation notes
- Route registered **before** `/runs/{run_id}` so the literal segment is never captured as a run id (pinned by test).
- One code path resolves candidates: the winning run is projected through the existing accepted-output builder, so context, reviewer identity and hash cannot drift between the two surfaces.
- `query_runs` gains a `pack_family` filter (protocol + memory + SQLAlchemy).
- `wiki/Platform-Surfaces.md` documents the surface.

### Evidence
- 12 service-level tests (review-recency ordering + ties, wildcard refusal, filter fallback to older asserted match, supersession exclusion, saturation, corrupt-candidate/no-review fail-closed, tenant isolation, identity-only field set pinned).
- 9 API contract tests (two-step consumer flow with hash chaining, both not-found reasons, tenant isolation, 403, OpenAPI boundary, 503).
- Local gates: `make check` green (1629 tests), coverage gate green at 99% (fail-under=99).

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
