### PR TITLE
test(resilience): promoted-profile evaluation condition end to end (#153 S4)

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -183,7 +183,8 @@ Boundary rules:
 1. other Lotus apps provide structured business context and remain responsible for business meaning,
 2. `lotus-ai` provides bounded governed AI capabilities with audit and evidence,
 3. framework choices must not obscure control flow, governance, or auditability,
-4. live-provider, retrieval, async, and workflow-pack control seams remain rollout-governed and evidence-backed.
+4. live-provider, retrieval, async, and workflow-pack control seams remain rollout-governed and evidence-backed,
+5. `LOTUS_AI_RUNTIME_PROFILE=promoted` applies the protection default set (retries with backoff, quota/budget/breaker enforcement, SQL-backed provider-operations and admission stores, degrade readiness, enforce startup) while explicit per-key settings always win; the setting-by-profile table lives in `docs/runbooks/service-operations.md` (Runtime Profile).
 
 ## Repo-Native Commands
 

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -184,6 +184,26 @@ Expected operator flow for SQL-backed stores:
 15. verify `GET /platform/retrieval/runtime-status` when retrieval persistence is relevant
 16. only then proceed with rollout if readiness is `READY`
 
+## Runtime Profile
+
+`LOTUS_AI_RUNTIME_PROFILE` selects the protection default set at settings construction. `local` (the default) keeps the light per-key defaults; `promoted` applies the protection set below. A key explicitly set through its own environment variable always keeps the explicit value — the profile only fills keys the operator did not set.
+
+| Setting | `local` default | `promoted` default |
+| --- | --- | --- |
+| `LOTUS_AI_PROVIDER_RETRY_LIMIT` | `0` | `2` |
+| `LOTUS_AI_LIVE_TEXT_QUOTA_ENFORCED` | `false` | `true` |
+| `LOTUS_AI_LIVE_TEXT_BUDGET_ENFORCED` | `false` | `true` |
+| `LOTUS_AI_LIVE_TEXT_DEGRADATION_ENFORCED` | `false` | `true` |
+| `LOTUS_AI_LIVE_TEXT_DEGRADED_FAILURE_COUNT_THRESHOLD` | unset | `3` |
+| `LOTUS_AI_LIVE_TEXT_CIRCUIT_OPEN_FAILURE_COUNT_THRESHOLD` | unset | `5` |
+| `LOTUS_AI_LIVE_TEXT_CIRCUIT_OPEN_SECONDS` | unset | `60` |
+| `LOTUS_AI_PROVIDER_OPERATIONS_STORE_MODE` | `memory` | `sqlalchemy` |
+| `LOTUS_AI_WORKFLOW_PACK_ADMISSION_STORE_MODE` | `memory` | `sqlalchemy` |
+| `LOTUS_AI_READINESS_PROBE_POLICY` | `observe` | `degrade` |
+| `LOTUS_AI_STARTUP_READINESS_POLICY` | `warn` | `enforce` |
+
+The promoted profile never invents economic limits: `LOTUS_AI_LIVE_TEXT_TASK_QUOTA_LIMITS`, `LOTUS_AI_LIVE_TEXT_HARD_BUDGET_USD`, and the live-text token cost rates stay operator-supplied. In the promoted profile, a memory-backed workflow-pack admission store is a startup finding in every provider mode; with a live provider mode (`openai` or `local_openai_compatible`), disabled quota, budget, or breaker enforcement, enabled quota or budget enforcement with no configured limits, and a memory-backed provider-operations store are further findings. The promoted startup policy is `enforce`, so these findings fail startup instead of letting the service run unprotected.
+
 ## Resilience Governance
 
 Before treating service continuity posture as anything stronger than bounded governed recovery truth:

--- a/src/app/services/audit_store.py
+++ b/src/app/services/audit_store.py
@@ -5,12 +5,15 @@ from app.repositories.audit_repository import AuditRepository
 from app.repositories.memory_audit_repository import InMemoryAuditRepository
 from app.repositories.sqlalchemy_audit_repository import SqlAlchemyAuditRepository
 
-_memory_repository = InMemoryAuditRepository()
+_memory_repository: InMemoryAuditRepository | None = None
 _sqlalchemy_repository: SqlAlchemyAuditRepository | None = None
 
 
 def get_audit_store() -> AuditRepository:
     if settings.audit_store_mode == "memory":
+        global _memory_repository
+        if _memory_repository is None:
+            _memory_repository = InMemoryAuditRepository()
         return _memory_repository
     if settings.audit_store_mode == "sqlalchemy":
         if not settings.database_url:
@@ -25,5 +28,6 @@ def get_audit_store() -> AuditRepository:
 
 
 def reset_audit_store_cache() -> None:
-    global _sqlalchemy_repository
+    global _memory_repository, _sqlalchemy_repository
+    _memory_repository = None
     _sqlalchemy_repository = None

--- a/tests/integration/test_promoted_profile_resilience.py
+++ b/tests/integration/test_promoted_profile_resilience.py
@@ -1,0 +1,175 @@
+"""The #153 evaluation condition, end to end under promoted protections.
+
+A fake provider that fails twice then succeeds completes after two
+backed-off retries within the deadline; an always-failing provider opens
+the breaker after the threshold and subsequent calls are rejected fast at
+preflight without reaching the transport; the enforcement counters are
+visible from a second repository instance, as a second replica would see
+them.
+"""
+
+from email.message import Message
+from io import BytesIO
+from pathlib import Path
+from urllib import error
+
+from fastapi import HTTPException
+from pytest import MonkeyPatch, raises
+
+from app.config import settings
+from app.contracts.providers import ProviderQuotaScope
+from app.contracts.tasks import OutputLabel
+from app.repositories.sqlalchemy_provider_operations_repository import (
+    SqlAlchemyProviderOperationsRepository,
+)
+from app.services.task_executor import execute_task
+from tests.support.migration_runner import upgrade_database_to_head
+from tests.unit.test_task_executor import _request
+
+
+def _promoted_live_settings(tmp_path: Path) -> str:
+    # The promoted protection set (S2 derives these from the profile; the
+    # derivation itself is unit-tested - here the protections run live)
+    # plus the operator-supplied limits promoted demands.
+    settings.runtime_profile = "promoted"
+    settings.provider_retry_limit = 2
+    settings.live_text_degradation_enforced = True
+    settings.live_text_degraded_failure_count_threshold = 2
+    settings.live_text_circuit_open_failure_count_threshold = 3
+    settings.live_text_circuit_open_seconds = 60
+    settings.live_text_quota_enforced = True
+    settings.live_text_task_quota_limits = "explain.v1=100"
+    settings.live_text_budget_enforced = True
+    settings.live_text_hard_budget_usd = 100.0
+    settings.live_text_input_cost_per_1k_tokens = 0.0
+    settings.live_text_output_cost_per_1k_tokens = 0.0
+    settings.provider_operations_store_mode = "sqlalchemy"
+    database_url = f"sqlite:///{tmp_path / 'promoted-resilience.db'}"
+    settings.database_url = database_url
+    upgrade_database_to_head(database_url)
+
+    settings.provider_mode = "local_openai_compatible"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    settings.live_text_provider_id = "text.local"
+    settings.live_text_model_id = "qwen3:8b"
+    settings.live_text_api_base = "http://ollama:11434/v1"
+    settings.live_text_allowed_task_ids = "explain.v1"
+    return database_url
+
+
+def _fake_probe(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.services.provider_live_execution_state.build_local_openai_compatible_endpoint_status",
+        lambda: type(
+            "ProbeStatus",
+            (),
+            {"endpoint_reachable": True, "model_available": True, "blocking_reason": None},
+        )(),
+    )
+
+
+class _SuccessResponse:
+    def __enter__(self) -> "_SuccessResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return (
+            b'{"id": "resp_resilient", "model": "qwen3:8b",'
+            b' "output_text": "Recovered live response.",'
+            b' "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}}'
+        )
+
+
+def _http_503() -> error.HTTPError:
+    return error.HTTPError(
+        url="http://ollama:11434/v1/responses",
+        code=503,
+        msg="unavailable",
+        hdrs=Message(),
+        fp=BytesIO(b"{}"),
+    )
+
+
+def test_fails_twice_then_succeeds_within_backed_off_deadline(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    database_url = _promoted_live_settings(tmp_path)
+    _fake_probe(monkeypatch)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "app.services.provider_retry_backoff._sleep", lambda delay: sleeps.append(delay)
+    )
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+
+    attempts = {"count": 0}
+
+    def _urlopen(request: object, timeout: float) -> object:
+        attempts["count"] += 1
+        if attempts["count"] <= 2:
+            raise _http_503()
+        return _SuccessResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    response = execute_task(
+        _request("explain.v1", expected_output_label=OutputLabel.EXPLANATION_ONLY)
+    )
+
+    assert response.status == "COMPLETED"
+    assert response.result.message == "Recovered live response."
+    assert attempts["count"] == 3
+    assert sleeps == [0.25, 0.5]
+    assert response.result.structured_output["retry_count"] == 2
+
+    # The quota and budget counters are durable and visible from a second
+    # repository instance - what a second replica would read.
+    second_replica = SqlAlchemyProviderOperationsRepository(database_url)
+    quota = second_replica.get_quota_state(scope=ProviderQuotaScope.TASK, scope_key="explain.v1")
+    assert quota is not None
+    assert quota.request_count == 1
+    budget = second_replica.get_budget_state(budget_key="live_text_generation")
+    assert budget is not None
+    assert budget.current_spend_usd == 0.0  # zero-rate card: recorded spend, zero cost
+
+
+def test_always_failing_provider_opens_the_breaker_and_fast_rejects(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    database_url = _promoted_live_settings(tmp_path)
+    _fake_probe(monkeypatch)
+    monkeypatch.setattr("app.services.provider_retry_backoff._sleep", lambda delay: None)
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+
+    attempts = {"count": 0}
+
+    def _urlopen(request: object, timeout: float) -> object:
+        attempts["count"] += 1
+        raise _http_503()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    failures = 0
+    for _ in range(3):
+        with raises(HTTPException):
+            execute_task(_request("explain.v1", expected_output_label=OutputLabel.EXPLANATION_ONLY))
+        failures += 1
+    assert failures == 3
+    transport_attempts_when_breaker_opened = attempts["count"]
+
+    # The breaker is open: the next call is rejected at preflight without
+    # reaching the transport at all.
+    with raises(HTTPException) as exc_info:
+        execute_task(_request("explain.v1", expected_output_label=OutputLabel.EXPLANATION_ONLY))
+    assert "CIRCUIT_OPEN" in str(exc_info.value.detail)
+    assert attempts["count"] == transport_attempts_when_breaker_opened
+
+    # The enforcement state is durable and visible from a second repository
+    # instance - what a second replica would read.
+    second_replica = SqlAlchemyProviderOperationsRepository(database_url)
+    degradation = second_replica.get_degradation_state(degradation_key="live_text_generation")
+    assert degradation is not None
+    assert degradation.consecutive_failure_count >= 3


### PR DESCRIPTION
Closes #153.

S4 of 4: the evaluation condition end-to-end, plus the docs the acceptance criteria require. With S1 (#213), S2 (#214), and S3 (#216) merged, this closes the issue.

## What this PR adds

- `tests/integration/test_promoted_profile_resilience.py` — the issue's evaluation condition, executed live through `execute_task` under the full promoted protection set (retries 2, quota/budget/breaker enforced, sqlalchemy stores on a migrated database):
  - a fake provider that fails twice (503) then succeeds completes after exactly two backed-off retries (`sleeps == [0.25, 0.5]`, 3 transport attempts) within the deadline, with `retry_count == 2` in the structured output, and the quota counter (`TASK/explain.v1 == 1`) and budget spend row are readable from a **second repository instance** on the same database;
  - an always-failing provider opens the breaker after the threshold (3), the next call is rejected fast at preflight (`CIRCUIT_OPEN`) with **zero additional transport attempts**, and `consecutive_failure_count >= 3` is readable from a second repository instance.
- `docs/runbooks/service-operations.md` — new **Runtime Profile** section with the setting-by-profile table (11 profiled keys, local vs promoted), the explicit-override-wins rule, and the exact startup-finding behavior (verified against `_provider_protection_findings()`: memory admission store is a finding in every promoted mode; quota/budget/breaker/store findings require a live provider mode).
- `REPOSITORY-ENGINEERING-CONTEXT.md` — boundary rule pointing at the profile and the table.
- `src/app/services/audit_store.py` — reset now clears the memory adapter too (defect found by these tests; details below).

## Defect found and fixed: audit-store reset skipped the memory adapter

The new end-to-end tests exposed a latent test-isolation defect: `src/app/services/audit_store.py` held its memory repository as an eagerly-created module global that `reset_audit_store_cache()` never cleared — audit records accumulated across the entire test process. Every other store in the repo (caller-policy, kill-switch, model-catalogue, rate-card, retention, admission-lease, queue-event, registry) recreates its memory adapter on reset; the audit store was the single exception, predating the pattern. Symptom: in a single-process full run, this PR's `execute_task` calls leaked audit records into `test_capability_pack_governance`'s pack sampler (expected 0 matching records, saw 12). Fixed by aligning the audit store with the sibling pattern (lazy memory singleton, reset nulls both adapters). No production behavior change — the reset seam is only invoked by test tooling.

A note for reviewers: the promoted profile with `budget_enforced` requires an effective rate card — without cost scalars, budget configuration is invalid and execution fails closed (`INVALID_BUDGET_CONFIGURATION`). The test therefore supplies an explicit zero-rate card; that fail-closed behavior is existing S2/#178 semantics, reconfirmed here.

## Per-criterion audit (issue #153)

1. **Profile-driven defaults + docs table + unit tests both profiles + blocking startup finding in promoted** — defaults and derivation: PR #214 (merge f897c8b, gate run 33351604615); blocking-finding proof: `tests/unit/test_runtime_profile.py::test_promoted_live_mode_without_limits_yields_blocking_findings` (plus disabled-protection and local/stub no-finding cases); the docs table (setting × profile) lands in **this PR** (runbook + context).
2. **Backoff/jitter/deadline in transport with tests; audit record carries attempt count** — PR #213 (merge f3e3dc1, gate run 33347525803): `provider_retry_backoff.py` (base 0.25s, cap 4.0s, jitter 0.25, plan-before-log), delay-sequence and deadline-cap tests; attempt count in audit/structured output, re-asserted end-to-end here (`retry_count == 2`).
3. **Queue admission leases in SQL under `sqlalchemy` with a two-process single-admission proof** — PR #216 (merge a80546b, gate run 33354333114): atomic `try_admit` behind a FOR UPDATE guard row, migration 0055, `tests/unit/test_workflow_pack_admission_leases.py` proves one admission across two repository instances sharing one database and release-then-admit.
4. **`make runtime-mode-smoke`, `make test`, `make lint` green; context/runbook updated with the profile table** — this PR: runtime-mode-smoke 8 passed; full suite + coverage gate green locally (result below); `make lint` and `make typecheck` green; runbook + context updated.

## Evaluation condition

Covered by the two tests in this PR, as described above: backed-off recovery within the deadline, breaker-open fast rejection without a transport hit, and all counters (quota, budget, degradation) visible from a second repository instance — what a second replica reads from the shared store.

## Invariants check

- No live call without budget envelope, quota check, breaker: enforced at preflight in `execute_task`, exercised live in both tests.
- Retries never exceed the attempt/deadline budget; each attempt observable: asserted (3 attempts at limit 2, `retry_count` recorded).
- Readiness truthful in promoted: S2 (`readiness_probe_policy=degrade`, `startup_readiness_policy=enforce` derived), proven in #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
