### PR TITLE
feat(identity): registered-caller gate on every protected route (#149 S2)

### DIFF
--- a/alembic/versions/0056_seed_provider_operations_caller_policy.py
+++ b/alembic/versions/0056_seed_provider_operations_caller_policy.py
@@ -1,0 +1,59 @@
+"""seed lotus-ai-provider-operations caller policy
+
+Revision ID: 0056_seed_provider_operations_caller_policy
+Revises: 0055_add_workflow_pack_admission_leases
+Create Date: 2026-08-31
+
+Issue #149 S2: every protected route now requires a registered ACTIVE
+caller. The provider-operations recorder identity posts retention and
+deletion confirmations over HTTP and therefore needs its own policy row;
+it grants no task, retrieval, or control capability.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0056_seed_provider_operations_caller_policy"
+down_revision = "0055_add_workflow_pack_admission_leases"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO caller_policies (
+            caller_app,
+            lifecycle_status,
+            description,
+            allowed_task_ids,
+            allowed_retrieval_source_ids,
+            allow_live_provider,
+            allow_async_control,
+            allow_prompt_control,
+            allow_provider_control,
+            tenant_policy_mode,
+            restricted_tenant_ids,
+            updated_at
+        ) VALUES (
+            'lotus-ai-provider-operations',
+            'ACTIVE',
+            'Internal provider-operations recorder identity for retention and deletion confirmations; grants no task, retrieval, or control capability.',
+            '[]',
+            '[]',
+            FALSE,
+            FALSE,
+            FALSE,
+            FALSE,
+            'OPTIONAL',
+            '[]',
+            '2026-08-31T00:00:00Z'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM caller_policies WHERE caller_app = 'lotus-ai-provider-operations'")

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -575,6 +575,7 @@ Before treating caller identity and tenant isolation as fully governed rollout p
 5. confirm the embedded `access_control_runtime` and `access_control_governance` blocks in `GET /platform/runtime-status` match the detailed access-control views
 6. confirm unknown callers still fail closed on protected data-plane and control-plane paths
 7. confirm every route from a named product router receives a trusted `X-Caller-App` value from ingress or service-to-service routing and rejects missing, empty, unknown, or disabled caller identities; routes declaring body-level caller metadata must also reject mismatches before side effects
+8. every protected route additionally requires the identified caller to be a registered ACTIVE caller-policy entry (the `platform_read` capability — the policy row itself is the grant): an unregistered or disabled caller is refused `403` even on diagnostic read surfaces, and route- or service-level capability rules still apply on top for mutations
 8. treat SQL-backed caller policy storage as the activation gate for restart-safe access-control governance
 
 Current operational expectations:

--- a/src/app/contracts/access_control.py
+++ b/src/app/contracts/access_control.py
@@ -32,6 +32,7 @@ class AuthorizationCapabilityType(str, Enum):
     ASYNC_CONTROL = "async_control"
     PROMPT_CONTROL = "prompt_control"
     PROVIDER_CONTROL = "provider_control"
+    PLATFORM_READ = "platform_read"
 
 
 class AuthorizationOutcome(str, Enum):

--- a/src/app/http/platform_read.py
+++ b/src/app/http/platform_read.py
@@ -1,0 +1,32 @@
+"""Registered-caller gate for every protected route (issue #149, S2).
+
+Caller identity alone is not authorization: this dependency runs after
+``require_authenticated_caller`` and requires the identified caller to be a
+registered, ACTIVE caller-policy entry before any protected route executes.
+Route- and service-level capability rules (task execution, provider control,
+audit scopes, ...) still apply on top; this gate closes the gap where
+diagnostic read surfaces answered to any identity string.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from app.contracts.access_control import AuthorizationCapabilityType
+from app.http.authenticated_caller import get_authenticated_caller
+from app.services.access_control_authorization import authorize_request, require_authorized
+
+
+async def require_registered_caller() -> None:
+    authenticated_caller = get_authenticated_caller()
+    if authenticated_caller is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=("Authenticated caller identity is required for this protected lotus-ai route."),
+        )
+    require_authorized(
+        authorize_request(
+            caller_app=authenticated_caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PLATFORM_READ,
+        )
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -14,6 +14,7 @@ from app.api_errors import install_problem_detail_handlers
 from app.config import settings
 from app.contracts.api_errors import COMMON_PROBLEM_RESPONSES, ProblemDetails
 from app.http.authenticated_caller import require_authenticated_caller
+from app.http.platform_read import require_registered_caller
 from app.middleware.correlation import CorrelationIdMiddleware
 from app.services.tracing_runtime import configure_tracing
 from app.middleware.http_boundary import HttpBoundaryMiddleware
@@ -205,7 +206,9 @@ Instrumentator().instrument(app).expose(app)
 for _router_name, protected_router in PROTECTED_ROUTER_BINDINGS:
     app.include_router(
         protected_router,
-        dependencies=[Depends(require_authenticated_caller)],
+        # Order matters: the identity dependency binds the caller contextvar
+        # the registered-caller gate then reads.
+        dependencies=[Depends(require_authenticated_caller), Depends(require_registered_caller)],
     )
 _install_problem_details_openapi(app)
 

--- a/src/app/repositories/memory_caller_policy_repository.py
+++ b/src/app/repositories/memory_caller_policy_repository.py
@@ -120,6 +120,23 @@ _DEFAULT_POLICIES = [
         tenant_policy_mode=TenantPolicyMode.OPTIONAL,
         restricted_tenant_ids=[],
     ),
+    CallerPolicyDescriptor(
+        caller_app="lotus-ai-provider-operations",
+        lifecycle_status=CallerLifecycleStatus.ACTIVE,
+        description=(
+            "Internal provider-operations recorder identity for retention and deletion "
+            "confirmations; grants no task, retrieval, or control capability."
+        ),
+        allowed_task_ids=[],
+        allowed_retrieval_source_ids=[],
+        allow_live_provider=False,
+        allow_async_control=False,
+        allow_prompt_control=False,
+        allow_provider_control=False,
+        allow_audit_read_all_tenants=False,
+        tenant_policy_mode=TenantPolicyMode.OPTIONAL,
+        restricted_tenant_ids=[],
+    ),
 ]
 
 

--- a/src/app/services/access_control_authorization.py
+++ b/src/app/services/access_control_authorization.py
@@ -105,6 +105,30 @@ def authorize_request(
             ),
         )
 
+    if capability_type == AuthorizationCapabilityType.PLATFORM_READ:
+        # The policy row itself is the read grant (issue #149, S2): any
+        # registered ACTIVE caller may read platform posture surfaces; the
+        # unknown-caller and disabled-caller refusals above are the rule.
+        return AuthorizationDecision(
+            caller_app=caller_app,
+            authenticated_caller_app=(
+                authenticated_caller.caller_app if authenticated_caller else None
+            ),
+            caller_identity_source=identity_source,
+            caller_identity_bound=identity_bound,
+            capability_type=capability_type,
+            outcome=AuthorizationOutcome.ALLOWED,
+            allowed=True,
+            tenant_policy_mode=policy.tenant_policy_mode,
+            task_id=task_id,
+            requested_source_ids=requested_source_ids,
+            tenant_id=tenant_id,
+            summary=(
+                f"Caller '{caller_app}' is registered and active and may read "
+                "platform posture surfaces."
+            ),
+        )
+
     if capability_type == AuthorizationCapabilityType.ASYNC_CONTROL:
         return _evaluate_control_capability(
             caller_app=caller_app,

--- a/tests/unit/test_registered_caller_gate.py
+++ b/tests/unit/test_registered_caller_gate.py
@@ -1,0 +1,104 @@
+"""Registered-caller gate on every protected route (issue #149, S2).
+
+Identity is not authorization: an identified but unregistered caller is
+refused on every protected route - including the diagnostic read surfaces
+that previously answered to any identity string - while registered ACTIVE
+callers read them under the PLATFORM_READ capability. Route- and
+service-level capability rules still apply on top.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.contracts.access_control import (
+    AuthorizationCapabilityType,
+    AuthorizationOutcome,
+    CallerLifecycleStatus,
+)
+from app.http.authenticated_caller import bind_internal_authenticated_caller
+from app.main import app
+from app.services.access_control_authorization import authorize_request
+from app.services.caller_policy_store import get_caller_policy_repository
+
+
+def _platform_read_decision(caller_app: str) -> AuthorizationOutcome:
+    with bind_internal_authenticated_caller(
+        caller_app=caller_app, trust_source="trusted_http_header"
+    ):
+        return authorize_request(
+            caller_app=caller_app,
+            capability_type=AuthorizationCapabilityType.PLATFORM_READ,
+        ).outcome
+
+
+def test_platform_read_is_granted_by_the_policy_row_itself() -> None:
+    assert _platform_read_decision("lotus-manage") is AuthorizationOutcome.ALLOWED
+    assert _platform_read_decision("lotus-ai-provider-operations") is AuthorizationOutcome.ALLOWED
+
+
+def test_platform_read_blocks_unknown_and_disabled_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _platform_read_decision("intruder-app") is AuthorizationOutcome.BLOCKED_UNKNOWN_CALLER
+
+    inner = get_caller_policy_repository()
+
+    class _SuspendingRepository:
+        def get_policy(self, caller_app: str) -> object:
+            policy = inner.get_policy(caller_app)
+            if policy is not None and caller_app == "lotus-workbench":
+                return policy.model_copy(
+                    update={"lifecycle_status": CallerLifecycleStatus.DISABLED}
+                )
+            return policy
+
+        def list_policies(self) -> object:
+            return inner.list_policies()
+
+    monkeypatch.setattr(
+        "app.services.access_control_authorization.get_caller_policy_repository",
+        lambda: _SuspendingRepository(),
+    )
+    assert (
+        _platform_read_decision("lotus-workbench") is AuthorizationOutcome.BLOCKED_CALLER_DISABLED
+    )
+
+
+def test_diagnostic_reads_refuse_an_unregistered_caller() -> None:
+    # These surfaces previously answered to ANY identity string; the gate
+    # closes exactly that gap, across several routers.
+    sample_reads = [
+        "/platform/runtime-status",
+        "/platform/observability/runtime-status",
+        "/platform/providers/routing-posture",
+        "/platform/access-control/runtime-status",
+    ]
+    with TestClient(app) as client:
+        for path in sample_reads:
+            refused = client.get(path, headers={"X-Caller-App": "intruder-app"})
+            assert refused.status_code == 403, f"{path} answered an unregistered caller"
+            assert refused.json()["error_code"] == "LOTUS_AI_CALLER_FORBIDDEN"
+
+        for path in sample_reads:
+            allowed = client.get(path, headers={"X-Caller-App": "lotus-platform"})
+            assert allowed.status_code == 200, f"{path} refused a registered caller"
+
+
+def test_the_recorder_identity_reaches_its_protected_route() -> None:
+    # The internal recorder identity is a registered caller like any other;
+    # its route's own service rule still applies on top of the gate.
+    with TestClient(app) as client:
+        response = client.post(
+            "/platform/provider-operations/workflow-runs/run_missing/retention-confirmations",
+            json={
+                "recorded_by": "lotus-ai-provider-operations",
+                "provider_id": "text.local",
+                "retention_mode": "ZERO_RETENTION_REQUESTED",
+                "deletion_state": "CONFIRMED_DELETED",
+                "evidence_ref": "provider-ops:retention:run_missing",
+            },
+            headers={"X-Caller-App": "lotus-ai-provider-operations"},
+        )
+        # Past the registered-caller gate: the route's own validation answers
+        # (unknown run / contract detail), not the gate's 403.
+        assert response.status_code != 403


### PR DESCRIPTION
Part of #149 (S2 of the amended plan on the issue — the registered-caller gate). S3 (audit trust fields, context item-4 rewrite, OpenAPI credential docs, consumer notes) follows and closes the issue.

## What this adds

**Identity is not authorization.** The router-level binding from the earlier #149 commits established that every protected route requires an *identified* caller — but an identity string alone still opened every diagnostic read surface: any non-empty `X-Caller-App` (header mode) or any credential subject (verified mode) could read runtime posture, provider policy, routing posture, and the rest, because `AuthorizationCapabilityType` had no read-class member and the read routers never consulted the caller-policy registry.

This PR closes that gap with a second router-level dependency, `require_registered_caller`, attached after the identity dependency on every protected router: the identified caller must be a **registered, ACTIVE caller-policy entry**. The new `PLATFORM_READ` capability's rule is deliberately the registry itself — the policy row is the grant, so no schema change and no new policy field; the existing unknown-caller and disabled-caller refusals are the enforcement. Route- and service-level capability rules (task execution, provider control, audit scopes, …) still apply on top for mutations.

**The recorder identity becomes a registered caller.** `lotus-ai-provider-operations` (the retention/deletion confirmation recorder, enforced by its route's own service rule) was never in the caller-policy registry — under the gate it would have been refused. It now has a policy row granting no task, retrieval, or control capability: memory seed + migration **0056** (same shape as the 0024/0026 caller seeds).

## Why uniform (no per-router selection)

Routers own no capability calls — every capability rule lives in the service layer — so applying the gate uniformly to all 21 protected routers adds exactly one invariant ("registered active caller") without touching any existing rule. A per-router selection table would have been speculation about which reads are "sensitive"; the registry-as-grant rule makes the question moot.

## Tests

- `PLATFORM_READ` allowed for registered active callers (including the recorder identity); blocked `BLOCKED_UNKNOWN_CALLER` for unregistered; blocked `BLOCKED_CALLER_DISABLED` for a disabled policy — the disabled-caller branch had **no test anywhere** before this PR.
- Diagnostic reads across four routers (platform, observability, providers, access-control) refuse an unregistered caller with 403 `LOTUS_AI_CALLER_FORBIDDEN` and answer a registered one — the exact surfaces that previously answered any string.
- The recorder identity passes the gate and reaches its route's own service rule.
- The existing behavior-level route-coverage tests (every published non-public operation refuses an unidentified caller; exact public allowlist) continue to hold on top.

## Runbook

Access-control governance section updated: every protected route now requires a registered ACTIVE caller; unknown callers are refused even on read surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
