### PR TITLE
feat(validation): deterministic output validation with authority marking (#156 S1)

### DIFF
--- a/alembic/versions/0057_add_audit_output_validation.py
+++ b/alembic/versions/0057_add_audit_output_validation.py
@@ -1,0 +1,38 @@
+"""add audit output validation columns
+
+Revision ID: 0057_add_audit_output_validation
+Revises: 0056_seed_provider_operations_caller_policy
+Create Date: 2026-08-31
+
+Issue #156 S1: every audit record carries the deterministic
+output-validation verdict - the full outcome payload for evidence, and the
+state alone as a queryable column. Nullable: records persisted before
+validation existed, and runtime-failure records with no output, carry null.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0057_add_audit_output_validation"
+down_revision = "0056_seed_provider_operations_caller_policy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audit_records",
+        sa.Column("output_validation_payload", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "audit_records",
+        sa.Column("validation_state", sa.String(length=40), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("audit_records", "validation_state")
+    op.drop_column("audit_records", "output_validation_payload")

--- a/src/app/contracts/audit.py
+++ b/src/app/contracts/audit.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import BaseModel, Field, computed_field
 
 from app.contracts.access_control import AuthorizationDecision
+from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.evidence import ExecutionEvidenceBundle
 from app.contracts.prompts import PromptSelectionTraceDescriptor
 from app.contracts.providers import ProviderAdapterKind, RoutingDecisionDescriptor
@@ -100,6 +101,13 @@ class AuditRecordResponse(BaseModel):
     )
     enforced_safety_controls: list[str] = Field(
         description="Stable identifiers for safety controls enforced for the execution."
+    )
+    output_validation: OutputValidationOutcome | None = Field(
+        default=None,
+        description=(
+            "Deterministic output-validation verdict recorded for the execution; null for "
+            "records persisted before validation existed or when no output was produced."
+        ),
     )
     safety_outcome: SafetyExecutionOutcome = Field(
         description="Typed safety execution outcome associated with the audit record."

--- a/src/app/contracts/output_validation.py
+++ b/src/app/contracts/output_validation.py
@@ -1,0 +1,48 @@
+"""Deterministic output-validation vocabulary (issue #156, S1).
+
+Every AI output leaving the service carries a validation verdict and an
+explicit non-authoritative marking. The vocabulary is bounded: a REJECTED
+output is withheld whole; VALIDATION_UNAVAILABLE is the fail-closed state
+for a validator fault; UNVALIDATED_LOCAL_ONLY marks a local-profile output
+that bypassed a rule promoted profiles enforce.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+AI_OUTPUT_AUTHORITY = "non_authoritative_ai_output"
+OUTPUT_VALIDATION_RULESET_VERSION = "output-validation.v1"
+
+
+class OutputValidationState(str, Enum):
+    VALIDATED = "VALIDATED"
+    REJECTED = "REJECTED"
+    UNVALIDATED_LOCAL_ONLY = "UNVALIDATED_LOCAL_ONLY"
+    VALIDATION_UNAVAILABLE = "VALIDATION_UNAVAILABLE"
+
+
+class OutputValidationOutcome(BaseModel):
+    """The recorded verdict for one execution's output."""
+
+    validation_state: OutputValidationState = Field(
+        description="Deterministic validation verdict for the output."
+    )
+    authority: str = Field(
+        default=AI_OUTPUT_AUTHORITY,
+        description="Authority marking: AI output is never authoritative financial truth.",
+    )
+    ruleset_version: str = Field(
+        default=OUTPUT_VALIDATION_RULESET_VERSION,
+        description="Version of the validation rule set that produced this verdict.",
+    )
+    failed_rule_ids: list[str] = Field(
+        default_factory=list,
+        description="Rule identifiers that rejected the output; empty unless REJECTED.",
+    )
+    findings: list[str] = Field(
+        default_factory=list,
+        description="Bounded human-readable statements for each failed or waived rule.",
+    )

--- a/src/app/contracts/tasks.py
+++ b/src/app/contracts/tasks.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from app.contracts.access_control import AuthorizationDecision
+from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.evidence import ExecutionEvidenceBundle
 from app.contracts.prompts import PromptSelectionTraceDescriptor
 from app.contracts.providers import ProviderAdapterKind, RoutingDecisionDescriptor
@@ -100,6 +101,13 @@ class TaskExecutionRequest(BaseModel):
 
 class TaskAuditMetadata(BaseModel):
     request_id: str = Field(description="Generated task execution request identifier.")
+    output_validation: OutputValidationOutcome | None = Field(
+        default=None,
+        description=(
+            "Deterministic output-validation verdict for this execution; null only when "
+            "no provider output was produced (runtime failure before execution)."
+        ),
+    )
     workflow_pack_run_id: str | None = Field(
         default=None,
         description=(
@@ -184,6 +192,13 @@ class TaskExecutionResult(BaseModel):
 
 class TaskExecutionResponse(BaseModel):
     status: TaskExecutionStatus = Field(description="Execution outcome for the task request.")
+    output_validation: OutputValidationOutcome | None = Field(
+        default=None,
+        description=(
+            "Deterministic output-validation verdict and authority marking for the "
+            "returned result; null only when no provider output was produced."
+        ),
+    )
     task_id: str = Field(description="Executed task identifier.")
     category: TaskCategory = Field(description="Task category associated with the task id.")
     output_label: OutputLabel = Field(description="Output label emitted by the task.")

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -39,6 +39,8 @@ class AuditRecordModel(Base):
     redaction_posture: Mapped[str] = mapped_column(String(64), nullable=False)
     enforced_safety_controls: Mapped[list[str]] = mapped_column(JSON, nullable=False)
     safety_outcome_payload: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
+    output_validation_payload: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
+    validation_state: Mapped[str | None] = mapped_column(String(40), nullable=True)
     authorization_payload: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
     generated_at: Mapped[str] = mapped_column(String(64), nullable=False)
     stubbed: Mapped[bool] = mapped_column(Boolean, nullable=False)

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -482,7 +482,11 @@ def build_structured_output(
     if not is_advisor_brief_payload(request.context_payload):
         return output_message, structured_output
 
-    parsed = parse_json_object(output_message)
+    parsed, salvaged = parse_json_object_with_posture(output_message)
+    if salvaged:
+        # The validator decides what salvage means per profile (issue #156):
+        # promoted rejects, local marks the output UNVALIDATED_LOCAL_ONLY.
+        structured_output["strict_json_salvaged"] = True
     quality_result = normalize_advisor_brief_output(
         parsed_output=parsed,
         output_message=output_message,
@@ -494,18 +498,30 @@ def build_structured_output(
 
 
 def parse_json_object(value: str) -> dict[str, Any] | None:
+    parsed, _ = parse_json_object_with_posture(value)
+    return parsed
+
+
+def parse_json_object_with_posture(value: str) -> tuple[dict[str, Any] | None, bool]:
+    """Parse a model answer, reporting whether balanced-brace salvage ran.
+
+    Salvage is a recovery, not a validation: the output validator downgrades
+    or rejects salvaged output by runtime profile (issue #156).
+    """
+
     normalized = strip_json_code_fence(value)
     try:
         parsed = json.loads(normalized)
     except json.JSONDecodeError:
         candidate = extract_balanced_json_object(normalized)
         if candidate is None:
-            return None
+            return None, True
         try:
             parsed = json.loads(candidate)
         except json.JSONDecodeError:
-            return None
-    return parsed if isinstance(parsed, dict) else None
+            return None, True
+        return (parsed, True) if isinstance(parsed, dict) else (None, True)
+    return (parsed if isinstance(parsed, dict) else None), False
 
 
 def strip_json_code_fence(value: str) -> str:

--- a/src/app/repositories/sqlalchemy_audit_repository.py
+++ b/src/app/repositories/sqlalchemy_audit_repository.py
@@ -13,6 +13,7 @@ from app.contracts.access_control import (
     TenantPolicyMode,
 )
 from app.contracts.audit import AuditRecordResponse
+from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.audit_access import (
     AuditAccessEvent,
     AuditAccessOperation,
@@ -73,6 +74,16 @@ class SqlAlchemyAuditRepository(SqlAlchemyRepositoryBase):
             redaction_posture=record.redaction_posture.value,
             enforced_safety_controls=record.enforced_safety_controls,
             safety_outcome_payload=record.safety_outcome.model_dump(mode="json"),
+            output_validation_payload=(
+                record.output_validation.model_dump(mode="json")
+                if record.output_validation is not None
+                else None
+            ),
+            validation_state=(
+                record.output_validation.validation_state.value
+                if record.output_validation is not None
+                else None
+            ),
             authorization_payload=record.authorization.model_dump(mode="json"),
             generated_at=record.generated_at,
             stubbed=record.stubbed,
@@ -221,6 +232,11 @@ class SqlAlchemyAuditRepository(SqlAlchemyRepositoryBase):
             redaction_posture=redaction_posture,
             enforced_safety_controls=model.enforced_safety_controls,
             safety_outcome=safety_outcome,
+            output_validation=(
+                OutputValidationOutcome.model_validate(model.output_validation_payload)
+                if model.output_validation_payload is not None
+                else None
+            ),
             authorization=(
                 AuthorizationDecision.model_validate(model.authorization_payload)
                 if model.authorization_payload is not None

--- a/src/app/services/output_validation.py
+++ b/src/app/services/output_validation.py
@@ -1,0 +1,166 @@
+"""Deterministic validation of every AI output (issue #156, S1).
+
+One validator on the execution path, after the provider call and before
+safety redaction (redaction must never be able to erase a fabricated
+reference and flip a verdict). S1 ships the rules that need no per-task
+contract:
+
+- ``evidence_grounding``: every ``source_ref``/``source_refs``/
+  ``evidence_ref``/``evidence_refs`` value anywhere in the structured
+  output must be one of the supplied request ``source_refs`` - a set
+  check, not a prompt instruction.
+- ``strict_json`` (recorded by the transport): a promoted-profile output
+  recovered by balanced-brace salvage is not a validated output.
+
+Per-task schema contracts and numeric grounding activate in later slices
+under the same ruleset seam. A validator fault fails closed as
+``VALIDATION_UNAVAILABLE`` - never an unmarked output.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.contracts.output_validation import (
+    OutputValidationOutcome,
+    OutputValidationState,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_EVIDENCE_GROUNDING = "evidence_grounding"
+RULE_STRICT_JSON = "strict_json"
+
+_REFERENCE_KEYS = frozenset({"source_ref", "source_refs", "evidence_ref", "evidence_refs"})
+_MAX_RECORDED_FINDINGS = 10
+_MAX_TRAVERSAL_DEPTH = 24
+
+
+def validate_provider_output(
+    *,
+    structured_output: Any,
+    supplied_source_refs: list[str],
+    salvaged_json: bool,
+    runtime_profile: str,
+) -> OutputValidationOutcome:
+    try:
+        return _validate(
+            structured_output=structured_output,
+            supplied_source_refs=supplied_source_refs,
+            salvaged_json=salvaged_json,
+            runtime_profile=runtime_profile,
+        )
+    except Exception:  # noqa: BLE001 - a validator fault must fail closed, never fall open
+        logger.exception("output validation fault; failing closed as VALIDATION_UNAVAILABLE")
+        return OutputValidationOutcome(
+            validation_state=OutputValidationState.VALIDATION_UNAVAILABLE,
+            findings=["The output validator faulted; the output is withheld fail-closed."],
+        )
+
+
+def _validate(
+    *,
+    structured_output: Any,
+    supplied_source_refs: list[str],
+    salvaged_json: bool,
+    runtime_profile: str,
+) -> OutputValidationOutcome:
+    failed_rule_ids: list[str] = []
+    findings: list[str] = []
+
+    unsupported = _ungrounded_references(
+        structured_output, supplied={ref for ref in supplied_source_refs if ref}
+    )
+    if unsupported:
+        failed_rule_ids.append(RULE_EVIDENCE_GROUNDING)
+        for reference in unsupported[:_MAX_RECORDED_FINDINGS]:
+            findings.append(
+                f"{RULE_EVIDENCE_GROUNDING}: output references evidence "
+                f"'{reference}' that was not supplied to this execution"
+            )
+        if len(unsupported) > _MAX_RECORDED_FINDINGS:
+            findings.append(
+                f"{RULE_EVIDENCE_GROUNDING}: {len(unsupported) - _MAX_RECORDED_FINDINGS} "
+                "further unsupported references withheld from this summary"
+            )
+
+    if salvaged_json:
+        if runtime_profile == "promoted":
+            failed_rule_ids.append(RULE_STRICT_JSON)
+            findings.append(
+                f"{RULE_STRICT_JSON}: the provider answer was not a strict JSON document; "
+                "salvaged output is not accepted in the promoted profile"
+            )
+        else:
+            findings.append(
+                f"{RULE_STRICT_JSON}: the provider answer required balanced-brace salvage; "
+                "accepted unvalidated in the local profile only"
+            )
+
+    if failed_rule_ids:
+        return OutputValidationOutcome(
+            validation_state=OutputValidationState.REJECTED,
+            failed_rule_ids=failed_rule_ids,
+            findings=findings,
+        )
+    if salvaged_json:
+        return OutputValidationOutcome(
+            validation_state=OutputValidationState.UNVALIDATED_LOCAL_ONLY,
+            findings=findings,
+        )
+    return OutputValidationOutcome(
+        validation_state=OutputValidationState.VALIDATED,
+        findings=findings,
+    )
+
+
+def _ungrounded_references(value: Any, *, supplied: set[str]) -> list[str]:
+    """Every reference value in the output that is not in the supplied set.
+
+    The traversal is shape-agnostic: any mapping key named like a reference
+    carries either a string or a list of strings; non-string entries under a
+    reference key are themselves violations (a fabricated structure is not
+    grounded evidence). Order of first appearance, deduplicated.
+    """
+
+    unsupported: list[str] = []
+    seen: set[str] = set()
+
+    def record(reference: Any, depth: int) -> None:
+        if isinstance(reference, str):
+            if reference and reference not in supplied and reference not in seen:
+                seen.add(reference)
+                unsupported.append(reference)
+            return
+        if isinstance(reference, (dict, list)):
+            # The domain vocabulary nests structured evidence entries under
+            # reference keys (e.g. advisor-brief ``evidence_refs`` fact
+            # objects whose ``source_ref`` is the string reference): recurse,
+            # so the inner string references are checked.
+            walk(reference, depth + 1)
+            return
+        marker = f"<non-string reference: {type(reference).__name__}>"
+        if marker not in seen:
+            seen.add(marker)
+            unsupported.append(marker)
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > _MAX_TRAVERSAL_DEPTH:
+            raise ValueError("structured output exceeds the validation traversal depth")
+        if isinstance(node, dict):
+            for key, child in node.items():
+                if isinstance(key, str) and key in _REFERENCE_KEYS:
+                    if isinstance(child, list):
+                        for item in child:
+                            record(item, depth)
+                    else:
+                        record(child, depth)
+                else:
+                    walk(child, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+
+    walk(value, 0)
+    return unsupported

--- a/src/app/services/task_execution_mapping.py
+++ b/src/app/services/task_execution_mapping.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from app.contracts.audit import AuditRecordResponse
+from app.contracts.output_validation import OutputValidationState
 from app.contracts.safety import RedactionPosture
 from app.contracts.tasks import (
     TaskAuditMetadata,
@@ -35,26 +36,55 @@ def map_task_execution_response(
         provider_execution=resolved.provider_execution,
         safety_outcome=resolved.safety_outcome,
     )
+    validation = resolved.output_validation
+    validation_withholds = validation.validation_state in {
+        OutputValidationState.REJECTED,
+        OutputValidationState.VALIDATION_UNAVAILABLE,
+    }
     execution_status = (
         TaskExecutionStatus.REJECTED
-        if resolved.safety_outcome.disposition.value == "BLOCKED"
+        if resolved.safety_outcome.disposition.value == "BLOCKED" or validation_withholds
         else TaskExecutionStatus.COMPLETED
     )
-    return TaskExecutionResponse(
-        status=execution_status,
-        task_id=context.capability.task_id,
-        category=context.capability.category,
-        output_label=context.capability.output_label,
-        result=TaskExecutionResult(
+    if validation_withholds:
+        # Fail closed: a rejected output is withheld whole - never partially
+        # returned - with the stable code and the failing rule ids.
+        error_code = (
+            "OUTPUT_VALIDATION_REJECTED"
+            if validation.validation_state is OutputValidationState.REJECTED
+            else "VALIDATION_UNAVAILABLE"
+        )
+        result = TaskExecutionResult(
+            message=(
+                "The AI output was withheld: deterministic output validation "
+                f"{validation.validation_state.value.lower().replace('_', ' ')}."
+            ),
+            structured_output={
+                "error_code": error_code,
+                "failed_rule_ids": list(validation.failed_rule_ids),
+                "validation_findings": list(validation.findings),
+                "input_mode": context.request.input_mode,
+            },
+        )
+    else:
+        result = TaskExecutionResult(
             message=resolved.provider_execution.message,
             structured_output=build_task_result_payload(
                 context=context,
                 resolved=resolved,
             ),
-        ),
+        )
+    return TaskExecutionResponse(
+        status=execution_status,
+        output_validation=validation,
+        task_id=context.capability.task_id,
+        category=context.capability.category,
+        output_label=context.capability.output_label,
+        result=result,
         evidence=evidence,
         audit=TaskAuditMetadata(
             request_id=context.request_id,
+            output_validation=validation,
             task_id=context.capability.task_id,
             output_label=context.capability.output_label,
             prompt_version=context.prompt.prompt_version,
@@ -194,6 +224,7 @@ def map_audit_record(
         redaction_posture=response.audit.safety.redaction_posture,
         enforced_safety_controls=response.audit.safety.enforced_controls,
         safety_outcome=response.audit.safety,
+        output_validation=response.audit.output_validation,
         authorization=response.audit.authorization,
         generated_at=response.audit.generated_at,
         stubbed=response.audit.stubbed,

--- a/src/app/services/task_execution_models.py
+++ b/src/app/services/task_execution_models.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from app.contracts.access_control import AuthorizationDecision
 from app.contracts.prompts import PromptDescriptor, PromptSelectionTraceDescriptor
 from app.contracts.providers import ProviderExecutionRequest, ProviderExecutionResponse
+from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.safety import SafetyExecutionOutcome
 from app.contracts.tasks import CapabilityDescriptor, TaskExecutionRequest
 
@@ -26,4 +27,5 @@ class ResolvedTaskExecution:
     context: TaskExecutionContext
     provider_execution: ProviderExecutionResponse
     safety_outcome: SafetyExecutionOutcome
+    output_validation: OutputValidationOutcome
     provider_request: ProviderExecutionRequest | None = None

--- a/src/app/services/task_execution_pipeline.py
+++ b/src/app/services/task_execution_pipeline.py
@@ -17,6 +17,7 @@ from app.contracts.tasks import (
 from app.services.audit_store import get_audit_store
 from app.services.execution_evidence import build_routing_decision_descriptor
 from app.services.knowledge_answer_execution import execute_knowledge_answer
+from app.services.output_validation import validate_provider_output
 from app.services.knowledge_search_execution import execute_knowledge_search
 from app.services.provider_request_builder import build_provider_execution_request
 from app.services.caller_policy_store import get_caller_policy_repository
@@ -49,6 +50,15 @@ def resolve_task_execution(
     else:
         provider_request = build_provider_execution_request(context=context)
         provider_execution = execute_text_generation(provider_request)
+    # Deterministic output validation runs on the provider's actual output,
+    # BEFORE safety redaction: redaction must never be able to erase a
+    # fabricated reference and flip a verdict (issue #156).
+    output_validation = validate_provider_output(
+        structured_output=provider_execution.structured_output,
+        supplied_source_refs=context.request.context.source_refs,
+        salvaged_json=bool(provider_execution.structured_output.get("strict_json_salvaged", False)),
+        runtime_profile=settings.runtime_profile,
+    )
     client_identifiers = _caller_redaction_identifiers(context.request.caller.caller_app)
     safe_provider_execution, safety_outcome = apply_safety_enforcement(
         policy=resolve_safety_policy_for_output(context.capability.output_label),
@@ -74,6 +84,7 @@ def resolve_task_execution(
         provider_request=provider_request,
         provider_execution=safe_provider_execution,
         safety_outcome=safety_outcome,
+        output_validation=output_validation,
     )
 
 

--- a/tests/unit/test_output_validation.py
+++ b/tests/unit/test_output_validation.py
@@ -1,0 +1,211 @@
+"""Deterministic output validation (issue #156, S1).
+
+Every AI output carries a validation verdict and the non-authoritative
+marking; a fabricated evidence reference is rejected fail-closed with the
+rule id, the output withheld whole, and the verdict persisted on the audit
+record; salvaged JSON is rejected in promoted and marked
+UNVALIDATED_LOCAL_ONLY in local; a validator fault fails closed.
+"""
+
+import pytest
+
+from app.config import settings
+from app.contracts.output_validation import (
+    AI_OUTPUT_AUTHORITY,
+    OUTPUT_VALIDATION_RULESET_VERSION,
+    OutputValidationOutcome,
+    OutputValidationState,
+)
+from app.contracts.tasks import OutputLabel, TaskExecutionStatus
+from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
+from app.services.audit_store import get_audit_store
+from app.services.output_validation import validate_provider_output
+from app.services.task_executor import execute_task
+from tests.unit.test_task_executor import _request
+
+GROUNDED_REFS = ["lotus-manage:run:reb_001", "lotus-manage:run:reb_002"]
+
+
+def _validate(structured_output: object, **overrides: object) -> OutputValidationOutcome:
+    kwargs: dict[str, object] = {
+        "structured_output": structured_output,
+        "supplied_source_refs": GROUNDED_REFS,
+        "salvaged_json": False,
+        "runtime_profile": "local",
+    }
+    kwargs.update(overrides)
+    return validate_provider_output(**kwargs)  # type: ignore[arg-type]
+
+
+def test_grounded_output_is_validated_with_the_authority_marking() -> None:
+    outcome = _validate(
+        {
+            "grounded_facts": [
+                {"metric_label": "Return", "source_ref": GROUNDED_REFS[0]},
+                {"metric_label": "Benchmark", "source_ref": GROUNDED_REFS[1]},
+            ],
+            "sections": [{"evidence_refs": [GROUNDED_REFS[0]]}],
+        }
+    )
+    assert outcome.validation_state is OutputValidationState.VALIDATED
+    assert outcome.authority == AI_OUTPUT_AUTHORITY
+    assert outcome.ruleset_version == OUTPUT_VALIDATION_RULESET_VERSION
+    assert outcome.failed_rule_ids == []
+
+
+def test_fabricated_reference_is_rejected_with_the_rule_id() -> None:
+    outcome = _validate(
+        {
+            "narrative": "text",
+            "sections": [{"evidence_refs": [GROUNDED_REFS[0], "lotus-manage:run:fabricated_999"]}],
+        }
+    )
+    assert outcome.validation_state is OutputValidationState.REJECTED
+    assert outcome.failed_rule_ids == ["evidence_grounding"]
+    assert any("fabricated_999" in finding for finding in outcome.findings)
+
+
+def test_reference_rules_cover_nesting_shapes_and_non_strings() -> None:
+    outcome = _validate(
+        {
+            "deep": {"list": [{"inner": {"source_ref": "unsupplied:a"}}]},
+            "evidence_ref": "unsupplied:b",
+            "sections": [{"source_refs": [12345]}],
+            # A structured evidence entry under a reference key is the domain
+            # vocabulary (advisor-brief fact objects): its inner source_ref is
+            # what gets checked.
+            "points": [{"evidence_refs": [{"metric_label": "x", "source_ref": "unsupplied:c"}]}],
+            "grounded_entry": {"evidence_refs": [{"source_ref": GROUNDED_REFS[0]}]},
+            "duplicated": {"source_ref": "unsupplied:a"},
+        }
+    )
+    assert outcome.validation_state is OutputValidationState.REJECTED
+    joined = "\n".join(outcome.findings)
+    assert "unsupplied:a" in joined and "unsupplied:b" in joined and "unsupplied:c" in joined
+    assert "<non-string reference: int>" in joined
+    assert GROUNDED_REFS[0] not in joined
+    # Deduplicated: unsupplied:a appears once despite two citations.
+    assert joined.count("unsupplied:a") == 1
+
+
+def test_finding_volume_is_bounded_with_the_overflow_stated() -> None:
+    outcome = _validate(
+        {"sections": [{"source_ref": f"unsupplied:{index}"} for index in range(15)]}
+    )
+    assert outcome.validation_state is OutputValidationState.REJECTED
+    assert len([f for f in outcome.findings if "unsupplied:" in f]) == 10
+    assert any("5 further unsupported references withheld" in f for f in outcome.findings)
+
+
+def test_empty_evidence_packet_rejects_any_citation() -> None:
+    outcome = _validate({"sections": [{"source_ref": GROUNDED_REFS[0]}]}, supplied_source_refs=[])
+    assert outcome.validation_state is OutputValidationState.REJECTED
+
+
+def test_salvaged_json_is_local_only_and_rejected_in_promoted() -> None:
+    local = _validate({"answer": "text"}, salvaged_json=True)
+    assert local.validation_state is OutputValidationState.UNVALIDATED_LOCAL_ONLY
+    assert local.failed_rule_ids == []
+    assert any("strict_json" in finding for finding in local.findings)
+
+    promoted = _validate({"answer": "text"}, salvaged_json=True, runtime_profile="promoted")
+    assert promoted.validation_state is OutputValidationState.REJECTED
+    assert promoted.failed_rule_ids == ["strict_json"]
+
+
+def test_both_rule_families_report_together() -> None:
+    outcome = _validate(
+        {"source_ref": "unsupplied:x"}, salvaged_json=True, runtime_profile="promoted"
+    )
+    assert outcome.validation_state is OutputValidationState.REJECTED
+    assert outcome.failed_rule_ids == ["evidence_grounding", "strict_json"]
+
+
+def test_validator_fault_fails_closed_as_validation_unavailable() -> None:
+    bomb: dict[str, object] = {}
+    cursor = bomb
+    for _ in range(40):
+        nested: dict[str, object] = {}
+        cursor["deeper"] = nested
+        cursor = nested
+    cursor["source_ref"] = "unsupplied:deep"
+    outcome = _validate(bomb)
+    assert outcome.validation_state is OutputValidationState.VALIDATION_UNAVAILABLE
+
+
+def test_stub_execution_returns_a_validated_marked_output() -> None:
+    response = execute_task(
+        _request("explain.v1", expected_output_label=OutputLabel.EXPLANATION_ONLY)
+    )
+    assert response.status == TaskExecutionStatus.COMPLETED
+    assert response.output_validation is not None
+    assert response.output_validation.validation_state is OutputValidationState.VALIDATED
+    assert response.output_validation.authority == AI_OUTPUT_AUTHORITY
+    assert response.audit.output_validation == response.output_validation
+
+    records = get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=1)
+    assert records[0].output_validation is not None
+    assert records[0].output_validation.validation_state is OutputValidationState.VALIDATED
+
+
+def test_fabricated_reference_is_withheld_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The issue's core proof for a non-advisor-brief task: an output citing
+    unsupplied evidence never leaves the service, and the audit record
+    carries the REJECTED verdict with the rule id."""
+
+    class _FabricatingAdapter:
+        def execute(self, request: object, *, config: object) -> object:
+            return type(
+                "Response",
+                (),
+                {
+                    "provider_id": "text.stub",
+                    "provider_mode": settings.provider_mode,
+                    "adapter_kind": None,
+                    "failure_category": None,
+                    "timeout_ms": 4000,
+                    "retry_count": 0,
+                    "max_output_tokens": 512,
+                    "model_id": "stub",
+                    "model_version": None,
+                    "model_catalogue_entry_id": None,
+                    "model_revision_pinned": None,
+                    "routing_decision": None,
+                    "estimated_cost_usd": None,
+                    "rate_card_ref": None,
+                    "input_tokens": None,
+                    "output_tokens": None,
+                    "total_tokens": None,
+                    "provider_request_id": "req_fab",
+                    "stubbed": True,
+                    "message": "A claim citing evidence that was never supplied.",
+                    "structured_output": {
+                        "claims": [{"source_ref": "lotus-manage:run:fabricated_777"}]
+                    },
+                },
+            )()
+
+    monkeypatch.setattr(
+        "app.services.provider_gateway.resolve_text_generation_adapter",
+        lambda mode: _FabricatingAdapter(),
+    )
+
+    response = execute_task(
+        _request("explain.v1", expected_output_label=OutputLabel.EXPLANATION_ONLY)
+    )
+
+    assert response.status == TaskExecutionStatus.REJECTED
+    assert response.output_validation is not None
+    assert response.output_validation.validation_state is OutputValidationState.REJECTED
+    assert response.output_validation.failed_rule_ids == ["evidence_grounding"]
+    # Withheld whole: neither the message nor the structured output leaves.
+    assert "fabricated_777" not in response.result.message
+    assert response.result.structured_output["error_code"] == "OUTPUT_VALIDATION_REJECTED"
+    assert "claims" not in response.result.structured_output
+
+    records = get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=1)
+    record = records[0]
+    assert record.execution_status == TaskExecutionStatus.REJECTED
+    assert record.output_validation is not None
+    assert record.output_validation.validation_state is OutputValidationState.REJECTED
+    assert "fabricated_777" not in record.result_preview


### PR DESCRIPTION
Part of #156 (S1 of the plan on the issue — the validator seam and authority marking). S2 (per-task output contracts as data), S3 (numeric grounding + advisor-brief unification), and S4 (eval unification + the issue's evaluation condition; closes the issue) follow.

## What this adds

**One validator on the execution path.** `services/output_validation.py` runs in `resolve_task_execution` immediately after the provider call — deliberately **before** safety redaction, so redaction can never erase a fabricated reference and flip a verdict. It applies to every path through the pipeline: live, local-compatible, stub, and the knowledge tasks.

**S1 rules** (the ones needing no per-task contract; the ruleset is versioned `output-validation.v1`):
- `evidence_grounding` — every `source_ref`/`source_refs`/`evidence_ref`/`evidence_refs` value anywhere in the structured output must be one of the supplied request `source_refs`. A set check, not a prompt instruction. The traversal follows the domain vocabulary: structured evidence entries under reference keys (advisor-brief fact objects) recurse so their inner `source_ref` strings are checked; scalar non-strings under reference keys are violations; depth-bounded.
- `strict_json` — the transport now reports when balanced-brace salvage recovered the model answer (`parse_json_object_with_posture`); salvage in the promoted profile is REJECTED, in local the output is marked `UNVALIDATED_LOCAL_ONLY`.

**Authority marking, everywhere the output goes.** `OutputValidationOutcome` (state, `authority="non_authoritative_ai_output"`, ruleset version, failed rule ids, bounded findings) rides the response top-level, the response audit metadata, and the persisted audit record (JSON payload + a queryable `validation_state` column; migration **0057**, nullable for pre-validation records and runtime failures with no output).

**Fail closed, withheld whole.** A `REJECTED` (or `VALIDATION_UNAVAILABLE` — validator fault) verdict makes the execution status `REJECTED`, mirroring the safety-BLOCKED pattern: the audit record persists carrying the verdict, and the caller receives a bounded refusal (`error_code=OUTPUT_VALIDATION_REJECTED` / `VALIDATION_UNAVAILABLE`, the failing rule ids, the findings) — never the provider output, not even partially. The end-to-end test proves a fabricated `evidence_ref` on a **non-advisor-brief** path is withheld from both the response and the audit `result_preview`.

## Deliberate S1 scope notes

- Knowledge-task outputs (`source_ids`, `citations`, `hits`) use a different vocabulary than the `source_ref` evidence keys; their retrieval-grounding rule (citations ⊆ retrieval hits) arrives with the per-task contracts in S2 — recorded here so the boundary is explicit, not silent.
- The advisor-brief token rules (percent/currency) remain in their guardrail until S3 unifies them onto this seam, per the plan.

## Tests (9 new)

Rule-class units: grounded output VALIDATED with authority + ruleset version; fabricated ref REJECTED with rule id and finding; nesting/recursion/dedup/non-string shapes; empty evidence packet rejects any citation; salvage local-vs-promoted; both rule families reporting together; traversal-depth fault failing closed as VALIDATION_UNAVAILABLE. Seam end-to-end: stub execution returns VALIDATED with the marking on response + audit metadata + persisted record; fabricated-reference execution REJECTED end-to-end with the output withheld everywhere.

Coverage note: the pipeline sweep (task executor, mapping, execution path, advisor-brief live contract, task API contract, live provider) passes unchanged — the S1 rules confirmed every existing producer already grounds its references, which is exactly what the rule is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
