### PR TITLE
feat(validation): per-task output contracts as data (#156 S2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY alembic.ini ./
 COPY alembic ./alembic
+COPY contracts ./contracts
 COPY docs ./docs
 COPY src ./src
 COPY scripts ./scripts

--- a/contracts/ai-task-outputs/advisor_brief.pack.v1.json
+++ b/contracts/ai-task-outputs/advisor_brief.pack.v1.json
@@ -1,0 +1,477 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/advisor_brief.pack.v1.json",
+  "title": "advisor_brief.pack output contract",
+  "description": "Structured output contract for advisor_brief.pack executions: the deterministic governed stub shape, or the live-transport shape normalized by the advisor-brief quality guardrails. The review-gated, non-authoritative posture of the output is part of the contract.",
+  "anyOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "adapter_kind": {
+          "type": "string"
+        },
+        "advisor_brief_status": {
+          "type": "string"
+        },
+        "context_keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context_summary": {
+          "type": "string"
+        },
+        "coverage_state": {
+          "type": "string"
+        },
+        "grounded_facts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "metric_label": {
+                "type": "string"
+              },
+              "metric_value": {
+                "type": "string"
+              },
+              "source_ref": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "grounded_summary": {
+          "type": "string"
+        },
+        "max_output_tokens": {
+          "type": "integer"
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "period": {
+          "type": "string"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "portfolio_id": {
+          "type": "string"
+        },
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "recommended_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "evidence_refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "metric_label": {
+                      "type": "string"
+                    },
+                    "metric_value": {
+                      "type": "string"
+                    },
+                    "source_ref": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "label": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "risks_and_exceptions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "evidence_refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "metric_label": {
+                      "type": "string"
+                    },
+                    "metric_value": {
+                      "type": "string"
+                    },
+                    "source_ref": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "headline": {
+                "type": "string"
+              },
+              "tone": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "stub_reason": {
+          "type": "string"
+        },
+        "talking_points": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "detail": {
+                "type": "string"
+              },
+              "evidence_refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "metric_label": {
+                      "type": "string"
+                    },
+                    "metric_value": {
+                      "type": "string"
+                    },
+                    "source_ref": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "headline": {
+                "type": "string"
+              },
+              "tone": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "timeout_ms": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "adapter_kind",
+        "advisor_brief_status",
+        "context_keys",
+        "context_summary",
+        "coverage_state",
+        "grounded_facts",
+        "grounded_summary",
+        "max_output_tokens",
+        "output_label",
+        "period",
+        "phase",
+        "portfolio_id",
+        "provider_id",
+        "provider_mode",
+        "recommended_actions",
+        "redaction_posture",
+        "retry_count",
+        "risks_and_exceptions",
+        "safety_mode",
+        "source_refs",
+        "stub_reason",
+        "talking_points",
+        "timeout_ms"
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count",
+        "grounded_summary",
+        "talking_points",
+        "recommended_actions",
+        "risks_and_exceptions",
+        "advisor_brief_guardrail_triggered"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "estimated_cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "rate_card_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cost_posture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strict_json_salvaged": {
+          "type": "boolean"
+        },
+        "grounded_summary": {
+          "type": "string"
+        },
+        "talking_points": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "headline": {
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              },
+              "tone": {
+                "type": "string"
+              },
+              "evidence_refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "metric_label": {
+                      "type": "string"
+                    },
+                    "metric_value": {
+                      "type": "string"
+                    },
+                    "source_ref": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "recommended_actions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "headline": {
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              },
+              "tone": {
+                "type": "string"
+              },
+              "evidence_refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "metric_label": {
+                      "type": "string"
+                    },
+                    "metric_value": {
+                      "type": "string"
+                    },
+                    "source_ref": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "risks_and_exceptions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "headline": {
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              },
+              "tone": {
+                "type": "string"
+              },
+              "evidence_refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "metric_label": {
+                      "type": "string"
+                    },
+                    "metric_value": {
+                      "type": "string"
+                    },
+                    "source_ref": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "grounded_facts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "metric_label": {
+                "type": "string"
+              },
+              "metric_value": {
+                "type": "string"
+              },
+              "source_ref": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "advisor_brief_guardrail_triggered": {
+          "type": "boolean"
+        },
+        "advisor_brief_guardrail_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "raw_output_excerpt": {
+          "type": "string"
+        }
+      }
+    }
+  ]
+}

--- a/contracts/ai-task-outputs/advisory_copilot_client_follow_up_draft.pack.v1.json
+++ b/contracts/ai-task-outputs/advisory_copilot_client_follow_up_draft.pack.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/advisory_copilot_client_follow_up_draft.pack.v1.json",
+  "title": "advisory_copilot_client_follow_up_draft.pack output contract",
+  "description": "Structured output contract for advisory_copilot_client_follow_up_draft.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "action_family": {
+      "type": "string"
+    },
+    "audience": {
+      "type": "string"
+    },
+    "client_ready_publication": {
+      "type": "string"
+    },
+    "evidence_packet_hash": {
+      "type": "string"
+    },
+    "evidence_packet_id": {
+      "type": "string"
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "model_risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approved_instruction_set": {
+          "type": "string"
+        },
+        "approved_model_version": {
+          "type": "string"
+        },
+        "approved_provider_id": {
+          "type": "string"
+        },
+        "evaluation_pack_ref": {
+          "type": "string"
+        },
+        "output_schema_version": {
+          "type": "string"
+        },
+        "prompt_template_version": {
+          "type": "string"
+        }
+      }
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "claims": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "claim_id": {
+                  "type": "string"
+                },
+                "claim_text": {
+                  "type": "string"
+                },
+                "source_refs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "section_key": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unsupported_evidence_count": {
+      "type": "integer"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "action_family",
+    "audience",
+    "client_ready_publication",
+    "evidence_packet_hash",
+    "evidence_packet_id",
+    "human_review_required",
+    "model_risk",
+    "review_guidance",
+    "scope",
+    "section_count",
+    "sections",
+    "state",
+    "unsupported_claims",
+    "unsupported_evidence_count",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/advisory_copilot_compliance_review_summary.pack.v1.json
+++ b/contracts/ai-task-outputs/advisory_copilot_compliance_review_summary.pack.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/advisory_copilot_compliance_review_summary.pack.v1.json",
+  "title": "advisory_copilot_compliance_review_summary.pack output contract",
+  "description": "Structured output contract for advisory_copilot_compliance_review_summary.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "action_family": {
+      "type": "string"
+    },
+    "audience": {
+      "type": "string"
+    },
+    "client_ready_publication": {
+      "type": "string"
+    },
+    "evidence_packet_hash": {
+      "type": "string"
+    },
+    "evidence_packet_id": {
+      "type": "string"
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "model_risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approved_instruction_set": {
+          "type": "string"
+        },
+        "approved_model_version": {
+          "type": "string"
+        },
+        "approved_provider_id": {
+          "type": "string"
+        },
+        "evaluation_pack_ref": {
+          "type": "string"
+        },
+        "output_schema_version": {
+          "type": "string"
+        },
+        "prompt_template_version": {
+          "type": "string"
+        }
+      }
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "claims": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "claim_id": {
+                  "type": "string"
+                },
+                "claim_text": {
+                  "type": "string"
+                },
+                "source_refs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "section_key": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unsupported_evidence_count": {
+      "type": "integer"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "action_family",
+    "audience",
+    "client_ready_publication",
+    "evidence_packet_hash",
+    "evidence_packet_id",
+    "human_review_required",
+    "model_risk",
+    "review_guidance",
+    "scope",
+    "section_count",
+    "sections",
+    "state",
+    "unsupported_claims",
+    "unsupported_evidence_count",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/advisory_copilot_evidence_qa.pack.v1.json
+++ b/contracts/ai-task-outputs/advisory_copilot_evidence_qa.pack.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/advisory_copilot_evidence_qa.pack.v1.json",
+  "title": "advisory_copilot_evidence_qa.pack output contract",
+  "description": "Structured output contract for advisory_copilot_evidence_qa.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "action_family": {
+      "type": "string"
+    },
+    "audience": {
+      "type": "string"
+    },
+    "client_ready_publication": {
+      "type": "string"
+    },
+    "evidence_packet_hash": {
+      "type": "string"
+    },
+    "evidence_packet_id": {
+      "type": "string"
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "model_risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approved_instruction_set": {
+          "type": "string"
+        },
+        "approved_model_version": {
+          "type": "string"
+        },
+        "approved_provider_id": {
+          "type": "string"
+        },
+        "evaluation_pack_ref": {
+          "type": "string"
+        },
+        "output_schema_version": {
+          "type": "string"
+        },
+        "prompt_template_version": {
+          "type": "string"
+        }
+      }
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "claims": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "claim_id": {
+                  "type": "string"
+                },
+                "claim_text": {
+                  "type": "string"
+                },
+                "source_refs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "section_key": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unsupported_evidence_count": {
+      "type": "integer"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "action_family",
+    "audience",
+    "client_ready_publication",
+    "evidence_packet_hash",
+    "evidence_packet_id",
+    "human_review_required",
+    "model_risk",
+    "review_guidance",
+    "scope",
+    "section_count",
+    "sections",
+    "state",
+    "unsupported_claims",
+    "unsupported_evidence_count",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/advisory_copilot_meeting_preparation.pack.v1.json
+++ b/contracts/ai-task-outputs/advisory_copilot_meeting_preparation.pack.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/advisory_copilot_meeting_preparation.pack.v1.json",
+  "title": "advisory_copilot_meeting_preparation.pack output contract",
+  "description": "Structured output contract for advisory_copilot_meeting_preparation.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "action_family": {
+      "type": "string"
+    },
+    "audience": {
+      "type": "string"
+    },
+    "client_ready_publication": {
+      "type": "string"
+    },
+    "evidence_packet_hash": {
+      "type": "string"
+    },
+    "evidence_packet_id": {
+      "type": "string"
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "model_risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approved_instruction_set": {
+          "type": "string"
+        },
+        "approved_model_version": {
+          "type": "string"
+        },
+        "approved_provider_id": {
+          "type": "string"
+        },
+        "evaluation_pack_ref": {
+          "type": "string"
+        },
+        "output_schema_version": {
+          "type": "string"
+        },
+        "prompt_template_version": {
+          "type": "string"
+        }
+      }
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "claims": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "claim_id": {
+                  "type": "string"
+                },
+                "claim_text": {
+                  "type": "string"
+                },
+                "source_refs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "section_key": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unsupported_evidence_count": {
+      "type": "integer"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "action_family",
+    "audience",
+    "client_ready_publication",
+    "evidence_packet_hash",
+    "evidence_packet_id",
+    "human_review_required",
+    "model_risk",
+    "review_guidance",
+    "scope",
+    "section_count",
+    "sections",
+    "state",
+    "unsupported_claims",
+    "unsupported_evidence_count",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/advisory_copilot_operations_report_handoff.pack.v1.json
+++ b/contracts/ai-task-outputs/advisory_copilot_operations_report_handoff.pack.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/advisory_copilot_operations_report_handoff.pack.v1.json",
+  "title": "advisory_copilot_operations_report_handoff.pack output contract",
+  "description": "Structured output contract for advisory_copilot_operations_report_handoff.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "action_family": {
+      "type": "string"
+    },
+    "audience": {
+      "type": "string"
+    },
+    "client_ready_publication": {
+      "type": "string"
+    },
+    "evidence_packet_hash": {
+      "type": "string"
+    },
+    "evidence_packet_id": {
+      "type": "string"
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "model_risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approved_instruction_set": {
+          "type": "string"
+        },
+        "approved_model_version": {
+          "type": "string"
+        },
+        "approved_provider_id": {
+          "type": "string"
+        },
+        "evaluation_pack_ref": {
+          "type": "string"
+        },
+        "output_schema_version": {
+          "type": "string"
+        },
+        "prompt_template_version": {
+          "type": "string"
+        }
+      }
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "claims": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "claim_id": {
+                  "type": "string"
+                },
+                "claim_text": {
+                  "type": "string"
+                },
+                "source_refs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "section_key": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unsupported_evidence_count": {
+      "type": "integer"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "action_family",
+    "audience",
+    "client_ready_publication",
+    "evidence_packet_hash",
+    "evidence_packet_id",
+    "human_review_required",
+    "model_risk",
+    "review_guidance",
+    "scope",
+    "section_count",
+    "sections",
+    "state",
+    "unsupported_claims",
+    "unsupported_evidence_count",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/advisory_copilot_proposal_explanation.pack.v1.json
+++ b/contracts/ai-task-outputs/advisory_copilot_proposal_explanation.pack.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/advisory_copilot_proposal_explanation.pack.v1.json",
+  "title": "advisory_copilot_proposal_explanation.pack output contract",
+  "description": "Structured output contract for advisory_copilot_proposal_explanation.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "action_family": {
+      "type": "string"
+    },
+    "audience": {
+      "type": "string"
+    },
+    "client_ready_publication": {
+      "type": "string"
+    },
+    "evidence_packet_hash": {
+      "type": "string"
+    },
+    "evidence_packet_id": {
+      "type": "string"
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "model_risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "approved_instruction_set": {
+          "type": "string"
+        },
+        "approved_model_version": {
+          "type": "string"
+        },
+        "approved_provider_id": {
+          "type": "string"
+        },
+        "evaluation_pack_ref": {
+          "type": "string"
+        },
+        "output_schema_version": {
+          "type": "string"
+        },
+        "prompt_template_version": {
+          "type": "string"
+        }
+      }
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "claims": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "claim_id": {
+                  "type": "string"
+                },
+                "claim_text": {
+                  "type": "string"
+                },
+                "source_refs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "section_key": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unsupported_evidence_count": {
+      "type": "integer"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "action_family",
+    "audience",
+    "client_ready_publication",
+    "evidence_packet_hash",
+    "evidence_packet_id",
+    "human_review_required",
+    "model_risk",
+    "review_guidance",
+    "scope",
+    "section_count",
+    "sections",
+    "state",
+    "unsupported_claims",
+    "unsupported_evidence_count",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/classify.v1.v1.json
+++ b/contracts/ai-task-outputs/classify.v1.v1.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/classify.v1.v1.json",
+  "title": "classify.v1 output contract",
+  "description": "Structured output for classify.v1: the deterministic stub envelope or the live transport envelope. No caller policy currently authorizes this task; the contract exists because every registered task must carry one.",
+  "anyOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count",
+        "timeout_ms",
+        "max_output_tokens",
+        "phase",
+        "context_keys",
+        "context_summary"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "max_output_tokens": {
+          "type": "integer"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "context_keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context_summary": {
+          "type": "string"
+        },
+        "stub_reason": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "estimated_cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "rate_card_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cost_posture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strict_json_salvaged": {
+          "type": "boolean"
+        }
+      }
+    }
+  ]
+}

--- a/contracts/ai-task-outputs/dpm_exception_summary.pack.v1.json
+++ b/contracts/ai-task-outputs/dpm_exception_summary.pack.v1.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/dpm_exception_summary.pack.v1.json",
+  "title": "dpm_exception_summary.pack output contract",
+  "description": "Structured output contract for dpm_exception_summary.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "critical_exception_count": {
+      "type": "integer"
+    },
+    "exception_count": {
+      "type": "integer"
+    },
+    "exception_summary_content_hash": {
+      "type": "string"
+    },
+    "high_exception_count": {
+      "type": "integer"
+    },
+    "mandate_id": {
+      "type": "string"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "narrative_type": {
+      "type": "string"
+    },
+    "open_exception_count": {
+      "type": "integer"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "portfolio_id": {
+      "type": "string"
+    },
+    "portfolio_memory_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_context_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_event_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_ref_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_omitted": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_truncated": {
+      "type": "boolean"
+    },
+    "portfolio_memory_event_types": {
+      "type": "array"
+    },
+    "portfolio_memory_source_systems": {
+      "type": "array"
+    },
+    "portfolio_memory_status": {
+      "type": "string"
+    },
+    "portfolio_memory_supportability_state": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "requested_outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "context_keys",
+    "context_summary",
+    "critical_exception_count",
+    "exception_count",
+    "exception_summary_content_hash",
+    "high_exception_count",
+    "mandate_id",
+    "max_output_tokens",
+    "narrative_type",
+    "open_exception_count",
+    "output_label",
+    "phase",
+    "portfolio_id",
+    "portfolio_memory_content_hash",
+    "portfolio_memory_context_content_hash",
+    "portfolio_memory_event_count",
+    "portfolio_memory_event_ref_count",
+    "portfolio_memory_event_refs_omitted",
+    "portfolio_memory_event_refs_truncated",
+    "portfolio_memory_event_types",
+    "portfolio_memory_source_systems",
+    "portfolio_memory_status",
+    "portfolio_memory_supportability_state",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "requested_outputs",
+    "retry_count",
+    "review_guidance",
+    "safety_mode",
+    "scope",
+    "source_refs",
+    "state",
+    "stub_reason",
+    "timeout_ms",
+    "unsupported_claims",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/dpm_operations_handoff_summary.pack.v1.json
+++ b/contracts/ai-task-outputs/dpm_operations_handoff_summary.pack.v1.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/dpm_operations_handoff_summary.pack.v1.json",
+  "title": "dpm_operations_handoff_summary.pack output contract",
+  "description": "Structured output contract for dpm_operations_handoff_summary.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "blocked_item_count": {
+      "type": "integer"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "external_execution_claimed": {
+      "type": "boolean"
+    },
+    "forbidden_actions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "handoff_ref_count": {
+      "type": "integer"
+    },
+    "item_count": {
+      "type": "integer"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "narrative_type": {
+      "type": "string"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "portfolio_memory_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_context_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_event_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_ref_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_omitted": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_truncated": {
+      "type": "boolean"
+    },
+    "portfolio_memory_event_types": {
+      "type": "array"
+    },
+    "portfolio_memory_source_systems": {
+      "type": "array"
+    },
+    "portfolio_memory_status": {
+      "type": "string"
+    },
+    "portfolio_memory_supportability_state": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "requested_outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "source_ref_count": {
+      "type": "integer"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "wave_id": {
+      "type": "string"
+    },
+    "wave_report_content_hash": {
+      "type": "string"
+    },
+    "wave_state": {
+      "type": "string"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "blocked_item_count",
+    "context_keys",
+    "context_summary",
+    "external_execution_claimed",
+    "forbidden_actions",
+    "handoff_ref_count",
+    "item_count",
+    "max_output_tokens",
+    "narrative_type",
+    "output_label",
+    "phase",
+    "portfolio_memory_content_hash",
+    "portfolio_memory_context_content_hash",
+    "portfolio_memory_event_count",
+    "portfolio_memory_event_ref_count",
+    "portfolio_memory_event_refs_omitted",
+    "portfolio_memory_event_refs_truncated",
+    "portfolio_memory_event_types",
+    "portfolio_memory_source_systems",
+    "portfolio_memory_status",
+    "portfolio_memory_supportability_state",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "requested_outputs",
+    "retry_count",
+    "review_guidance",
+    "safety_mode",
+    "scope",
+    "source_ref_count",
+    "source_refs",
+    "state",
+    "stub_reason",
+    "timeout_ms",
+    "unsupported_claims",
+    "wave_id",
+    "wave_report_content_hash",
+    "wave_state",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/dpm_pm_memo.pack.v1.json
+++ b/contracts/ai-task-outputs/dpm_pm_memo.pack.v1.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/dpm_pm_memo.pack.v1.json",
+  "title": "dpm_pm_memo.pack output contract",
+  "description": "Structured output contract for dpm_pm_memo.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "ai_evidence_content_hash": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "forbidden_actions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "forbidden_fields_removed": {
+      "type": "array"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "narrative_type": {
+      "type": "string"
+    },
+    "output_count": {
+      "type": "integer"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "portfolio_id": {
+      "type": "string"
+    },
+    "portfolio_memory_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_context_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_event_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_ref_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_omitted": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_truncated": {
+      "type": "boolean"
+    },
+    "portfolio_memory_event_types": {
+      "type": "array"
+    },
+    "portfolio_memory_source_systems": {
+      "type": "array"
+    },
+    "portfolio_memory_status": {
+      "type": "string"
+    },
+    "portfolio_memory_supportability_state": {
+      "type": "string"
+    },
+    "proof_pack_content_hash": {
+      "type": "string"
+    },
+    "proof_pack_id": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "requested_outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "source_ref_count": {
+      "type": "integer"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "supportability_status": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "ai_evidence_content_hash",
+    "context_keys",
+    "context_summary",
+    "forbidden_actions",
+    "forbidden_fields_removed",
+    "max_output_tokens",
+    "narrative_type",
+    "output_count",
+    "output_label",
+    "phase",
+    "portfolio_id",
+    "portfolio_memory_content_hash",
+    "portfolio_memory_context_content_hash",
+    "portfolio_memory_event_count",
+    "portfolio_memory_event_ref_count",
+    "portfolio_memory_event_refs_omitted",
+    "portfolio_memory_event_refs_truncated",
+    "portfolio_memory_event_types",
+    "portfolio_memory_source_systems",
+    "portfolio_memory_status",
+    "portfolio_memory_supportability_state",
+    "proof_pack_content_hash",
+    "proof_pack_id",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "requested_outputs",
+    "retry_count",
+    "review_guidance",
+    "safety_mode",
+    "scope",
+    "section_count",
+    "source_ref_count",
+    "source_refs",
+    "state",
+    "stub_reason",
+    "supportability_status",
+    "timeout_ms",
+    "unsupported_claims",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/dpm_wave_pm_memo.pack.v1.json
+++ b/contracts/ai-task-outputs/dpm_wave_pm_memo.pack.v1.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/dpm_wave_pm_memo.pack.v1.json",
+  "title": "dpm_wave_pm_memo.pack output contract",
+  "description": "Structured output contract for dpm_wave_pm_memo.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "event_count": {
+      "type": "integer"
+    },
+    "forbidden_actions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "item_count": {
+      "type": "integer"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "narrative_type": {
+      "type": "string"
+    },
+    "output_count": {
+      "type": "integer"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "portfolio_memory_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_context_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_event_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_ref_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_omitted": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_truncated": {
+      "type": "boolean"
+    },
+    "portfolio_memory_event_types": {
+      "type": "array"
+    },
+    "portfolio_memory_source_systems": {
+      "type": "array"
+    },
+    "portfolio_memory_status": {
+      "type": "string"
+    },
+    "portfolio_memory_supportability_state": {
+      "type": "string"
+    },
+    "proof_pack_ref_count": {
+      "type": "integer"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "requested_outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "source_ref_count": {
+      "type": "integer"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "wave_content_hash": {
+      "type": "string"
+    },
+    "wave_id": {
+      "type": "string"
+    },
+    "wave_report_content_hash": {
+      "type": "string"
+    },
+    "wave_state": {
+      "type": "string"
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "context_keys",
+    "context_summary",
+    "event_count",
+    "forbidden_actions",
+    "item_count",
+    "max_output_tokens",
+    "narrative_type",
+    "output_count",
+    "output_label",
+    "phase",
+    "portfolio_memory_content_hash",
+    "portfolio_memory_context_content_hash",
+    "portfolio_memory_event_count",
+    "portfolio_memory_event_ref_count",
+    "portfolio_memory_event_refs_omitted",
+    "portfolio_memory_event_refs_truncated",
+    "portfolio_memory_event_types",
+    "portfolio_memory_source_systems",
+    "portfolio_memory_status",
+    "portfolio_memory_supportability_state",
+    "proof_pack_ref_count",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "requested_outputs",
+    "retry_count",
+    "review_guidance",
+    "safety_mode",
+    "scope",
+    "source_ref_count",
+    "source_refs",
+    "state",
+    "stub_reason",
+    "timeout_ms",
+    "unsupported_claims",
+    "wave_content_hash",
+    "wave_id",
+    "wave_report_content_hash",
+    "wave_state",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/explain.v1.v1.json
+++ b/contracts/ai-task-outputs/explain.v1.v1.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/explain.v1.v1.json",
+  "title": "explain.v1 output contract",
+  "description": "Structured output for unbound explain.v1 executions: the deterministic stub envelope or the live transport envelope. Pack-bound explain.v1 executions validate against their pack family's contract instead.",
+  "anyOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count",
+        "timeout_ms",
+        "max_output_tokens",
+        "phase",
+        "context_keys",
+        "context_summary"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "max_output_tokens": {
+          "type": "integer"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "context_keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context_summary": {
+          "type": "string"
+        },
+        "stub_reason": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "estimated_cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "rate_card_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cost_posture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strict_json_salvaged": {
+          "type": "boolean"
+        }
+      }
+    }
+  ]
+}

--- a/contracts/ai-task-outputs/extract.v1.v1.json
+++ b/contracts/ai-task-outputs/extract.v1.v1.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/extract.v1.v1.json",
+  "title": "extract.v1 output contract",
+  "description": "Structured output for extract.v1: the deterministic stub envelope or the live transport envelope. No caller policy currently authorizes this task; the contract exists because every registered task must carry one.",
+  "anyOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count",
+        "timeout_ms",
+        "max_output_tokens",
+        "phase",
+        "context_keys",
+        "context_summary"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "max_output_tokens": {
+          "type": "integer"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "context_keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context_summary": {
+          "type": "string"
+        },
+        "stub_reason": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "estimated_cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "rate_card_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cost_posture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strict_json_salvaged": {
+          "type": "boolean"
+        }
+      }
+    }
+  ]
+}

--- a/contracts/ai-task-outputs/generate_structured.v1.v1.json
+++ b/contracts/ai-task-outputs/generate_structured.v1.v1.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/generate_structured.v1.v1.json",
+  "title": "generate_structured.v1 output contract",
+  "description": "Structured output for generate_structured.v1: the deterministic stub envelope or the live transport envelope.",
+  "anyOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count",
+        "timeout_ms",
+        "max_output_tokens",
+        "phase",
+        "context_keys",
+        "context_summary"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "max_output_tokens": {
+          "type": "integer"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "context_keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context_summary": {
+          "type": "string"
+        },
+        "stub_reason": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "estimated_cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "rate_card_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cost_posture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strict_json_salvaged": {
+          "type": "boolean"
+        }
+      }
+    }
+  ]
+}

--- a/contracts/ai-task-outputs/idea_explanation.pack.v1.json
+++ b/contracts/ai-task-outputs/idea_explanation.pack.v1.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/idea_explanation.pack.v1.json",
+  "title": "idea_explanation.pack output contract",
+  "description": "Structured output contract for idea_explanation.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "candidate_id": {
+      "type": "string"
+    },
+    "client_ready_publication": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "downstream_authority": {
+      "type": "string"
+    },
+    "evaluation_ref": {
+      "type": "string"
+    },
+    "evidence_content_hash": {
+      "type": "string"
+    },
+    "evidence_packet_id": {
+      "type": "string"
+    },
+    "family": {
+      "type": "string"
+    },
+    "forbidden_actions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "human_review_required": {
+      "type": "boolean"
+    },
+    "lifecycle_status": {
+      "type": "string"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "purpose": {
+      "type": "string"
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "requested_outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "review_posture": {
+      "type": "string"
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "score_policy_version": {
+      "type": "string"
+    },
+    "source_ref_count": {
+      "type": "integer"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "source_signal_count": {
+      "type": "integer"
+    },
+    "state": {
+      "type": "string"
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "candidate_id",
+    "client_ready_publication",
+    "context_keys",
+    "context_summary",
+    "downstream_authority",
+    "evaluation_ref",
+    "evidence_content_hash",
+    "evidence_packet_id",
+    "family",
+    "forbidden_actions",
+    "human_review_required",
+    "lifecycle_status",
+    "max_output_tokens",
+    "output_label",
+    "phase",
+    "provider_id",
+    "provider_mode",
+    "purpose",
+    "reason_codes",
+    "redaction_posture",
+    "requested_outputs",
+    "retry_count",
+    "review_guidance",
+    "review_posture",
+    "safety_mode",
+    "scope",
+    "score_policy_version",
+    "source_ref_count",
+    "source_refs",
+    "source_signal_count",
+    "state",
+    "stub_reason",
+    "timeout_ms",
+    "unsupported_claims",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/knowledge_answer.v1.v1.json
+++ b/contracts/ai-task-outputs/knowledge_answer.v1.v1.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/knowledge_answer.v1.json",
+  "title": "knowledge_answer.v1 output contract",
+  "description": "Conservative retrieval-grounded answer with citations from approved Lotus knowledge sources.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "phase",
+    "provider_id",
+    "provider_mode",
+    "catalog_only",
+    "query",
+    "source_ids",
+    "vector_store",
+    "execution_stage",
+    "retrieval_status",
+    "hit_count",
+    "citation_count",
+    "support_score",
+    "answer_mode",
+    "citations",
+    "hits",
+    "answer"
+  ],
+  "properties": {
+    "phase": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "catalog_only": {
+      "type": "boolean"
+    },
+    "query": {
+      "type": "string"
+    },
+    "source_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "vector_store": {
+      "type": "string"
+    },
+    "execution_stage": {
+      "type": "string"
+    },
+    "retrieval_status": {
+      "type": "string"
+    },
+    "hit_count": {
+      "type": "integer"
+    },
+    "citation_count": {
+      "type": "integer"
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "hits": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "support_score": {
+      "type": "number"
+    },
+    "answer_mode": {
+      "type": "string"
+    },
+    "answer": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/ai-task-outputs/knowledge_search.v1.v1.json
+++ b/contracts/ai-task-outputs/knowledge_search.v1.v1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/knowledge_search.v1.json",
+  "title": "knowledge_search.v1 output contract",
+  "description": "Bounded retrieval search output over approved Lotus knowledge sources.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "phase",
+    "provider_id",
+    "provider_mode",
+    "catalog_only",
+    "query",
+    "source_ids",
+    "vector_store",
+    "execution_stage",
+    "retrieval_status",
+    "hit_count",
+    "citation_count",
+    "support_score",
+    "citations",
+    "hits"
+  ],
+  "properties": {
+    "phase": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "catalog_only": {
+      "type": "boolean"
+    },
+    "query": {
+      "type": "string"
+    },
+    "source_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "vector_store": {
+      "type": "string"
+    },
+    "execution_stage": {
+      "type": "string"
+    },
+    "retrieval_status": {
+      "type": "string"
+    },
+    "hit_count": {
+      "type": "integer"
+    },
+    "citation_count": {
+      "type": "integer"
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "hits": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "support_score": {
+      "type": "number"
+    }
+  }
+}

--- a/contracts/ai-task-outputs/outcome_review_narrative.pack.v1.json
+++ b/contracts/ai-task-outputs/outcome_review_narrative.pack.v1.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/outcome_review_narrative.pack.v1.json",
+  "title": "outcome_review_narrative.pack output contract",
+  "description": "Structured output contract for outcome_review_narrative.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "dimension_count": {
+      "type": "integer"
+    },
+    "evidence_content_hash": {
+      "type": "string"
+    },
+    "forbidden_actions_enforced": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "forbidden_fields_removed": {
+      "type": "array"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "narrative_scope": {
+      "type": "string"
+    },
+    "outcome_review_content_hash": {
+      "type": "string"
+    },
+    "outcome_review_id": {
+      "type": "string"
+    },
+    "outcome_review_narrative_status": {
+      "type": "string"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "overall_outcome": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "portfolio_id": {
+      "type": "string"
+    },
+    "portfolio_memory_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_context_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_event_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_ref_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_omitted": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_truncated": {
+      "type": "boolean"
+    },
+    "portfolio_memory_event_types": {
+      "type": "array"
+    },
+    "portfolio_memory_source_systems": {
+      "type": "array"
+    },
+    "portfolio_memory_status": {
+      "type": "string"
+    },
+    "portfolio_memory_supportability_state": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "requested_outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "string"
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "source_ref_count": {
+      "type": "integer"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "context_keys",
+    "context_summary",
+    "dimension_count",
+    "evidence_content_hash",
+    "forbidden_actions_enforced",
+    "forbidden_fields_removed",
+    "max_output_tokens",
+    "narrative_scope",
+    "outcome_review_content_hash",
+    "outcome_review_id",
+    "outcome_review_narrative_status",
+    "output_label",
+    "overall_outcome",
+    "phase",
+    "portfolio_id",
+    "portfolio_memory_content_hash",
+    "portfolio_memory_context_content_hash",
+    "portfolio_memory_event_count",
+    "portfolio_memory_event_ref_count",
+    "portfolio_memory_event_refs_omitted",
+    "portfolio_memory_event_refs_truncated",
+    "portfolio_memory_event_types",
+    "portfolio_memory_source_systems",
+    "portfolio_memory_status",
+    "portfolio_memory_supportability_state",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "requested_outputs",
+    "retry_count",
+    "review_guidance",
+    "safety_mode",
+    "source_ref_count",
+    "source_refs",
+    "stub_reason",
+    "timeout_ms",
+    "unsupported_claims"
+  ]
+}

--- a/contracts/ai-task-outputs/pm_quality_summary.pack.v1.json
+++ b/contracts/ai-task-outputs/pm_quality_summary.pack.v1.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/pm_quality_summary.pack.v1.json",
+  "title": "pm_quality_summary.pack output contract",
+  "description": "Structured output contract for pm_quality_summary.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "forbidden_actions_enforced": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "indicator_result_count": {
+      "type": "integer"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "narrative_type": {
+      "type": "string"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "policy_id": {
+      "type": "string"
+    },
+    "policy_version": {
+      "type": "string"
+    },
+    "portfolio_id": {
+      "type": "string"
+    },
+    "portfolio_manager_id": {
+      "type": "string"
+    },
+    "portfolio_memory_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_context_content_hash": {
+      "type": "string"
+    },
+    "portfolio_memory_event_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_ref_count": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_omitted": {
+      "type": "integer"
+    },
+    "portfolio_memory_event_refs_truncated": {
+      "type": "boolean"
+    },
+    "portfolio_memory_event_types": {
+      "type": "array"
+    },
+    "portfolio_memory_source_systems": {
+      "type": "array"
+    },
+    "portfolio_memory_status": {
+      "type": "string"
+    },
+    "portfolio_memory_supportability_state": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "requested_outputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "string"
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "score_run_content_hash": {
+      "type": "string"
+    },
+    "score_run_id": {
+      "type": "string"
+    },
+    "score_run_state": {
+      "type": "string"
+    },
+    "source_ref_count": {
+      "type": "integer"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "context_keys",
+    "context_summary",
+    "forbidden_actions_enforced",
+    "indicator_result_count",
+    "max_output_tokens",
+    "narrative_type",
+    "output_label",
+    "phase",
+    "policy_id",
+    "policy_version",
+    "portfolio_id",
+    "portfolio_manager_id",
+    "portfolio_memory_content_hash",
+    "portfolio_memory_context_content_hash",
+    "portfolio_memory_event_count",
+    "portfolio_memory_event_ref_count",
+    "portfolio_memory_event_refs_omitted",
+    "portfolio_memory_event_refs_truncated",
+    "portfolio_memory_event_types",
+    "portfolio_memory_source_systems",
+    "portfolio_memory_status",
+    "portfolio_memory_supportability_state",
+    "provider_id",
+    "provider_mode",
+    "reason_codes",
+    "redaction_posture",
+    "requested_outputs",
+    "retry_count",
+    "review_guidance",
+    "safety_mode",
+    "scope",
+    "score_run_content_hash",
+    "score_run_id",
+    "score_run_state",
+    "source_ref_count",
+    "source_refs",
+    "state",
+    "stub_reason",
+    "timeout_ms",
+    "unsupported_claims",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/proposal_memo_commentary.pack.v1.json
+++ b/contracts/ai-task-outputs/proposal_memo_commentary.pack.v1.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/proposal_memo_commentary.pack.v1.json",
+  "title": "proposal_memo_commentary.pack output contract",
+  "description": "Structured output contract for proposal_memo_commentary.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "memo_hash": {
+      "type": "string"
+    },
+    "memo_id": {
+      "type": "string"
+    },
+    "memo_status": {
+      "type": "string"
+    },
+    "narrative_type": {
+      "type": "string"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "review_guidance": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    },
+    "section_count": {
+      "type": "integer"
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "section_key": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "source_ref_count": {
+      "type": "integer"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "state": {
+      "type": "string"
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    },
+    "unsupported_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "workflow_pack_family": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "context_keys",
+    "context_summary",
+    "max_output_tokens",
+    "memo_hash",
+    "memo_id",
+    "memo_status",
+    "narrative_type",
+    "output_label",
+    "phase",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "retry_count",
+    "review_guidance",
+    "safety_mode",
+    "scope",
+    "section_count",
+    "sections",
+    "source_ref_count",
+    "source_refs",
+    "state",
+    "stub_reason",
+    "timeout_ms",
+    "unsupported_claims",
+    "workflow_pack_family"
+  ]
+}

--- a/contracts/ai-task-outputs/summarize.v1.v1.json
+++ b/contracts/ai-task-outputs/summarize.v1.v1.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/summarize.v1.v1.json",
+  "title": "summarize.v1 output contract",
+  "description": "Structured output for summarize.v1: the deterministic stub envelope or the live transport envelope.",
+  "anyOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count",
+        "timeout_ms",
+        "max_output_tokens",
+        "phase",
+        "context_keys",
+        "context_summary"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "timeout_ms": {
+          "type": "integer"
+        },
+        "max_output_tokens": {
+          "type": "integer"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "context_keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context_summary": {
+          "type": "string"
+        },
+        "stub_reason": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id",
+        "provider_mode",
+        "adapter_kind",
+        "output_label",
+        "safety_mode",
+        "redaction_posture",
+        "source_refs",
+        "retry_count"
+      ],
+      "properties": {
+        "provider_id": {
+          "type": "string"
+        },
+        "provider_mode": {
+          "type": "string"
+        },
+        "adapter_kind": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider_request_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_label": {
+          "type": "string"
+        },
+        "safety_mode": {
+          "type": "string"
+        },
+        "redaction_posture": {
+          "type": "string"
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retry_count": {
+          "type": "integer"
+        },
+        "input_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_tokens": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "estimated_cost_usd": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "rate_card_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cost_posture": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strict_json_salvaged": {
+          "type": "boolean"
+        }
+      }
+    }
+  ]
+}

--- a/contracts/ai-task-outputs/twr_inspection_support_brief.pack.v1.json
+++ b/contracts/ai-task-outputs/twr_inspection_support_brief.pack.v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/twr_inspection_support_brief.pack.v1.json",
+  "title": "twr_inspection_support_brief.pack output contract",
+  "description": "Structured output contract for twr_inspection_support_brief.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "context_keys",
+    "context_summary",
+    "max_output_tokens",
+    "output_label",
+    "phase",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "retry_count",
+    "safety_mode",
+    "source_refs",
+    "stub_reason",
+    "timeout_ms"
+  ]
+}

--- a/contracts/ai-task-outputs/workspace_rationale.pack.v1.json
+++ b/contracts/ai-task-outputs/workspace_rationale.pack.v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lotus.ai/contracts/ai-task-outputs/workspace_rationale.pack.v1.json",
+  "title": "workspace_rationale.pack output contract",
+  "description": "Structured output contract for workspace_rationale.pack executions, derived from the deterministic governed stub runtime; the review-gated, non-authoritative posture of the output is part of the contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "adapter_kind": {
+      "type": "string"
+    },
+    "context_keys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "context_summary": {
+      "type": "string"
+    },
+    "max_output_tokens": {
+      "type": "integer"
+    },
+    "output_label": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "provider_mode": {
+      "type": "string"
+    },
+    "redaction_posture": {
+      "type": "string"
+    },
+    "retry_count": {
+      "type": "integer"
+    },
+    "safety_mode": {
+      "type": "string"
+    },
+    "source_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stub_reason": {
+      "type": "string"
+    },
+    "timeout_ms": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "adapter_kind",
+    "context_keys",
+    "context_summary",
+    "max_output_tokens",
+    "output_label",
+    "phase",
+    "provider_id",
+    "provider_mode",
+    "redaction_posture",
+    "retry_count",
+    "safety_mode",
+    "source_refs",
+    "stub_reason",
+    "timeout_ms"
+  ]
+}

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -555,6 +555,17 @@ Restart-survival expectations:
 2. when `LOTUS_AI_EVALUATION_RUNTIME_STORE_MODE=sqlalchemy`, prompt approval evidence must survive service restart and remain inspectable through the prompt approval gate
 3. restart must not be used as a workaround to clear prompt rollout history or revert a prompt change
 
+## AI Output Validation
+
+Every AI task and workflow-pack execution passes deterministic output validation before safety redaction, and every response and audit record carries `output_validation` (`validation_state`, `authority=non_authoritative_ai_output`, the ruleset version, and any failed rule ids):
+
+1. `evidence_grounding` - every `source_ref`/`evidence_ref` value in the structured output must be one of the supplied request `source_refs`; violations reject in every profile
+2. `strict_json` - a provider answer recovered by balanced-brace salvage rejects in the promoted profile and marks the output `UNVALIDATED_LOCAL_ONLY` in local
+3. `output_schema` - the structured output must conform to the JSON Schema contract for its task id or (for pack-bound executions, explicit or inferred) its workflow-pack family, under `contracts/ai-task-outputs/`; violations reject in promoted and warn in local
+4. `contract_missing` - workflow-pack registration refuses a family without a contract, so a missing contract at execution time is a wiring defect: promoted fails closed
+
+A `REJECTED` (or `VALIDATION_UNAVAILABLE`) verdict withholds the output whole: the caller receives `error_code=OUTPUT_VALIDATION_REJECTED` (or `VALIDATION_UNAVAILABLE`) with the failing rule ids, and the audit record persists carrying the verdict. `output_contract_notes` on task requests is prompt guidance only; the schema contract is the validation authority.
+
 ## Caller Trust Mode
 
 `LOTUS_AI_CALLER_TRUST_MODE` selects how the caller identity on protected routes is established:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "alembic>=1.16.0",
   "cryptography>=46.0.0",
   "fastapi>=0.133.0",
+  "jsonschema>=4.25",
   "psycopg[binary]>=3.2.10",
   "uvicorn>=0.41.0",
   "pydantic>=2.12.0",
@@ -32,6 +33,7 @@ dependencies = [
 dev = [
   "ruff==0.15.7",
   "mypy>=1.19.0",
+  "types-jsonschema>=4.25",
   "pytest>=9.0.0",
   "pytest-mock>=3.15.1",
   "pytest-asyncio>=1.2.0",

--- a/src/app/contracts/output_validation.py
+++ b/src/app/contracts/output_validation.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 AI_OUTPUT_AUTHORITY = "non_authoritative_ai_output"
-OUTPUT_VALIDATION_RULESET_VERSION = "output-validation.v1"
+OUTPUT_VALIDATION_RULESET_VERSION = "output-validation.v2"
 
 
 class OutputValidationState(str, Enum):

--- a/src/app/services/output_contracts.py
+++ b/src/app/services/output_contracts.py
@@ -1,0 +1,74 @@
+"""Per-task output contracts as data (issue #156, S2).
+
+One JSON Schema per registered task id and per workflow-pack family, under
+``contracts/ai-task-outputs/``. The schema is the validation authority for
+the structured output; ``output_contract_notes`` remains prompt guidance
+only. Resolution is by execution context, never by sniffing the output: a
+pack-bound execution validates against its pack family's contract, any
+other execution against its task id's contract.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+_CONTRACTS_DIR = Path(__file__).resolve().parents[3] / "contracts" / "ai-task-outputs"
+_CONTRACT_VERSION = "v1"
+
+
+def output_contract_path(contract_key: str) -> Path:
+    return _CONTRACTS_DIR / f"{contract_key}.{_CONTRACT_VERSION}.json"
+
+
+def output_contract_exists(contract_key: str) -> bool:
+    return output_contract_path(contract_key).is_file()
+
+
+def list_output_contract_keys() -> list[str]:
+    if not _CONTRACTS_DIR.is_dir():
+        return []
+    suffix = f".{_CONTRACT_VERSION}.json"
+    return sorted(
+        entry.name.removesuffix(suffix)
+        for entry in _CONTRACTS_DIR.iterdir()
+        if entry.name.endswith(suffix)
+    )
+
+
+@lru_cache(maxsize=64)
+def _load_validator(contract_key: str) -> Draft202012Validator | None:
+    path = output_contract_path(contract_key)
+    if not path.is_file():
+        return None
+    schema = json.loads(path.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def reset_output_contract_cache() -> None:
+    _load_validator.cache_clear()
+
+
+def schema_violations(contract_key: str, structured_output: Any) -> list[str] | None:
+    """Bounded violation statements, or None when no contract exists.
+
+    An empty list means the output conforms. Messages are bounded and name
+    the JSON path so an operator can locate the offending field without the
+    output itself being echoed.
+    """
+
+    validator = _load_validator(contract_key)
+    if validator is None:
+        return None
+    violations: list[str] = []
+    for error in sorted(validator.iter_errors(structured_output), key=lambda e: str(e.json_path)):
+        violations.append(f"{error.json_path}: {error.message[:200]}")
+        if len(violations) >= 10:
+            violations.append("further schema violations withheld from this summary")
+            break
+    return violations

--- a/src/app/services/output_validation.py
+++ b/src/app/services/output_validation.py
@@ -1,20 +1,26 @@
-"""Deterministic validation of every AI output (issue #156, S1).
+"""Deterministic validation of every AI output (issue #156, S1+S2).
 
 One validator on the execution path, after the provider call and before
 safety redaction (redaction must never be able to erase a fabricated
-reference and flip a verdict). S1 ships the rules that need no per-task
-contract:
+reference and flip a verdict). Rules:
 
 - ``evidence_grounding``: every ``source_ref``/``source_refs``/
   ``evidence_ref``/``evidence_refs`` value anywhere in the structured
   output must be one of the supplied request ``source_refs`` - a set
-  check, not a prompt instruction.
+  check, not a prompt instruction. Rejects in every profile.
 - ``strict_json`` (recorded by the transport): a promoted-profile output
   recovered by balanced-brace salvage is not a validated output.
+- ``output_schema``: the structured output must conform to the task's or
+  pack family's JSON Schema contract (``contracts/ai-task-outputs/``).
+  Promoted rejects violations; local accepts with a warning and marks the
+  output UNVALIDATED_LOCAL_ONLY.
+- ``contract_missing``: registration refuses contract-less tasks and
+  packs, so a missing contract at execution time is a wiring defect -
+  promoted fails closed, local marks the output honestly.
 
-Per-task schema contracts and numeric grounding activate in later slices
-under the same ruleset seam. A validator fault fails closed as
-``VALIDATION_UNAVAILABLE`` - never an unmarked output.
+Numeric grounding activates in S3 under the same ruleset seam. A
+validator fault fails closed as ``VALIDATION_UNAVAILABLE`` - never an
+unmarked output.
 """
 
 from __future__ import annotations
@@ -26,11 +32,14 @@ from app.contracts.output_validation import (
     OutputValidationOutcome,
     OutputValidationState,
 )
+from app.services.output_contracts import schema_violations
 
 logger = logging.getLogger(__name__)
 
 RULE_EVIDENCE_GROUNDING = "evidence_grounding"
 RULE_STRICT_JSON = "strict_json"
+RULE_OUTPUT_SCHEMA = "output_schema"
+RULE_CONTRACT_MISSING = "contract_missing"
 
 _REFERENCE_KEYS = frozenset({"source_ref", "source_refs", "evidence_ref", "evidence_refs"})
 _MAX_RECORDED_FINDINGS = 10
@@ -43,6 +52,7 @@ def validate_provider_output(
     supplied_source_refs: list[str],
     salvaged_json: bool,
     runtime_profile: str,
+    contract_key: str,
 ) -> OutputValidationOutcome:
     try:
         return _validate(
@@ -50,6 +60,7 @@ def validate_provider_output(
             supplied_source_refs=supplied_source_refs,
             salvaged_json=salvaged_json,
             runtime_profile=runtime_profile,
+            contract_key=contract_key,
         )
     except Exception:  # noqa: BLE001 - a validator fault must fail closed, never fall open
         logger.exception("output validation fault; failing closed as VALIDATION_UNAVAILABLE")
@@ -65,9 +76,11 @@ def _validate(
     supplied_source_refs: list[str],
     salvaged_json: bool,
     runtime_profile: str,
+    contract_key: str,
 ) -> OutputValidationOutcome:
     failed_rule_ids: list[str] = []
     findings: list[str] = []
+    local_only = False
 
     unsupported = _ungrounded_references(
         structured_output, supplied={ref for ref in supplied_source_refs if ref}
@@ -98,13 +111,40 @@ def _validate(
                 "accepted unvalidated in the local profile only"
             )
 
+    if salvaged_json and runtime_profile != "promoted":
+        local_only = True
+
+    violations = schema_violations(contract_key, structured_output)
+    if violations is None:
+        # Registration refuses a task or pack without a contract, so a
+        # missing contract at execution time is a wiring defect: promoted
+        # fails closed, local marks the output honestly.
+        message = f"{RULE_CONTRACT_MISSING}: no output contract exists for '{contract_key}'"
+        if runtime_profile == "promoted":
+            failed_rule_ids.append(RULE_CONTRACT_MISSING)
+            findings.append(message)
+        else:
+            local_only = True
+            findings.append(f"{message}; accepted unvalidated in the local profile only")
+    elif violations:
+        if runtime_profile == "promoted":
+            failed_rule_ids.append(RULE_OUTPUT_SCHEMA)
+            findings.extend(f"{RULE_OUTPUT_SCHEMA}: {violation}" for violation in violations)
+        else:
+            local_only = True
+            findings.extend(
+                f"{RULE_OUTPUT_SCHEMA}: {violation}; accepted with a warning in the "
+                "local profile only"
+                for violation in violations
+            )
+
     if failed_rule_ids:
         return OutputValidationOutcome(
             validation_state=OutputValidationState.REJECTED,
             failed_rule_ids=failed_rule_ids,
             findings=findings,
         )
-    if salvaged_json:
+    if local_only:
         return OutputValidationOutcome(
             validation_state=OutputValidationState.UNVALIDATED_LOCAL_ONLY,
             findings=findings,

--- a/src/app/services/task_execution_pipeline.py
+++ b/src/app/services/task_execution_pipeline.py
@@ -41,7 +41,9 @@ def validate_task_request(request: TaskExecutionRequest) -> TaskExecutionContext
 def resolve_task_execution(
     *,
     context: TaskExecutionContext,
+    output_contract_key: str | None = None,
 ) -> ResolvedTaskExecution:
+    contract_key = output_contract_key or context.capability.task_id
     provider_request = None
     if context.capability.category == TaskCategory.KNOWLEDGE_SEARCH:
         provider_execution = execute_knowledge_search(context=context)
@@ -58,6 +60,7 @@ def resolve_task_execution(
         supplied_source_refs=context.request.context.source_refs,
         salvaged_json=bool(provider_execution.structured_output.get("strict_json_salvaged", False)),
         runtime_profile=settings.runtime_profile,
+        contract_key=contract_key,
     )
     client_identifiers = _caller_redaction_identifiers(context.request.caller.caller_app)
     safe_provider_execution, safety_outcome = apply_safety_enforcement(

--- a/src/app/services/task_executor.py
+++ b/src/app/services/task_executor.py
@@ -50,7 +50,12 @@ def execute_task_with_optional_workflow_pack_recording(
         else nullcontext()
     )
     with admission:
-        resolved = resolve_task_execution(context=context)
+        resolved = resolve_task_execution(
+            context=context,
+            output_contract_key=(
+                resolved_binding.registration.pack_id if resolved_binding is not None else None
+            ),
+        )
         response = build_task_execution_response(resolved=resolved)
         persist_task_execution_audit(context=context, response=response)
         workflow_pack_run = record_workflow_pack_run_for_task_execution(

--- a/src/app/services/workflow_pack_execution.py
+++ b/src/app/services/workflow_pack_execution.py
@@ -115,7 +115,9 @@ def execute_workflow_pack(
         caller_identity_class=request.caller_identity_class,
     ):
         try:
-            resolved = resolve_task_execution(context=context)
+            resolved = resolve_task_execution(
+                context=context, output_contract_key=registration.pack_id
+            )
             response = build_task_execution_response(resolved=resolved)
         except HTTPException as exc:
             response = build_failed_task_execution_response(context=context, exc=exc)

--- a/src/app/services/workflow_pack_registry_seed.py
+++ b/src/app/services/workflow_pack_registry_seed.py
@@ -11,6 +11,7 @@ from app.contracts.workflow_packs import (
     WorkflowPackRegistrationStatus,
     WorkflowPackValidationRuleDescriptor,
 )
+from app.services.output_contracts import output_contract_exists
 from app.services.workflow_pack_phase1_specs import (
     ADVISOR_BRIEF_V1_SPEC,
     ADVISORY_COPILOT_ACTION_PACK_SPECS,
@@ -543,6 +544,27 @@ def validate_workflow_pack_registrations(
     _validate_registered_entries_have_scope(registrations)
     _validate_retired_entries_are_not_active(registrations)
     _validate_definition_references(registrations)
+    _validate_output_contracts_exist(registrations)
+
+
+def _validate_output_contracts_exist(
+    registrations: list[WorkflowPackRegistrationDescriptor],
+) -> None:
+    # A pack family without a deterministic output contract cannot be
+    # registered (issue #156, S2): the validator would have nothing to
+    # enforce and the output would run unvalidated.
+    missing = sorted(
+        {
+            registration.pack_id
+            for registration in registrations
+            if not output_contract_exists(registration.pack_id)
+        }
+    )
+    if missing:
+        raise ValueError(
+            "Workflow-pack registration requires a deterministic output contract in "
+            f"contracts/ai-task-outputs for: {', '.join(missing)}"
+        )
 
 
 def _advisor_brief_v1_definition_refs() -> list[WorkflowPackDefinitionReferenceDescriptor]:

--- a/tests/support/workflow_pack_fixtures.py
+++ b/tests/support/workflow_pack_fixtures.py
@@ -1356,3 +1356,79 @@ def idea_explanation_workflow_pack_execution_request_json(
     if workflow_surface is not None:
         request["workflow_surface"] = workflow_surface
     return request
+
+
+def advisory_copilot_variant_workflow_pack_execution_request_json(
+    *,
+    pack_id: str,
+    workflow_surface: str,
+    action_family: str,
+    correlation_id: str,
+) -> dict[str, object]:
+    """A sibling advisory-copilot action pack request: the shared payload
+    with the pack identity and action family swapped (issue #156, S2 - the
+    four action packs previously had no execution coverage at all)."""
+
+    import copy
+
+    request = copy.deepcopy(
+        advisory_copilot_workflow_pack_execution_request_json(correlation_id=correlation_id)
+    )
+    request["pack_id"] = pack_id
+    request["workflow_surface"] = workflow_surface
+    task_request = request["task_request"]
+    assert isinstance(task_request, dict)
+    payload = task_request["context"]["payload"]
+    payload["copilot_request"]["action_family"] = action_family
+    payload["copilot_evidence_packet"]["action_family"] = action_family
+    return request
+
+
+def proposal_memo_commentary_workflow_pack_execution_request_json(
+    *,
+    correlation_id: str,
+) -> dict[str, object]:
+    return {
+        "pack_id": "proposal_memo_commentary.pack",
+        "version": "v1",
+        "environment": "DEVELOPMENT",
+        "caller_identity_class": "INTERNAL_SERVICE",
+        "workflow_surface": "advisor-proposal-memo-commentary",
+        "task_request": {
+            "task_id": "explain.v1",
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": "lotus-advise",
+                "correlation_id": correlation_id,
+                "tenant_id": "tenant-sg-001",
+            },
+            "context": {
+                "summary": "Draft advisor proposal memo commentary.",
+                "payload": {
+                    "memo_evidence": {
+                        "memo_id": "memo-prop-001-v3",
+                        "memo_hash": "sha256:memo-001",
+                        "memo_status": "ADVISOR_REVIEW_REQUIRED",
+                        "source_refs": [
+                            "lotus-advise:memo:memo-prop-001-v3",
+                            "lotus-core:portfolio:PB_SG_GLOBAL_BAL_001",
+                        ],
+                    },
+                    "commentary_request": {
+                        "requested_sections": [
+                            "EXECUTIVE_SUMMARY",
+                            "RISK_AND_SUITABILITY_LIMITATIONS",
+                        ]
+                    },
+                    "supportability": {
+                        "unsupported_claims": [
+                            "client_ready_publication",
+                            "suitability_approval",
+                        ]
+                    },
+                },
+                "source_refs": ["lotus-advise:memo:memo-prop-001-v3"],
+            },
+            "expected_output_label": "EXPLANATION_ONLY",
+        },
+    }

--- a/tests/unit/test_output_contracts.py
+++ b/tests/unit/test_output_contracts.py
@@ -1,0 +1,333 @@
+"""Output contracts as data (issue #156, S2).
+
+Every registered task id and workflow-pack family carries a JSON Schema
+contract; a pack without one cannot be registered; every pack family
+executes through the governed stub runtime to a VALIDATED output under its
+contract - including the four advisory-copilot action packs and the
+proposal-memo commentary pack, which previously had no execution coverage
+at all; schema violations reject in the promoted profile and mark the
+output UNVALIDATED_LOCAL_ONLY in local.
+"""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from app.contracts.output_validation import OutputValidationState
+from app.contracts.tasks import TaskExecutionStatus
+from app.contracts.workflow_packs import WorkflowPackExecutionRequest
+from app.services.capability_catalog import build_capability_catalog
+from app.services.output_contracts import (
+    list_output_contract_keys,
+    output_contract_exists,
+    reset_output_contract_cache,
+)
+from app.services.output_validation import validate_provider_output
+from app.services.workflow_pack_execution import execute_workflow_pack
+from app.services.workflow_pack_registry_seed import build_seed_workflow_pack_registrations
+from app.services.workflow_pack_registry import (
+    get_workflow_pack_registration,
+    save_workflow_pack_registration,
+)
+from tests.support import workflow_pack_fixtures as fixtures
+
+_COPILOT_VARIANTS = {
+    "advisory_copilot_operations_report_handoff.pack": (
+        "advisory-copilot-operations-report-handoff",
+        "OPERATIONS_REPORT_HANDOFF",
+    ),
+    "advisory_copilot_evidence_qa.pack": ("advisory-copilot-evidence-qa", "EVIDENCE_QA"),
+    "advisory_copilot_meeting_preparation.pack": (
+        "advisory-copilot-meeting-preparation",
+        "MEETING_PREPARATION",
+    ),
+    "advisory_copilot_compliance_review_summary.pack": (
+        "advisory-copilot-compliance-review-summary",
+        "COMPLIANCE_REVIEW_SUMMARY",
+    ),
+    "advisory_copilot_client_follow_up_draft.pack": (
+        "advisory-copilot-client-follow-up-draft",
+        "CLIENT_FOLLOW_UP_DRAFT",
+    ),
+}
+
+_HELPERS: dict[str, Callable[..., dict[str, object]]] = {
+    "advisor_brief.pack": fixtures.advisor_brief_workflow_pack_execution_request_json,
+    "workspace_rationale.pack": (fixtures.workspace_rationale_workflow_pack_execution_request_json),
+    "advisory_copilot_proposal_explanation.pack": (
+        fixtures.advisory_copilot_workflow_pack_execution_request_json
+    ),
+    "twr_inspection_support_brief.pack": (
+        fixtures.twr_inspection_support_brief_workflow_pack_execution_request_json
+    ),
+    "dpm_pm_memo.pack": fixtures.proof_pack_pm_memo_workflow_pack_execution_request_json,
+    "dpm_wave_pm_memo.pack": fixtures.wave_pm_memo_workflow_pack_execution_request_json,
+    "dpm_exception_summary.pack": (
+        fixtures.dpm_exception_summary_workflow_pack_execution_request_json
+    ),
+    "dpm_operations_handoff_summary.pack": (
+        fixtures.operations_handoff_summary_workflow_pack_execution_request_json
+    ),
+    "outcome_review_narrative.pack": (
+        fixtures.outcome_review_narrative_workflow_pack_execution_request_json
+    ),
+    "pm_quality_summary.pack": (fixtures.pm_quality_summary_workflow_pack_execution_request_json),
+    "idea_explanation.pack": fixtures.idea_explanation_workflow_pack_execution_request_json,
+    "proposal_memo_commentary.pack": (
+        fixtures.proposal_memo_commentary_workflow_pack_execution_request_json
+    ),
+}
+
+
+def _pack_request(pack_id: str) -> WorkflowPackExecutionRequest:
+    correlation_id = f"corr-contract-{pack_id.split('.')[0].replace('_', '-')}"
+    if pack_id in _COPILOT_VARIANTS:
+        surface, family = _COPILOT_VARIANTS[pack_id]
+        payload = fixtures.advisory_copilot_variant_workflow_pack_execution_request_json(
+            pack_id=pack_id,
+            workflow_surface=surface,
+            action_family=family,
+            correlation_id=correlation_id,
+        )
+    else:
+        payload = _HELPERS[pack_id](correlation_id=correlation_id)
+    return WorkflowPackExecutionRequest.model_validate(payload)
+
+
+def _registered_pack_ids() -> set[str]:
+    return {registration.pack_id for registration in build_seed_workflow_pack_registrations()}
+
+
+def test_every_registered_task_and_pack_family_has_exactly_one_contract() -> None:
+    task_ids = {task.task_id for task in build_capability_catalog().tasks}
+    expected = task_ids | _registered_pack_ids()
+    assert set(list_output_contract_keys()) == expected, (
+        "contracts/ai-task-outputs must hold exactly one contract per registered "
+        "task id and workflow-pack family - no gaps, no orphans"
+    )
+
+
+@pytest.mark.parametrize("pack_id", sorted(_registered_pack_ids()))
+def test_every_pack_family_executes_to_a_validated_output(pack_id: str) -> None:
+    response = execute_workflow_pack(_pack_request(pack_id))
+    execution = response.execution
+    assert execution.status == TaskExecutionStatus.COMPLETED
+    assert execution.output_validation is not None
+    assert execution.output_validation.validation_state is OutputValidationState.VALIDATED, (
+        f"{pack_id} output failed its contract: {execution.output_validation.findings}"
+    )
+
+
+def test_a_pack_without_a_contract_cannot_be_registered() -> None:
+    registration = get_workflow_pack_registration(pack_id="advisor_brief.pack", version="v1")
+    assert registration is not None
+    contractless = registration.model_copy(update={"pack_id": "uncontracted_family.pack"})
+    with pytest.raises(ValueError, match="uncontracted_family.pack"):
+        save_workflow_pack_registration(contractless)
+    assert not output_contract_exists("uncontracted_family.pack")
+
+
+def test_schema_violations_reject_in_promoted_and_warn_in_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services import output_contracts
+
+    directory = tmp_path / "ai-task-outputs"
+    directory.mkdir()
+    (directory / "strict.task.v1.json").write_text(
+        json.dumps(
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["message_kind"],
+                "properties": {"message_kind": {"type": "string"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(output_contracts, "_CONTRACTS_DIR", directory)
+    reset_output_contract_cache()
+    try:
+        nonconforming = {"message_kind": "summary", "unknown_extra": True}
+        local = validate_provider_output(
+            structured_output=nonconforming,
+            supplied_source_refs=[],
+            salvaged_json=False,
+            runtime_profile="local",
+            contract_key="strict.task",
+        )
+        assert local.validation_state is OutputValidationState.UNVALIDATED_LOCAL_ONLY
+        assert any("unknown_extra" in finding for finding in local.findings)
+        assert any("accepted with a warning" in finding for finding in local.findings)
+
+        promoted = validate_provider_output(
+            structured_output=nonconforming,
+            supplied_source_refs=[],
+            salvaged_json=False,
+            runtime_profile="promoted",
+            contract_key="strict.task",
+        )
+        assert promoted.validation_state is OutputValidationState.REJECTED
+        assert promoted.failed_rule_ids == ["output_schema"]
+
+        conforming = validate_provider_output(
+            structured_output={"message_kind": "summary"},
+            supplied_source_refs=[],
+            salvaged_json=False,
+            runtime_profile="promoted",
+            contract_key="strict.task",
+        )
+        assert conforming.validation_state is OutputValidationState.VALIDATED
+    finally:
+        reset_output_contract_cache()
+
+
+def test_missing_contract_fails_closed_in_promoted_and_marks_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services import output_contracts
+
+    directory = tmp_path / "ai-task-outputs"
+    directory.mkdir()
+    monkeypatch.setattr(output_contracts, "_CONTRACTS_DIR", directory)
+    reset_output_contract_cache()
+    try:
+        promoted = validate_provider_output(
+            structured_output={"anything": True},
+            supplied_source_refs=[],
+            salvaged_json=False,
+            runtime_profile="promoted",
+            contract_key="unwired.task",
+        )
+        assert promoted.validation_state is OutputValidationState.REJECTED
+        assert promoted.failed_rule_ids == ["contract_missing"]
+
+        local = validate_provider_output(
+            structured_output={"anything": True},
+            supplied_source_refs=[],
+            salvaged_json=False,
+            runtime_profile="local",
+            contract_key="unwired.task",
+        )
+        assert local.validation_state is OutputValidationState.UNVALIDATED_LOCAL_ONLY
+        assert any("accepted unvalidated" in finding for finding in local.findings)
+    finally:
+        reset_output_contract_cache()
+
+
+def test_contract_listing_is_empty_without_the_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services import output_contracts
+
+    monkeypatch.setattr(output_contracts, "_CONTRACTS_DIR", tmp_path / "absent")
+    assert output_contracts.list_output_contract_keys() == []
+
+
+def test_schema_violation_volume_is_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services import output_contracts
+
+    directory = tmp_path / "ai-task-outputs"
+    directory.mkdir()
+    (directory / "bounded.task.v1.json").write_text(
+        json.dumps(
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [f"field_{index}" for index in range(12)],
+                "properties": {f"field_{index}": {"type": "string"} for index in range(12)},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(output_contracts, "_CONTRACTS_DIR", directory)
+    reset_output_contract_cache()
+    try:
+        violations = output_contracts.schema_violations("bounded.task", {})
+        assert violations is not None
+        assert len(violations) == 11
+        assert violations[-1] == "further schema violations withheld from this summary"
+    finally:
+        reset_output_contract_cache()
+
+
+def test_live_advisor_brief_output_validates_under_the_pack_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pack contract carries both shapes: the stub branch (proven above)
+    and the live-transport branch normalized by the quality guardrails."""
+
+    from fastapi.testclient import TestClient
+
+    from app.config import settings
+    from app.main import app
+
+    settings.provider_mode = "local_openai_compatible"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    settings.live_text_provider_id = "text.local"
+    settings.live_text_model_id = "qwen2.5:1.5b"
+    settings.live_text_api_base = "http://ollama:11434/v1"
+    settings.live_text_allowed_task_ids = "explain.v1"
+    settings.live_text_input_cost_per_1k_tokens = 0.0
+    settings.live_text_output_cost_per_1k_tokens = 0.0
+    monkeypatch.setattr(
+        "app.services.provider_live_execution_state.build_local_openai_compatible_endpoint_status",
+        lambda: type(
+            "ProbeStatus",
+            (),
+            {"endpoint_reachable": True, "model_available": True, "blocking_reason": None},
+        )(),
+    )
+    monkeypatch.setattr(
+        "app.providers.openai_compatible_text_transport.post_openai_compatible_response",
+        lambda **_: {
+            "id": "resp_contract_live",
+            "model": "qwen2.5:1.5b",
+            "output_text": (
+                '{"grounded_summary":"All figures stayed within tolerance.",'
+                '"talking_points":[],"recommended_actions":[],"risks_and_exceptions":[]}'
+            ),
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        },
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/ai/tasks/execute",
+            json={
+                "task_id": "explain.v1",
+                "input_mode": "STRUCTURED_CONTEXT",
+                "caller": {
+                    "caller_app": "lotus-gateway",
+                    "correlation_id": "corr-contract-live-brief",
+                    "tenant_id": "tenant-sg-001",
+                },
+                "context": {
+                    "summary": "Generate Advisor Brief",
+                    "payload": {
+                        "portfolio": {"portfolio_id": "PB_X", "display_label": "PB X"},
+                        "period": {"period": "YTD"},
+                        "performance": {
+                            "portfolio_return_pct": 1.25,
+                            "benchmark_return_pct": 7.93,
+                            "active_return_pct": -6.68,
+                        },
+                        "supportability": [{"key": "performance_context", "value": "ready"}],
+                    },
+                    "source_refs": ["lotus-gateway:performance-summary:YTD"],
+                },
+                "expected_output_label": "EXPLANATION_ONLY",
+            },
+            headers={"X-Caller-App": "lotus-gateway"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "COMPLETED"
+    assert body["output_validation"]["validation_state"] == "VALIDATED", body["output_validation"][
+        "findings"
+    ]

--- a/tests/unit/test_output_validation.py
+++ b/tests/unit/test_output_validation.py
@@ -7,6 +7,8 @@ record; salvaged JSON is rejected in promoted and marked
 UNVALIDATED_LOCAL_ONLY in local; a validator fault fails closed.
 """
 
+from collections.abc import Generator
+
 import pytest
 
 from app.config import settings
@@ -26,12 +28,37 @@ from tests.unit.test_task_executor import _request
 GROUNDED_REFS = ["lotus-manage:run:reb_001", "lotus-manage:run:reb_002"]
 
 
+@pytest.fixture(autouse=True)
+def _permissive_rules_contract(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> Generator[None, None, None]:
+    """The rule-unit tests exercise one rule at a time against synthetic
+    outputs, so they run under a permissive contract in an isolated
+    contracts directory; the real committed contracts are exercised by the
+    end-to-end and per-contract tests."""
+
+    import json
+    import shutil
+    from pathlib import Path
+
+    from app.services import output_contracts
+
+    directory = Path(str(tmp_path)) / "ai-task-outputs"
+    shutil.copytree(output_contracts._CONTRACTS_DIR, directory)
+    (directory / "rules.test.v1.json").write_text(json.dumps({"type": "object"}), encoding="utf-8")
+    monkeypatch.setattr(output_contracts, "_CONTRACTS_DIR", directory)
+    output_contracts.reset_output_contract_cache()
+    yield
+    output_contracts.reset_output_contract_cache()
+
+
 def _validate(structured_output: object, **overrides: object) -> OutputValidationOutcome:
     kwargs: dict[str, object] = {
         "structured_output": structured_output,
         "supplied_source_refs": GROUNDED_REFS,
         "salvaged_json": False,
         "runtime_profile": "local",
+        "contract_key": "rules.test",
     }
     kwargs.update(overrides)
     return validate_provider_output(**kwargs)  # type: ignore[arg-type]


### PR DESCRIPTION
Part of #156 (S2 of the plan on the issue — output contracts as data). S3 (numeric grounding + advisor-brief guardrail unification) and S4 (eval unification + the issue's evaluation condition; closes the issue) follow.

## What this adds

**24 JSON Schema contracts under `contracts/ai-task-outputs/`** — one per registered task id (7) and one per workflow-pack family (17). Every contract was **derived from the implemented runtime, not invented**: each pack family was executed through the governed stub runtime (via the shared `workflow_pack_fixtures` helpers) and its actual structured output shaped into a Draft 2020-12 schema; the generic task contracts carry both the stub envelope and the live transport envelope as `anyOf` branches; `advisor_brief.pack` additionally carries the live-transport branch normalized by the quality guardrails, locked by a live-path test.

**The schema rule in the validator** (`output_schema`, ruleset bumped to `output-validation.v2`): contract resolution is by execution context — a pack-bound execution (explicit or inferred binding) validates against its pack family's contract, any other execution against its task id's contract — never by sniffing the output. Promoted rejects violations (`additionalProperties: false` enforced); local accepts with a warning and marks the output `UNVALIDATED_LOCAL_ONLY`. A missing contract (`contract_missing`) fails closed in promoted; registration makes that near-unreachable:

**A pack family without a contract cannot be registered** — enforced in `validate_workflow_pack_registrations` (the chokepoint every save passes through), with a test proving the refusal. The coverage test asserts **exact set equality** between `contracts/ai-task-outputs/` and the registered task ids + pack families: no gaps, no orphan contracts.

**`jsonschema>=4.25`** added as the schema engine — the issue's design names JSON Schema as the validation authority, and hand-rolling a schema checker would be the speculative abstraction. `output_contract_notes` is now documented as prompt guidance only.

**Dockerfile ships `contracts/`** (it previously only shipped alembic/docs/src/scripts — the loader anchors to the repo root in both layouts).

## Coverage finding fixed along the way

Five pack families had **no execution test anywhere** (`proposal_memo_commentary.pack` and the four advisory-copilot action packs — they appeared only in registry/health listing assertions). The new parametrized conformance test executes **all 17 families** to `COMPLETED` + `VALIDATED`, and the two new shared fixtures (`advisory_copilot_variant_workflow_pack_execution_request_json`, `proposal_memo_commentary_workflow_pack_execution_request_json`) make those five replayable by any future test.

## Tests (21 new in `test_output_contracts.py`)

Exact-set contract coverage; 17 per-family execute-to-VALIDATED proofs; registration refusal for a contractless family; promoted-rejects/local-warns schema semantics with a strict tmp contract (extra unknown field per the issue's edge case); the live advisor-brief path validating under the pack contract's live branch.

## Schema strictness posture (recorded)

Top-level keys are `required` (deterministic stubs produce stable envelopes); nested object properties are typed but individually optional (input-conditional entries vary legitimately); everything is `additionalProperties: false`, so a new output field is a contract change by construction — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
