### PR TITLE
feat(validation): numeric grounding + advisor-brief unification (#156 S3)

### DIFF
--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -560,9 +560,10 @@ Restart-survival expectations:
 Every AI task and workflow-pack execution passes deterministic output validation before safety redaction, and every response and audit record carries `output_validation` (`validation_state`, `authority=non_authoritative_ai_output`, the ruleset version, and any failed rule ids):
 
 1. `evidence_grounding` - every `source_ref`/`evidence_ref` value in the structured output must be one of the supplied request `source_refs`; violations reject in every profile
-2. `strict_json` - a provider answer recovered by balanced-brace salvage rejects in the promoted profile and marks the output `UNVALIDATED_LOCAL_ONLY` in local
-3. `output_schema` - the structured output must conform to the JSON Schema contract for its task id or (for pack-bound executions, explicit or inferred) its workflow-pack family, under `contracts/ai-task-outputs/`; violations reject in promoted and warn in local
-4. `contract_missing` - workflow-pack registration refuses a family without a contract, so a missing contract at execution time is a wiring defect: promoted fails closed
+2. `numeric_grounding` - every percent or currency token in output narrative must trace (within display tolerance) to a numeric value supplied in the execution context; violations reject in every profile. Bare numbers are deliberately out of scope. This generalises the advisor-brief token rules; there is no second implementation
+3. `strict_json` - a provider answer recovered by balanced-brace salvage rejects in the promoted profile and marks the output `UNVALIDATED_LOCAL_ONLY` in local
+4. `output_schema` - the structured output must conform to the JSON Schema contract for its task id or (for pack-bound executions, explicit or inferred) its workflow-pack family, under `contracts/ai-task-outputs/`; violations reject in promoted and warn in local
+5. `contract_missing` - workflow-pack registration refuses a family without a contract, so a missing contract at execution time is a wiring defect: promoted fails closed
 
 A `REJECTED` (or `VALIDATION_UNAVAILABLE`) verdict withholds the output whole: the caller receives `error_code=OUTPUT_VALIDATION_REJECTED` (or `VALIDATION_UNAVAILABLE`) with the failing rule ids, and the audit record persists carrying the verdict. `output_contract_notes` on task requests is prompt guidance only; the schema contract is the validation authority.
 

--- a/src/app/contracts/output_validation.py
+++ b/src/app/contracts/output_validation.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 AI_OUTPUT_AUTHORITY = "non_authoritative_ai_output"
-OUTPUT_VALIDATION_RULESET_VERSION = "output-validation.v2"
+OUTPUT_VALIDATION_RULESET_VERSION = "output-validation.v3"
 
 
 class OutputValidationState(str, Enum):

--- a/src/app/providers/advisor_brief_quality_guardrails.py
+++ b/src/app/providers/advisor_brief_quality_guardrails.py
@@ -18,8 +18,6 @@ _FORBIDDEN_SUMMARY_FRAGMENTS = (
     "advisor brief output contract",
     "task_id",
 )
-_PERCENT_TOKEN_PATTERN = re.compile(r"(?<![\w-])[-+]?\d+(?:\.\d+)?%")
-_CURRENCY_TOKEN_PATTERN = re.compile(r"(?<![\w-])[-+]?\$\d[\d,]*(?:\.\d+)?")
 
 
 @dataclass(frozen=True)
@@ -117,16 +115,6 @@ def normalize_advisor_brief_output(
             message=fallback_message,
             output=fallback_output,
             reason="invalid_grounded_summary_language",
-        )
-
-    if _has_numeric_consistency_mismatch(
-        grounded_summary=grounded_summary,
-        context_payload=context_payload,
-    ):
-        return _fallback_result(
-            message=fallback_message,
-            output=fallback_output,
-            reason="numeric_consistency_mismatch",
         )
 
     return AdvisorBriefQualityResult(
@@ -262,59 +250,6 @@ def _contains_forbidden_summary_language(value: str) -> bool:
     if normalized.startswith("{") or normalized.startswith("```") or "```" in normalized:
         return True
     return any(fragment in normalized for fragment in _FORBIDDEN_SUMMARY_FRAGMENTS)
-
-
-def _has_numeric_consistency_mismatch(
-    *,
-    grounded_summary: str,
-    context_payload: dict[str, Any],
-) -> bool:
-    performance = context_payload.get("performance")
-    if not isinstance(performance, dict):
-        return False
-    allowed_percents = [
-        float(
-            value
-        )  # monetary-float-ok: leak-detection comparison of caller-supplied display values
-        for value in (
-            performance.get("portfolio_return_pct"),
-            performance.get("benchmark_return_pct"),
-            performance.get("active_return_pct"),
-            performance.get("money_weighted_return_pct"),
-        )
-        if isinstance(value, int | float)
-    ]
-    allowed_currency_values = [
-        float(
-            value
-        )  # monetary-float-ok: leak-detection comparison of caller-supplied display values
-        for value in (
-            performance.get("net_cash_flow"),
-            performance.get("end_market_value"),
-        )
-        if isinstance(value, int | float)
-    ]
-
-    for token in _PERCENT_TOKEN_PATTERN.findall(grounded_summary):
-        try:
-            candidate = float(token.replace("%", "").replace(",", ""))
-        except ValueError:
-            continue
-        if not any(abs(candidate - expected) <= 0.02 for expected in allowed_percents):
-            return True
-
-    for token in _CURRENCY_TOKEN_PATTERN.findall(grounded_summary):
-        normalized = token.replace("$", "").replace(",", "")
-        if not normalized:
-            continue
-        try:
-            candidate = float(normalized)
-        except ValueError:
-            continue
-        if not any(abs(candidate - expected) <= 1.0 for expected in allowed_currency_values):
-            return True
-
-    return False
 
 
 def _clean_text(value: Any) -> str | None:

--- a/src/app/services/output_validation.py
+++ b/src/app/services/output_validation.py
@@ -26,6 +26,7 @@ unmarked output.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from app.contracts.output_validation import (
@@ -39,11 +40,21 @@ logger = logging.getLogger(__name__)
 RULE_EVIDENCE_GROUNDING = "evidence_grounding"
 RULE_STRICT_JSON = "strict_json"
 RULE_OUTPUT_SCHEMA = "output_schema"
+RULE_NUMERIC_GROUNDING = "numeric_grounding"
 RULE_CONTRACT_MISSING = "contract_missing"
 
 _REFERENCE_KEYS = frozenset({"source_ref", "source_refs", "evidence_ref", "evidence_refs"})
 _MAX_RECORDED_FINDINGS = 10
 _MAX_TRAVERSAL_DEPTH = 24
+
+# The advisor-brief token vocabulary, generalised (issue #156, S3): only
+# tokens that carry a percent or currency marker are policed - bare numbers
+# in narrative text are deliberately out of scope (counts, ordinals, and
+# dates would drown the signal).
+_PERCENT_TOKEN_PATTERN = re.compile(r"(?<![\w-])[-+]?\d+(?:\.\d+)?%")
+_CURRENCY_TOKEN_PATTERN = re.compile(r"(?<![\w-])[-+]?\$\d[\d,]*(?:\.\d+)?")
+_PERCENT_TOLERANCE = 0.02
+_CURRENCY_TOLERANCE = 1.0
 
 
 def validate_provider_output(
@@ -53,6 +64,7 @@ def validate_provider_output(
     salvaged_json: bool,
     runtime_profile: str,
     contract_key: str,
+    context_payload: dict[str, Any] | None = None,
 ) -> OutputValidationOutcome:
     try:
         return _validate(
@@ -61,6 +73,7 @@ def validate_provider_output(
             salvaged_json=salvaged_json,
             runtime_profile=runtime_profile,
             contract_key=contract_key,
+            context_payload=context_payload or {},
         )
     except Exception:  # noqa: BLE001 - a validator fault must fail closed, never fall open
         logger.exception("output validation fault; failing closed as VALIDATION_UNAVAILABLE")
@@ -77,6 +90,7 @@ def _validate(
     salvaged_json: bool,
     runtime_profile: str,
     contract_key: str,
+    context_payload: dict[str, Any],
 ) -> OutputValidationOutcome:
     failed_rule_ids: list[str] = []
     findings: list[str] = []
@@ -96,6 +110,17 @@ def _validate(
             findings.append(
                 f"{RULE_EVIDENCE_GROUNDING}: {len(unsupported) - _MAX_RECORDED_FINDINGS} "
                 "further unsupported references withheld from this summary"
+            )
+
+    ungrounded_tokens = _ungrounded_numeric_tokens(
+        structured_output, basis=_numeric_basis(context_payload)
+    )
+    if ungrounded_tokens:
+        failed_rule_ids.append(RULE_NUMERIC_GROUNDING)
+        for token in ungrounded_tokens[:_MAX_RECORDED_FINDINGS]:
+            findings.append(
+                f"{RULE_NUMERIC_GROUNDING}: narrative token '{token}' does not trace to "
+                "any numeric value supplied in the execution context"
             )
 
     if salvaged_json:
@@ -204,3 +229,82 @@ def _ungrounded_references(value: Any, *, supplied: set[str]) -> list[str]:
 
     walk(value, 0)
     return unsupported
+
+
+def _numeric_basis(context_payload: dict[str, Any]) -> list[float]:
+    """Every numeric value supplied anywhere in the execution context."""
+
+    basis: list[float] = []
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > _MAX_TRAVERSAL_DEPTH:
+            raise ValueError("context payload exceeds the validation traversal depth")
+        if isinstance(node, bool):
+            return
+        if isinstance(node, (int, float)):
+            basis.append(float(node))  # monetary-float-ok: leak-detection comparison basis
+            return
+        if isinstance(node, str):
+            try:
+                basis.append(  # monetary-float-ok: leak-detection comparison basis
+                    float(node.replace(",", ""))
+                )
+            except ValueError:
+                pass
+            return
+        if isinstance(node, dict):
+            for child in node.values():
+                walk(child, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+
+    walk(context_payload, 0)
+    return basis
+
+
+def _ungrounded_numeric_tokens(value: Any, *, basis: list[float]) -> list[str]:
+    """Percent/currency tokens in output narrative that trace to no supplied value."""
+
+    ungrounded: list[str] = []
+    seen: set[str] = set()
+
+    def check_text(text: str) -> None:
+        for token in _PERCENT_TOKEN_PATTERN.findall(text):
+            candidate = float(  # monetary-float-ok: leak-detection comparison of display token
+                token.replace("%", "").replace(",", "")
+            )
+            if (
+                not any(abs(candidate - expected) <= _PERCENT_TOLERANCE for expected in basis)
+                and token not in seen
+            ):
+                seen.add(token)
+                ungrounded.append(token)
+        for token in _CURRENCY_TOKEN_PATTERN.findall(text):
+            normalized = token.replace("$", "").replace(",", "")
+            if not normalized:
+                continue
+            candidate = float(  # monetary-float-ok: leak-detection comparison of display token
+                normalized
+            )
+            if (
+                not any(abs(candidate - expected) <= _CURRENCY_TOLERANCE for expected in basis)
+                and token not in seen
+            ):
+                seen.add(token)
+                ungrounded.append(token)
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > _MAX_TRAVERSAL_DEPTH:
+            raise ValueError("structured output exceeds the validation traversal depth")
+        if isinstance(node, str):
+            check_text(node)
+        elif isinstance(node, dict):
+            for child in node.values():
+                walk(child, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+
+    walk(value, 0)
+    return ungrounded

--- a/src/app/services/task_execution_pipeline.py
+++ b/src/app/services/task_execution_pipeline.py
@@ -61,6 +61,7 @@ def resolve_task_execution(
         salvaged_json=bool(provider_execution.structured_output.get("strict_json_salvaged", False)),
         runtime_profile=settings.runtime_profile,
         contract_key=contract_key,
+        context_payload=context.request.context.payload,
     )
     client_identifiers = _caller_redaction_identifiers(context.request.caller.caller_app)
     safe_provider_execution, safety_outcome = apply_safety_enforcement(

--- a/tests/unit/test_advisor_brief_quality_guardrails.py
+++ b/tests/unit/test_advisor_brief_quality_guardrails.py
@@ -73,7 +73,14 @@ def test_normalize_advisor_brief_output_falls_back_when_summary_leaks_contract_t
     assert result.structured_output["talking_points"]
 
 
-def test_normalize_advisor_brief_output_falls_back_on_numeric_consistency_mismatch() -> None:
+def test_numeric_fabrication_is_the_shared_validator_concern() -> None:
+    """The guardrail no longer silently recovers a summary that fabricates a
+    number (issue #156, S3): the shared numeric_grounding rule rejects the
+    output fail-closed instead - unsupported claims are rejected, not
+    annotated. The guardrail keeps only shaping and contract-echo recovery."""
+
+    from app.services.output_validation import validate_provider_output
+
     result = normalize_advisor_brief_output(
         parsed_output={
             "grounded_summary": (
@@ -88,10 +95,19 @@ def test_normalize_advisor_brief_output_falls_back_on_numeric_consistency_mismat
         context_payload=_advisor_context(),
         source_refs=["lotus-gateway:workbench:performance-summary:YTD"],
     )
+    assert result.guardrail_triggered is False
 
-    assert result.guardrail_triggered is True
-    assert result.guardrail_reason == "numeric_consistency_mismatch"
-    assert "PB SG GLOBAL BAL 001 delivered 1.25% over YTD" in result.message
+    outcome = validate_provider_output(
+        structured_output=result.structured_output,
+        supplied_source_refs=["lotus-gateway:workbench:performance-summary:YTD"],
+        salvaged_json=False,
+        runtime_profile="local",
+        contract_key="advisor_brief.pack",
+        context_payload=_advisor_context(),
+    )
+    assert outcome.validation_state.value == "REJECTED"
+    assert "numeric_grounding" in outcome.failed_rule_ids
+    assert any("6.80898%" in finding for finding in outcome.findings)
 
 
 def test_normalize_advisor_brief_output_falls_back_when_summary_is_missing() -> None:
@@ -128,7 +144,9 @@ def test_normalize_advisor_brief_output_rejects_code_fenced_summary() -> None:
     assert result.guardrail_reason == "invalid_grounded_summary_language"
 
 
-def test_normalize_advisor_brief_output_rejects_ungrounded_currency_claim() -> None:
+def test_ungrounded_currency_claim_is_the_shared_validator_concern() -> None:
+    from app.services.output_validation import validate_provider_output
+
     result = normalize_advisor_brief_output(
         parsed_output={
             "grounded_summary": "Portfolio cash flow was $999,999 over YTD.",
@@ -140,9 +158,19 @@ def test_normalize_advisor_brief_output_rejects_ungrounded_currency_claim() -> N
         context_payload=_advisor_context(),
         source_refs=["lotus-gateway:workbench:performance-summary:YTD"],
     )
+    assert result.guardrail_triggered is False
 
-    assert result.guardrail_triggered is True
-    assert result.guardrail_reason == "numeric_consistency_mismatch"
+    outcome = validate_provider_output(
+        structured_output=result.structured_output,
+        supplied_source_refs=["lotus-gateway:workbench:performance-summary:YTD"],
+        salvaged_json=False,
+        runtime_profile="local",
+        contract_key="advisor_brief.pack",
+        context_payload=_advisor_context(),
+    )
+    assert outcome.validation_state.value == "REJECTED"
+    assert "numeric_grounding" in outcome.failed_rule_ids
+    assert any("$999,999" in finding for finding in outcome.findings)
 
 
 def test_normalize_advisor_brief_output_preserves_clean_structured_brief() -> None:

--- a/tests/unit/test_output_validation.py
+++ b/tests/unit/test_output_validation.py
@@ -148,6 +148,46 @@ def test_both_rule_families_report_together() -> None:
     assert outcome.failed_rule_ids == ["evidence_grounding", "strict_json"]
 
 
+def test_numeric_grounding_traces_tokens_to_the_supplied_context() -> None:
+    payload = {"performance": {"portfolio_return_pct": 1.25, "net_cash_flow": 25000}}
+
+    grounded = _validate(
+        {"summary": "Returned 1.25% with $25,000 of net flows."}, context_payload=payload
+    )
+    assert grounded.validation_state is OutputValidationState.VALIDATED
+
+    fabricated = _validate(
+        {"summary": "Returned 6.8% with $999,999 of net flows."}, context_payload=payload
+    )
+    assert fabricated.validation_state is OutputValidationState.REJECTED
+    assert fabricated.failed_rule_ids == ["numeric_grounding"]
+    joined = "\n".join(fabricated.findings)
+    assert "6.8%" in joined and "$999,999" in joined
+
+
+def test_numeric_grounding_scans_nested_narrative_and_respects_tolerance() -> None:
+    payload = {"metrics": [{"value": "7.93"}], "count": 3}
+
+    within_tolerance = _validate(
+        {"sections": [{"detail": "Benchmark delivered 7.94% this period."}]},
+        context_payload=payload,
+    )
+    assert within_tolerance.validation_state is OutputValidationState.VALIDATED
+
+    nested_fabrication = _validate(
+        {"sections": [{"points": [{"detail": "Benchmark delivered 12.5% this period."}]}]},
+        context_payload=payload,
+    )
+    assert nested_fabrication.validation_state is OutputValidationState.REJECTED
+    assert nested_fabrication.failed_rule_ids == ["numeric_grounding"]
+
+    # Bare numbers are deliberately out of scope: only % and $ tokens police.
+    bare_numbers = _validate(
+        {"summary": "Reviewed 42 positions across 7 sleeves."}, context_payload=payload
+    )
+    assert bare_numbers.validation_state is OutputValidationState.VALIDATED
+
+
 def test_validator_fault_fails_closed_as_validation_unavailable() -> None:
     bomb: dict[str, object] = {}
     cursor = bomb


### PR DESCRIPTION
Part of #156 (S3 of the plan on the issue — numeric grounding + advisor-brief unification). S4 (eval unification + the issue's evaluation condition) follows and closes the issue.

## What this adds

**The `numeric_grounding` rule** (ruleset `output-validation.v3`): every percent or currency token in output narrative — any string leaf of the structured output, depth-bounded — must trace, within the established display tolerances (±0.02 for percents, ±1.0 for currency), to a numeric value supplied anywhere in the execution context payload. Violations reject in every profile. Bare numbers are deliberately out of scope (counts, ordinals, and dates would drown the signal) — the same bound the advisor-brief rules always had, now stated in the module contract.

**The advisor-brief guardrail is unified onto the shared validator — no second implementation.** `_has_numeric_consistency_mismatch` and its token patterns are deleted from `advisor_brief_quality_guardrails.py`; the guardrail keeps only output shaping and contract-echo recovery. This is a deliberate semantic strengthening, per the issue's invariant ("unsupported claims are rejected, not annotated"): a summary that fabricates a number previously fell back to a silently-served conservative brief; it now **rejects fail-closed** with `numeric_grounding` and the offending token in the findings. The two guardrail tests that asserted the silent fallback are re-pointed to assert the rejection.

The generalisation also **widens the basis honestly**: the old rule compared against six named advisor-brief performance fields; the issue defines the rule as "must trace to a supplied evidence value", so the basis is now every numeric supplied in the context payload (including numeric strings). For advisor-brief inputs the outcome is unchanged on all existing tests.

## Tests

Validator level: grounded percent+currency pass; fabricated tokens reject with both tokens named; nested-narrative scanning; tolerance boundary (7.94% vs supplied 7.93); bare numbers out of scope. Guardrail level: numeric fabrication and ungrounded currency now flow through `normalize → validator REJECTED` with the rule id, proving the single-implementation seam. The e2e sweep (task executor, task API contract incl. the live advisor-brief paths, promoted resilience) passes unchanged — the guardrail's deterministic fallback texts derive from payload values, so they ground by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
