### PR TITLE
fix(routing): attribute executions to the serving candidate's identity (#226)

### DIFF
--- a/src/app/providers/local_openai_compatible_text_provider.py
+++ b/src/app/providers/local_openai_compatible_text_provider.py
@@ -23,4 +23,5 @@ class LocalOpenAICompatibleTextProvider(TextGenerationProviderAdapter):
             require_api_key=False,
             model_id=config.model_id,
             model_version=config.model_version,
+            provider_id=config.provider_id,
         )

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -47,7 +47,13 @@ def execute_openai_compatible_text_request(
     require_api_key: bool,
     model_id: str | None,
     model_version: str | None,
+    provider_id: str | None = None,
 ) -> ProviderExecutionResponse:
+    # The serving identity is the execution config's provider id (issue
+    # #226): under ordered fallback both candidates run through the same
+    # adapter, so the static descriptor constant would attribute the
+    # alternate's executions to the primary in audit, cost, and metrics.
+    serving_provider_id = provider_id or descriptor.provider_id
     payload: dict[str, object] = {
         "model": model_id,
         "input": [
@@ -91,6 +97,7 @@ def execute_openai_compatible_text_request(
         response_payload=response_payload,
         output_message=output_message,
         configured_model_id=model_id,
+        provider_id=serving_provider_id,
     )
     input_tokens, output_tokens, total_tokens = extract_usage(response_payload)
     cost = estimate_live_text_cost(
@@ -99,7 +106,7 @@ def execute_openai_compatible_text_request(
         model_revision=model_version or model_id,
     )
     return ProviderExecutionResponse(
-        provider_id=descriptor.provider_id,
+        provider_id=serving_provider_id,
         provider_mode=descriptor.runtime_mode.value,
         adapter_kind=descriptor.adapter_kind,
         failure_category=None,
@@ -450,9 +457,10 @@ def build_structured_output(
     response_payload: dict[str, Any],
     output_message: str,
     configured_model_id: str | None = None,
+    provider_id: str | None = None,
 ) -> tuple[str, dict[str, Any]]:
     structured_output: dict[str, Any] = {
-        "provider_id": descriptor.provider_id,
+        "provider_id": provider_id or descriptor.provider_id,
         "provider_mode": descriptor.runtime_mode.value,
         "adapter_kind": descriptor.adapter_kind.value,
         "model_id": as_str(response_payload.get("model")) or configured_model_id,

--- a/src/app/providers/openai_live_text_provider.py
+++ b/src/app/providers/openai_live_text_provider.py
@@ -23,4 +23,5 @@ class OpenAILiveTextProvider(TextGenerationProviderAdapter):
             require_api_key=True,
             model_id=config.model_id,
             model_version=config.model_version,
+            provider_id=config.provider_id,
         )

--- a/tests/unit/test_ordered_fallback_routing.py
+++ b/tests/unit/test_ordered_fallback_routing.py
@@ -442,3 +442,72 @@ def test_routing_posture_names_both_candidates_under_ordered_fallback() -> None:
     assert fixed_posture.strategy is RoutingStrategy.FIXED
     assert fixed_posture.fallback_candidate is None
     assert fixed_posture.fallback_degradation is None
+
+
+def test_real_transport_attributes_the_alternate_identity_end_to_end() -> None:
+    """Issue #226: the REAL transport must stamp the serving candidate's
+    configured identity - not the static adapter descriptor - on the
+    response, the structured output, and the audit record. Fakes live only
+    at the HTTP boundary (the transport post override seam)."""
+
+    from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
+    from app.contracts.tasks import (
+        CallerMetadata,
+        OutputLabel,
+        TaskContextEnvelope,
+        TaskExecutionRequest,
+        TaskInputMode,
+    )
+    from app.providers.base import ProviderExecutionError
+    from app.services.audit_store import get_audit_store
+    from app.services.provider_execution_overrides import override_text_transport_post
+    from app.services.task_executor import execute_task
+
+    _ordered_fallback_settings()
+    settings.live_text_provider_api_key = "primary-secret"
+
+    calls: list[str] = []
+
+    def transport_post(**kwargs: object) -> dict[str, object]:
+        api_base = str(kwargs["api_base"])
+        calls.append(api_base)
+        if api_base == settings.live_text_api_base:
+            raise ProviderExecutionError(
+                category=ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR,
+                message="simulated primary upstream failure",
+            )
+        return {
+            "id": "resp_alternate_serving",
+            "model": "claude-sonnet-5",
+            "output_text": "Grounded explanation without figures.",
+            "usage": {"input_tokens": 9, "output_tokens": 4, "total_tokens": 13},
+        }
+
+    with override_text_transport_post(transport_post):
+        response = execute_task(
+            TaskExecutionRequest(
+                task_id="explain.v1",
+                input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+                caller=CallerMetadata(
+                    caller_app="lotus-manage",
+                    correlation_id="corr-226-attribution",
+                    tenant_id="tenant-sg-001",
+                ),
+                context=TaskContextEnvelope(
+                    summary="Explain rebalance outcome",
+                    payload={"status": "BLOCKED", "rule_count": 3},
+                    source_refs=["lotus-manage:run:reb_001"],
+                ),
+                expected_output_label=OutputLabel.EXPLANATION_ONLY,
+            )
+        )
+
+    assert len(calls) == 2
+    assert response.audit.provider_id == ALTERNATE
+    assert response.result.structured_output["provider_id"] == ALTERNATE
+    assert response.audit.routing_decision is not None
+    assert response.audit.routing_decision.selected_provider_id == ALTERNATE
+
+    records = get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=5)
+    record = next(r for r in records if r.correlation_id == "corr-226-attribution")
+    assert record.provider_id == ALTERNATE


### PR DESCRIPTION
Closes #226. Found by adversarial cross-session review of the #176 S3 merge.

**Defect**: the transport stamped every response with the static per-mode adapter descriptor id, never the execution config's provider id. Under `routing_strategy=ordered_fallback` both candidates run through the same adapter, so an execution served by the governed alternate was attributed to the **primary** in the audit row, structured output, provider-resolution evidence, metrics labels, and cost identity — while `routing_decision.selected_provider_id` correctly named the alternate. Explainable routing that logs the wrong identity defeats #176's purpose.

**Fix**: `execute_openai_compatible_text_request` and `build_structured_output` take the serving `provider_id` (descriptor remains the fallback for unconfigured/stub modes); both live providers pass `config.provider_id`.

**Why the tests missed it**: the ordered-fallback unit fake returned `provider_id=config.provider_id` — behavior the real transport did not have. The new regression drives the **real transport** with a fake only at the HTTP boundary (the transport post override seam), dispatching by `api_base`, and asserts the alternate's identity on the response audit metadata, the structured output, **and** the persisted audit record. Standing lesson recorded: a fake must never model behavior the real code lacks.

Full suite 2118 passed (98.61%); lint, typecheck green.