### PR TITLE
fix(validation): validate the narrative channel, not just structured output (#227)

### DIFF
--- a/src/app/contracts/output_validation.py
+++ b/src/app/contracts/output_validation.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 AI_OUTPUT_AUTHORITY = "non_authoritative_ai_output"
-OUTPUT_VALIDATION_RULESET_VERSION = "output-validation.v3"
+OUTPUT_VALIDATION_RULESET_VERSION = "output-validation.v4"
 
 
 class OutputValidationState(str, Enum):

--- a/src/app/services/output_validation.py
+++ b/src/app/services/output_validation.py
@@ -56,6 +56,15 @@ _CURRENCY_TOKEN_PATTERN = re.compile(r"(?<![\w-])[-+]?\$\d[\d,]*(?:\.\d+)?")
 _PERCENT_TOLERANCE = 0.02
 _CURRENCY_TOLERANCE = 1.0
 
+# The bounded platform reference grammar (issue #227): a narrative token
+# shaped like a Lotus evidence reference must trace to supplied evidence.
+# Only `lotus-*` prefixed tokens are policed - prose punctuation and
+# ordinary words can never be mistaken for a citation.
+# Each segment may contain dots (hashes, file-ish ids) but must END on an
+# identifier character, so sentence punctuation is never swallowed into the
+# token - a trailing period would otherwise fabricate a mismatch.
+_PLATFORM_REF_PATTERN = re.compile(r"\blotus-[a-z0-9-]+(?::[A-Za-z0-9._@-]*[A-Za-z0-9_-])+")
+
 
 def validate_provider_output(
     *,
@@ -65,6 +74,7 @@ def validate_provider_output(
     runtime_profile: str,
     contract_key: str,
     context_payload: dict[str, Any] | None = None,
+    message: str = "",
 ) -> OutputValidationOutcome:
     try:
         return _validate(
@@ -74,6 +84,7 @@ def validate_provider_output(
             runtime_profile=runtime_profile,
             contract_key=contract_key,
             context_payload=context_payload or {},
+            message=message,
         )
     except Exception:  # noqa: BLE001 - a validator fault must fail closed, never fall open
         logger.exception("output validation fault; failing closed as VALIDATION_UNAVAILABLE")
@@ -91,13 +102,22 @@ def _validate(
     runtime_profile: str,
     contract_key: str,
     context_payload: dict[str, Any],
+    message: str,
 ) -> OutputValidationOutcome:
     failed_rule_ids: list[str] = []
     findings: list[str] = []
     local_only = False
 
-    unsupported = _ungrounded_references(
-        structured_output, supplied={ref for ref in supplied_source_refs if ref}
+    supplied = {ref for ref in supplied_source_refs if ref}
+    unsupported = _ungrounded_references(structured_output, supplied=supplied)
+    # The narrative channel carries the model's own words: for every family
+    # except advisor-brief the live transport returns them only as the
+    # message, so a citation fabricated there would never be seen if the
+    # structured output alone were validated (issue #227).
+    unsupported.extend(
+        _ungrounded_narrative_citations(
+            message, supplied=supplied, structured_output=structured_output
+        )
     )
     if unsupported:
         failed_rule_ids.append(RULE_EVIDENCE_GROUNDING)
@@ -112,9 +132,11 @@ def _validate(
                 "further unsupported references withheld from this summary"
             )
 
-    ungrounded_tokens = _ungrounded_numeric_tokens(
-        structured_output, basis=_numeric_basis(context_payload)
-    )
+    numeric_basis = _numeric_basis(context_payload)
+    ungrounded_tokens = _ungrounded_numeric_tokens(structured_output, basis=numeric_basis)
+    for token in _ungrounded_numeric_tokens(message, basis=numeric_basis):
+        if token not in ungrounded_tokens:
+            ungrounded_tokens.append(token)
     if ungrounded_tokens:
         failed_rule_ids.append(RULE_NUMERIC_GROUNDING)
         for token in ungrounded_tokens[:_MAX_RECORDED_FINDINGS]:
@@ -308,3 +330,52 @@ def _ungrounded_numeric_tokens(value: Any, *, basis: list[float]) -> list[str]:
 
     walk(value, 0)
     return ungrounded
+
+
+def _ungrounded_narrative_citations(
+    message: str, *, supplied: set[str], structured_output: Any
+) -> list[str]:
+    """Platform-reference tokens in narrative that trace to no evidence.
+
+    The basis is the supplied references plus references the validated
+    structured channel already carries - including the composite form a
+    retrieval citation entry declares as ``source_id`` + ``document_id``,
+    which the narrative renders joined. A token that appears ONLY in the
+    narrative is exactly the fabrication this rule exists to catch.
+    """
+
+    if not message:
+        return []
+    basis = supplied | _structured_reference_basis(structured_output)
+    ungrounded: list[str] = []
+    seen: set[str] = set()
+    for token in _PLATFORM_REF_PATTERN.findall(message):
+        if token in basis or token in seen:
+            continue
+        seen.add(token)
+        ungrounded.append(token)
+    return ungrounded
+
+
+def _structured_reference_basis(structured_output: Any) -> set[str]:
+    basis: set[str] = set()
+
+    def walk(node: Any, depth: int) -> None:
+        if depth > _MAX_TRAVERSAL_DEPTH:
+            raise ValueError("structured output exceeds the validation traversal depth")
+        if isinstance(node, str):
+            basis.add(node)
+        elif isinstance(node, dict):
+            source_id = node.get("source_id")
+            document_id = node.get("document_id")
+            if isinstance(source_id, str) and isinstance(document_id, str):
+                # The declared citation shape, rendered joined in narrative.
+                basis.add(f"{source_id}:{document_id}")
+            for child in node.values():
+                walk(child, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, depth + 1)
+
+    walk(structured_output, 0)
+    return basis

--- a/src/app/services/task_execution_pipeline.py
+++ b/src/app/services/task_execution_pipeline.py
@@ -62,6 +62,7 @@ def resolve_task_execution(
         runtime_profile=settings.runtime_profile,
         contract_key=contract_key,
         context_payload=context.request.context.payload,
+        message=provider_execution.message,
     )
     client_identifiers = _caller_redaction_identifiers(context.request.caller.caller_app)
     safe_provider_execution, safety_outcome = apply_safety_enforcement(

--- a/tests/integration/test_output_validation_evaluation_condition.py
+++ b/tests/integration/test_output_validation_evaluation_condition.py
@@ -12,7 +12,10 @@ eval-path execution.
 import pytest
 
 from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
-from app.contracts.output_validation import OutputValidationState
+from app.contracts.output_validation import (
+    OUTPUT_VALIDATION_RULESET_VERSION,
+    OutputValidationState,
+)
 from app.contracts.tasks import TaskExecutionStatus
 from app.contracts.workflow_packs import WorkflowPackExecutionRequest
 from app.services.audit_store import get_audit_store
@@ -149,4 +152,4 @@ def test_eval_path_executions_carry_the_same_validation_verdict() -> None:
     )
     assert response.output_validation is not None
     assert response.output_validation.validation_state is OutputValidationState.VALIDATED
-    assert response.output_validation.ruleset_version == "output-validation.v3"
+    assert response.output_validation.ruleset_version == OUTPUT_VALIDATION_RULESET_VERSION

--- a/tests/unit/test_narrative_channel_validation.py
+++ b/tests/unit/test_narrative_channel_validation.py
@@ -1,0 +1,233 @@
+"""The narrative channel is validated too (issue #227).
+
+For every family except advisor-brief the live transport returns the
+model's words only as the message, so validating the structured output
+alone let a fabricated figure or citation reach consumers marked
+VALIDATED. These tests drive the REAL transport with a fake only at the
+HTTP boundary, and pin the rule that a reference appearing ONLY in the
+narrative is never self-grounding.
+"""
+
+from collections.abc import Generator
+
+import pytest
+
+from app.config import settings
+from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
+from app.contracts.output_validation import OutputValidationOutcome, OutputValidationState
+from app.contracts.tasks import (
+    CallerMetadata,
+    OutputLabel,
+    TaskContextEnvelope,
+    TaskExecutionRequest,
+    TaskExecutionStatus,
+    TaskInputMode,
+)
+from app.services.audit_store import get_audit_store
+from app.services.output_validation import validate_provider_output
+from app.services.provider_execution_overrides import override_text_transport_post
+from app.services.task_executor import execute_task
+
+SUPPLIED_REF = "lotus-manage:run:reb_001"
+
+
+@pytest.fixture(autouse=True)
+def _permissive_rules_contract(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> Generator[None, None, None]:
+    """The rule-unit cases below use synthetic outputs, so they resolve a
+    permissive contract from an isolated directory that still carries the
+    real contracts the end-to-end cases resolve."""
+
+    import json
+    import shutil
+    from pathlib import Path
+
+    from app.services import output_contracts
+
+    directory = Path(str(tmp_path)) / "ai-task-outputs"
+    shutil.copytree(output_contracts._CONTRACTS_DIR, directory)
+    (directory / "rules.test.v1.json").write_text(json.dumps({"type": "object"}), encoding="utf-8")
+    monkeypatch.setattr(output_contracts, "_CONTRACTS_DIR", directory)
+    output_contracts.reset_output_contract_cache()
+    yield
+    output_contracts.reset_output_contract_cache()
+
+
+def _validate(message: str, structured_output: dict[str, object]) -> OutputValidationOutcome:
+    return validate_provider_output(
+        structured_output=structured_output,
+        supplied_source_refs=[SUPPLIED_REF],
+        salvaged_json=False,
+        runtime_profile="local",
+        contract_key="rules.test",
+        context_payload={"performance": {"portfolio_return_pct": 1.25}},
+        message=message,
+    )
+
+
+def test_a_reference_only_in_the_narrative_is_never_self_grounding() -> None:
+    outcome = _validate("Reviewed per lotus-manage:doc:999.", {"provider_id": "text.stub"})
+    assert outcome.validation_state is OutputValidationState.REJECTED
+    assert outcome.failed_rule_ids == ["evidence_grounding"]
+    assert any("lotus-manage:doc:999" in finding for finding in outcome.findings)
+
+
+def test_supplied_and_structured_references_ground_the_narrative() -> None:
+    supplied = _validate(f"Grounded in {SUPPLIED_REF}.", {"provider_id": "text.stub"})
+    assert supplied.validation_state is OutputValidationState.VALIDATED
+
+    # The retrieval citation shape: the structured channel declares
+    # source_id + document_id, the narrative renders them joined.
+    composed = _validate(
+        "Sources: lotus-platform-rfcs:doc-1.",
+        {
+            "provider_id": "retrieval.catalog",
+            "citations": [{"source_id": "lotus-platform-rfcs", "document_id": "doc-1"}],
+        },
+    )
+    assert composed.validation_state is OutputValidationState.VALIDATED
+
+
+def test_narrative_numbers_must_trace_to_supplied_values() -> None:
+    grounded = _validate("The portfolio returned 1.25%.", {"provider_id": "text.stub"})
+    assert grounded.validation_state is OutputValidationState.VALIDATED
+
+    fabricated = _validate("The portfolio returned 42.5%.", {"provider_id": "text.stub"})
+    assert fabricated.validation_state is OutputValidationState.REJECTED
+    assert fabricated.failed_rule_ids == ["numeric_grounding"]
+    assert any("42.5%" in finding for finding in fabricated.findings)
+
+
+def _live_summarize_settings() -> None:
+    settings.provider_mode = "local_openai_compatible"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    settings.live_text_provider_id = "text.local"
+    settings.live_text_model_id = "qwen3:8b"
+    settings.live_text_api_base = "http://ollama:11434/v1"
+    settings.live_text_allowed_task_ids = "summarize.v1"
+
+
+def _summarize_request(correlation_id: str) -> TaskExecutionRequest:
+    return TaskExecutionRequest(
+        task_id="summarize.v1",
+        input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+        caller=CallerMetadata(
+            caller_app="lotus-manage",
+            correlation_id=correlation_id,
+            tenant_id="tenant-sg-001",
+        ),
+        context=TaskContextEnvelope(
+            summary="Summarize the rebalance outcome",
+            payload={"status": "BLOCKED", "rule_count": 3},
+            source_refs=[SUPPLIED_REF],
+        ),
+        expected_output_label=OutputLabel.DRAFT,
+    )
+
+
+def test_live_message_only_fabrication_is_rejected_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defect this issue was filed for: a live non-advisor-brief family
+    returns its narrative solely as the message, and a fabricated figure
+    plus a fabricated citation there must not reach a consumer VALIDATED."""
+
+    _live_summarize_settings()
+    monkeypatch.setattr(
+        "app.services.provider_live_execution_state.build_local_openai_compatible_endpoint_status",
+        lambda: type(
+            "ProbeStatus",
+            (),
+            {"endpoint_reachable": True, "model_available": True, "blocking_reason": None},
+        )(),
+    )
+
+    fabricated = "The portfolio returned 42.5% (per lotus-manage:doc:999)."
+    with override_text_transport_post(
+        lambda **_: {
+            "id": "resp_narrative_fabrication",
+            "model": "qwen3:8b",
+            "output_text": fabricated,
+            "usage": {"input_tokens": 10, "output_tokens": 6, "total_tokens": 16},
+        }
+    ):
+        response = execute_task(_summarize_request("corr-227-fabrication"))
+
+    assert response.status == TaskExecutionStatus.REJECTED
+    assert response.output_validation is not None
+    assert response.output_validation.validation_state is OutputValidationState.REJECTED
+    assert response.output_validation.failed_rule_ids == [
+        "evidence_grounding",
+        "numeric_grounding",
+    ]
+    # Withheld whole: neither the figure nor the citation leaves the service.
+    assert "42.5%" not in response.result.message
+    assert "lotus-manage:doc:999" not in response.result.message
+
+    records = get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=5)
+    record = next(r for r in records if r.correlation_id == "corr-227-fabrication")
+    assert record.execution_status == TaskExecutionStatus.REJECTED
+    assert "42.5%" not in record.result_preview
+
+
+def test_live_grounded_narrative_is_validated_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _live_summarize_settings()
+    monkeypatch.setattr(
+        "app.services.provider_live_execution_state.build_local_openai_compatible_endpoint_status",
+        lambda: type(
+            "ProbeStatus",
+            (),
+            {"endpoint_reachable": True, "model_available": True, "blocking_reason": None},
+        )(),
+    )
+
+    with override_text_transport_post(
+        lambda **_: {
+            "id": "resp_narrative_grounded",
+            "model": "qwen3:8b",
+            "output_text": f"The rebalance is blocked; see {SUPPLIED_REF}.",
+            "usage": {"input_tokens": 10, "output_tokens": 6, "total_tokens": 16},
+        }
+    ):
+        response = execute_task(_summarize_request("corr-227-grounded"))
+
+    assert response.status == TaskExecutionStatus.COMPLETED
+    assert response.output_validation is not None
+    assert response.output_validation.validation_state is OutputValidationState.VALIDATED
+
+
+def test_knowledge_answer_citations_are_not_false_positives() -> None:
+    """The deterministic retrieval answer renders its citations as
+    `source_id:document_id` in the narrative while the structured channel
+    declares the parts - it must stay VALIDATED."""
+
+    response = execute_task(
+        TaskExecutionRequest(
+            task_id="knowledge_answer.v1",
+            input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+            caller=CallerMetadata(
+                caller_app="lotus-manage",
+                correlation_id="corr-227-knowledge",
+                tenant_id="tenant-sg-001",
+            ),
+            context=TaskContextEnvelope(
+                summary="Answer from approved sources",
+                payload={
+                    "query": "shared ai platform service",
+                    "source_ids": ["lotus-platform-rfcs"],
+                    "limit": 3,
+                },
+                source_refs=["lotus-manage:knowledge-answer:001"],
+            ),
+            expected_output_label=OutputLabel.RETRIEVAL_ANSWER,
+        )
+    )
+
+    assert response.status == TaskExecutionStatus.COMPLETED
+    assert response.output_validation is not None
+    assert response.output_validation.validation_state is OutputValidationState.VALIDATED, (
+        response.output_validation.findings
+    )


### PR DESCRIPTION
Closes #227. Found by adversarial cross-session review of the #156 programme.

**Defect**: the pipeline passed only `structured_output` to the validator, but for every family except advisor-brief the live transport returns the model's narrative **solely as the message** — which `task_execution_mapping` then serves as `result.message` under a VALIDATED verdict. A live `summarize.v1` answering "The portfolio returned 42.5% (per lotus-manage:doc:999)" reached consumers VALIDATED with a fabricated figure and a fabricated citation. The #156 invariant held only for advisor-brief and stub envelopes.

**Fix** (ruleset `output-validation.v4`): the message is a first-class validator input.
- `numeric_grounding` scans the narrative — percent/currency tokens must trace to supplied context values.
- `evidence_grounding` extends to narrative citations via a bounded platform-reference grammar (`lotus-*` tokens only, so prose can never be mistaken for a citation). The basis is supplied refs ∪ references the validated structured channel already carries, **including** the composite `source_id:document_id` form a retrieval citation entry declares and the narrative renders joined. A reference appearing **only** in the narrative is never self-grounding — pinned by test at the reviewer's request.

**A regression that earned its keep immediately**: the knowledge-answer false-positive guard caught the reference pattern swallowing a sentence-ending period (`…rfc-0068.`) and rejecting a legitimate deterministic retrieval answer; segments must now end on an identifier character.

**Test fidelity**: both end-to-end cases drive the **real transport** with a fake only at the HTTP boundary — the S4 proof had placed its fabrication inside `structured_output`, a shape no shipped adapter produces for these families. Six new tests; full suite 2123 passed (98.61%); lint, typecheck, and the eval-run gate green.