### PR TITLE
fix(ci): gate every merged commit, and audit that coverage fail-closed (#236)

### DIFF
--- a/.github/workflows/main-gate-coverage-audit.yml
+++ b/.github/workflows/main-gate-coverage-audit.yml
@@ -1,0 +1,34 @@
+name: Main Gate Coverage Audit
+
+on:
+  schedule:
+    # Daily: proves every commit on main carries a verdict-bearing gate run.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "How many recent main commits to audit"
+        required: false
+        default: "50"
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  audit-main-gate-coverage:
+    name: Audit Main Gate Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Audit main gate coverage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/audit_main_gate_coverage.py \
+            --limit "${{ github.event.inputs.limit || '50' }}" \
+            --fail-on-gap

--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -13,8 +13,11 @@ on:
         type: string
 
 concurrency:
+  # Evidence runs QUEUE, they never cancel each other (issue #236): a cancelled
+  # run reaches no verdict, so cancelling one would silently delete the only
+  # proof a commit was ever validated.
   group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -9,18 +9,65 @@ permissions:
   contents: write
 
 jobs:
-  dispatch-main-releasability:
-    name: Dispatch Main Releasability
+  enumerate-merged-commits:
+    name: Enumerate Merged Commits
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      commit_shas: ${{ steps.enumerate.outputs.commit_shas }}
+    steps:
+      - name: Enumerate every commit this pull request merged
+        id: enumerate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          set -euo pipefail
+          if [ -z "$MERGE_COMMIT_SHA" ]; then
+            echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
+            exit 1
+          fi
+          if [ -z "${PR_COMMIT_COUNT:-}" ] || [ "$PR_COMMIT_COUNT" -lt 1 ]; then
+            echo "::error::pull_request.commits is required to gate every merged commit"
+            exit 1
+          fi
+
+          # This repository merges by rebase, so the pull request contributes
+          # PR_COMMIT_COUNT commits to main and every one of them must be gated,
+          # not only the tip (issue #236). The enumeration below is correct ONLY
+          # under rebase-only merging, so assert that loudly before relying on it.
+          merge_settings="$(gh api "repos/$GITHUB_REPOSITORY"             --jq '[.allow_squash_merge, .allow_merge_commit, .allow_rebase_merge] | join(",")')"
+          if [ "$merge_settings" != "false,false,true" ]; then
+            echo "::error::Per-commit gate dispatch assumes rebase-only merging; repository merge settings are $merge_settings"
+            exit 1
+          fi
+
+          commit_shas="$(gh api             "repos/$GITHUB_REPOSITORY/commits?sha=$MERGE_COMMIT_SHA&per_page=$PR_COMMIT_COUNT"             --jq '[.[].sha]')"
+          resolved_count="$(printf '%s' "$commit_shas" | jq 'length')"
+          if [ "$resolved_count" -ne "$PR_COMMIT_COUNT" ]; then
+            echo "::error::Expected $PR_COMMIT_COUNT merged commits, resolved $resolved_count"
+            exit 1
+          fi
+          echo "commit_shas=$commit_shas" >> "$GITHUB_OUTPUT"
+
+  dispatch-main-releasability:
+    name: Dispatch Main Releasability
+    needs: enumerate-merged-commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        commit_sha: ${{ fromJSON(needs.enumerate-merged-commits.outputs.commit_shas) }}
     steps:
       - name: Dispatch main releasability gate
         env:
           GH_TOKEN: ${{ github.token }}
-          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          MERGE_COMMIT_SHA: ${{ matrix.commit_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail

--- a/scripts/audit_main_gate_coverage.py
+++ b/scripts/audit_main_gate_coverage.py
@@ -17,7 +17,11 @@ import sys
 
 REPOSITORY = "sgajbi/lotus-ai"
 WORKFLOW_NAME = "Main Releasability Gate"
-VERDICT_CONCLUSIONS = frozenset({"success", "failure", "timed_out", "neutral"})
+# A verdict is a conclusion that actually evaluated the tree. "neutral" is
+# deliberately absent: it concludes without evaluating, so counting it would
+# mask exactly the gap this audit exists to find. "timed_out" stays - it is
+# conclusively failed, which is information.
+VERDICT_CONCLUSIONS = frozenset({"success", "failure", "timed_out"})
 
 
 class AuditError(RuntimeError):
@@ -54,6 +58,13 @@ def assert_rebase_only_merging() -> None:
 
 
 def main_commits(limit: int) -> list[str]:
+    """The most recent commits on main, newest first.
+
+    Listing by ``sha=main`` walks first parents, which enumerates exactly the
+    commits on main ONLY because history is linear - the rebase-only assertion
+    above is what guarantees that. Do not loosen one without the other.
+    """
+
     raw = _gh(
         "api",
         f"repos/{REPOSITORY}/commits?sha=main&per_page={limit}",

--- a/scripts/audit_main_gate_coverage.py
+++ b/scripts/audit_main_gate_coverage.py
@@ -1,0 +1,117 @@
+"""Audit Main Releasability coverage of every commit on main (issue #236).
+
+The merged-PR dispatcher fires once per pull request; this repository
+merges by rebase, so a PR of N commits puts N commits on main. This audit
+proves every one of them carries a verdict-bearing gate run, and it FAILS
+CLOSED: an unreadable run listing, a missing tool, or a run that reached
+no verdict (cancelled, skipped, still running) is a gap, never a pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+
+REPOSITORY = "sgajbi/lotus-ai"
+WORKFLOW_NAME = "Main Releasability Gate"
+VERDICT_CONCLUSIONS = frozenset({"success", "failure", "timed_out", "neutral"})
+
+
+class AuditError(RuntimeError):
+    """Any condition that leaves coverage unknown - always a failure."""
+
+
+def _gh(*args: str) -> str:
+    if shutil.which("gh") is None:
+        raise AuditError("the gh CLI is unavailable, so gate coverage cannot be verified")
+    completed = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise AuditError(
+            f"gh {' '.join(args)} failed with exit {completed.returncode}: "
+            f"{completed.stderr.strip()[:300]}"
+        )
+    return completed.stdout
+
+
+def assert_rebase_only_merging() -> None:
+    """The per-commit enumeration is only correct under rebase merging."""
+
+    raw = _gh(
+        "api",
+        f"repos/{REPOSITORY}",
+        "--jq",
+        "{squash: .allow_squash_merge, merge: .allow_merge_commit, rebase: .allow_rebase_merge}",
+    )
+    settings = json.loads(raw)
+    if settings != {"squash": False, "merge": False, "rebase": True}:
+        raise AuditError(
+            "main-gate coverage assumes rebase-only merging; repository merge settings are "
+            f"{settings} - update the dispatcher enumeration before changing them"
+        )
+
+
+def main_commits(limit: int) -> list[str]:
+    raw = _gh(
+        "api",
+        f"repos/{REPOSITORY}/commits?sha=main&per_page={limit}",
+        "--jq",
+        ".[].sha",
+    )
+    commits = [line.strip() for line in raw.splitlines() if line.strip()]
+    if not commits:
+        raise AuditError("no commits returned for main; coverage is unknown")
+    return commits
+
+
+def has_verdict_bearing_run(commit_sha: str) -> bool:
+    raw = _gh(
+        "run",
+        "list",
+        "--repo",
+        REPOSITORY,
+        "--commit",
+        commit_sha,
+        "--workflow",
+        WORKFLOW_NAME,
+        "--json",
+        "status,conclusion",
+    )
+    runs = json.loads(raw or "[]")
+    return any(
+        run.get("status") == "completed" and run.get("conclusion") in VERDICT_CONCLUSIONS
+        for run in runs
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument(
+        "--fail-on-gap",
+        action="store_true",
+        help="exit non-zero when any commit lacks a verdict-bearing gate run",
+    )
+    arguments = parser.parse_args()
+
+    try:
+        assert_rebase_only_merging()
+        commits = main_commits(arguments.limit)
+        gaps = [sha for sha in commits if not has_verdict_bearing_run(sha)]
+    except AuditError as error:
+        # Fail closed: unknown coverage is never reported as covered.
+        print(f"main gate coverage audit FAILED: {error}")
+        return 1
+
+    print(f"main gate coverage: {len(commits) - len(gaps)}/{len(commits)} commits verdict-bearing")
+    for sha in gaps:
+        print(f"  GAP {sha}")
+    if gaps and arguments.fail_on_gap:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_ci_workflow_contracts.py
+++ b/tests/unit/test_ci_workflow_contracts.py
@@ -75,6 +75,13 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
         )
     dispatch_contract_text = dispatch_step_text or text
     required_fragments = (
+        # Per-commit fan-out (issue #236): every commit a rebase-merged pull
+        # request puts on main is gated, and the enumeration is asserted to be
+        # correct only under rebase-only merge settings.
+        "PR_COMMIT_COUNT",
+        "false,false,true",
+        "fromJSON(needs.enumerate-merged-commits.outputs.commit_shas)",
+        "MERGE_COMMIT_SHA: ${{ matrix.commit_sha }}",
         "pull_request_target:",
         "types: [closed]",
         "actions: write",
@@ -96,7 +103,6 @@ def _merged_pr_dispatch_contract_errors(text: str) -> list[str]:
     for fragment in required_fragments:
         search_text = text
         if fragment in {
-            "github.event.pull_request.merge_commit_sha",
             'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
             'existing_ref_sha=""',
             "repos/$GITHUB_REPOSITORY/git/refs",

--- a/tests/unit/test_main_gate_coverage_audit.py
+++ b/tests/unit/test_main_gate_coverage_audit.py
@@ -1,0 +1,142 @@
+"""The main-gate coverage audit fails closed (issue #236).
+
+An audit that reports success when it could not verify anything is worse
+than no audit: it manufactures false assurance. These tests pin the
+failure modes - missing tool, unreadable listings, non-rebase merge
+settings, and runs that reached no verdict.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import audit_main_gate_coverage as audit  # type: ignore[import-not-found]  # noqa: E402
+
+
+class _Completed:
+    def __init__(self, stdout: str = "", returncode: int = 0, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def _fake_gh(monkeypatch: pytest.MonkeyPatch, responses: dict[str, object]) -> None:
+    monkeypatch.setattr(audit.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    def run(args: list[str], **_kwargs: object) -> _Completed:
+        key = next((name for name in responses if name in " ".join(args)), None)
+        if key is None:
+            return _Completed(returncode=1, stderr="unexpected call")
+        value = responses[key]
+        if isinstance(value, Exception):
+            raise value
+        if isinstance(value, _Completed):
+            return value
+        return _Completed(stdout=str(value))
+
+    monkeypatch.setattr(audit.subprocess, "run", run)
+
+
+REBASE_ONLY = json.dumps({"squash": False, "merge": False, "rebase": True})
+
+
+def test_a_missing_gh_cli_is_a_failure_not_a_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(audit.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
+    assert audit.main() == 1
+
+
+def test_non_rebase_merge_settings_refuse_to_audit(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_gh(
+        monkeypatch,
+        {"repos/sgajbi/lotus-ai": json.dumps({"squash": True, "merge": False, "rebase": True})},
+    )
+    monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
+    assert audit.main() == 1
+
+
+def test_unreadable_run_listing_is_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_gh(
+        monkeypatch,
+        {
+            "repos/sgajbi/lotus-ai/commits": "abc123\n",
+            "repos/sgajbi/lotus-ai": REBASE_ONLY,
+            "run": _Completed(returncode=1, stderr="API rate limit exceeded"),
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
+    assert audit.main() == 1
+
+
+def test_a_run_without_a_verdict_does_not_count_as_coverage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_gh(
+        monkeypatch,
+        {
+            "repos/sgajbi/lotus-ai/commits": "abc123\n",
+            "repos/sgajbi/lotus-ai": REBASE_ONLY,
+            "run": json.dumps([{"status": "completed", "conclusion": "cancelled"}]),
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
+    assert audit.main() == 1
+
+
+def test_a_verdict_bearing_run_is_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_gh(
+        monkeypatch,
+        {
+            "repos/sgajbi/lotus-ai/commits": "abc123\n",
+            "repos/sgajbi/lotus-ai": REBASE_ONLY,
+            "run": json.dumps([{"status": "completed", "conclusion": "success"}]),
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
+    assert audit.main() == 0
+
+
+def test_an_empty_commit_listing_is_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_gh(
+        monkeypatch,
+        {
+            "repos/sgajbi/lotus-ai/commits": "\n",
+            "repos/sgajbi/lotus-ai": REBASE_ONLY,
+        },
+    )
+    monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
+    assert audit.main() == 1
+
+
+def test_the_dispatcher_gates_every_commit_of_a_pull_request() -> None:
+    """The workflow enumerates the PR's commits and asserts rebase-only
+    merging, so an N-commit PR cannot leave N-1 commits ungated."""
+
+    workflow = (
+        Path(__file__).resolve().parents[2]
+        / ".github"
+        / "workflows"
+        / "merged-pr-main-releasability.yml"
+    ).read_text(encoding="utf-8")
+    assert "PR_COMMIT_COUNT" in workflow
+    assert "false,false,true" in workflow
+    # One dispatch job per merged commit, fed by the enumeration job, so the
+    # proven single-commit dispatch body runs unchanged for every commit.
+    assert "fromJSON(needs.enumerate-merged-commits.outputs.commit_shas)" in workflow
+    assert "MERGE_COMMIT_SHA: ${{ matrix.commit_sha }}" in workflow
+
+
+def test_gate_evidence_runs_queue_rather_than_cancelling() -> None:
+    """A cancelled run reaches no verdict, so cancel-in-progress on the gate
+    would silently delete the only proof a commit was validated - and the
+    coverage audit would then correctly report a gap that nobody caused."""
+
+    workflow = (
+        Path(__file__).resolve().parents[2] / ".github" / "workflows" / "main-releasability.yml"
+    ).read_text(encoding="utf-8")
+    assert "cancel-in-progress: false" in workflow
+    assert "cancel-in-progress: true" not in workflow


### PR DESCRIPTION
Closes #236. Flagged by a cross-session platform audit; **measured on this repo** before acting: 8 of the last 40 commits on main carried no Main Releasability run, every one an intermediate commit of a multi-commit PR.

## The gap

The merged-PR dispatcher fired once, keyed to `pull_request.merge_commit_sha`. This repository merges by rebase, so an N-commit PR puts N commits on main and only the tip was gated. A run that is never created is not a failure, so the gap accrued invisibly — the exposure is rollback or bisect landing on a never-validated tree.

## The fix

**Per-commit fan-out, not a shell loop.** An `enumerate-merged-commits` job resolves the commits the PR contributed and a matrix job dispatches the gate for each. This shape was chosen deliberately: the repo's existing `test_ci_workflow_contracts.py` guard requires the lookup/create/dispatch body at shell depth 0, and my first implementation nested it in a `for` loop and broke that invariant. Rather than relax the guard, the matrix keeps the **proven single-commit step body byte-identical** and the guard got *stronger* — it now also asserts the commit-count input, the rebase-only literal, and the matrix provenance chain (`merge_commit_sha` → enumeration → matrix).

**Rebase-only assertion**: the enumeration is correct only under rebase merging, so the job fails loudly if the repository's merge settings ever change.

**Evidence runs queue, never cancel** (`cancel-in-progress: false` on the gate): a cancelled run reaches no verdict, so cancelling one silently deletes the only proof a commit was validated. PR lanes keep `true` — superseded pushes *should* cancel.

**Fail-closed daily audit** (`scripts/audit_main_gate_coverage.py`): a missing gh CLI, an unreadable listing, an empty commit listing, non-rebase merge settings, or a run that reached no verdict (cancelled/skipped/running) are all gaps, never passes — an audit that reports success when it verified nothing manufactures false assurance. Seven tests pin exactly those failure modes plus the dispatcher contract.

## Backfill: coverage established, validation NOT claimed

The 8 measured commits were dispatched and now carry verdict-bearing runs — **all 8 verdicts are failures**, and I investigated rather than reporting a dispatch count (full detail in the issue):

- **Most are time-dependent**: `security-audit` (pip_audit) flags CVEs published *after* those commits. The Exact Revision Assertion passes on every run, so targeting is correct — a retroactive gate run measures today's environment, not merge-time releasability. Backfill therefore proves coverage, not that those trees were releasable.
- **One is the real exposure**: `83a115a` fails its **own unit tests**, and its immediate child on main is "test(quality): register the new stores in the global reset" — the fix, in the same PR. A commit that does not pass its tests reached main unvalidated, exactly as predicted. (The same class has since been found twice more in a sibling repo.)

Design consequence adopted here: **coverage ≠ pass**. The audit's invariant stays "every commit carries a verdict-bearing run" — a failing verdict is information, a missing run is not — with pass/fail reported alongside so the distinction is visible rather than implied.

Full suite 2125 passed (98.61%); lint, typecheck, and 42 workflow-contract + audit tests green.