### PR TITLE
fix(readiness): derive provider evidence readiness and drop vacuous guards (#154 S2)

### DIFF
--- a/src/app/services/access_control_activation_readiness.py
+++ b/src/app/services/access_control_activation_readiness.py
@@ -6,8 +6,6 @@ from app.contracts.access_control import (
 )
 from app.services.access_control_runtime import (
     build_access_control_runtime_status,
-    control_plane_authorization_enforced,
-    data_plane_authorization_enforced,
 )
 
 
@@ -17,14 +15,6 @@ def build_access_control_activation_readiness() -> AccessControlActivationReadin
     if settings.access_control_store_mode != "sqlalchemy":
         blocking_findings.append(
             "Full access-control activation requires SQL-backed caller policy storage so caller authorization remains restart-safe."
-        )
-    if not control_plane_authorization_enforced():
-        blocking_findings.append(
-            "Control-plane authorization must be enforced for async, prompt, and provider control actions before access-control rollout is fully activatable."
-        )
-    if not data_plane_authorization_enforced():
-        blocking_findings.append(
-            "Data-plane authorization must be enforced for task, retrieval, and live-provider request paths before access-control rollout is fully activatable."
         )
     activation_path = [
         "Keep the caller policy registry authoritative for all protected surfaces, including task execution, retrieval execution, live-provider execution, async control, prompt control, and provider control.",

--- a/src/app/services/access_control_runtime.py
+++ b/src/app/services/access_control_runtime.py
@@ -13,10 +13,23 @@ _PROTECTED_SURFACE_COUNT = 6
 
 
 def data_plane_authorization_enforced() -> bool:
+    """Structural invariant, not an unmeasured claim (issue #154).
+
+    Every protected router binds caller authentication and the
+    registered-active-caller gate at inclusion, so no data-plane route can
+    execute unauthorized; the property is proven by the route-coverage
+    guard in tests rather than sampled at runtime. It is a constant here
+    because it is enforced by construction - if that ever stops being
+    true, the coverage guard fails before this value could mislead anyone.
+    """
+
     return True
 
 
 def control_plane_authorization_enforced() -> bool:
+    """Structural invariant, as above: control-plane routes are bound by the
+    same router-level dependencies and covered by the same guard."""
+
     return True
 
 

--- a/src/app/services/artifact_activation_readiness.py
+++ b/src/app/services/artifact_activation_readiness.py
@@ -25,6 +25,10 @@ def build_artifact_activation_readiness() -> ArtifactActivationReadinessResponse
             "Artifact object-store durability is still in-memory and not restart-safe."
         )
     if len(ACTIVE_CUTOVER_DOMAINS) < 3:
+        # A tripwire on the declared cutover set, not dead code: it cannot fire
+        # while the constant lists three domains, and it fires the moment a
+        # future edit narrows it. Its test monkeypatches the constant to prove
+        # the wire is live (issue #154 review).
         blocking_findings.append(
             "Artifact consumer cutover is still too narrow for stronger governed rollout posture."
         )

--- a/src/app/services/provider_evidence_readiness.py
+++ b/src/app/services/provider_evidence_readiness.py
@@ -141,10 +141,16 @@ def build_provider_evidence_readiness() -> ProviderEvidenceReadinessResponse:
         ),
     ]
     required_item_count, completed_required_item_count = summarize_activation_items(items)
+    # Derived, not asserted (issue #154): the counts were computed and then
+    # discarded behind a hard-coded False, so the surface could not have
+    # reported readiness even once the evidence genuinely arrived.
+    evidence_ready = (
+        required_item_count > 0 and completed_required_item_count == required_item_count
+    )
     return ProviderEvidenceReadinessResponse(
         service=settings.service_name,
         version=settings.service_version,
-        evidence_ready=False,
+        evidence_ready=evidence_ready,
         required_item_count=required_item_count,
         completed_required_item_count=completed_required_item_count,
         items=items,

--- a/tests/unit/test_provider_evidence_readiness.py
+++ b/tests/unit/test_provider_evidence_readiness.py
@@ -26,3 +26,21 @@ def test_provider_evidence_readiness_reports_foundation_evidence_gaps() -> None:
     assert readiness.items[8].status == "NOT_READY"
     assert readiness.approval_gate.domain_id == "provider_execution"
     assert readiness.approval_gate.evidence_state.value == "STAGED_ONLY"
+
+
+def test_provider_evidence_readiness_is_derived_from_its_own_counts() -> None:
+    """The flag was hard-coded False while the counts were computed and then
+    discarded, so the surface could not have reported readiness even once
+    the evidence genuinely arrived (issue #154)."""
+
+    readiness = build_provider_evidence_readiness()
+
+    expected = (
+        readiness.required_item_count > 0
+        and readiness.completed_required_item_count == readiness.required_item_count
+    )
+    assert readiness.evidence_ready is expected
+    # Today one required item is a documented gap, so the honest answer is
+    # still False - but it is now an answer, not an assertion.
+    assert readiness.evidence_ready is False
+    assert readiness.completed_required_item_count < readiness.required_item_count


### PR DESCRIPTION
Part of #154 (S2 — making the mixed readiness modules honest). S3 (the new-module guard, module-size budget, and context-document corrections) closes the issue.

## What changed

**`provider_evidence_readiness` now derives the flag it was computing.** It called `summarize_activation_items`, produced required and completed counts, and then returned `evidence_ready=False` as a literal — so the surface could not have reported readiness even once the evidence genuinely arrived. The flag is derived; today's answer is still `False` because one required item is a documented gap, but it is now *an answer*. A test pins the derivation against the counts rather than against the constant.

**Two guards that could never fire are gone.** `access_control_activation_readiness` branched on `control_plane_authorization_enforced()` and `data_plane_authorization_enforced()`, both of which `return True` unconditionally — no test asserted those findings, and they presented as live controls. The predicates remain (they populate the runtime-status enforcement fields) and now carry their rationale: enforcement is **structural** — every protected router binds authentication and the registered-active-caller gate at inclusion (#149) — and is proven by the route-coverage guard rather than sampled at runtime. If that ever stops being true, the guard fails before the constant could mislead anyone.

## A finding that did not survive verification

The same review flagged `len(ACTIVE_CUTOVER_DOMAINS) < 3` as dead code against a three-element constant. It is a **deliberate tripwire**: a test monkeypatches the constant to a single domain and asserts the finding fires. I had removed it, the test failed, and I restored it with that rationale recorded in the code. Deleting a working guard is not simplification — recording why it looks inert is.

## Scope note

The remaining literal statuses inside the mixed evidence modules (for example the always-`READY` audit-traceability items) are deliberately **not** in this slice: flipping them to honest execution states cascades through the governance aggregations the way S1 did, and that belongs with S3's guard so the new posture and the rule that enforces it land together.

Full suite 2140 passed (98.61%); lint and typecheck green.