### PR TITLE
feat(quality): budget module size and readiness shape as a ratchet (#154 S3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint monetary-float-guard runtime-purity-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply runtime-mode-smoke test test-unit test-integration test-e2e test-coverage coverage-gate security-audit check ci docker-build clean
+.PHONY: install lint module-budget-guard monetary-float-guard runtime-purity-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply runtime-mode-smoke test test-unit test-integration test-e2e test-coverage coverage-gate security-audit check ci docker-build clean
 
 install:
 	python -m pip install --upgrade pip
@@ -9,6 +9,7 @@ lint:
 	python -m ruff format --check .
 	python scripts/check_runtime_purity.py
 	python scripts/check_monetary_float_usage.py
+	python scripts/check_module_budget.py
 
 monetary-float-guard:
 	python scripts/check_monetary_float_usage.py

--- a/scripts/check_module_budget.py
+++ b/scripts/check_module_budget.py
@@ -1,0 +1,121 @@
+"""Module-size and readiness-shape budget (issue #154, S3).
+
+Two rules, both ratchets rather than bands:
+
+1. No new ``*_readiness.py`` service module. The runbook family is one
+   catalog plus one builder; the surviving modules are the genuinely
+   computed ones, enumerated below. A new copy-paste readiness module is
+   how the 30-module duplication started, so adding one now fails the
+   lane.
+2. No module grows past its recorded ceiling. The three oversized modules
+   carry dated allowlist entries that may only ever shrink; every other
+   module is bounded by the default ceiling.
+
+Both lists are ratchets: shrinking a value is always allowed, raising one
+is a deliberate edit that shows up in review.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPO_ROOT / "src" / "app"
+
+DEFAULT_MAX_LINES = 1000
+
+# Dated ceilings for modules that were already oversized when the budget
+# landed (2026-09-01). These may only shrink - see the module docstring.
+OVERSIZED_ALLOWLIST: dict[str, int] = {
+    "services/eval_runtime_execution.py": 1471,
+    "services/workflow_pack_registry_seed.py": 1365,
+    "routers/workflow_packs.py": 1250,
+    "contracts/providers.py": 1023,
+}
+
+# The readiness modules that survive because they genuinely compute from
+# runtime state or serve as shared infrastructure (issue #154, S1/S2).
+ALLOWED_READINESS_MODULES = frozenset(
+    {
+        "access_control_activation_readiness.py",
+        "artifact_activation_readiness.py",
+        "capability_pack_activation_readiness.py",
+        "capability_pack_runbook_readiness.py",
+        "deployment_split_activation_readiness.py",
+        "first_use_case_readiness.py",
+        "governance_readiness.py",
+        "observability_activation_readiness.py",
+        "production_baseline_activation_readiness.py",
+        "production_go_live_activation_readiness.py",
+        "production_go_live_runbook_readiness.py",
+        "prompt_activation_readiness.py",
+        "prompt_evidence_readiness.py",
+        "provider_activation_readiness.py",
+        "provider_evidence_readiness.py",
+        "provider_runbook_readiness.py",
+        "resilience_activation_readiness.py",
+        "retrieval_activation_readiness.py",
+        "retrieval_evidence_readiness.py",
+        "runtime_readiness.py",
+        "safety_evidence_readiness.py",
+    }
+)
+
+
+def _relative(path: Path) -> str:
+    return path.relative_to(SOURCE_ROOT).as_posix()
+
+
+def module_budget_violations() -> list[str]:
+    violations: list[str] = []
+    for path in sorted(SOURCE_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        relative = _relative(path)
+        line_count = len(path.read_text(encoding="utf-8").splitlines())
+        ceiling = OVERSIZED_ALLOWLIST.get(relative, DEFAULT_MAX_LINES)
+        if line_count > ceiling:
+            violations.append(f"{relative}: {line_count} lines exceeds its budget of {ceiling}")
+    for relative, ceiling in sorted(OVERSIZED_ALLOWLIST.items()):
+        path = SOURCE_ROOT / relative
+        if not path.is_file():
+            violations.append(f"{relative}: allowlisted but missing - remove the stale entry")
+            continue
+        line_count = len(path.read_text(encoding="utf-8").splitlines())
+        if line_count < ceiling:
+            violations.append(
+                f"{relative}: now {line_count} lines - lower its allowlist ceiling from "
+                f"{ceiling} so the ratchet holds"
+            )
+    return violations
+
+
+def readiness_module_violations() -> list[str]:
+    violations: list[str] = []
+    for path in sorted((SOURCE_ROOT / "services").glob("*_readiness.py")):
+        if path.name not in ALLOWED_READINESS_MODULES:
+            violations.append(
+                f"services/{path.name}: new readiness modules are not accepted - declare the "
+                "items in contracts/readiness/runbook_readiness_catalog.json and build them "
+                "with services/readiness_catalog.py, or add a computed module to the "
+                "allowlist with its reason"
+            )
+    for name in sorted(ALLOWED_READINESS_MODULES):
+        if not (SOURCE_ROOT / "services" / name).is_file():
+            violations.append(f"services/{name}: allowlisted but missing - remove the stale entry")
+    return violations
+
+
+def main() -> int:
+    violations = module_budget_violations() + readiness_module_violations()
+    for violation in violations:
+        print(f"module budget violation: {violation}")
+    if violations:
+        return 1
+    print("Module budget guard passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app/services/prompt_evidence_readiness.py
+++ b/src/app/services/prompt_evidence_readiness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_readiness import get_audit_store_runtime_status
 from app.contracts.evals import EvaluationApprovalEvidenceState
 from app.contracts.prompts import (
     PromptEvidenceReadinessItem,
@@ -45,7 +46,13 @@ def build_prompt_evidence_readiness() -> PromptEvidenceReadinessResponse:
         ),
         PromptEvidenceReadinessItem(
             evidence_id="prompt_audit_traceability_pack",
-            status="READY",
+            # Measured, not asserted (issue #154): prompt lineage is only
+            # traceable if the audit store can persist and serve it.
+            status=(
+                "READY"
+                if get_audit_store_runtime_status().status in {"READY", "DEGRADED"}
+                else "NOT_READY"
+            ),
             required_for_activation=True,
             notes=(
                 "Task responses, audit records, and execution evidence now preserve prompt selection lineage plus latest control-event history."

--- a/src/app/services/safety_evidence_readiness.py
+++ b/src/app/services/safety_evidence_readiness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.config import settings
+from app.services.runtime_readiness import get_audit_store_runtime_status
 from app.contracts.evals import EvaluationApprovalEvidenceState
 from app.contracts.safety import SafetyEvidenceReadinessItem, SafetyEvidenceReadinessResponse
 from app.services.eval_approval_gate_summary import build_safety_approval_gate_summary
@@ -14,7 +15,12 @@ def build_safety_evidence_readiness() -> SafetyEvidenceReadinessResponse:
     approval_gate = build_safety_approval_gate_summary()
     policy_fixture_ready = "safety_policy_examples" in staged_fixture_ids
     runtime_fixture_ready = "safety_runtime_examples" in staged_fixture_ids
-    audit_traceability_ready = True
+    # Measured, not asserted (issue #154): traceability depends on the audit
+    # store actually being able to persist and serve the records.
+    audit_traceability_ready = get_audit_store_runtime_status().status in {
+        "READY",
+        "DEGRADED",
+    }
     runtime_evidence_status = _approval_gate_status(approval_gate.evidence_state)
     runtime_evidence_notes = {
         EvaluationApprovalEvidenceState.STAGED_ONLY: (

--- a/tests/unit/test_module_budget_guard.py
+++ b/tests/unit/test_module_budget_guard.py
@@ -1,0 +1,69 @@
+"""The module budget is a ratchet, not a band (issue #154, S3).
+
+Both rules exist because the 30-module readiness duplication and the
+four >1,000-line modules grew one accepted exception at a time. The guard
+fails on growth, refuses new copy-paste readiness modules, and - the part
+that keeps a ratchet honest - fails when a recorded ceiling is now higher
+than reality, so shrinking must be banked rather than leaving headroom.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import check_module_budget as budget  # type: ignore[import-not-found]  # noqa: E402
+
+
+def test_the_repository_currently_satisfies_its_budget() -> None:
+    assert budget.module_budget_violations() == []
+    assert budget.readiness_module_violations() == []
+
+
+def test_a_module_over_its_ceiling_is_a_violation(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(budget, "DEFAULT_MAX_LINES", 10)
+    monkeypatch.setattr(budget, "OVERSIZED_ALLOWLIST", {})
+    violations = budget.module_budget_violations()
+    assert violations
+    assert any("exceeds its budget" in violation for violation in violations)
+
+
+def test_a_ceiling_above_reality_must_be_lowered(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(budget, "OVERSIZED_ALLOWLIST", {"services/readiness_catalog.py": 100_000})
+    violations = budget.module_budget_violations()
+    assert any("lower its allowlist ceiling" in violation for violation in violations)
+
+
+def test_a_stale_allowlist_entry_is_a_violation(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(budget, "OVERSIZED_ALLOWLIST", {"services/deleted_module.py": 1200})
+    assert any(
+        "allowlisted but missing" in violation for violation in budget.module_budget_violations()
+    )
+
+
+def test_a_new_readiness_module_is_refused(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(budget, "ALLOWED_READINESS_MODULES", frozenset())
+    violations = budget.readiness_module_violations()
+    assert violations
+    assert any("new readiness modules are not accepted" in violation for violation in violations)
+
+
+def test_the_deleted_runbook_family_stays_deleted() -> None:
+    """S1 replaced ten copy-paste runbook modules with one catalog; none of
+    them may reappear without failing this guard."""
+
+    deleted = {
+        "artifact_runbook_readiness.py",
+        "access_control_runbook_readiness.py",
+        "production_baseline_runbook_readiness.py",
+        "deployment_split_runbook_readiness.py",
+        "prompt_runbook_readiness.py",
+        "observability_runbook_readiness.py",
+        "resilience_runbook_readiness.py",
+        "first_use_case_runbook_readiness.py",
+        "safety_runbook_readiness.py",
+        "retrieval_runbook_readiness.py",
+    }
+    assert deleted.isdisjoint(budget.ALLOWED_READINESS_MODULES)
+    services = budget.SOURCE_ROOT / "services"
+    assert not [name for name in deleted if (services / name).is_file()]


### PR DESCRIPTION
Part of #154 (S3 — the guards that make S1/S2 permanent).

## Why a rule, not a cleanup

The 30-module readiness duplication and the four >1,000-line modules each grew *one accepted exception at a time*. Deleting them (S1) and making the survivors honest (S2) does nothing if the next slice can add module thirty-one.

**`scripts/check_module_budget.py`, wired into `make lint`:**

- **No new `*_readiness.py` service module.** The runbook family is one catalog plus one builder; the survivors are enumerated with their reason (genuinely computed, or shared infrastructure). A test also proves the ten deleted runbook modules stay deleted.
- **Module ceilings ratchet in both directions.** Growth past a ceiling fails — and so does a ceiling that has drifted *above* reality, so shrinking must be banked rather than left as headroom for the next regression. The four already-oversized modules carry dated entries (eval_runtime_execution 1471, workflow_pack_registry_seed 1365, routers/workflow_packs 1250, contracts/providers 1023 — the fourth found while measuring, not assumed).

Six tests pin the guard: current-state clean, over-ceiling detected, drifted ceiling detected, stale entry detected, new readiness module refused, deleted family stays deleted.

## Two claims became measurements

Prompt and safety evidence readiness asserted `audit_traceability_ready = True`. Traceability is only real if the audit store can persist and serve the records, so both now derive from `get_audit_store_runtime_status()` — the same signal the platform surfaces already trust.

## A finding that did not survive verification

The issue reported two cited onboarding documents as missing ("the `docs/onboarding/` directory is absent"). Both exist at exactly the path the context file links to — `../lotus-platform/docs/onboarding/` — in the platform sibling repository; the finding measured *this* repository's `docs/`. The references are correct and are left alone. (This is the second #154 finding to fail verification, after the artifact cutover tripwire in S2.)

## What remains on #154

Not closing the issue with this PR. Still open: the Current-State Summary item 3 restructure (a ~1,100-word sentence), and the conditional-`READY` items inside the computed evidence adapters, which are correct today but would read better as declared execution states. Both are documentation-shaped work that deserves its own slice rather than being bundled into a guard PR.

Full suite 2146 passed (98.61%); lint (including the new guard) and typecheck green.