### PR TITLE
fix(attribution): name the serving candidate on every execution surface

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -58,7 +58,10 @@ candidates pass the same fences under their own execution config: kill switches,
 per-provider circuit breaker, and governed catalogue binding. Quota counters and
 the budget envelope are request-scoped and charged once. Every execution records
 a routing decision — each candidate, its rejection reason where rejected, the
-selection, and the `fallback_path`.
+selection, and the `fallback_path`. Whichever candidate serves, it is the one
+named on every surface: audit record, routing decision, response, cost, metrics
+labels, structured logs, tracing spans, bounded failure messages, breaker
+evidence, and the attested run ledger all carry the serving identity.
 
 **Model catalogue.** Provider, family, revision, deployment, and SKU are
 first-class governed identity. Lifecycle state gates execution (a retired or
@@ -104,11 +107,10 @@ refuses new copy-paste readiness modules and ratchets module size.
 **Current limitations.** Consumers still name a task and rely on configured
 provider identity rather than requesting a capability with requirements;
 eligibility is configuration-driven rather than evidence-driven; model capability
-dimensions and eval-backed fungibility do not exist yet (#244, #245). Two
-evidence surfaces still resolve the primary identity for alternate-served
-executions (#237), and an OPEN breaker does not yet survive key migration (#234).
-High-impact governance actions still accept caller-supplied approver strings
-(#157). Forward priorities live on the North Star execution board (#246).
+dimensions and eval-backed fungibility do not exist yet (#244, #245). An OPEN
+breaker does not yet survive deployment or key migration (#234), and the
+breaker's posture resolver still writes while reading (#248). High-impact
+governance actions still accept caller-supplied approver strings (#157). Forward priorities live on the North Star execution board (#246).
 
 ## Architecture And Module Map
 

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -49,10 +49,11 @@ def execute_openai_compatible_text_request(
     model_version: str | None,
     provider_id: str | None = None,
 ) -> ProviderExecutionResponse:
-    # The serving identity is the execution config's provider id (issue
-    # #226): under ordered fallback both candidates run through the same
-    # adapter, so the static descriptor constant would attribute the
-    # alternate's executions to the primary in audit, cost, and metrics.
+    # The serving identity is the execution config's provider id (issues
+    # #226, #237): under ordered fallback both candidates run through the
+    # same adapter, so the static descriptor constants would attribute the
+    # alternate's executions to the primary on every surface naming a
+    # provider.
     serving_provider_id = provider_id or descriptor.provider_id
     payload: dict[str, object] = {
         "model": model_id,
@@ -86,7 +87,7 @@ def execute_openai_compatible_text_request(
         api_key=api_key,
         payload=payload,
         timeout_seconds=max(request.timeout_ms / 1000.0, 1.0),
-        provider_display_name=descriptor.display_name,
+        serving_provider_id=serving_provider_id,
         require_api_key=require_api_key,
         retry_limit=request.retry_limit,
     )
@@ -155,10 +156,22 @@ def post_openai_compatible_response(
     api_key: str | None,
     payload: dict[str, object],
     timeout_seconds: float,
-    provider_display_name: str,
+    serving_provider_id: str,
     require_api_key: bool,
     retry_limit: int = 0,
 ) -> dict[str, Any]:
+    """POST one OpenAI-compatible request, labelling every surface it emits
+    with ``serving_provider_id``.
+
+    This used to take the descriptor's display name. Under ordered fallback
+    both candidates run through the same adapter, so the display name is
+    structurally unable to say which one served: it names the adapter, not
+    the candidate. Metrics, logs, spans, and bounded failure messages all
+    take the execution config's provider id instead, which is the identity
+    the audit record, routing decision, breaker key, and kill switch
+    already use (issue #237).
+    """
+
     override = get_text_transport_post_override()
     if override is not None:
         return override(
@@ -166,14 +179,14 @@ def post_openai_compatible_response(
             api_key=api_key,
             payload=payload,
             timeout_seconds=timeout_seconds,
-            provider_display_name=provider_display_name,
+            serving_provider_id=serving_provider_id,
             require_api_key=require_api_key,
             retry_limit=retry_limit,
         )
     if require_api_key and api_key is None:
         raise ProviderExecutionError(
             category=ProviderFailureCategory.INVALID_LIVE_CONFIGURATION,
-            message=f"Live provider credentials are not configured for {provider_display_name}.",
+            message=f"Live provider credentials are not configured for {serving_provider_id}.",
         )
     ensure_network_execution_permitted(
         seam="openai_compatible_text_transport.post_openai_compatible_response"
@@ -204,7 +217,7 @@ def post_openai_compatible_response(
         try:
             with (
                 provider_attempt_span(
-                    provider_id=provider_display_name,
+                    provider_id=serving_provider_id,
                     model_id=model_identity if isinstance(model_identity, str) else None,
                     attempt=attempt_index,
                 ) as attempt_span,
@@ -217,7 +230,7 @@ def post_openai_compatible_response(
                 usage_fields = usage if isinstance(usage, dict) else {}
                 attempt_latency_ms = _attempt_latency_ms(attempt_started)
                 record_provider_attempt(
-                    provider_id=provider_display_name,
+                    provider_id=serving_provider_id,
                     model_id=model_identity if isinstance(model_identity, str) else None,
                     outcome="success",
                     latency_seconds=attempt_latency_ms / 1000.0,
@@ -225,7 +238,7 @@ def post_openai_compatible_response(
                 log_event(
                     _logger,
                     "provider_attempt",
-                    provider_id=provider_display_name,
+                    provider_id=serving_provider_id,
                     model_id=model_identity,
                     attempt=attempt_index,
                     attempt_limit=bounded_retry_limit,
@@ -247,7 +260,7 @@ def post_openai_compatible_response(
             )
             attempt_latency_ms = _attempt_latency_ms(attempt_started)
             record_provider_attempt(
-                provider_id=provider_display_name,
+                provider_id=serving_provider_id,
                 model_id=model_identity if isinstance(model_identity, str) else None,
                 outcome="retry" if will_retry else "failed",
                 latency_seconds=attempt_latency_ms / 1000.0,
@@ -255,7 +268,7 @@ def post_openai_compatible_response(
             log_event(
                 _logger,
                 "provider_attempt",
-                provider_id=provider_display_name,
+                provider_id=serving_provider_id,
                 model_id=model_identity,
                 attempt=attempt_index,
                 attempt_limit=bounded_retry_limit,
@@ -271,7 +284,7 @@ def post_openai_compatible_response(
                 category=category,
                 message=safe_provider_error_message(
                     category=category,
-                    provider_display_name=provider_display_name,
+                    serving_provider_id=serving_provider_id,
                 ),
             ) from exc
         except TimeoutError as exc:
@@ -281,7 +294,7 @@ def post_openai_compatible_response(
             will_retry = attempt_index < bounded_retry_limit and retry_decision.permitted
             attempt_latency_ms = _attempt_latency_ms(attempt_started)
             record_provider_attempt(
-                provider_id=provider_display_name,
+                provider_id=serving_provider_id,
                 model_id=model_identity if isinstance(model_identity, str) else None,
                 outcome="retry" if will_retry else "failed",
                 latency_seconds=attempt_latency_ms / 1000.0,
@@ -289,7 +302,7 @@ def post_openai_compatible_response(
             log_event(
                 _logger,
                 "provider_attempt",
-                provider_id=provider_display_name,
+                provider_id=serving_provider_id,
                 model_id=model_identity,
                 attempt=attempt_index,
                 attempt_limit=bounded_retry_limit,
@@ -304,7 +317,7 @@ def post_openai_compatible_response(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,
                 message=safe_provider_error_message(
                     category=ProviderFailureCategory.PROVIDER_TIMEOUT,
-                    provider_display_name=provider_display_name,
+                    serving_provider_id=serving_provider_id,
                 ),
             ) from exc
         except error.URLError as exc:
@@ -314,7 +327,7 @@ def post_openai_compatible_response(
             will_retry = attempt_index < bounded_retry_limit and retry_decision.permitted
             attempt_latency_ms = _attempt_latency_ms(attempt_started)
             record_provider_attempt(
-                provider_id=provider_display_name,
+                provider_id=serving_provider_id,
                 model_id=model_identity if isinstance(model_identity, str) else None,
                 outcome="retry" if will_retry else "failed",
                 latency_seconds=attempt_latency_ms / 1000.0,
@@ -322,7 +335,7 @@ def post_openai_compatible_response(
             log_event(
                 _logger,
                 "provider_attempt",
-                provider_id=provider_display_name,
+                provider_id=serving_provider_id,
                 model_id=model_identity,
                 attempt=attempt_index,
                 attempt_limit=bounded_retry_limit,
@@ -337,14 +350,14 @@ def post_openai_compatible_response(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,
                 message=safe_provider_error_message(
                     category=ProviderFailureCategory.PROVIDER_TIMEOUT,
-                    provider_display_name=provider_display_name,
+                    serving_provider_id=serving_provider_id,
                 ),
             ) from exc
     raise ProviderExecutionError(
         category=ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR,
         message=safe_provider_error_message(
             category=ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR,
-            provider_display_name=provider_display_name,
+            serving_provider_id=serving_provider_id,
         ),
     )
 
@@ -387,13 +400,13 @@ def is_retryable_provider_failure(
 
 
 def safe_provider_error_message(
-    *, category: ProviderFailureCategory, provider_display_name: str
+    *, category: ProviderFailureCategory, serving_provider_id: str
 ) -> str:
     if category == ProviderFailureCategory.PROVIDER_RATE_LIMITED:
-        return f"{provider_display_name} rate limit exceeded."
+        return f"{serving_provider_id} rate limit exceeded."
     if category == ProviderFailureCategory.PROVIDER_TIMEOUT:
-        return f"{provider_display_name} request did not complete within the configured timeout."
-    return f"{provider_display_name} request failed at the upstream provider boundary."
+        return f"{serving_provider_id} request did not complete within the configured timeout."
+    return f"{serving_provider_id} request failed at the upstream provider boundary."
 
 
 def extract_output_text(payload: dict[str, Any]) -> str:

--- a/src/app/providers/openai_live_embedding_provider.py
+++ b/src/app/providers/openai_live_embedding_provider.py
@@ -23,9 +23,15 @@ from app.providers.openai_compatible_text_transport import (
 )
 
 
+# One identity for this provider: the descriptor binds it, and bounded
+# failure messages name it, so operators read the same token here as in
+# metrics, breaker keys, and kill switches (issue #237).
+EMBEDDING_PROVIDER_ID = "embeddings.openai"
+
+
 class OpenAILiveEmbeddingProvider:
     descriptor = ProviderAdapterDescriptor(
-        provider_id="embeddings.openai",
+        provider_id=EMBEDDING_PROVIDER_ID,
         display_name="OpenAI Live Embedding Provider",
         capability=ProviderCapability.EMBEDDINGS,
         adapter_kind=ProviderAdapterKind.OPENAI_EMBEDDINGS_LIVE,
@@ -111,7 +117,7 @@ def _post_openai_embedding(
             category=category,
             message=safe_provider_error_message(
                 category=category,
-                provider_display_name="OpenAI embedding provider",
+                serving_provider_id=EMBEDDING_PROVIDER_ID,
             ),
         ) from exc
     except TimeoutError as exc:
@@ -119,7 +125,7 @@ def _post_openai_embedding(
             category=ProviderFailureCategory.PROVIDER_TIMEOUT,
             message=safe_provider_error_message(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,
-                provider_display_name="OpenAI embedding provider",
+                serving_provider_id=EMBEDDING_PROVIDER_ID,
             ),
         ) from exc
     except error.URLError as exc:
@@ -127,7 +133,7 @@ def _post_openai_embedding(
             category=ProviderFailureCategory.PROVIDER_TIMEOUT,
             message=safe_provider_error_message(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,
-                provider_display_name="OpenAI embedding provider",
+                serving_provider_id=EMBEDDING_PROVIDER_ID,
             ),
         ) from exc
 

--- a/src/app/services/execution_evidence.py
+++ b/src/app/services/execution_evidence.py
@@ -102,7 +102,11 @@ def _provider_descriptor(
     *,
     provider_execution: ProviderExecutionResponse,
 ) -> ExecutionEvidenceDescriptor:
-    degradation_status = build_provider_degradation_status()
+    # Evidence is built after the gateway's per-candidate config override
+    # has exited, so an ambient read would report the primary's breaker for
+    # an alternate-served execution. Ask about the identity that served
+    # (issue #237).
+    degradation_status = build_provider_degradation_status(provider_execution.provider_id)
     return ExecutionEvidenceDescriptor(
         evidence_type="provider_resolution",
         summary="Execution flowed through the provider gateway and resolved to the current provider path.",

--- a/src/app/services/provider_degradation_state.py
+++ b/src/app/services/provider_degradation_state.py
@@ -15,7 +15,7 @@ from app.services.provider_execution_config import resolve_provider_execution_co
 _DEGRADATION_KEY_PREFIX = "live_text_generation"
 
 
-def _degradation_key() -> str:
+def _degradation_key(provider_id: str | None = None) -> str:
     """Failure bookkeeping is keyed per provider identity (issue #176, S3).
 
     Ordered fallback requires the primary's failures to never open the
@@ -24,11 +24,17 @@ def _degradation_key() -> str:
     selects the candidate being checked or charged. Without a configured
     provider identity (stub and disabled modes) the bare prefix remains the
     key.
+
+    Passing ``provider_id`` names an identity explicitly. Recording a failure
+    or a success omits it: those run inside the gateway's per-candidate
+    config override, so the ambient identity is already the right one.
+    Reading posture for evidence or an operator view happens after that
+    scope has exited and must name the identity it means (issue #237).
     """
 
-    provider_id = resolve_provider_execution_config().provider_id
-    if provider_id:
-        return f"{_DEGRADATION_KEY_PREFIX}:{provider_id}"
+    resolved = provider_id or resolve_provider_execution_config().provider_id
+    if resolved:
+        return f"{_DEGRADATION_KEY_PREFIX}:{resolved}"
     return _DEGRADATION_KEY_PREFIX
 
 
@@ -48,8 +54,19 @@ class ProviderDegradationState:
     findings: list[str]
 
 
-def build_provider_degradation_status() -> ProviderDegradationStatusDescriptor:
-    state = _resolve_provider_degradation_state()
+def build_provider_degradation_status(
+    provider_id: str | None = None,
+) -> ProviderDegradationStatusDescriptor:
+    """Breaker posture for a provider identity.
+
+    ``provider_id`` names the identity to report on. Evidence for an
+    execution must pass the identity that actually SERVED it: the gateway's
+    per-candidate config override has already exited by the time evidence is
+    built, so resolving the ambient config would report the primary's
+    breaker for an alternate-served execution (issue #237).
+    """
+
+    state = _resolve_provider_degradation_state(provider_id)
     return ProviderDegradationStatusDescriptor(
         status=state.status,
         enforcement_enabled=state.enforcement_enabled,
@@ -118,9 +135,14 @@ def reset_provider_degradation_state() -> None:
     repository.reset_degradation_states()
 
 
-def _resolve_provider_degradation_state() -> ProviderDegradationState:
+def _resolve_provider_degradation_state(
+    provider_id: str | None = None,
+) -> ProviderDegradationState:
     findings: list[str] = []
-    state_record = _load_degradation_record()
+    state_record = _load_degradation_record(provider_id)
+    # Enforcement thresholds are shared across candidates by construction
+    # (see derive_fallback_execution_config), so the ambient read is correct
+    # here even when the record above belongs to a named identity.
     enforcement = resolve_provider_execution_config().enforcement
     enforcement_enabled = enforcement.degradation_enforced
     degraded_threshold = enforcement.degraded_failure_count_threshold
@@ -187,8 +209,10 @@ def _resolve_provider_degradation_state() -> ProviderDegradationState:
             findings=findings,
         )
 
-    circuit_remaining_seconds = _remaining_circuit_open_seconds(state_record.circuit_open_until)
-    state_record = _load_degradation_record()
+    circuit_remaining_seconds = _remaining_circuit_open_seconds(
+        state_record.circuit_open_until, provider_id=provider_id
+    )
+    state_record = _load_degradation_record(provider_id)
     if circuit_remaining_seconds is not None:
         return ProviderDegradationState(
             status="CIRCUIT_OPEN",
@@ -208,8 +232,8 @@ def _resolve_provider_degradation_state() -> ProviderDegradationState:
         )
 
     if state_record.consecutive_failure_count >= (circuit_threshold or 0):
-        _open_circuit()
-        return _resolve_provider_degradation_state()
+        _open_circuit(provider_id)
+        return _resolve_provider_degradation_state(provider_id)
 
     if state_record.consecutive_failure_count >= (degraded_threshold or 0):
         return ProviderDegradationState(
@@ -247,15 +271,25 @@ def _resolve_provider_degradation_state() -> ProviderDegradationState:
     )
 
 
-def _remaining_circuit_open_seconds(circuit_open_until: str | None) -> int | None:
+def _remaining_circuit_open_seconds(
+    circuit_open_until: str | None, *, provider_id: str | None = None
+) -> int | None:
+    """Remaining cooldown for ``provider_id``, clearing an expired one.
+
+    The clear is a write on a read path, so it has to be keyed to the
+    identity being asked about: keyed ambiently, inspecting the alternate's
+    posture would reset the primary's breaker (issue #237).
+    """
+
     if circuit_open_until is None:
         return None
     until = datetime.fromisoformat(circuit_open_until)
     remaining = int((until - _utcnow()).total_seconds())
     if remaining > 0:
         return remaining
-    state_record = _load_degradation_record()
+    state_record = _load_degradation_record(provider_id)
     _save_degradation_record(
+        provider_id=provider_id,
         consecutive_failure_count=0,
         last_failure_category=None,
         circuit_open_until=None,
@@ -266,10 +300,11 @@ def _remaining_circuit_open_seconds(circuit_open_until: str | None) -> int | Non
     return None
 
 
-def _open_circuit() -> None:
-    state_record = _load_degradation_record()
+def _open_circuit(provider_id: str | None = None) -> None:
+    state_record = _load_degradation_record(provider_id)
     cooldown_seconds = resolve_provider_execution_config().enforcement.circuit_open_seconds or 0
     _save_degradation_record(
+        provider_id=provider_id,
         consecutive_failure_count=state_record.consecutive_failure_count,
         last_failure_category=state_record.last_failure_category,
         circuit_open_until=(_utcnow() + timedelta(seconds=cooldown_seconds)).isoformat(),
@@ -287,9 +322,11 @@ def _tracked_failure_categories() -> set[ProviderFailureCategory]:
     }
 
 
-def _load_degradation_record() -> ProviderDegradationStateRecord:
+def _load_degradation_record(
+    provider_id: str | None = None,
+) -> ProviderDegradationStateRecord:
     repository = get_provider_operations_store()
-    degradation_key = _degradation_key()
+    degradation_key = _degradation_key(provider_id)
     record = repository.get_degradation_state(degradation_key=degradation_key)
     if record is not None:
         return record
@@ -307,6 +344,7 @@ def _load_degradation_record() -> ProviderDegradationStateRecord:
 
 def _save_degradation_record(
     *,
+    provider_id: str | None = None,
     consecutive_failure_count: int,
     last_failure_category: ProviderFailureCategory | None,
     circuit_open_until: str | None,
@@ -317,7 +355,7 @@ def _save_degradation_record(
     repository = get_provider_operations_store()
     repository.save_degradation_state(
         ProviderDegradationStateRecord(
-            degradation_key=_degradation_key(),
+            degradation_key=_degradation_key(provider_id),
             consecutive_failure_count=consecutive_failure_count,
             last_failure_category=last_failure_category,
             circuit_open_until=circuit_open_until,

--- a/src/app/services/routing_posture.py
+++ b/src/app/services/routing_posture.py
@@ -15,7 +15,6 @@ from app.config import settings
 from app.services.provider_execution_config import (
     ProviderExecutionConfig,
     derive_fallback_execution_config,
-    override_provider_execution_config,
     resolve_provider_execution_config,
 )
 from app.contracts.model_catalogue import ModelCatalogueEntry, derive_model_catalogue_entry_id
@@ -41,9 +40,12 @@ def build_routing_posture() -> RoutingPostureResponse:
     fallback_candidate: RoutingPostureCandidateDescriptor | None = None
     fallback_degradation: ProviderDegradationStatusDescriptor | None = None
     if alternate is not None:
-        with override_provider_execution_config(alternate):
-            fallback_candidate = _resolve_candidate(alternate)
-            fallback_degradation = build_provider_degradation_status()
+        # Both reads name the alternate explicitly rather than relying on an
+        # ambient override to mean it. Scope-implicit identity is how the
+        # alternate's evidence used to come back describing the primary
+        # (issue #237).
+        fallback_candidate = _resolve_candidate(alternate)
+        fallback_degradation = build_provider_degradation_status(alternate.provider_id)
     notes = [
         "Per-request gates (caller authorization, task/tenant/caller kill-switch scopes, "
         "quota counters) are evaluated per execution and recorded on its routing decision.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,11 @@ from app.workflow_pack_execution_idempotency.store import (
     reset_workflow_pack_execution_idempotency_store_cache,
 )
 
+# Imported for registration: pytest discovers fixtures defined in conftest's
+# namespace, which is how tests/support/log_collection.py's collector reaches
+# every test module without being copied into each one.
+from tests.support.log_collection import app_log_collector  # noqa: F401
+
 
 @pytest.fixture(autouse=True)
 def reset_runtime_settings() -> Generator[None, None, None]:

--- a/tests/support/log_collection.py
+++ b/tests/support/log_collection.py
@@ -1,0 +1,72 @@
+"""Deterministic capture of the service's structured log lines.
+
+Naive capture (pytest's ``caplog``) is unreliable here: the app logger tree
+carries handlers, levels, propagation flags and a global ``logging.disable``
+level that other tests and the app's own configuration mutate. This snapshots
+that state, normalizes it for the duration of one test, and restores it - so a
+test can assert on emitted lines regardless of the order it runs in.
+
+Shared rather than copied: log attribution is asserted both by the logging
+foundation tests and by the routing tests that check which candidate a line
+names (issue #237).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from app.services.structured_logging import StructuredJsonFormatter
+
+_NORMALIZED_CHILD_LOGGERS = ("app.http", "app.provider", "app.errors", "app.test")
+
+
+class CollectingLogHandler(logging.Handler):
+    """Collects formatted structured lines as parsed dicts."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lines: list[dict[str, object]] = []
+        self.setFormatter(StructuredJsonFormatter())
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.lines.append(json.loads(self.format(record)))
+
+    def events(self, event: str) -> list[dict[str, object]]:
+        return [line for line in self.lines if line.get("event") == event]
+
+
+@pytest.fixture
+def app_log_collector() -> Iterator[CollectingLogHandler]:
+    logger = logging.getLogger("app")
+    snapshot = (list(logger.handlers), logger.level, logger.propagate)
+    child_snapshots = {
+        name: (child.level, child.propagate)
+        for name in _NORMALIZED_CHILD_LOGGERS
+        for child in (logging.getLogger(name),)
+    }
+    ambient_disable = logging.root.manager.disable
+
+    handler = CollectingLogHandler()
+    logging.disable(logging.NOTSET)
+    logger.handlers = [handler]
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    logger.disabled = False
+    for name in child_snapshots:
+        child = logging.getLogger(name)
+        child.setLevel(logging.NOTSET)
+        child.propagate = True
+        child.disabled = False
+    yield handler
+    logger.handlers, level, propagate = snapshot[0], snapshot[1], snapshot[2]
+    logger.setLevel(level)
+    logger.propagate = propagate
+    for name, (child_level, child_propagate) in child_snapshots.items():
+        child = logging.getLogger(name)
+        child.setLevel(child_level)
+        child.propagate = child_propagate
+    logging.disable(ambient_disable)

--- a/tests/unit/test_openai_live_embedding_provider.py
+++ b/tests/unit/test_openai_live_embedding_provider.py
@@ -81,7 +81,7 @@ def test_openai_live_embedding_provider_maps_rate_limit_errors(
         )
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_RATE_LIMITED
-        assert exc.message == "OpenAI embedding provider rate limit exceeded."
+        assert exc.message == "embeddings.openai rate limit exceeded."
         assert "Embedding rate limit hit" not in exc.message
     else:
         raise AssertionError("Expected rate-limited embedding request to fail")
@@ -110,7 +110,7 @@ def test_openai_live_embedding_provider_maps_upstream_http_errors(
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR
         assert exc.message == (
-            "OpenAI embedding provider request failed at the upstream provider boundary."
+            "embeddings.openai request failed at the upstream provider boundary."
         )
     else:
         raise AssertionError("Expected upstream embedding request to fail")
@@ -131,7 +131,7 @@ def test_openai_live_embedding_provider_maps_timeout_errors(monkeypatch: MonkeyP
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_TIMEOUT
         assert exc.message == (
-            "OpenAI embedding provider request did not complete within the configured timeout."
+            "embeddings.openai request did not complete within the configured timeout."
         )
     else:
         raise AssertionError("Expected timeout embedding request to fail")
@@ -152,7 +152,7 @@ def test_openai_live_embedding_provider_maps_url_errors(monkeypatch: MonkeyPatch
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_TIMEOUT
         assert exc.message == (
-            "OpenAI embedding provider request did not complete within the configured timeout."
+            "embeddings.openai request did not complete within the configured timeout."
         )
         assert "connection refused" not in exc.message
     else:

--- a/tests/unit/test_openai_live_text_provider.py
+++ b/tests/unit/test_openai_live_text_provider.py
@@ -37,7 +37,7 @@ def _post_openai_response(
         api_key=api_key,
         payload=payload,
         timeout_seconds=timeout_seconds,
-        provider_display_name="OpenAI Managed Text Provider",
+        serving_provider_id="text.openai",
         require_api_key=True,
         retry_limit=retry_limit,
     )
@@ -416,7 +416,7 @@ def test_openai_live_text_provider_maps_rate_limit_errors(monkeypatch: MonkeyPat
         )
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_RATE_LIMITED
-        assert exc.message == "OpenAI Managed Text Provider rate limit exceeded."
+        assert exc.message == "text.openai rate limit exceeded."
         assert "Rate limit hit" not in exc.message
     else:
         raise AssertionError("Expected ProviderExecutionError for rate-limited provider response")
@@ -443,10 +443,7 @@ def test_openai_live_text_provider_maps_upstream_http_errors(monkeypatch: Monkey
         )
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR
-        assert (
-            exc.message
-            == "OpenAI Managed Text Provider request failed at the upstream provider boundary."
-        )
+        assert exc.message == "text.openai request failed at the upstream provider boundary."
         assert "Transient upstream failure" not in exc.message
     else:
         raise AssertionError("Expected ProviderExecutionError for upstream provider response")
@@ -468,7 +465,7 @@ def test_openai_live_text_provider_maps_timeout_errors(monkeypatch: MonkeyPatch)
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_TIMEOUT
         assert exc.message == (
-            "OpenAI Managed Text Provider request did not complete within the configured timeout."
+            "text.openai request did not complete within the configured timeout."
         )
     else:
         raise AssertionError("Expected ProviderExecutionError for provider timeout")
@@ -490,7 +487,7 @@ def test_openai_live_text_provider_maps_url_errors(monkeypatch: MonkeyPatch) -> 
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_TIMEOUT
         assert exc.message == (
-            "OpenAI Managed Text Provider request did not complete within the configured timeout."
+            "text.openai request did not complete within the configured timeout."
         )
         assert "connection refused" not in exc.message
     else:
@@ -602,7 +599,7 @@ def test_openai_compatible_transport_preserves_category_when_retries_exhaust(
     except ProviderExecutionError as exc:
         assert attempts["count"] == 3
         assert exc.category == ProviderFailureCategory.PROVIDER_RATE_LIMITED
-        assert exc.message == "OpenAI Managed Text Provider rate limit exceeded."
+        assert exc.message == "text.openai rate limit exceeded."
         assert "raw account detail" not in exc.message
     else:
         raise AssertionError("Expected ProviderExecutionError after exhausted retries")
@@ -681,10 +678,7 @@ def test_openai_live_text_provider_handles_non_json_error_bodies(monkeypatch: Mo
         )
     except ProviderExecutionError as exc:
         assert exc.category == ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR
-        assert (
-            exc.message
-            == "OpenAI Managed Text Provider request failed at the upstream provider boundary."
-        )
+        assert exc.message == "text.openai request failed at the upstream provider boundary."
     else:
         raise AssertionError("Expected ProviderExecutionError for invalid JSON error body")
 

--- a/tests/unit/test_ordered_fallback_routing.py
+++ b/tests/unit/test_ordered_fallback_routing.py
@@ -9,7 +9,11 @@ reject both candidates; and every outcome is recorded on the routing
 decision with the fallback path named.
 """
 
+import json
+from email.message import Message
+from io import BytesIO
 from pathlib import Path
+from urllib import error
 
 import pytest
 from fastapi import HTTPException
@@ -33,6 +37,7 @@ from app.services.provider_gateway import (
 from app.services.provider_operations_store import get_provider_operations_store
 from app.services.routing_posture import build_routing_posture
 from app.services.startup_policy import apply_startup_readiness_policy
+from tests.support.log_collection import CollectingLogHandler
 from tests.support.migration_runner import upgrade_database_to_head
 
 PRIMARY = "text.openai"
@@ -511,3 +516,164 @@ def test_real_transport_attributes_the_alternate_identity_end_to_end() -> None:
     records = get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=5)
     record = next(r for r in records if r.correlation_id == "corr-226-attribution")
     assert record.provider_id == ALTERNATE
+
+
+def test_every_evidence_surface_names_the_serving_candidate(
+    monkeypatch: pytest.MonkeyPatch, app_log_collector: CollectingLogHandler
+) -> None:
+    """Issue #237: one answer to "which provider served this execution".
+
+    The #226 test above fakes at the transport post override, which returns
+    before the transport emits any telemetry - so it can prove the audit
+    record but is structurally blind to metrics, logs and spans. This one
+    fakes at the true HTTP boundary instead, so the real telemetry path
+    runs, and it covers the surfaces the issue listed as unverified:
+    metrics labels, structured log lines, breaker/degradation evidence,
+    and the identity the run ledger attests.
+
+    The primary's breaker is left open by its own failure, so the two
+    candidates hold genuinely different postures: evidence that reported
+    the ambient provider would report the wrong one, visibly.
+    """
+
+    from prometheus_client import REGISTRY
+
+    from app.contracts.tasks import (
+        CallerMetadata,
+        OutputLabel,
+        TaskContextEnvelope,
+        TaskExecutionRequest,
+        TaskInputMode,
+    )
+    from app.services.provider_degradation_state import build_provider_degradation_status
+    from app.services.task_executor import execute_task
+    from app.services.task_execution_context_builder import build_task_execution_context
+    from app.services.workflow_pack_registry import get_workflow_pack_registration
+    from app.services.workflow_run_attestation_source import (
+        capture_workflow_run_attestation_source,
+    )
+
+    _ordered_fallback_settings()
+    settings.live_text_degradation_enforced = True
+    settings.live_text_degraded_failure_count_threshold = 1
+    settings.live_text_circuit_open_failure_count_threshold = 1
+    settings.live_text_circuit_open_seconds = 60
+
+    def _attempts(provider_id: str, model_id: str, outcome: str) -> float:
+        return (
+            REGISTRY.get_sample_value(
+                "lotus_ai_provider_requests_total",
+                {"provider_id": provider_id, "model_id": model_id, "outcome": outcome},
+            )
+            or 0.0
+        )
+
+    before_alternate = _attempts(ALTERNATE, "claude-sonnet-5", "success")
+    before_primary = _attempts(PRIMARY, "gpt-5.4", "failed")
+
+    class _Served:
+        def __enter__(self) -> "_Served":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "id": "resp_alternate_serving",
+                    "model": "claude-sonnet-5",
+                    "output_text": "Grounded explanation without figures.",
+                    "usage": {"input_tokens": 9, "output_tokens": 4, "total_tokens": 13},
+                }
+            ).encode("utf-8")
+
+    def _urlopen(request: object, timeout: float) -> object:
+        url = str(getattr(request, "full_url", ""))
+        if url.startswith(settings.live_text_api_base):
+            raise error.HTTPError(
+                url=url, code=503, msg="Service Unavailable", hdrs=Message(), fp=BytesIO(b"{}")
+            )
+        return _Served()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    request = TaskExecutionRequest(
+        task_id="explain.v1",
+        input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+        caller=CallerMetadata(
+            caller_app="lotus-manage",
+            correlation_id="corr-237-attribution",
+            tenant_id="tenant-sg-001",
+        ),
+        context=TaskContextEnvelope(
+            summary="Explain rebalance outcome",
+            payload={"status": "BLOCKED", "rule_count": 3},
+            source_refs=["lotus-manage:run:reb_001"],
+        ),
+        expected_output_label=OutputLabel.EXPLANATION_ONLY,
+    )
+    response = execute_task(request)
+
+    # Already-correct surfaces (issue #226), re-pinned so they stay correct.
+    assert response.audit.provider_id == ALTERNATE
+    assert response.result.structured_output["provider_id"] == ALTERNATE
+    assert response.audit.routing_decision is not None
+    assert response.audit.routing_decision.selected_provider_id == ALTERNATE
+
+    # Metrics: each attempt counted against the candidate that made it.
+    assert _attempts(ALTERNATE, "claude-sonnet-5", "success") == before_alternate + 1
+    assert _attempts(PRIMARY, "gpt-5.4", "failed") == before_primary + 1
+    for descriptor_display_name in (
+        "OpenAI Managed Text Provider",
+        "Local OpenAI-Compatible Text Provider",
+    ):
+        assert (
+            REGISTRY.get_sample_value(
+                "lotus_ai_provider_requests_total",
+                {
+                    "provider_id": descriptor_display_name,
+                    "model_id": "claude-sonnet-5",
+                    "outcome": "success",
+                },
+            )
+            is None
+        )
+
+    # Logs: the same two identities, in attempt order.
+    attempts = app_log_collector.events("provider_attempt")
+    assert [line["provider_id"] for line in attempts] == [PRIMARY, ALTERNATE]
+    assert [line["outcome"] for line in attempts] == ["failed", "success"]
+    assert [line["model_id"] for line in attempts] == ["gpt-5.4", "claude-sonnet-5"]
+
+    # Breaker evidence: the serving candidate's posture, not the ambient one.
+    # The primary's breaker opened on its failure, so these genuinely differ -
+    # reading the ambient config here would report the primary's open circuit
+    # as though it described the execution that actually succeeded.
+    alternate_posture = build_provider_degradation_status(ALTERNATE)
+    primary_posture = build_provider_degradation_status(PRIMARY)
+    assert primary_posture.status != alternate_posture.status
+    provider_evidence = next(
+        descriptor
+        for descriptor in response.evidence.descriptors
+        if descriptor.evidence_type == "provider_resolution"
+    )
+    assert provider_evidence.attributes["provider_id"] == ALTERNATE
+    assert provider_evidence.attributes["degradation_status"] == alternate_posture.status
+
+    # Execution ledger: the attested identity is derived from the audit
+    # record, so it inherits the serving candidate rather than re-deriving it.
+    registration = get_workflow_pack_registration(pack_id="idea_explanation.pack", version="v1")
+    assert registration is not None
+    attestation = capture_workflow_run_attestation_source(
+        run_id="wpr_237",
+        # The registration supplies evaluator identity only; what is under
+        # test here is which provider the attested record names.
+        context=build_task_execution_context(request),
+        response=response,
+        registration=registration,
+        model_risk_status="APPROVED",
+        model_risk_approval_ref="mr-237",
+    )
+    assert attestation.provider_id == ALTERNATE
+    assert attestation.model_id == "claude-sonnet-5"

--- a/tests/unit/test_provider_execution_overrides.py
+++ b/tests/unit/test_provider_execution_overrides.py
@@ -46,7 +46,7 @@ def test_transport_override_applies_only_inside_the_installing_execution() -> No
             api_key=None,
             payload={"model": "gpt-5.4"},
             timeout_seconds=1.0,
-            provider_display_name="OpenAI Managed Text Provider",
+            serving_provider_id="text.openai",
             require_api_key=True,
             retry_limit=0,
         )
@@ -65,7 +65,7 @@ def test_hermetic_execution_blocks_text_transport_without_override() -> None:
                 api_key="credential-ref:test",
                 payload={"model": "gpt-5.4"},
                 timeout_seconds=1.0,
-                provider_display_name="OpenAI Managed Text Provider",
+                serving_provider_id="text.openai",
                 require_api_key=True,
                 retry_limit=0,
             )

--- a/tests/unit/test_provider_retry_backoff.py
+++ b/tests/unit/test_provider_retry_backoff.py
@@ -84,7 +84,7 @@ def test_transport_backs_off_between_retries_and_succeeds(monkeypatch: MonkeyPat
         api_key=None,
         payload={"model": "m"},
         timeout_seconds=4.0,
-        provider_display_name="Local OpenAI-Compatible Text Provider",
+        serving_provider_id="text.local",
         require_api_key=False,
         retry_limit=2,
     )
@@ -121,7 +121,7 @@ def test_deadline_exhaustion_converts_a_retryable_failure_into_a_final_one(
             api_key=None,
             payload={"model": "m"},
             timeout_seconds=1.0,
-            provider_display_name="Local OpenAI-Compatible Text Provider",
+            serving_provider_id="text.local",
             require_api_key=False,
             retry_limit=5,
         )

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterator
 from io import BytesIO
 from email.message import Message
 from urllib import error
@@ -24,56 +23,11 @@ from app.services.structured_logging import (
     configure_structured_logging,
     log_event,
 )
-
-
-class _CollectingHandler(logging.Handler):
-    def __init__(self) -> None:
-        super().__init__()
-        self.lines: list[dict[str, object]] = []
-        self.setFormatter(StructuredJsonFormatter())
-
-    def emit(self, record: logging.LogRecord) -> None:
-        self.lines.append(json.loads(self.format(record)))
-
-
-@pytest.fixture
-def _collector() -> Iterator["_CollectingHandler"]:
-    """Deterministic collection regardless of ambient suite state: snapshot the
-    app logger tree, normalize it for the test, restore afterwards."""
-
-    logger = logging.getLogger("app")
-    snapshot = (list(logger.handlers), logger.level, logger.propagate)
-    child_snapshots = {
-        name: (child.level, child.propagate)
-        for name in ("app.http", "app.provider", "app.errors", "app.test")
-        for child in (logging.getLogger(name),)
-    }
-    ambient_disable = logging.root.manager.disable
-
-    handler = _CollectingHandler()
-    logging.disable(logging.NOTSET)
-    logger.handlers = [handler]
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
-    logger.disabled = False
-    for name in child_snapshots:
-        child = logging.getLogger(name)
-        child.setLevel(logging.NOTSET)
-        child.propagate = True
-        child.disabled = False
-    yield handler
-    logger.handlers, level, propagate = snapshot[0], snapshot[1], snapshot[2]
-    logger.setLevel(level)
-    logger.propagate = propagate
-    for name, (child_level, child_propagate) in child_snapshots.items():
-        child = logging.getLogger(name)
-        child.setLevel(child_level)
-        child.propagate = child_propagate
-    logging.disable(ambient_disable)
+from tests.support.log_collection import CollectingLogHandler
 
 
 def test_formatter_enforces_the_field_allowlist_and_correlation_context(
-    _collector: _CollectingHandler,
+    app_log_collector: CollectingLogHandler,
 ) -> None:
     bind_correlation_context(correlation_id="corr-log-001", source="provided")
     log_event(
@@ -86,8 +40,8 @@ def test_formatter_enforces_the_field_allowlist_and_correlation_context(
         authorization="Bearer nope",
     )
 
-    assert len(_collector.lines) == 1
-    line = _collector.lines[0]
+    assert len(app_log_collector.lines) == 1
+    line = app_log_collector.lines[0]
     assert line["event"] == "unit_event"
     assert line["correlation_id"] == "corr-log-001"
     assert line["correlation_source"] == "provided"
@@ -150,7 +104,7 @@ def test_configure_is_idempotent_and_respects_the_level(
 
 
 def test_provider_attempts_share_the_correlation_id_across_retry_and_success(
-    monkeypatch: pytest.MonkeyPatch, _collector: _CollectingHandler
+    monkeypatch: pytest.MonkeyPatch, app_log_collector: CollectingLogHandler
 ) -> None:
     """The issue's evaluation condition: 429 then success under retry_limit=1
     produces two provider_attempt lines with the same correlation id, distinct
@@ -197,7 +151,7 @@ def test_provider_attempts_share_the_correlation_id_across_retry_and_success(
         api_key="secret",
         payload={"model": "gpt-5.4"},
         timeout_seconds=4.0,
-        provider_display_name="text.openai",
+        serving_provider_id="text.openai",
         require_api_key=True,
         retry_limit=1,
     )
@@ -205,7 +159,7 @@ def test_provider_attempts_share_the_correlation_id_across_retry_and_success(
     assert payload["_lotus_retry_count"] == 1
     assert all(headers.get("X-correlation-id") == "corr-retry-777" for headers in seen_headers)
 
-    attempts = [line for line in _collector.lines if line["event"] == "provider_attempt"]
+    attempts = [line for line in app_log_collector.lines if line["event"] == "provider_attempt"]
     assert [line["attempt"] for line in attempts] == [0, 1]
     assert [line["outcome"] for line in attempts] == ["retry", "success"]
     assert attempts[0]["failure_class"] == "PROVIDER_RATE_LIMITED"

--- a/tests/unit/test_tracing_runtime.py
+++ b/tests/unit/test_tracing_runtime.py
@@ -123,7 +123,7 @@ def test_traceparent_is_injected_on_provider_egress(monkeypatch: MonkeyPatch) ->
             api_key=None,
             payload={"model": "m"},
             timeout_seconds=1.0,
-            provider_display_name="Local OpenAI-Compatible Text Provider",
+            serving_provider_id="text.local",
             require_api_key=False,
             retry_limit=0,
         )


### PR DESCRIPTION
Closes #237.

## Control-plane outcome

There is one answer to "which provider served this execution", and every surface
gives it. Under ordered fallback an alternate-served execution now names the
alternate in metrics, structured logs, tracing spans, bounded failure messages,
breaker/degradation evidence, and the attested run ledger — the same identity the
audit record, routing decision, response, and cost already carried.

## Invariant

A surface that names a provider names the one that *served*, not the one that was
configured, and never the adapter it happened to run through.

## One authority

The execution config's `provider_id` is the serving identity. The adapter
descriptor's `display_name` is not an identity at all: under ordered fallback both
candidates run through the same adapter, so the display name is structurally
unable to distinguish them — it names the adapter. `post_openai_compatible_response`
therefore takes `serving_provider_id` **instead of** `provider_display_name`
(a replaced parameter, not an added one), and metrics, logs, spans and failure
messages all label from it.

Bounded failure messages now read `text.openai rate limit exceeded.` rather than
`OpenAI Managed Text Provider rate limit exceeded.` That is deliberate: the provider
id is the token an operator already uses in breaker keys, kill switches, routing
decisions and metric labels, and the display name appears nowhere else in that
vocabulary.

## What was actually wrong

Measured before changing anything, rather than assumed:

| Surface | Before | Now |
| --- | --- | --- |
| Audit record, routing decision, response, cost | serving candidate | unchanged (#226) |
| Metrics labels | adapter display name | serving candidate |
| Structured logs | adapter display name | serving candidate |
| Tracing spans | adapter display name | serving candidate |
| Bounded failure messages | adapter display name | serving candidate |
| Degradation/breaker evidence | ambient config → the *primary* | serving candidate |
| Execution ledger / attestation | derived from the audit record | unchanged; now pinned by a test |

`provider_metrics.py` claims metrics and logs "can never disagree about what
happened". They did agree — on the wrong identity, both reading the same static
constant.

Threading the identity into `provider_degradation_state.py` exposed a second
defect underneath: every write inside the resolve path keyed off the *ambient*
execution config, so resolving one identity could open or clear a different
identity's breaker. The new test caught it as unbounded recursion (resolve the
alternate → open the primary → alternate still under threshold → repeat). Reads
and writes in that path now stay on the identity they were asked about.

## Simplification

- One parameter removed, not added: `provider_display_name` is gone from the text
  transport rather than sitting beside a new identity parameter.
- `routing_posture.py` no longer installs a config override just to make an
  ambient read mean "the alternate"; both reads name the alternate explicitly, and
  the override import is deleted. Scope-implicit identity is precisely what this
  issue is about.
- `openai_live_embedding_provider.py` had its provider identity written as a
  descriptor field plus three copies of a prose string; it is now one constant
  used by both.
- The structured-log collector fixture moved to `tests/support/log_collection.py`
  and is registered in `conftest.py`, so the routing tests share it instead of
  copying 35 lines of logger-state handling.

## Evidence

`test_every_evidence_surface_names_the_serving_candidate` fakes at the true HTTP
boundary (`urlopen`), not at the transport post override — the override returns
*before* the transport emits any telemetry, so the existing #226 test is
structurally blind to metrics, logs and spans. The primary's breaker is left open
by its own failure, so the two candidates hold genuinely different postures and a
wrong read is visible rather than coincidentally equal.

Both fixes were verified to be load-bearing by reverting each in turn:

- transport reverted → `assert _attempts('text.claude', 'claude-sonnet-5', 'success') == 0.0 + 1`
  fails: the alternate's successful call was counted under the display name.
- evidence reverted → `assert provider_evidence.attributes['degradation_status'] == 'NORMAL'`
  fails with `CIRCUIT_OPEN`: the evidence for an execution the healthy alternate
  served reported the primary's open circuit.

In both reverts the audit assertions still passed, which is the disagreement this
issue names: the record was right while the telemetry beside it was wrong.

Full local gate: 1749 unit tests, integration suite, `make lint` (ruff check,
format, runtime purity, monetary float, module budget), `make typecheck` (727
files) all green.

## Follow-up filed

#248 — the breaker's posture resolver is a read that writes (it opens circuits and
clears expired cooldowns), and `record_provider_failure` depends on that side
effect. This PR made those writes identity-correct; making the read pure is a
separate bounded change with its own consumer risk, specified there rather than
folded in here.
