### PR TITLE
fix(resilience): carry an OPEN circuit across the breaker key migration

### DIFF
--- a/src/app/services/provider_degradation_reconciliation.py
+++ b/src/app/services/provider_degradation_reconciliation.py
@@ -1,0 +1,100 @@
+"""Legacy circuit-breaker state reconciliation (issue #234).
+
+Issue #176 S3 moved degradation bookkeeping from the bare
+``live_text_generation`` key to ``live_text_generation:<provider_id>`` so the
+primary's failures could never open the alternate's breaker. That migration
+treated rows still under the bare key as stale transient bookkeeping, which is
+true of a closed breaker and wrong for an open one.
+
+An OPEN breaker is not bookkeeping. It is an active protection decision: the
+runtime is refusing live calls because it has already judged a provider to be
+failing. If that row becomes unreadable at the new key, the next deployment
+silently resumes traffic to a provider the system had ruled unsafe, with no
+operator action and no evidence that anything was overridden.
+
+So reconciliation runs at startup and is deliberately conservative: it carries
+an open circuit across to the provider-scoped key with its cooldown intact,
+drops closed rows without ceremony, and refuses to delete an open row it cannot
+attribute - that becomes a startup finding naming the orphaned state instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+
+from app.repositories.provider_operations_repository import ProviderDegradationStateRecord
+from app.services.provider_degradation_state import (
+    DEGRADATION_KEY_PREFIX,
+    degradation_key_for,
+)
+from app.services.provider_execution_config import resolve_provider_execution_config
+from app.services.provider_operations_store import get_provider_operations_store
+from app.services.runtime_readiness import get_provider_operations_store_runtime_status
+
+LEGACY_DEGRADATION_KEY = DEGRADATION_KEY_PREFIX
+
+
+def reconcile_legacy_degradation_state() -> list[str]:
+    """Migrate pre-#176-S3 breaker state, returning startup findings.
+
+    Idempotent: the legacy row is removed once its meaning has been carried
+    over, so a second run finds nothing to do. A provider-scoped row that
+    already exists wins - it is current bookkeeping, and the legacy row can
+    only be older.
+    """
+
+    store_status = get_provider_operations_store_runtime_status()
+    if store_status.status != "READY":
+        # Resolving the store would raise here and take startup down with an
+        # error that bypasses the warn/enforce policy entirely. Report it as a
+        # finding instead, and say plainly what was not done.
+        return [
+            "provider degradation: legacy circuit-breaker reconciliation was skipped because "
+            f"the provider-operations store is not ready ({store_status.detail}). If a "
+            "pre-migration OPEN circuit exists it has not been carried over, so a provider "
+            "the runtime had already refused may be called again."
+        ]
+
+    repository = get_provider_operations_store()
+    legacy = repository.get_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY)
+    if legacy is None:
+        return []
+
+    if not circuit_is_open(legacy):
+        # A closed breaker carries no protection decision worth preserving.
+        repository.reset_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY)
+        return []
+
+    provider_id = resolve_provider_execution_config().provider_id
+    if not provider_id:
+        # Deleting here would discard an open circuit that no longer has an
+        # owner - exactly the silent re-enable this reconciliation exists to
+        # prevent. Leave the row and make an operator look at it.
+        return [
+            "provider degradation: an OPEN circuit is recorded under the pre-migration key "
+            f"'{LEGACY_DEGRADATION_KEY}' (open until {legacy.circuit_open_until}, "
+            f"{legacy.consecutive_failure_count} consecutive failures) but no live text "
+            "provider identity is configured, so it cannot be attributed to a provider. "
+            "The row has been left in place: configure the provider identity it belongs to, "
+            "or clear it explicitly through provider operations."
+        ]
+
+    scoped_key = degradation_key_for(provider_id)
+    if repository.get_degradation_state(degradation_key=scoped_key) is None:
+        repository.save_degradation_state(replace(legacy, degradation_key=scoped_key))
+    repository.reset_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY)
+    return []
+
+
+def circuit_is_open(record: ProviderDegradationStateRecord) -> bool:
+    """Whether ``record`` carries a cooldown that has not yet elapsed.
+
+    Deliberately not reusing the degradation module's remaining-seconds
+    helper: that one clears an expired cooldown as a side effect, and a
+    migration decision must not mutate the state it is deciding about.
+    """
+
+    if record.circuit_open_until is None:
+        return False
+    return datetime.fromisoformat(record.circuit_open_until) > datetime.now(UTC)

--- a/src/app/services/provider_degradation_state.py
+++ b/src/app/services/provider_degradation_state.py
@@ -12,10 +12,13 @@ from app.repositories.provider_operations_repository import ProviderDegradationS
 from app.services.provider_operations_store import get_provider_operations_store
 from app.services.provider_execution_config import resolve_provider_execution_config
 
-_DEGRADATION_KEY_PREFIX = "live_text_generation"
+# The bare prefix was the whole key before #176 S3 keyed bookkeeping per
+# provider identity, so it is also the shape a pre-migration row still
+# carries (issue #234).
+DEGRADATION_KEY_PREFIX = "live_text_generation"
 
 
-def _degradation_key(provider_id: str | None = None) -> str:
+def degradation_key_for(provider_id: str | None = None) -> str:
     """Failure bookkeeping is keyed per provider identity (issue #176, S3).
 
     Ordered fallback requires the primary's failures to never open the
@@ -34,8 +37,8 @@ def _degradation_key(provider_id: str | None = None) -> str:
 
     resolved = provider_id or resolve_provider_execution_config().provider_id
     if resolved:
-        return f"{_DEGRADATION_KEY_PREFIX}:{resolved}"
-    return _DEGRADATION_KEY_PREFIX
+        return f"{DEGRADATION_KEY_PREFIX}:{resolved}"
+    return DEGRADATION_KEY_PREFIX
 
 
 @dataclass(frozen=True)
@@ -109,7 +112,7 @@ def record_provider_failure(category: ProviderFailureCategory) -> None:
 
     repository = get_provider_operations_store()
     repository.record_degradation_failure(
-        degradation_key=_degradation_key(),
+        degradation_key=degradation_key_for(),
         category=category,
         updated_at=_utcnow().isoformat(),
     )
@@ -326,7 +329,7 @@ def _load_degradation_record(
     provider_id: str | None = None,
 ) -> ProviderDegradationStateRecord:
     repository = get_provider_operations_store()
-    degradation_key = _degradation_key(provider_id)
+    degradation_key = degradation_key_for(provider_id)
     record = repository.get_degradation_state(degradation_key=degradation_key)
     if record is not None:
         return record
@@ -355,7 +358,7 @@ def _save_degradation_record(
     repository = get_provider_operations_store()
     repository.save_degradation_state(
         ProviderDegradationStateRecord(
-            degradation_key=_degradation_key(provider_id),
+            degradation_key=degradation_key_for(provider_id),
             consecutive_failure_count=consecutive_failure_count,
             last_failure_category=last_failure_category,
             circuit_open_until=circuit_open_until,

--- a/src/app/services/runtime_readiness.py
+++ b/src/app/services/runtime_readiness.py
@@ -108,7 +108,16 @@ def get_prompt_store_runtime_status() -> StoreRuntimeStatusDescriptor:
 def get_provider_operations_store_runtime_status() -> StoreRuntimeStatusDescriptor:
     return _build_store_runtime_status(
         configured_mode=settings.provider_operations_store_mode,
-        expected_tables=["provider_operations_state", "provider_operations_events"],
+        # The tables the provider-operations repository actually reads and
+        # writes. "provider_operations_state" was never one of them, so this
+        # probe reported MIGRATION_REQUIRED on every correctly migrated
+        # database; every test of its consumers stubs it, so nothing caught it.
+        expected_tables=[
+            "provider_budget_state",
+            "provider_degradation_state",
+            "provider_operations_events",
+            "provider_quota_state",
+        ],
         memory_detail="In-memory provider-operations state is active for local or foundation-phase rollout work.",
         unsupported_detail="Configured provider-operations store mode is not supported by lotus-ai.",
     )

--- a/src/app/services/startup_policy.py
+++ b/src/app/services/startup_policy.py
@@ -9,6 +9,9 @@ from app.http.caller_credential import (
     SUPPORTED_CALLER_TRUST_MODES,
     parse_caller_credential_public_keys,
 )
+from app.services.provider_degradation_reconciliation import (
+    reconcile_legacy_degradation_state,
+)
 from app.services.provider_execution_config import (
     fallback_configuration_findings,
     resolve_provider_execution_config,
@@ -33,7 +36,6 @@ class StartupReadinessEvaluation:
 
 def evaluate_startup_readiness() -> StartupReadinessEvaluation:
     findings: list[str] = []
-    blocking = False
 
     audit_status = get_audit_store_runtime_status()
     retrieval_status = get_retrieval_store_runtime_status()
@@ -60,14 +62,27 @@ def evaluate_startup_readiness() -> StartupReadinessEvaluation:
     findings.extend(_caller_identity_findings())
     findings.extend(_provider_protection_findings())
 
-    if settings.startup_readiness_policy == "enforce" and findings:
-        blocking = True
+    return _evaluation_for(findings)
 
+
+def _evaluation_for(findings: list[str]) -> StartupReadinessEvaluation:
+    """One place decides whether findings block startup."""
+
+    blocking = settings.startup_readiness_policy == "enforce" and bool(findings)
     return StartupReadinessEvaluation(blocking=blocking, findings=findings)
 
 
 def apply_startup_readiness_policy() -> StartupReadinessEvaluation:
-    evaluation = evaluate_startup_readiness()
+    """Reconcile what startup owns, then evaluate what it can only report.
+
+    Reconciliation writes, so it lives here rather than inside
+    ``evaluate_startup_readiness``: that one stays a pure read, callable by
+    an operator surface without changing the state it is describing.
+    """
+
+    reconciliation_findings = reconcile_legacy_degradation_state()
+    evaluated = evaluate_startup_readiness()
+    evaluation = _evaluation_for(reconciliation_findings + evaluated.findings)
     if evaluation.findings:
         for finding in evaluation.findings:
             logger.warning("startup readiness finding: %s", finding)

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -413,7 +413,19 @@ def test_build_platform_runtime_status_reports_dedicated_async_worker_cutover(
     assert status.evaluation_runtime.async_execution_route_mode.value == "UNIFIED_INTERNAL"
     assert status.resilience_runtime.posture.value == "PARTIAL_RUNTIME_DURABILITY"
     assert status.resilience_runtime.delivery_stage.value == "DRILL_VERIFIED"
-    assert status.resilience_runtime.recovery_state.value == "DEGRADED"
+    # This asserted DEGRADED until the provider-operations readiness probe was
+    # corrected. The probe expected a table no migration creates, so it returned
+    # MIGRATION_REQUIRED against this fully migrated database - and one degraded
+    # dependency forces the whole recovery state to DEGRADED, so the platform
+    # reported degraded recovery in every SQL-backed deployment. The store is
+    # genuinely ready here; the remaining findings come from other dependencies.
+    assert status.resilience_runtime.recovery_state.value == "RESTORED_WITH_FINDINGS"
+    provider_operations_dependency = next(
+        dependency
+        for dependency in status.resilience_runtime.dependencies
+        if dependency.dependency_id == "provider_operations_store"
+    )
+    assert provider_operations_dependency.recovery_state.value != "DEGRADED"
     assert status.production_baseline.posture.value == "LOCAL_OR_DEMO_CAPABLE"
     assert status.production_baseline.prod_shaped_local is False
     assert status.production_baseline.production_ready is False

--- a/tests/unit/test_provider_degradation_reconciliation.py
+++ b/tests/unit/test_provider_degradation_reconciliation.py
@@ -1,0 +1,202 @@
+"""An OPEN circuit survives the per-provider key migration (issue #234).
+
+#176 S3 rekeyed degradation bookkeeping per provider identity and treated
+rows left under the bare key as stale transient state. For a CLOSED breaker
+that is true. For an OPEN one it is a safety defect: the row is an active
+refusal to call a provider, and losing it re-enables that provider on the
+next deployment with no operator action and no evidence.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from app.config import settings
+from app.contracts.providers import ProviderFailureCategory
+from app.providers.base import ProviderExecutionError
+from app.repositories.provider_operations_repository import ProviderDegradationStateRecord
+from app.services.provider_degradation_reconciliation import (
+    LEGACY_DEGRADATION_KEY,
+    reconcile_legacy_degradation_state,
+)
+from app.services.provider_degradation_state import (
+    build_provider_degradation_status,
+    degradation_key_for,
+    enforce_provider_degradation_preflight,
+)
+from app.services.provider_operations_store import (
+    get_provider_operations_store,
+    reset_provider_operations_store_cache,
+)
+from app.services.startup_policy import apply_startup_readiness_policy
+from tests.support.migration_runner import upgrade_database_to_head
+
+PRIMARY = "text.openai"
+
+
+def _legacy_record(*, open_for_seconds: int | None, failures: int = 5) -> None:
+    circuit_open_until = (
+        (datetime.now(UTC) + timedelta(seconds=open_for_seconds)).isoformat()
+        if open_for_seconds is not None
+        else None
+    )
+    get_provider_operations_store().save_degradation_state(
+        ProviderDegradationStateRecord(
+            degradation_key=LEGACY_DEGRADATION_KEY,
+            consecutive_failure_count=failures,
+            last_failure_category=ProviderFailureCategory.PROVIDER_TIMEOUT,
+            circuit_open_until=circuit_open_until,
+            timeout_failure_count=failures,
+            rate_limited_failure_count=0,
+            upstream_error_failure_count=0,
+            updated_at=datetime.now(UTC).isoformat(),
+        )
+    )
+
+
+def _enforcing_primary() -> None:
+    settings.provider_mode = "openai"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    settings.live_text_provider_id = PRIMARY
+    settings.live_text_model_id = "gpt-5.4"
+    settings.live_text_provider_api_key = "secret"
+    settings.live_text_allowed_task_ids = "explain.v1"
+    settings.live_text_degradation_enforced = True
+    settings.live_text_degraded_failure_count_threshold = 3
+    settings.live_text_circuit_open_failure_count_threshold = 5
+    settings.live_text_circuit_open_seconds = 60
+    settings.startup_readiness_policy = "warn"
+
+
+def test_an_open_legacy_circuit_still_refuses_execution_after_reconciliation() -> None:
+    """The issue's evaluation condition: an open bare-key breaker present at
+    startup leaves the provider's breaker open, with the cooldown preserved,
+    and live execution still refused."""
+
+    _enforcing_primary()
+    _legacy_record(open_for_seconds=900)
+
+    apply_startup_readiness_policy()
+
+    store = get_provider_operations_store()
+    assert store.get_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY) is None
+    migrated = store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY))
+    assert migrated is not None
+    assert migrated.consecutive_failure_count == 5
+    assert migrated.last_failure_category is ProviderFailureCategory.PROVIDER_TIMEOUT
+
+    status = build_provider_degradation_status(PRIMARY)
+    assert status.status == "CIRCUIT_OPEN"
+    assert status.circuit_open_remaining_seconds is not None
+    assert status.circuit_open_remaining_seconds > 0
+
+    with pytest.raises(ProviderExecutionError) as exc_info:
+        enforce_provider_degradation_preflight()
+    assert exc_info.value.category is ProviderFailureCategory.CIRCUIT_OPEN
+
+
+def test_an_unattributable_open_circuit_is_a_finding_not_a_deletion() -> None:
+    _enforcing_primary()
+    settings.live_text_provider_id = None
+    _legacy_record(open_for_seconds=900)
+
+    evaluation = apply_startup_readiness_policy()
+
+    assert any(LEGACY_DEGRADATION_KEY in finding for finding in evaluation.findings)
+    assert any("cannot be attributed" in finding for finding in evaluation.findings)
+    # Left in place: discarding it is the silent re-enable this prevents.
+    assert (
+        get_provider_operations_store().get_degradation_state(
+            degradation_key=LEGACY_DEGRADATION_KEY
+        )
+        is not None
+    )
+
+
+def test_reconciliation_is_idempotent() -> None:
+    _enforcing_primary()
+    _legacy_record(open_for_seconds=900)
+
+    assert reconcile_legacy_degradation_state() == []
+    store = get_provider_operations_store()
+    after_first = store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY))
+
+    assert reconcile_legacy_degradation_state() == []
+    assert store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY)) == after_first
+    assert store.get_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY) is None
+
+
+def test_a_current_provider_scoped_row_wins_over_the_legacy_row() -> None:
+    _enforcing_primary()
+    store = get_provider_operations_store()
+    current = ProviderDegradationStateRecord(
+        degradation_key=degradation_key_for(PRIMARY),
+        consecutive_failure_count=1,
+        last_failure_category=ProviderFailureCategory.PROVIDER_RATE_LIMITED,
+        circuit_open_until=None,
+        timeout_failure_count=0,
+        rate_limited_failure_count=1,
+        upstream_error_failure_count=0,
+        updated_at=datetime.now(UTC).isoformat(),
+    )
+    store.save_degradation_state(current)
+    _legacy_record(open_for_seconds=900)
+
+    assert reconcile_legacy_degradation_state() == []
+
+    assert store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY)) == current
+    assert store.get_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY) is None
+
+
+def test_a_closed_legacy_row_is_dropped_without_ceremony() -> None:
+    _enforcing_primary()
+    _legacy_record(open_for_seconds=None, failures=2)
+
+    assert reconcile_legacy_degradation_state() == []
+
+    store = get_provider_operations_store()
+    assert store.get_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY) is None
+    assert store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY)) is None
+
+
+def test_an_expired_legacy_cooldown_is_closed_and_dropped() -> None:
+    """Expiry is not openness: a cooldown that has elapsed carries no live
+    protection decision, so it is bookkeeping like any other closed row."""
+
+    _enforcing_primary()
+    _legacy_record(open_for_seconds=-30)
+
+    assert reconcile_legacy_degradation_state() == []
+
+    store = get_provider_operations_store()
+    assert store.get_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY) is None
+    assert store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY)) is None
+
+
+def test_the_migration_behaves_identically_on_the_sql_store(tmp_path: Path) -> None:
+    """Production runs the SQL adapter in the promoted profile, so the case
+    that matters must be proven there and not only in memory - a delete or an
+    upsert that diverges between adapters would lose the open circuit exactly
+    where losing it costs something."""
+
+    _enforcing_primary()
+    settings.provider_operations_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-breaker-migration.db'}"
+    upgrade_database_to_head(settings.database_url)
+    reset_provider_operations_store_cache()
+
+    _legacy_record(open_for_seconds=900)
+
+    assert reconcile_legacy_degradation_state() == []
+
+    store = get_provider_operations_store()
+    assert store.get_degradation_state(degradation_key=LEGACY_DEGRADATION_KEY) is None
+    migrated = store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY))
+    assert migrated is not None
+    assert migrated.consecutive_failure_count == 5
+    assert build_provider_degradation_status(PRIMARY).status == "CIRCUIT_OPEN"
+
+    # Idempotent against a durable store too.
+    assert reconcile_legacy_degradation_state() == []
+    assert store.get_degradation_state(degradation_key=degradation_key_for(PRIMARY)) == migrated

--- a/tests/unit/test_runtime_readiness.py
+++ b/tests/unit/test_runtime_readiness.py
@@ -5,13 +5,21 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from app.config import settings
 from app.contracts.runtime_readiness import RuntimeReadinessStatus
+from app.db.models import (
+    ProviderBudgetStateModel,
+    ProviderDegradationStateModel,
+    ProviderOperationsEventModel,
+    ProviderQuotaStateModel,
+)
 from app.services.runtime_readiness import (
     get_access_control_store_runtime_status,
     get_audit_store_runtime_status,
+    get_provider_operations_store_runtime_status,
     get_retrieval_store_runtime_status,
     get_workflow_pack_registry_store_runtime_status,
     get_workflow_pack_task_flow_store_runtime_status,
 )
+from tests.support.migration_runner import upgrade_database_to_head
 
 
 def test_audit_store_runtime_status_defaults_to_ready_memory_mode() -> None:
@@ -198,3 +206,66 @@ def test_workflow_pack_task_flow_store_runtime_status_reports_unsupported_mode()
     assert status_descriptor.mode == "unsupported"
     assert status_descriptor.status == RuntimeReadinessStatus.UNAVAILABLE
     assert "not supported" in status_descriptor.detail
+
+
+def test_a_migrated_database_reports_every_store_ready(tmp_path: Path) -> None:
+    """Probes are measured, not declared.
+
+    The provider-operations probe expected a table named
+    "provider_operations_state" that no migration has ever created, so it
+    reported MIGRATION_REQUIRED on every correctly migrated database - and
+    every test of its consumers (production baseline, resilience runtime)
+    monkeypatches it, so the real probe was never once run against a real
+    schema. This test runs them all for real.
+    """
+
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-readiness.db'}"
+    upgrade_database_to_head(settings.database_url)
+    for mode_attribute in (
+        "audit_store_mode",
+        "retrieval_store_mode",
+        "access_control_store_mode",
+        "workflow_pack_registry_store_mode",
+        "workflow_pack_task_flow_store_mode",
+        "provider_operations_store_mode",
+    ):
+        setattr(settings, mode_attribute, "sqlalchemy")
+
+    for name, descriptor in (
+        ("audit", get_audit_store_runtime_status()),
+        ("retrieval", get_retrieval_store_runtime_status()),
+        ("access control", get_access_control_store_runtime_status()),
+        ("workflow-pack registry", get_workflow_pack_registry_store_runtime_status()),
+        ("workflow-pack task flow", get_workflow_pack_task_flow_store_runtime_status()),
+        ("provider operations", get_provider_operations_store_runtime_status()),
+    ):
+        assert descriptor.status == RuntimeReadinessStatus.READY, (
+            f"{name} store probe reports {descriptor.status} on a fully migrated "
+            f"database: {descriptor.detail}"
+        )
+
+
+def test_the_provider_operations_probe_names_the_tables_the_repository_uses() -> None:
+    """The probe's table list is a claim about the repository's storage; the
+    repository's own models are the authority. Keeping them tied here is what
+    stops the list drifting into naming a table nobody writes."""
+
+    repository_tables = {
+        model.__tablename__
+        for model in (
+            ProviderBudgetStateModel,
+            ProviderDegradationStateModel,
+            ProviderOperationsEventModel,
+            ProviderQuotaStateModel,
+        )
+    }
+    settings.provider_operations_store_mode = "sqlalchemy"
+    settings.database_url = None
+
+    descriptor = get_provider_operations_store_runtime_status()
+    assert descriptor.status == RuntimeReadinessStatus.CONFIGURATION_REQUIRED
+
+    with patch("app.services.runtime_readiness._probe_sql_tables") as probe:
+        probe.return_value = (RuntimeReadinessStatus.READY, "probed")
+        get_provider_operations_store_runtime_status()
+    assert set(probe.call_args.args[0]) == repository_tables


### PR DESCRIPTION
Closes #234.

## Control-plane outcome

A circuit the runtime opened stays open across the deployment that rekeyed
breaker bookkeeping. A provider the system has already judged unsafe is not
silently called again because its state became unreadable.

## Invariant

An OPEN breaker is an operator-visible safety decision, so it is never
discarded silently: it is either carried to the key that now owns it, or it is
reported as an orphan and left in place. Only a CLOSED breaker is bookkeeping.

## One authority

The degradation key format has one owner. `degradation_key_for()` and
`DEGRADATION_KEY_PREFIX` are now public on `provider_degradation_state` and the
reconciliation imports them, rather than a second module re-deriving
`f"{prefix}:{provider_id}"` — which is how the two halves of a migration drift
apart in the first place.

Store readiness also has one authority: reconciliation asks
`get_provider_operations_store_runtime_status()` rather than catching exceptions
from the store resolver.

## What changed

`reconcile_legacy_degradation_state()` runs at startup:

- no legacy row → nothing to do;
- legacy row, circuit closed or cooldown elapsed → dropped;
- legacy row, circuit open, provider identity configured → carried to
  `live_text_generation:<provider_id>` with `circuit_open_until`, the
  consecutive failure count and the last failure category intact, then the
  legacy row is removed;
- legacy row, circuit open, **no** identity to attribute it to → a startup
  finding naming the orphaned state, and the row is **left in place**. Deleting
  it is precisely the silent re-enable this exists to prevent;
- a provider-scoped row that already exists wins — it is current bookkeeping and
  the legacy row can only be older.

Idempotent by construction: the legacy row is removed once its meaning has been
carried over, so a second run finds nothing.

## Simplification

Reconciliation is a write, so it sits on `apply_startup_readiness_policy` while
`evaluate_startup_readiness` stays a pure read — an operator surface can call
the evaluation without mutating the state it is describing. That is the same
read/writes-during-read separation #248 asks for, applied here rather than
repeated as new debt. Both paths now share one `_evaluation_for()` helper, so
the `enforce + findings → blocking` rule is stated once instead of twice.

Open-circuit detection is written fresh rather than reusing
`_remaining_circuit_open_seconds`, because that helper *clears* an expired
cooldown as a side effect — a migration must not mutate the state it is
deciding about.

## A defect found while building the gate this depends on

`get_provider_operations_store_runtime_status()` expected a table named
`provider_operations_state`. **No migration has ever created that table.** The
provider-operations repository reads and writes `provider_budget_state`,
`provider_degradation_state`, `provider_operations_events` and
`provider_quota_state`.

So that probe returned `MIGRATION_REQUIRED` on every correctly migrated
database, in every deployment running the promoted profile — and it feeds
`production_baseline_runtime` and `resilience_runtime`, both of which report
production readiness. It went unnoticed because **every** test of those
consumers monkeypatches the probe, so the real one had never once run against a
real schema.

Fixed here because this PR's reconciliation gates on that signal, and shipping a
safety mechanism on top of a readiness surface known to be lying is not an
option. Two tests close the gap:

- one runs all six store probes for real against a migrated database and asserts
  `READY`;
- one ties the probe's expected-table list to the repository's own models, so
  the list cannot drift into naming a table nobody writes.

The blast radius was larger than "a status field reads wrong". `_resolve_recovery_state`
returns `DEGRADED` if *any* dependency is degraded, so the phantom
`MIGRATION_REQUIRED` forced the platform's resilience recovery state to `DEGRADED`
in every SQL-backed deployment. `test_build_platform_runtime_status_reports_dedicated_async_worker_cutover`
asserted exactly that `DEGRADED` — it had banked the defect. Its assertion is now
`RESTORED_WITH_FINDINGS`, with a comment explaining why it changed, plus a new
assertion that the provider-operations dependency specifically is not degraded, so
the test pins the corrected behaviour rather than a new enum value.

## Evidence

Seven reconciliation tests, including the two cases the issue names as
conditions and one that runs the whole migration against the **SQL** store —
production's adapter in the promoted profile — because a delete or upsert that
diverged between adapters would lose the open circuit exactly where losing it
costs something.

Guards verified to be load-bearing, not decorative:

- reconciliation stubbed out → the two startup-path tests fail: the legacy row
  is still present and the orphan finding is absent;
- probe table list reverted → `provider operations store probe reports
  MIGRATION_REQUIRED on a fully migrated database`.

Full local gate: whole suite, `make lint` (ruff check, format, runtime purity,
monetary float, module budget), `make typecheck` (729 files).
