### PR TITLE
fix(resilience): make breaker posture a read, and give the writes an owner

### DIFF
--- a/src/app/services/provider_degradation_state.py
+++ b/src/app/services/provider_degradation_state.py
@@ -98,6 +98,13 @@ def enforce_provider_degradation_preflight() -> None:
             ),
         )
     if state.status == "CIRCUIT_OPEN":
+        if state.circuit_open_remaining_seconds is None:
+            # The cooldown clock starts when the breaker actually begins
+            # refusing traffic. A breaker that opened because its threshold
+            # was lowered - rather than because a call failed - carries no
+            # deadline yet, and no further failure can arrive to stamp one
+            # while it is refusing, so it would stay open forever (#248).
+            _open_circuit()
         raise ProviderExecutionError(
             category=ProviderFailureCategory.CIRCUIT_OPEN,
             message=(
@@ -110,6 +117,7 @@ def record_provider_failure(category: ProviderFailureCategory) -> None:
     if category not in _tracked_failure_categories():
         return
 
+    _reclaim_elapsed_cooldown()
     repository = get_provider_operations_store()
     repository.record_degradation_failure(
         degradation_key=degradation_key_for(),
@@ -212,10 +220,7 @@ def _resolve_provider_degradation_state(
             findings=findings,
         )
 
-    circuit_remaining_seconds = _remaining_circuit_open_seconds(
-        state_record.circuit_open_until, provider_id=provider_id
-    )
-    state_record = _load_degradation_record(provider_id)
+    circuit_remaining_seconds = _remaining_circuit_open_seconds(state_record.circuit_open_until)
     if circuit_remaining_seconds is not None:
         return ProviderDegradationState(
             status="CIRCUIT_OPEN",
@@ -234,20 +239,45 @@ def _resolve_provider_degradation_state(
             ],
         )
 
-    if state_record.consecutive_failure_count >= (circuit_threshold or 0):
-        _open_circuit(provider_id)
-        return _resolve_provider_degradation_state(provider_id)
+    # A stamped cooldown that has elapsed has already answered for the
+    # failures that opened it, so they no longer count toward the posture.
+    # The persisted counters are cleared by the next write rather than by
+    # this read (#248).
+    cooldown_served = state_record.circuit_open_until is not None
+    effective_failure_count = 0 if cooldown_served else state_record.consecutive_failure_count
+    effective_last_category = None if cooldown_served else state_record.last_failure_category
 
-    if state_record.consecutive_failure_count >= (degraded_threshold or 0):
+    if effective_failure_count >= (circuit_threshold or 0):
+        # Open without a deadline: the threshold now sits at or below a count
+        # that is already recorded. Whoever acts on this - the failure
+        # recorder or the enforcing preflight - stamps the cooldown.
+        return ProviderDegradationState(
+            status="CIRCUIT_OPEN",
+            enforcement_enabled=True,
+            configuration_valid=True,
+            consecutive_failure_count=effective_failure_count,
+            degraded_failure_count_threshold=degraded_threshold,
+            circuit_open_failure_count_threshold=circuit_threshold,
+            circuit_open_remaining_seconds=None,
+            last_failure_category=effective_last_category,
+            timeout_failure_count=state_record.timeout_failure_count,
+            rate_limited_failure_count=state_record.rate_limited_failure_count,
+            upstream_error_failure_count=state_record.upstream_error_failure_count,
+            findings=[
+                "Provider circuit breaker is open because the recorded consecutive failures are at or above the configured circuit threshold."
+            ],
+        )
+
+    if effective_failure_count >= (degraded_threshold or 0):
         return ProviderDegradationState(
             status="DEGRADED_UPSTREAM",
             enforcement_enabled=True,
             configuration_valid=True,
-            consecutive_failure_count=state_record.consecutive_failure_count,
+            consecutive_failure_count=effective_failure_count,
             degraded_failure_count_threshold=degraded_threshold,
             circuit_open_failure_count_threshold=circuit_threshold,
             circuit_open_remaining_seconds=None,
-            last_failure_category=state_record.last_failure_category,
+            last_failure_category=effective_last_category,
             timeout_failure_count=state_record.timeout_failure_count,
             rate_limited_failure_count=state_record.rate_limited_failure_count,
             upstream_error_failure_count=state_record.upstream_error_failure_count,
@@ -260,11 +290,11 @@ def _resolve_provider_degradation_state(
         status="NORMAL",
         enforcement_enabled=True,
         configuration_valid=True,
-        consecutive_failure_count=state_record.consecutive_failure_count,
+        consecutive_failure_count=effective_failure_count,
         degraded_failure_count_threshold=degraded_threshold,
         circuit_open_failure_count_threshold=circuit_threshold,
         circuit_open_remaining_seconds=None,
-        last_failure_category=state_record.last_failure_category,
+        last_failure_category=effective_last_category,
         timeout_failure_count=state_record.timeout_failure_count,
         rate_limited_failure_count=state_record.rate_limited_failure_count,
         upstream_error_failure_count=state_record.upstream_error_failure_count,
@@ -274,23 +304,33 @@ def _resolve_provider_degradation_state(
     )
 
 
-def _remaining_circuit_open_seconds(
-    circuit_open_until: str | None, *, provider_id: str | None = None
-) -> int | None:
-    """Remaining cooldown for ``provider_id``, clearing an expired one.
+def _remaining_circuit_open_seconds(circuit_open_until: str | None) -> int | None:
+    """Seconds left on a stamped cooldown, or None when none remain.
 
-    The clear is a write on a read path, so it has to be keyed to the
-    identity being asked about: keyed ambiently, inspecting the alternate's
-    posture would reset the primary's breaker (issue #237).
+    A pure calculation. It used to clear an elapsed cooldown as a side
+    effect, which made every posture read a write and meant inspecting one
+    provider could reset another provider's breaker (issues #237, #248).
+    Clearing now belongs to ``_reclaim_elapsed_cooldown`` on the write path.
     """
 
     if circuit_open_until is None:
         return None
-    until = datetime.fromisoformat(circuit_open_until)
-    remaining = int((until - _utcnow()).total_seconds())
-    if remaining > 0:
-        return remaining
+    remaining = int((datetime.fromisoformat(circuit_open_until) - _utcnow()).total_seconds())
+    return remaining if remaining > 0 else None
+
+
+def _reclaim_elapsed_cooldown(provider_id: str | None = None) -> None:
+    """Clear a cooldown that has run its course, before a new failure counts.
+
+    The breaker served its cooldown, so the next failure starts a fresh
+    budget instead of resuming a count those failures already paid for.
+    """
+
     state_record = _load_degradation_record(provider_id)
+    if state_record.circuit_open_until is None:
+        return
+    if _remaining_circuit_open_seconds(state_record.circuit_open_until) is not None:
+        return
     _save_degradation_record(
         provider_id=provider_id,
         consecutive_failure_count=0,
@@ -300,7 +340,6 @@ def _remaining_circuit_open_seconds(
         rate_limited_failure_count=state_record.rate_limited_failure_count,
         upstream_error_failure_count=state_record.upstream_error_failure_count,
     )
-    return None
 
 
 def _open_circuit(provider_id: str | None = None) -> None:

--- a/tests/unit/test_provider_degradation_state.py
+++ b/tests/unit/test_provider_degradation_state.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from pytest import MonkeyPatch
 
 from app.config import settings
@@ -11,7 +12,10 @@ from app.services.provider_degradation_state import (
     record_provider_failure,
     record_successful_provider_execution,
 )
-from app.services.provider_operations_store import reset_provider_operations_store_cache
+from app.services.provider_operations_store import (
+    get_provider_operations_store,
+    reset_provider_operations_store_cache,
+)
 from app.providers.base import ProviderExecutionError
 from tests.support.migration_runner import upgrade_database_to_head
 
@@ -244,3 +248,188 @@ def test_provider_degradation_status_cooldown_recovery_survives_store_reset(
 
     assert status.status == "NORMAL"
     assert status.consecutive_failure_count == 0
+
+
+# --- Reading posture must not change it (issue #248) ---------------------
+
+
+def _degradation_snapshot() -> dict[str, object]:
+    """Every persisted degradation row, as plain comparable data."""
+
+    from dataclasses import asdict
+
+    from app.services.provider_degradation_state import DEGRADATION_KEY_PREFIX
+
+    repository = get_provider_operations_store()
+    snapshot: dict[str, object] = {}
+    for key in (
+        DEGRADATION_KEY_PREFIX,
+        f"{DEGRADATION_KEY_PREFIX}:text.openai",
+        f"{DEGRADATION_KEY_PREFIX}:text.claude",
+    ):
+        record = repository.get_degradation_state(degradation_key=key)
+        snapshot[key] = asdict(record) if record is not None else None
+    return snapshot
+
+
+def _enforcing_breaker() -> None:
+    settings.provider_mode = "openai"
+    settings.provider_rollout_state = "CANARY_ENABLED"
+    settings.live_text_provider_id = "text.openai"
+    settings.live_text_model_id = "gpt-5.4"
+    settings.live_text_provider_api_key = "secret"
+    settings.live_text_degradation_enforced = True
+    settings.live_text_degraded_failure_count_threshold = 2
+    settings.live_text_circuit_open_failure_count_threshold = 3
+    settings.live_text_circuit_open_seconds = 60
+
+
+def test_reading_posture_never_writes_whatever_the_state() -> None:
+    """The acceptance condition: posture is a read.
+
+    This case exercises the live-cooldown branch, which never wrote; it is a
+    regression pin, not proof of the fix. The two branches that did write -
+    an elapsed cooldown, and a failure count at or above a lowered circuit
+    threshold - are covered by the two tests below, both of which fail
+    against the writing resolver.
+    """
+
+    _enforcing_breaker()
+    for _ in range(3):
+        record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+
+    for _ in range(5):
+        before = _degradation_snapshot()
+        assert build_provider_degradation_status().status == "CIRCUIT_OPEN"
+        assert build_provider_degradation_status("text.openai").status == "CIRCUIT_OPEN"
+        assert _degradation_snapshot() == before
+
+
+def test_reading_an_elapsed_cooldown_reports_closed_without_writing(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _enforcing_breaker()
+    opened_at = datetime(2026, 3, 23, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr("app.services.provider_degradation_state._utcnow", lambda: opened_at)
+    for _ in range(3):
+        record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+    assert build_provider_degradation_status().status == "CIRCUIT_OPEN"
+
+    # Past the cooldown: the breaker has served its time.
+    monkeypatch.setattr(
+        "app.services.provider_degradation_state._utcnow",
+        lambda: opened_at + timedelta(seconds=120),
+    )
+    before = _degradation_snapshot()
+    status = build_provider_degradation_status()
+
+    assert status.status == "NORMAL"
+    assert status.consecutive_failure_count == 0
+    assert status.last_failure_category is None
+    # Lifetime counters are not posture and are not zeroed by the read.
+    assert status.timeout_failure_count == 3
+    assert _degradation_snapshot() == before, "an elapsed cooldown was cleared by a read"
+
+    # The next failure starts a fresh budget, and clearing happens on that write.
+    record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+    assert build_provider_degradation_status().consecutive_failure_count == 1
+    assert build_provider_degradation_status().status == "NORMAL"
+
+
+def test_reading_one_identity_never_writes_another(monkeypatch: MonkeyPatch) -> None:
+    """#237 fixed the attribution; this pins that a read cannot touch a
+    neighbour's row at all, which is the property that made the earlier
+    cross-identity write possible."""
+
+    _enforcing_breaker()
+    opened_at = datetime(2026, 3, 23, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr("app.services.provider_degradation_state._utcnow", lambda: opened_at)
+    for _ in range(3):
+        record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+
+    before = _degradation_snapshot()
+    for identity in ("text.claude", "text.openai", None):
+        build_provider_degradation_status(identity)
+    assert _degradation_snapshot() == before
+
+    # The alternate has no row of its own, and reading it did not create one.
+    assert (
+        get_provider_operations_store().get_degradation_state(
+            degradation_key="live_text_generation:text.claude"
+        )
+        is None
+    )
+
+
+def test_the_cooldown_deadline_is_stamped_once_per_crossing(monkeypatch: MonkeyPatch) -> None:
+    _enforcing_breaker()
+    opened_at = datetime(2026, 3, 23, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr("app.services.provider_degradation_state._utcnow", lambda: opened_at)
+    for _ in range(3):
+        record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+
+    repository = get_provider_operations_store()
+    stamped = repository.get_degradation_state(degradation_key="live_text_generation:text.openai")
+    assert stamped is not None
+    deadline = stamped.circuit_open_until
+
+    # Reads do not re-stamp, and neither does the enforcing preflight while a
+    # live deadline exists.
+    for _ in range(3):
+        build_provider_degradation_status()
+    with pytest.raises(ProviderExecutionError):
+        enforce_provider_degradation_preflight()
+    after = repository.get_degradation_state(degradation_key="live_text_generation:text.openai")
+    assert after is not None
+    assert after.circuit_open_until == deadline
+
+
+def test_lowering_the_threshold_opens_the_breaker_and_it_can_still_close(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A breaker opened by a configuration change, not by a call failing.
+
+    It has no cooldown deadline, and while it is refusing no further failure
+    can arrive to stamp one - so if nothing stamped it, it would stay open
+    forever. Enforcement stamps it when it begins refusing, which is also the
+    honest moment for the clock to start.
+    """
+
+    _enforcing_breaker()
+    now = datetime(2026, 3, 23, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr("app.services.provider_degradation_state._utcnow", lambda: now)
+    record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+    record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+    assert build_provider_degradation_status().status == "DEGRADED_UPSTREAM"
+
+    settings.live_text_circuit_open_failure_count_threshold = 2
+
+    status = build_provider_degradation_status()
+    assert status.status == "CIRCUIT_OPEN"
+    assert status.circuit_open_remaining_seconds is None, "a read must not stamp the deadline"
+
+    with pytest.raises(ProviderExecutionError) as exc_info:
+        enforce_provider_degradation_preflight()
+    assert exc_info.value.category is ProviderFailureCategory.CIRCUIT_OPEN
+    assert build_provider_degradation_status().circuit_open_remaining_seconds == 60
+
+    monkeypatch.setattr(
+        "app.services.provider_degradation_state._utcnow", lambda: now + timedelta(seconds=120)
+    )
+    assert build_provider_degradation_status().status == "NORMAL"
+    enforce_provider_degradation_preflight()
+
+
+def test_a_success_still_closes_an_open_breaker(monkeypatch: MonkeyPatch) -> None:
+    _enforcing_breaker()
+    now = datetime(2026, 3, 23, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr("app.services.provider_degradation_state._utcnow", lambda: now)
+    for _ in range(3):
+        record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+    assert build_provider_degradation_status().status == "CIRCUIT_OPEN"
+
+    record_successful_provider_execution()
+
+    status = build_provider_degradation_status()
+    assert status.status == "NORMAL"
+    assert status.circuit_open_remaining_seconds is None


### PR DESCRIPTION
Closes #248.

## Control-plane outcome

An operator can inspect a provider's breaker without changing it. Looking at the
control plane is no longer an action within it.

## Invariant

Posture resolution is a pure read. Every write to breaker state belongs to a
path that is deciding something — recording a failure, recording a success, or
refusing traffic — never to a path that is reporting.

## One authority

`record_provider_failure` owns the failure count and the cooldown stamp at a
threshold crossing. `_reclaim_elapsed_cooldown` owns clearing a cooldown that has
run its course. `enforce_provider_degradation_preflight` owns starting the clock
when the breaker actually begins refusing. The resolver owns nothing but the
answer.

## What was wrong

`_resolve_provider_degradation_state` wrote in two places while answering a
question: it called `_open_circuit()` and re-entered itself when the failure
count crossed the threshold, and `_remaining_circuit_open_seconds` cleared an
elapsed cooldown as a side effect of computing how much was left.

`record_provider_failure` then depended on that: it recorded the failure, called
the resolver, and stamped the deadline *again* if the resolver reported
`CIRCUIT_OPEN`. The writer's correctness was expressed through the reader.

Two consequences were already live. Any posture read — an operator view, an
execution's evidence — could stamp or clear a breaker deadline. And until #237
keyed those writes to the identity being asked about, a read for one provider
wrote to whichever provider happened to be ambient; #237's ordered-fallback test
surfaced that as unbounded recursion.

## The part that is not just deletion

Removing the write is not sufficient, because the expiry-clear was **load-bearing
for closing the breaker**. Clearing the failure count on expiry is what gives a
provider a fresh budget; without it the count stays above the threshold and the
breaker never closes.

So the resolver now treats a stamped cooldown that has elapsed as having answered
for the failures that opened it — posture reports closed, with the failure count
reported as `0` and the lifetime counters untouched, which is exactly what the
old expiry-clear produced. The persisted clear happens on the next recorded
failure, before it is counted.

## A hazard found in the fix itself

The design I first specified on the issue would have stranded a breaker
permanently. A breaker opened by *lowering the threshold* rather than by a call
failing carries no cooldown deadline. With a pure resolver, nothing stamps one —
and while the breaker is refusing, no further failure can arrive to stamp one
either. It would stay open until someone reset it by hand: strictly worse than
the behaviour being replaced.

`enforce_provider_degradation_preflight` therefore stamps the deadline when it
begins refusing. That is also the more truthful model: the cooldown measures time
spent refusing traffic, not time since a status page was last loaded.

## Risk, measured rather than assumed

I filed this issue saying `circuit_open_remaining_seconds` was the risky part,
because a pure resolver can report `CIRCUIT_OPEN` before any deadline exists.
That was inferred from the field's declaration. Measured, the only occurrence
outside the degradation module is the contract field itself — **no code branches
on it**. Every enforcement and posture decision reads `status == "CIRCUIT_OPEN"`
(`provider_operations_status.py:120`, `provider_activation_readiness.py:59,72`,
`ai_surface_supportability.py:240`). The null-remaining window is therefore
observable but not decidable-upon, which is what made this design viable.

## Evidence

Five new tests. Honest about which prove the fix:

- `test_reading_an_elapsed_cooldown_reports_closed_without_writing` and
  `test_lowering_the_threshold_opens_the_breaker_and_it_can_still_close` **fail
  against the writing resolver** — they cover the two branches that wrote.
- `test_reading_posture_never_writes_whatever_the_state`,
  `test_reading_one_identity_never_writes_another` and
  `test_the_cooldown_deadline_is_stamped_once_per_crossing` pass on the old code
  too; they exercise the live-cooldown path, which never wrote. They are
  regression pins, and their docstrings say so rather than implying coverage
  they do not have.

The lowered-threshold test also proves the breaker can still *close* afterwards,
which is the hazard above.

Full local gate: 2162 tests, `make lint` (ruff check, format, runtime purity,
monetary float, module budget), `make typecheck` (729 files).
