### PR TITLE
feat(authority): publish only output with a proven VALIDATED verdict

### DIFF
--- a/src/app/contracts/workflow_pack_run_accepted_output.py
+++ b/src/app/contracts/workflow_pack_run_accepted_output.py
@@ -81,6 +81,32 @@ class AdvisorBriefAcceptedReviewIdentity(BaseModel):
     reviewed_at: str = Field(description="Instant of the accepting review transition (UTC).")
 
 
+class AcceptedOutputValidationIdentity(BaseModel):
+    """The deterministic verdict that made this output publishable.
+
+    A consumer composing this projection into a client document must be able
+    to check the output's authority itself rather than trusting that the
+    publisher refused correctly. lotus-ai already refuses to publish anything
+    whose verdict is not VALIDATED, so this block is constant by construction
+    for a successful response - which is the point: it makes the guarantee
+    checkable rather than assumed (issue #231).
+
+    Deliberately not part of ``content_hash``: that hash means "this exact
+    narrative and context", and adding a field to its basis would change every
+    previously published hash and break consumers holding stored snapshots.
+    """
+
+    validation_state: str = Field(
+        description="Deterministic output-validation verdict; always VALIDATED when published.",
+    )
+    authority: str = Field(
+        description="Authority marking: AI output is never authoritative financial truth.",
+    )
+    ruleset_version: str = Field(
+        description="Version of the validation rule set that produced the verdict.",
+    )
+
+
 class WorkflowPackRunAcceptedOutputResponse(BaseModel):
     """The exact accepted `advisor_brief.pack@v1` output for one run.
 
@@ -105,6 +131,12 @@ class WorkflowPackRunAcceptedOutputResponse(BaseModel):
     tenant_id: str = Field(description="Tenant the run belongs to and was retrieved for.")
     workflow_authority_owner: str = Field(
         description="Service that owns consequence-bearing workflow authority for this pack.",
+    )
+    output_validation: AcceptedOutputValidationIdentity = Field(
+        description=(
+            "Deterministic validation verdict recorded for this exact output; a run whose "
+            "verdict is missing or not VALIDATED is never published."
+        ),
     )
     review: AdvisorBriefAcceptedReviewIdentity = Field(
         description="Accepting reviewer identity and time from the review event ledger.",

--- a/src/app/services/execution_evidence.py
+++ b/src/app/services/execution_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from app.contracts.access_control import AuthorizationDecision
 from app.contracts.evidence import ExecutionEvidenceBundle, ExecutionEvidenceDescriptor
+from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.prompts import PromptDescriptor, PromptSelectionTraceDescriptor
 from app.contracts.providers import ProviderExecutionResponse, RoutingDecisionDescriptor
 from app.contracts.retrieval import RetrievalExecutionStatusResponse
@@ -20,6 +21,7 @@ def build_execution_evidence(
     prompt_selection: PromptSelectionTraceDescriptor,
     provider_execution: ProviderExecutionResponse,
     safety_outcome: SafetyExecutionOutcome,
+    output_validation: OutputValidationOutcome,
 ) -> ExecutionEvidenceBundle:
     retrieval_status = build_retrieval_execution_status()
     descriptors = [
@@ -38,9 +40,43 @@ def build_execution_evidence(
                 provider_execution=provider_execution,
             ),
             _access_control_descriptor(authorization=authorization),
+            _output_validation_descriptor(output_validation=output_validation),
         ]
     )
     return ExecutionEvidenceBundle(descriptors=descriptors)
+
+
+def _output_validation_descriptor(
+    *, output_validation: OutputValidationOutcome
+) -> ExecutionEvidenceDescriptor:
+    """The output's verdict, carried as evidence rather than as a new field.
+
+    Downstream surfaces already persist and render this bundle, so the verdict
+    reaches the run record, the consumer view, the operator profile and the
+    accepted-output projector without a migration or a per-projection field
+    (issue #231).
+
+    ``findings`` is deliberately excluded: those statements quote the tokens
+    and references that failed a rule, so they carry output content, and this
+    bundle is persisted and read under a different redaction posture than the
+    response that produced it. Rule identifiers say which rule failed without
+    reproducing what it saw.
+    """
+
+    return ExecutionEvidenceDescriptor(
+        evidence_type="output_validation",
+        summary=(
+            f"Deterministic output validation returned {output_validation.validation_state.value} "
+            f"under ruleset {output_validation.ruleset_version}; this output is "
+            f"{output_validation.authority}."
+        ),
+        attributes={
+            "validation_state": output_validation.validation_state.value,
+            "authority": output_validation.authority,
+            "ruleset_version": output_validation.ruleset_version,
+            "failed_rule_ids": list(output_validation.failed_rule_ids),
+        },
+    )
 
 
 def build_routing_decision_descriptor(

--- a/src/app/services/task_execution_mapping.py
+++ b/src/app/services/task_execution_mapping.py
@@ -27,6 +27,7 @@ def map_task_execution_response(
     resolved: ResolvedTaskExecution,
 ) -> TaskExecutionResponse:
     context = resolved.context
+    validation = resolved.output_validation
     evidence = build_execution_evidence(
         request=context.request,
         capability=context.capability,
@@ -35,8 +36,8 @@ def map_task_execution_response(
         prompt_selection=context.prompt_selection,
         provider_execution=resolved.provider_execution,
         safety_outcome=resolved.safety_outcome,
+        output_validation=validation,
     )
-    validation = resolved.output_validation
     validation_withholds = validation.validation_state in {
         OutputValidationState.REJECTED,
         OutputValidationState.VALIDATION_UNAVAILABLE,

--- a/src/app/services/workflow_pack_run_accepted_output.py
+++ b/src/app/services/workflow_pack_run_accepted_output.py
@@ -30,12 +30,14 @@ from app.config import settings
 from app.contracts.workflow_pack_run_accepted_output import (
     ACCEPTED_OUTPUT_CONTENT_HASH_ALGORITHM,
     ACCEPTED_OUTPUT_SCHEMA_ADVISOR_BRIEF_V1,
+    AcceptedOutputValidationIdentity,
     AdvisorBriefAcceptedContextIdentity,
     AdvisorBriefAcceptedEvidenceRef,
     AdvisorBriefAcceptedNarrativeItem,
     AdvisorBriefAcceptedReviewIdentity,
     WorkflowPackRunAcceptedOutputResponse,
 )
+from app.contracts.output_validation import OutputValidationState
 from app.contracts.workflow_pack_runs import (
     WorkflowPackRunReviewState,
     WorkflowPackRunRuntimeState,
@@ -68,6 +70,7 @@ REASON_RUN_NOT_ACCEPTED = "run_not_accepted"
 REASON_RUN_SUPERSEDED = "run_superseded"
 REASON_OUTPUT_ARTIFACT_MISSING = "output_artifact_missing"
 REASON_OUTPUT_ARTIFACT_MALFORMED = "output_artifact_malformed"
+REASON_OUTPUT_NOT_VALIDATED = "output_not_validated"
 
 ACCEPTED_OUTPUT_REASON_CODES = frozenset(
     {
@@ -77,6 +80,7 @@ ACCEPTED_OUTPUT_REASON_CODES = frozenset(
         REASON_RUN_SUPERSEDED,
         REASON_OUTPUT_ARTIFACT_MISSING,
         REASON_OUTPUT_ARTIFACT_MALFORMED,
+        REASON_OUTPUT_NOT_VALIDATED,
     }
 )
 
@@ -128,10 +132,65 @@ def build_workflow_pack_run_accepted_output(
             REASON_RUN_SUPERSEDED,
             "This run has been superseded; retrieve the superseding accepted run instead.",
         )
+    validation = _require_validated_output(record)
 
     payload = _load_intact_output_payload(record)
     review = _accepting_review_identity(store=store, run_id=run_id)
-    return projector(record=record, payload=payload, review=review)
+    return projector(record=record, payload=payload, review=review, validation=validation)
+
+
+def _require_validated_output(record: WorkflowPackRunRecord) -> AcceptedOutputValidationIdentity:
+    """Publish only output whose own validation verdict is VALIDATED.
+
+    A review ACCEPT is human oversight, not a validation verdict: an
+    UNVALIDATED_LOCAL_ONLY output could be reviewed, accepted, and composed
+    into a client document with nothing marking it (issue #231).
+
+    A run whose evidence carries no verdict at all is refused too, and that is
+    a decision rather than an oversight. Runs that predate output-validation
+    evidence cannot have their authority established after the fact, and
+    accepted-output feeds new client and advisor document generation - so
+    authority is proven at generation time or it is absent. Age is not
+    evidence.
+    """
+
+    attributes = next(
+        (
+            descriptor.attributes
+            for descriptor in record.evidence_descriptors
+            if descriptor.evidence_type == "output_validation"
+        ),
+        None,
+    )
+    recorded_state = attributes.get("validation_state") if attributes is not None else None
+    if attributes is not None and recorded_state == OutputValidationState.VALIDATED.value:
+        return AcceptedOutputValidationIdentity(
+            validation_state=OutputValidationState.VALIDATED.value,
+            authority=_required_evidence_string(attributes, "authority"),
+            ruleset_version=_required_evidence_string(attributes, "ruleset_version"),
+        )
+    observed = recorded_state if isinstance(recorded_state, str) else "absent"
+    raise AcceptedOutputNotAvailableError(
+        REASON_OUTPUT_NOT_VALIDATED,
+        (
+            "Accepted output is only published for runs whose output validation verdict is "
+            f"VALIDATED; this run's recorded verdict is {observed}."
+        ),
+    )
+
+
+def _required_evidence_string(attributes: dict[str, Any], key: str) -> str:
+    """A verdict missing its authority marking or ruleset version is not a
+    verdict a consumer can act on, so it fails closed like any other
+    incomplete evidence rather than publishing a blank marking."""
+
+    value = attributes.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_NOT_VALIDATED,
+            f"The recorded output-validation evidence is missing its {key}.",
+        )
+    return value
 
 
 def _accepting_review_identity(*, store: Any, run_id: str) -> AdvisorBriefAcceptedReviewIdentity:
@@ -203,6 +262,7 @@ def _project_advisor_brief_v1(
     record: WorkflowPackRunRecord,
     payload: dict[str, Any],
     review: AdvisorBriefAcceptedReviewIdentity,
+    validation: AcceptedOutputValidationIdentity,
 ) -> WorkflowPackRunAcceptedOutputResponse:
     structured_output = payload.get("structured_output")
     if not isinstance(structured_output, dict):
@@ -259,6 +319,7 @@ def _project_advisor_brief_v1(
         request_id=record.request_id,
         tenant_id=str(record.tenant_id),
         workflow_authority_owner=record.workflow_authority_owner,
+        output_validation=validation,
         review=review,
         advisor_brief_status=advisor_brief_status,
         coverage_state=coverage_state,

--- a/tests/integration/test_task_api_contract.py
+++ b/tests/integration/test_task_api_contract.py
@@ -47,7 +47,11 @@ def test_task_execute_contract(client: TestClient) -> None:
     assert body["audit"]["safety"]["disposition"] == "DOCUMENTED_ONLY"
     assert body["audit"]["safety"]["runtime_redaction_active"] is True
     assert body["audit"]["authorization"]["outcome"] == "ALLOWED"
-    assert len(body["evidence"]["descriptors"]) == 7
+    assert len(body["evidence"]["descriptors"]) == 8
+    validation_evidence = body["evidence"]["descriptors"][-1]
+    assert validation_evidence["evidence_type"] == "output_validation"
+    assert validation_evidence["attributes"]["validation_state"] == "VALIDATED"
+    assert validation_evidence["attributes"]["authority"] == "non_authoritative_ai_output"
     assert body["evidence"]["descriptors"][0]["evidence_type"] == "task_contract"
     assert body["evidence"]["descriptors"][3]["evidence_type"] == "routing_decision"
     routing_attributes = body["evidence"]["descriptors"][3]["attributes"]
@@ -144,7 +148,11 @@ def test_task_execute_contract_returns_grounded_advisor_brief_for_gateway_fact_b
         "lotus-gateway:workbench:PB_SG_GLOBAL_BAL_001:performance-summary:YTD",
         "lotus-gateway:workbench:PB_SG_GLOBAL_BAL_001:performance-details:YTD",
     ]
-    assert len(body["evidence"]["descriptors"]) == 7
+    assert len(body["evidence"]["descriptors"]) == 8
+    validation_evidence = body["evidence"]["descriptors"][-1]
+    assert validation_evidence["evidence_type"] == "output_validation"
+    assert validation_evidence["attributes"]["validation_state"] == "VALIDATED"
+    assert validation_evidence["attributes"]["authority"] == "non_authoritative_ai_output"
 
 
 def test_task_execute_contract_enforces_runtime_redaction_when_enabled(client: TestClient) -> None:

--- a/tests/support/workflow_pack_run_builders.py
+++ b/tests/support/workflow_pack_run_builders.py
@@ -19,6 +19,27 @@ from app.services.workflow_pack_run_supportability import (
 )
 
 
+def validated_output_evidence() -> ExecutionEvidenceDescriptor:
+    """The verdict a real validated execution records (issue #231).
+
+    Hand-built run fixtures used to carry no evidence at all, which no real
+    run does; accepted-output now refuses a run whose output has no proven
+    VALIDATED verdict, so a fixture standing in for a publishable run has to
+    carry the evidence a publishable run actually has.
+    """
+
+    return ExecutionEvidenceDescriptor(
+        evidence_type="output_validation",
+        summary="Deterministic output validation returned VALIDATED.",
+        attributes={
+            "validation_state": "VALIDATED",
+            "authority": "non_authoritative_ai_output",
+            "ruleset_version": "output-validation.v4",
+            "failed_rule_ids": [],
+        },
+    )
+
+
 def build_workflow_pack_run_descriptor(
     *,
     run_id: str,

--- a/tests/unit/test_execution_evidence.py
+++ b/tests/unit/test_execution_evidence.py
@@ -1,5 +1,9 @@
 from typing import Any, cast
 
+from app.contracts.output_validation import (
+    OutputValidationOutcome,
+    OutputValidationState,
+)
 from app.contracts.access_control import (
     AuthorizationCapabilityType,
     AuthorizationDecision,
@@ -28,6 +32,10 @@ from app.contracts.tasks import (
 )
 from app.services.execution_evidence import build_execution_evidence
 from app.services.safety_runtime import build_safety_execution_outcome
+
+
+def _validated_outcome() -> OutputValidationOutcome:
+    return OutputValidationOutcome(validation_state=OutputValidationState.VALIDATED)
 
 
 def _authorization_decision() -> AuthorizationDecision:
@@ -104,9 +112,10 @@ def test_build_execution_evidence_returns_expected_descriptors() -> None:
         prompt_selection=prompt_selection,
         provider_execution=provider_execution,
         safety_outcome=safety_outcome,
+        output_validation=_validated_outcome(),
     )
 
-    assert len(evidence.descriptors) == 6
+    assert len(evidence.descriptors) == 7
     assert evidence.descriptors[0].evidence_type == "task_contract"
     assert evidence.descriptors[1].evidence_type == "prompt_selection"
     assert evidence.descriptors[1].attributes["rollout_role"] == "ACTIVE"
@@ -128,6 +137,15 @@ def test_build_execution_evidence_returns_expected_descriptors() -> None:
         list[dict[str, Any]], evidence.descriptors[3].attributes["control_results"]
     )
     assert control_results[-1]["control_id"] == ("runtime_redaction_engine")
+    validation_descriptor = evidence.descriptors[-1]
+    assert validation_descriptor.evidence_type == "output_validation"
+    assert validation_descriptor.attributes["validation_state"] == "VALIDATED"
+    assert validation_descriptor.attributes["authority"] == "non_authoritative_ai_output"
+    assert validation_descriptor.attributes["failed_rule_ids"] == []
+    # Findings quote the tokens and references a rule rejected, so they carry
+    # output content and must not ride a bundle persisted and read under a
+    # different redaction posture (issue #231).
+    assert "findings" not in validation_descriptor.attributes
     assert evidence.descriptors[4].evidence_type == "retrieval_posture"
     assert evidence.descriptors[5].evidence_type == "access_control"
     assert evidence.descriptors[5].attributes["outcome"] == "ALLOWED"
@@ -201,6 +219,7 @@ def test_build_execution_evidence_captures_live_retrieval_request_posture() -> N
         prompt_selection=prompt_selection,
         provider_execution=provider_execution,
         safety_outcome=safety_outcome,
+        output_validation=_validated_outcome(),
     )
 
     retrieval_descriptor = evidence.descriptors[4]

--- a/tests/unit/test_task_executor.py
+++ b/tests/unit/test_task_executor.py
@@ -81,7 +81,7 @@ def test_execute_task_returns_stubbed_completed_response() -> None:
         "runtime_redaction_engine",
     ]
     assert response.audit.safety.control_results[-1].control_id == "runtime_redaction_engine"
-    assert len(response.evidence.descriptors) == 7
+    assert len(response.evidence.descriptors) == 8
     assert response.evidence.descriptors[0].evidence_type == "task_contract"
     assert response.evidence.descriptors[1].evidence_type == "prompt_selection"
     assert response.evidence.descriptors[3].evidence_type == "routing_decision"
@@ -96,6 +96,12 @@ def test_execute_task_returns_stubbed_completed_response() -> None:
     assert response.audit.routing_decision.selected_provider_id == "text.stub"
     assert response.audit.authorization.outcome == AuthorizationOutcome.ALLOWED
     assert response.evidence.descriptors[6].evidence_type == "access_control"
+    # The verdict rides a real end-to-end execution's evidence bundle, which is
+    # what carries it to the run record and every projection built from it
+    # (issue #231).
+    assert response.evidence.descriptors[7].evidence_type == "output_validation"
+    assert response.evidence.descriptors[7].attributes["validation_state"] == "VALIDATED"
+    assert response.evidence.descriptors[7].attributes["authority"] == "non_authoritative_ai_output"
 
 
 def test_execute_task_enforces_runtime_redaction_for_provider_backed_output() -> None:

--- a/tests/unit/test_workflow_pack_run_accepted_latest.py
+++ b/tests/unit/test_workflow_pack_run_accepted_latest.py
@@ -31,6 +31,7 @@ from app.services.workflow_pack_run_accepted_latest import (
     build_workflow_pack_run_accepted_latest,
 )
 from app.services.workflow_pack_run_accepted_output import AcceptedOutputNotAvailableError
+from tests.support.workflow_pack_run_builders import validated_output_evidence
 
 TENANT = "tenant-sg-001"
 PORTFOLIO = "PB_SG_GLOBAL_BAL_001"
@@ -122,7 +123,7 @@ def _seed_run(
         stubbed=True,
         output_preview="preview",
         structured_output_keys=["grounded_summary"],
-        evidence_descriptors=[],
+        evidence_descriptors=[validated_output_evidence()],
         artifact_refs=[
             ArtifactDescriptor(
                 artifact_id=f"art-{run_id}",

--- a/tests/unit/test_workflow_pack_run_accepted_output.py
+++ b/tests/unit/test_workflow_pack_run_accepted_output.py
@@ -29,6 +29,8 @@ from app.services.workflow_pack_run_accepted_output import (
     AcceptedOutputNotFoundError,
     build_workflow_pack_run_accepted_output,
 )
+from tests.support.workflow_pack_run_builders import validated_output_evidence
+from app.contracts.evidence import ExecutionEvidenceDescriptor
 
 TENANT = "tenant-sg-001"
 
@@ -54,7 +56,7 @@ def _record(**overrides: Any) -> WorkflowPackRunRecord:
         "stubbed": True,
         "output_preview": "preview",
         "structured_output_keys": ["grounded_summary"],
-        "evidence_descriptors": [],
+        "evidence_descriptors": [validated_output_evidence()],
         "artifact_refs": [
             ArtifactDescriptor(
                 artifact_id="art-001",
@@ -370,3 +372,133 @@ def test_absent_evidence_refs_key_projects_as_empty(_wired: WireCallable) -> Non
         run_id="wfr-accepted-001", caller_tenant_id=TENANT
     )
     assert response.talking_points[0].evidence_refs == []
+
+
+def _validation_evidence(state: str) -> ExecutionEvidenceDescriptor:
+    return ExecutionEvidenceDescriptor(
+        evidence_type="output_validation",
+        summary=f"Deterministic output validation returned {state}.",
+        attributes={
+            "validation_state": state,
+            "authority": "non_authoritative_ai_output",
+            "ruleset_version": "output-validation.v4",
+            "failed_rule_ids": [] if state == "VALIDATED" else ["numeric_grounding"],
+        },
+    )
+
+
+@pytest.mark.parametrize("state", ["UNVALIDATED_LOCAL_ONLY", "REJECTED", "VALIDATION_UNAVAILABLE"])
+def test_output_without_a_validated_verdict_is_refused(state: str, _wired: WireCallable) -> None:
+    """A review ACCEPT is human oversight, not a validation verdict.
+
+    Without this, an UNVALIDATED_LOCAL_ONLY output could be reviewed,
+    accepted, and composed into a client document with nothing marking it
+    (issue #231).
+    """
+
+    _wired(_record(evidence_descriptors=[_validation_evidence(state)]), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_not_validated"
+    assert state in excinfo.value.message
+
+
+def test_a_run_predating_validation_evidence_is_refused_not_grandfathered(
+    _wired: WireCallable,
+) -> None:
+    """The explicit decision, not an oversight.
+
+    Runs accepted before output-validation evidence existed cannot have their
+    authority established after the fact, and accepted-output feeds new client
+    and advisor document generation. Authority is proven at generation time or
+    it is absent; age is not evidence.
+    """
+
+    _wired(_record(evidence_descriptors=[]), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_not_validated"
+    assert "absent" in excinfo.value.message
+
+
+def test_the_refusal_precedes_reading_the_output_artifact(_wired: WireCallable) -> None:
+    """Authority is settled before the content is loaded, so an unvalidated
+    run cannot be published even if its artifact is intact and vice versa."""
+
+    _wired(_record(evidence_descriptors=[_validation_evidence("REJECTED")]), None)
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_not_validated"
+
+
+def test_every_refusal_reason_is_declared_in_the_vocabulary() -> None:
+    """The reason set is the published error vocabulary - each code becomes a
+    LOTUS_AI_ACCEPTED_* error code - so a raised reason that is not declared
+    would ship an undocumented failure mode."""
+
+    raised = {
+        module.REASON_PACK_PROJECTION_UNSUPPORTED,
+        module.REASON_RUN_NOT_COMPLETED,
+        module.REASON_RUN_NOT_ACCEPTED,
+        module.REASON_RUN_SUPERSEDED,
+        module.REASON_OUTPUT_ARTIFACT_MISSING,
+        module.REASON_OUTPUT_ARTIFACT_MALFORMED,
+        module.REASON_OUTPUT_NOT_VALIDATED,
+    }
+    assert raised == set(module.ACCEPTED_OUTPUT_REASON_CODES)
+
+
+def test_the_published_response_carries_the_verdict_that_made_it_publishable(
+    _wired: WireCallable,
+) -> None:
+    """lotus-report composes this projection into a governed client document
+    and cannot check a field it is not sent. Refusing to publish unvalidated
+    output is the guarantee; carrying the verdict is what makes the guarantee
+    checkable by the consumer rather than assumed."""
+
+    _wired(_record(), _artifact_payload())
+    response = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+    assert response.output_validation.validation_state == "VALIDATED"
+    assert response.output_validation.authority == "non_authoritative_ai_output"
+    assert response.output_validation.ruleset_version == "output-validation.v4"
+
+
+def test_the_verdict_is_not_part_of_content_identity(_wired: WireCallable) -> None:
+    """`content_hash` means "this exact narrative and context".
+
+    Consumers hold stored hashes from immutable snapshots, so the hash basis
+    must not shift when a field is added beside it. Two runs identical except
+    for the ruleset version that validated them publish the same content.
+    """
+
+    _wired(_record(), _artifact_payload())
+    first = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+
+    later_ruleset = _validation_evidence("VALIDATED")
+    later_ruleset.attributes["ruleset_version"] = "output-validation.v9"
+    _wired(_record(evidence_descriptors=[later_ruleset]), _artifact_payload())
+    second = build_workflow_pack_run_accepted_output(
+        run_id="wfr-accepted-001", caller_tenant_id=TENANT
+    )
+
+    assert second.output_validation.ruleset_version == "output-validation.v9"
+    assert second.content_hash == first.content_hash
+
+
+@pytest.mark.parametrize("missing", ["authority", "ruleset_version"])
+def test_incomplete_validation_evidence_fails_closed(missing: str, _wired: WireCallable) -> None:
+    """A verdict without its authority marking or ruleset version is not
+    something a consumer can act on, so it is refused rather than published
+    with a blank marking."""
+
+    evidence = _validation_evidence("VALIDATED")
+    del evidence.attributes[missing]
+    _wired(_record(evidence_descriptors=[evidence]), _artifact_payload())
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
+    assert _reason(excinfo) == "output_not_validated"
+    assert missing in excinfo.value.message


### PR DESCRIPTION
Closes #231.

## Control-plane outcome

No workflow-pack output becomes consumable accepted-output unless that exact
output has a proven `VALIDATED` verdict — and the consumer composing it into a
governed document can check that for itself rather than trusting the publisher
refused correctly.

## Invariant

A review ACCEPT is human oversight, not a validation verdict. Publication
requires both: an accepting review **and** a deterministic `VALIDATED` verdict
recorded for that output.

## One authority

The verdict is one `output_validation` execution-evidence descriptor, produced
where the verdict is resolved and carried by the evidence bundle that already
exists. It is not a new ledger, and not a field duplicated across projections:
run detail, the consumer view and the provenance summary already copy
`evidence_descriptors`, so they pick it up with no per-projection plumbing and
**no migration** — the run record's evidence column is JSON.

Only the accepted-output response gained an explicit typed block, because that
is the one place the value crosses a service boundary into a governed client
document.

## What changed

- `build_execution_evidence` takes the resolved `OutputValidationOutcome` and
  emits an `output_validation` descriptor: `validation_state`, `authority`,
  `ruleset_version`, `failed_rule_ids`.
- `build_workflow_pack_run_accepted_output` refuses anything whose recorded
  verdict is not `VALIDATED`, with bounded reason `output_not_validated`. The
  check runs **before** the output artifact is loaded, so authority is settled
  before content is read. `build_workflow_pack_run_accepted_latest` delegates to
  the same builder, so one refusal covers both surfaces.
- The response carries `output_validation` (state, authority, ruleset version)
  so a consumer can verify admissibility instead of assuming it.
- Incomplete evidence — a verdict present but missing its authority marking or
  ruleset version — also fails closed rather than publishing a blank marking.

## The historical-run decision, made explicitly

A run whose evidence carries no verdict at all is **refused**, not
grandfathered. Runs accepted before output-validation evidence existed cannot
have their authority established after the fact, and accepted-output feeds new
client and advisor document generation: authority is proven at generation time
or it is absent. Age is not evidence.

The live consequence, stated rather than discovered later: regenerating a report
whose brief predates validation evidence now closes that section with a source
posture instead of composing it. That is the intended behaviour.

## Two deliberate exclusions

**`findings` are not persisted in the descriptor.** They quote the tokens and
references a rule rejected, so they carry output content, and this bundle is
persisted and rendered under a different redaction posture than the response
that produced it. `failed_rule_ids` says which rule failed without reproducing
what it saw. A test pins the exclusion so it is not helpfully added back.

**The verdict is not part of `content_hash`.** That hash means "this exact
narrative and context"; its basis never included `workflow_authority_owner`,
`review` or `evidence_types`. Adding a field to the basis would change every
previously published hash and break consumers holding stored snapshots. A test
pins it: two runs identical except the ruleset version that validated them
produce the same `content_hash`.

## Evidence

All **20 integration tests** that exercise accepted-output and accepted-latest
through the API passed unchanged from the first run — real executions do produce
`VALIDATED`, so the live path is unaffected. The only failures were unit tests
whose hand-built fixtures carried `evidence_descriptors: []`, which no real run
has; they now carry the evidence a publishable run actually carries, via one
shared `validated_output_evidence()` helper rather than copies.

New tests: each non-`VALIDATED` state refused (parameterised over
`UNVALIDATED_LOCAL_ONLY`, `REJECTED`, `VALIDATION_UNAVAILABLE`); a run with no
verdict refused as `absent`; refusal precedes artifact loading; the published
response carries the verdict; the content hash is unchanged by it; incomplete
evidence fails closed. `test_execute_task_returns_stubbed_completed_response`
now asserts the descriptor rides a real end-to-end execution rather than only a
unit-constructed bundle.

`ACCEPTED_OUTPUT_REASON_CODES` was declared but referenced nowhere. It is now a
live test asserting every raised reason is declared, since each becomes a
published `LOTUS_AI_ACCEPTED_*` error code — an undeclared reason would ship an
undocumented failure mode.

## Consumer note — lotus-report

Coordinated with the lotus-report session, which has made this an explicit
blocker on report#166's PDF leg. Conveyed: the refusal semantics and error codes
(`LOTUS_AI_ACCEPTED_OUTPUT_OUTPUT_NOT_VALIDATED`,
`LOTUS_AI_ACCEPTED_LATEST_OUTPUT_NOT_VALIDATED`, both 409 with
`metadata.reason_code`), the unchanged content-hash basis, and the historical-run
refusal.

They found that their source-reason mapping falls through to
`advisor_brief_not_found` for any unrecognised reason code, which would have
recorded this refusal as "brief not found" — false in the most expensive way,
since the brief exists and was refused on authority grounds. While confirming
that I found a second instance on their side: `lookup_scan_saturated` is a
retryable capacity condition that my own service already excludes from
`ACCEPTED_LATEST_NOT_FOUND_REASON_CODES`, and it was being reported as absence
too. They are fixing the mapping alongside their admissibility check.
