### PR TITLE
feat(audit): record refused privileged audit reads with their reason

### DIFF
--- a/alembic/versions/0058_add_audit_access_denial_reason.py
+++ b/alembic/versions/0058_add_audit_access_denial_reason.py
@@ -1,0 +1,33 @@
+"""add audit access denial reason
+
+Revision ID: 0058_add_audit_access_denial_reason
+Revises: 0057_add_audit_output_validation
+Create Date: 2026-09-01
+
+Issue #167 S1: a refused privileged audit read is now recorded, with the
+reason it was refused. Nullable: SUCCEEDED and NOT_FOUND events carry no
+denial reason, and every event written before this slice was one of those -
+a refusal left no row at all, which is the defect being closed.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0058_add_audit_access_denial_reason"
+down_revision = "0057_add_audit_output_validation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audit_access_events",
+        sa.Column("denial_reason", sa.String(length=32), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("audit_access_events", "denial_reason")

--- a/src/app/contracts/audit_access.py
+++ b/src/app/contracts/audit_access.py
@@ -8,6 +8,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class AuditReadScopeMode(str, Enum):
     RESTRICTED_TENANTS = "RESTRICTED_TENANTS"
     ALL_TENANTS = "ALL_TENANTS"
+    # A refusal happens before a scope is resolved, so a denial event has no
+    # scope to report. Saying so explicitly beats reporting a scope the caller
+    # never reached (issue #167).
+    UNRESOLVED = "UNRESOLVED"
 
 
 class AuditReadScope(BaseModel):
@@ -52,6 +56,26 @@ class AuditAccessOperation(str, Enum):
 class AuditAccessOutcome(str, Enum):
     SUCCEEDED = "SUCCEEDED"
     NOT_FOUND = "NOT_FOUND"
+    DENIED = "DENIED"
+
+
+class AuditAccessDenialReason(str, Enum):
+    """Why a privileged audit read was refused.
+
+    These are kept distinct rather than collapsed into one "denied" because
+    they carry different meanings for a reviewer. UNVERIFIED_TRUST_SOURCE is a
+    caller presenting an unverified identity for a privileged read - the fence
+    from #161, and the entry most worth investigating. CONFLICTING_POLICY is a
+    misconfigured grant. Recording both as the same thing would hide the first
+    inside the second.
+    """
+
+    NO_POLICY = "NO_POLICY"
+    INACTIVE_POLICY = "INACTIVE_POLICY"
+    CONFLICTING_POLICY = "CONFLICTING_POLICY"
+    NO_TENANT_SCOPE = "NO_TENANT_SCOPE"
+    MALFORMED_POLICY = "MALFORMED_POLICY"
+    UNVERIFIED_TRUST_SOURCE = "UNVERIFIED_TRUST_SOURCE"
 
 
 class AuditAccessEvent(BaseModel):
@@ -61,6 +85,10 @@ class AuditAccessEvent(BaseModel):
     scope_mode: AuditReadScopeMode
     operation: AuditAccessOperation
     outcome: AuditAccessOutcome
+    denial_reason: AuditAccessDenialReason | None = Field(
+        default=None,
+        description="Why access was refused; set only when the outcome is DENIED.",
+    )
     returned_record_count: int = Field(ge=0, le=100)
     recorded_at: str = Field(min_length=1, max_length=64)
 

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -61,6 +61,7 @@ class AuditAccessEventModel(Base):
     scope_mode: Mapped[str] = mapped_column(String(32), nullable=False)
     operation: Mapped[str] = mapped_column(String(32), nullable=False)
     outcome: Mapped[str] = mapped_column(String(32), nullable=False)
+    denial_reason: Mapped[str | None] = mapped_column(String(32), nullable=True)
     returned_record_count: Mapped[int] = mapped_column(Integer, nullable=False)
     recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
 

--- a/src/app/repositories/sqlalchemy_audit_repository.py
+++ b/src/app/repositories/sqlalchemy_audit_repository.py
@@ -15,6 +15,7 @@ from app.contracts.access_control import (
 from app.contracts.audit import AuditRecordResponse
 from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.audit_access import (
+    AuditAccessDenialReason,
     AuditAccessEvent,
     AuditAccessOperation,
     AuditAccessOutcome,
@@ -144,6 +145,7 @@ class SqlAlchemyAuditRepository(SqlAlchemyRepositoryBase):
             scope_mode=event.scope_mode.value,
             operation=event.operation.value,
             outcome=event.outcome.value,
+            denial_reason=event.denial_reason.value if event.denial_reason else None,
             returned_record_count=event.returned_record_count,
             recorded_at=event.recorded_at,
         )
@@ -167,6 +169,11 @@ class SqlAlchemyAuditRepository(SqlAlchemyRepositoryBase):
                     scope_mode=AuditReadScopeMode(model.scope_mode),
                     operation=AuditAccessOperation(model.operation),
                     outcome=AuditAccessOutcome(model.outcome),
+                    denial_reason=(
+                        AuditAccessDenialReason(model.denial_reason)
+                        if model.denial_reason
+                        else None
+                    ),
                     returned_record_count=model.returned_record_count,
                     recorded_at=model.recorded_at,
                 )

--- a/src/app/routers/audit.py
+++ b/src/app/routers/audit.py
@@ -70,7 +70,9 @@ async def list_audit_records(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Tenant scope is derived from authenticated caller policy.",
         )
-    scope = resolve_audit_read_scope(authenticated_caller)
+    scope = resolve_audit_read_scope(
+        authenticated_caller, operation=AuditAccessOperation.LIST_RECORDS
+    )
     records = get_audit_store().list(
         caller_app=caller_app,
         task_id=task_id,
@@ -130,7 +132,9 @@ async def get_audit_record(
     request_id: str,
     authenticated_caller: AuthenticatedCallerDependency,
 ) -> AuditRecordResponse:
-    scope = resolve_audit_read_scope(authenticated_caller)
+    scope = resolve_audit_read_scope(
+        authenticated_caller, operation=AuditAccessOperation.GET_RECORD
+    )
     record = get_audit_store().get(request_id, scope=scope)
     if record is None:
         record_all_tenant_audit_access(

--- a/src/app/routers/observability.py
+++ b/src/app/routers/observability.py
@@ -238,7 +238,9 @@ async def get_observability_breakdown_summary_route(
     authenticated_caller: AuthenticatedCallerDependency,
     limit: int = Query(default=100, ge=1, le=200),
 ) -> ObservabilityBreakdownSummaryResponse:
-    scope = resolve_audit_read_scope(authenticated_caller)
+    scope = resolve_audit_read_scope(
+        authenticated_caller, operation=AuditAccessOperation.AGGREGATE_BREAKDOWNS
+    )
     summary = build_observability_breakdown_summary(limit=limit, scope=scope)
     record_all_tenant_audit_access(
         caller=authenticated_caller,

--- a/src/app/services/audit_read_authorization.py
+++ b/src/app/services/audit_read_authorization.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from uuid import uuid4
 
+from typing import NoReturn
+
 from fastapi import HTTPException, status
 
 from app.contracts.access_control import CallerLifecycleStatus
 from app.contracts.audit_access import (
+    AuditAccessDenialReason,
     AuditAccessEvent,
     AuditAccessOperation,
     AuditAccessOutcome,
@@ -23,19 +26,65 @@ from app.services.caller_policy_store import get_caller_policy_repository
 _ACCESS_DENIED_DETAIL = "Caller is not authorized to inspect lotus-ai audit records."
 
 
-def resolve_audit_read_scope(caller: AuthenticatedCaller) -> AuditReadScope:
-    policy = get_caller_policy_repository().get_policy(caller.caller_app)
-    if policy is None or policy.lifecycle_status != CallerLifecycleStatus.ACTIVE:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_DETAIL)
+def resolve_audit_read_scope(
+    caller: AuthenticatedCaller, *, operation: AuditAccessOperation
+) -> AuditReadScope:
+    """Resolve the caller's audit read scope, recording every refusal.
 
-    tenant_ids = _normalized_tenant_ids(policy.restricted_tenant_ids)
+    A refused privileged read is the entry a security reviewer most wants and
+    the one that used to leave no trace anywhere: every 403 below was raised
+    before any evidence was written (issue #167). The event is written before
+    the refusal is raised, so a store failure surfaces as a 5xx rather than
+    turning a refusal into a clean, unrecorded 403.
+
+    ``operation`` is what the caller was attempting. The scope is deliberately
+    not a parameter: at refusal time it has not been resolved, which is what
+    ``AuditReadScopeMode.UNRESOLVED`` records.
+    """
+
+    policy = get_caller_policy_repository().get_policy(caller.caller_app)
+    if policy is None:
+        _refuse(caller, operation, AuditAccessDenialReason.NO_POLICY)
+    if policy.lifecycle_status != CallerLifecycleStatus.ACTIVE:
+        _refuse(caller, operation, AuditAccessDenialReason.INACTIVE_POLICY)
+
+    tenant_ids = _normalized_tenant_ids(policy.restricted_tenant_ids, caller, operation)
     if policy.allow_audit_read_all_tenants:
-        if tenant_ids or not is_privileged_caller_identity_accepted(caller):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_DETAIL)
+        # Two distinct failures, deliberately not one branch. A grant that also
+        # carries tenant restrictions is a misconfiguration; an unverified
+        # caller reaching for privileged access is a security event. Collapsing
+        # them would hide the second inside the first.
+        if tenant_ids:
+            _refuse(caller, operation, AuditAccessDenialReason.CONFLICTING_POLICY)
+        if not is_privileged_caller_identity_accepted(caller):
+            _refuse(caller, operation, AuditAccessDenialReason.UNVERIFIED_TRUST_SOURCE)
         return AuditReadScope.all_tenants()
     if not tenant_ids:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_DETAIL)
+        _refuse(caller, operation, AuditAccessDenialReason.NO_TENANT_SCOPE)
     return AuditReadScope.restricted(tenant_ids)
+
+
+def _refuse(
+    caller: AuthenticatedCaller,
+    operation: AuditAccessOperation,
+    reason: AuditAccessDenialReason,
+) -> NoReturn:
+    """Record the refusal, then raise it."""
+
+    get_audit_store().save_access_event(
+        AuditAccessEvent(
+            event_id=str(uuid4()),
+            caller_app=caller.caller_app,
+            caller_trust_source=caller.trust_source,
+            scope_mode=AuditReadScopeMode.UNRESOLVED,
+            operation=operation,
+            outcome=AuditAccessOutcome.DENIED,
+            denial_reason=reason,
+            returned_record_count=0,
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+    )
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_DETAIL)
 
 
 def record_all_tenant_audit_access(
@@ -62,10 +111,12 @@ def record_all_tenant_audit_access(
     )
 
 
-def _normalized_tenant_ids(values: list[str]) -> frozenset[str]:
+def _normalized_tenant_ids(
+    values: list[str], caller: AuthenticatedCaller, operation: AuditAccessOperation
+) -> frozenset[str]:
     normalized: set[str] = set()
     for value in values:
         if not isinstance(value, str) or not value.strip() or value != value.strip():
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_ACCESS_DENIED_DETAIL)
+            _refuse(caller, operation, AuditAccessDenialReason.MALFORMED_POLICY)
         normalized.add(value)
     return frozenset(normalized)

--- a/tests/unit/test_audit_read_authorization.py
+++ b/tests/unit/test_audit_read_authorization.py
@@ -4,7 +4,17 @@ import pytest
 from app.config import settings
 from app.contracts.audit_access import AuditReadScopeMode
 from app.http.authenticated_caller import AuthenticatedCaller
+from app.contracts.audit_access import AuditAccessOperation
 from app.services.audit_read_authorization import resolve_audit_read_scope
+from pathlib import Path
+from app.contracts.access_control import (
+    CallerLifecycleStatus,
+    CallerPolicyDescriptor,
+    TenantPolicyMode,
+)
+from app.contracts.audit_access import AuditAccessDenialReason, AuditAccessOutcome
+from app.services.audit_store import get_audit_store, reset_audit_store_cache
+from tests.support.migration_runner import upgrade_database_to_head
 
 
 @pytest.mark.parametrize(
@@ -19,7 +29,8 @@ def test_resolve_audit_read_scope_uses_policy_tenants(
     expected_tenants: frozenset[str],
 ) -> None:
     scope = resolve_audit_read_scope(
-        AuthenticatedCaller(caller_app=caller_app, trust_source="trusted_http_header")
+        AuthenticatedCaller(caller_app=caller_app, trust_source="trusted_http_header"),
+        operation=AuditAccessOperation.LIST_RECORDS,
     )
 
     assert scope.mode == AuditReadScopeMode.RESTRICTED_TENANTS
@@ -34,7 +45,8 @@ def test_resolve_audit_read_scope_keeps_restricted_tenant_access_in_promoted_pos
     monkeypatch.setattr(settings, "readiness_probe_policy", "degrade")
 
     scope = resolve_audit_read_scope(
-        AuthenticatedCaller(caller_app="lotus-manage", trust_source="trusted_http_header")
+        AuthenticatedCaller(caller_app="lotus-manage", trust_source="trusted_http_header"),
+        operation=AuditAccessOperation.LIST_RECORDS,
     )
 
     assert scope.mode == AuditReadScopeMode.RESTRICTED_TENANTS
@@ -49,7 +61,8 @@ def test_resolve_audit_read_scope_denies_header_operator_by_default(
 
     with pytest.raises(HTTPException) as exc_info:
         resolve_audit_read_scope(
-            AuthenticatedCaller(caller_app="lotus-platform", trust_source="trusted_http_header")
+            AuthenticatedCaller(caller_app="lotus-platform", trust_source="trusted_http_header"),
+            operation=AuditAccessOperation.LIST_RECORDS,
         )
 
     assert exc_info.value.status_code == 403
@@ -75,7 +88,8 @@ def test_resolve_audit_read_scope_allows_header_operator_only_when_explicitly_en
     monkeypatch.setattr(settings, "readiness_probe_policy", readiness_policy)
 
     scope = resolve_audit_read_scope(
-        AuthenticatedCaller(caller_app="lotus-platform", trust_source="trusted_http_header")
+        AuthenticatedCaller(caller_app="lotus-platform", trust_source="trusted_http_header"),
+        operation=AuditAccessOperation.LIST_RECORDS,
     )
 
     assert scope.mode == AuditReadScopeMode.ALL_TENANTS
@@ -104,7 +118,8 @@ def test_resolve_audit_read_scope_denies_header_operator_when_disabled_independe
 
     with pytest.raises(HTTPException) as exc_info:
         resolve_audit_read_scope(
-            AuthenticatedCaller(caller_app="lotus-platform", trust_source="trusted_http_header")
+            AuthenticatedCaller(caller_app="lotus-platform", trust_source="trusted_http_header"),
+            operation=AuditAccessOperation.LIST_RECORDS,
         )
 
     assert exc_info.value.status_code == 403
@@ -121,7 +136,8 @@ def test_resolve_audit_read_scope_allows_verified_operator_in_promoted_posture(
     monkeypatch.setattr(settings, "readiness_probe_policy", "degrade")
 
     scope = resolve_audit_read_scope(
-        AuthenticatedCaller(caller_app="lotus-platform", trust_source=trust_source)
+        AuthenticatedCaller(caller_app="lotus-platform", trust_source=trust_source),
+        operation=AuditAccessOperation.LIST_RECORDS,
     )
 
     assert scope.mode == AuditReadScopeMode.ALL_TENANTS
@@ -136,7 +152,8 @@ def test_resolve_audit_read_scope_denies_unknown_operator_trust_source(
 
     with pytest.raises(HTTPException) as exc_info:
         resolve_audit_read_scope(
-            AuthenticatedCaller(caller_app="lotus-platform", trust_source="unverified_internal")
+            AuthenticatedCaller(caller_app="lotus-platform", trust_source="unverified_internal"),
+            operation=AuditAccessOperation.LIST_RECORDS,
         )
 
     assert exc_info.value.status_code == 403
@@ -146,7 +163,8 @@ def test_resolve_audit_read_scope_denies_unknown_operator_trust_source(
 def test_resolve_audit_read_scope_denies_empty_or_unknown_policy(caller_app: str) -> None:
     with pytest.raises(HTTPException) as exc_info:
         resolve_audit_read_scope(
-            AuthenticatedCaller(caller_app=caller_app, trust_source="trusted_http_header")
+            AuthenticatedCaller(caller_app=caller_app, trust_source="trusted_http_header"),
+            operation=AuditAccessOperation.LIST_RECORDS,
         )
 
     assert exc_info.value.status_code == 403
@@ -193,7 +211,7 @@ def test_resolve_audit_read_scope_fails_closed_on_degenerate_policies(
         lambda: _StubPolicies(_policy([])),
     )
     with pytest.raises(HTTPException) as exc_info:
-        resolve_audit_read_scope(caller)
+        resolve_audit_read_scope(caller, operation=AuditAccessOperation.LIST_RECORDS)
     assert exc_info.value.status_code == 403
 
     # A malformed tenant id (surrounding whitespace) fails closed too.
@@ -202,5 +220,193 @@ def test_resolve_audit_read_scope_fails_closed_on_degenerate_policies(
         lambda: _StubPolicies(_policy([" tenant-sg-001 "])),
     )
     with pytest.raises(HTTPException) as exc_info:
-        resolve_audit_read_scope(caller)
+        resolve_audit_read_scope(caller, operation=AuditAccessOperation.LIST_RECORDS)
     assert exc_info.value.status_code == 403
+
+
+# --- Refusals leave a record (issue #167, S1) -----------------------------
+
+
+def _denial_policy(
+    *,
+    lifecycle: CallerLifecycleStatus = CallerLifecycleStatus.ACTIVE,
+    all_tenants: bool = False,
+    restricted: list[str] | None = None,
+) -> CallerPolicyDescriptor:
+    return CallerPolicyDescriptor(
+        caller_app="lotus-denied",
+        lifecycle_status=lifecycle,
+        description="policy under test",
+        allowed_task_ids=[],
+        allowed_retrieval_source_ids=[],
+        allow_live_provider=False,
+        allow_async_control=False,
+        allow_prompt_control=False,
+        allow_provider_control=False,
+        allow_audit_read_all_tenants=all_tenants,
+        tenant_policy_mode=TenantPolicyMode.RESTRICTED,
+        restricted_tenant_ids=restricted if restricted is not None else [],
+    )
+
+
+class _Policies:
+    def __init__(self, policy: object) -> None:
+        self._policy = policy
+
+    def get_policy(self, caller_app: str) -> object:
+        return self._policy
+
+
+def _install_policy(monkeypatch: pytest.MonkeyPatch, policy: object) -> None:
+    monkeypatch.setattr(
+        "app.services.audit_read_authorization.get_caller_policy_repository",
+        lambda: _Policies(policy),
+    )
+
+
+@pytest.mark.parametrize(
+    ("policy", "trust_source", "expected_reason"),
+    [
+        (None, "trusted_http_header", AuditAccessDenialReason.NO_POLICY),
+        (
+            _denial_policy(lifecycle=CallerLifecycleStatus.DISABLED),
+            "trusted_http_header",
+            AuditAccessDenialReason.INACTIVE_POLICY,
+        ),
+        (
+            _denial_policy(all_tenants=True, restricted=["tenant-sg-001"]),
+            "verified_service_jwt",
+            AuditAccessDenialReason.CONFLICTING_POLICY,
+        ),
+        (
+            _denial_policy(all_tenants=True),
+            "trusted_http_header",
+            AuditAccessDenialReason.UNVERIFIED_TRUST_SOURCE,
+        ),
+        (_denial_policy(), "trusted_http_header", AuditAccessDenialReason.NO_TENANT_SCOPE),
+        (
+            _denial_policy(restricted=[" tenant-sg-001 "]),
+            "trusted_http_header",
+            AuditAccessDenialReason.MALFORMED_POLICY,
+        ),
+    ],
+)
+def test_every_refusal_path_records_exactly_one_denied_event(
+    policy: object,
+    trust_source: str,
+    expected_reason: AuditAccessDenialReason,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The attempts a security reviewer most needs used to leave no trace: every
+    403 was raised before any evidence was written."""
+
+    settings.local_header_caller_identity_enabled = False
+    _install_policy(monkeypatch, policy)
+    caller = AuthenticatedCaller(caller_app="lotus-denied", trust_source=trust_source)
+
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_audit_read_scope(caller, operation=AuditAccessOperation.GET_RECORD)
+    assert exc_info.value.status_code == 403
+
+    events = list(get_audit_store().list_access_events(limit=10))
+    assert len(events) == 1
+    event = events[0]
+    assert event.outcome is AuditAccessOutcome.DENIED
+    assert event.denial_reason is expected_reason
+    assert event.operation is AuditAccessOperation.GET_RECORD
+    assert event.caller_app == "lotus-denied"
+    assert event.caller_trust_source == trust_source
+    # The scope was never resolved, so the event says so rather than naming a
+    # scope the caller did not reach.
+    assert event.scope_mode is AuditReadScopeMode.UNRESOLVED
+    assert event.returned_record_count == 0
+
+
+def test_a_misconfigured_grant_and_an_unverified_caller_are_not_the_same_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """These two used to share one branch.
+
+    One is a policy that grants all-tenant access while also carrying tenant
+    restrictions - a configuration mistake. The other is a caller presenting an
+    unverified identity for a privileged read - #161's fence, and the entry
+    most worth investigating. Recording both as one reason would hide the
+    security event inside the misconfiguration.
+    """
+
+    settings.local_header_caller_identity_enabled = False
+
+    _install_policy(monkeypatch, _denial_policy(all_tenants=True, restricted=["tenant-sg-001"]))
+    with pytest.raises(HTTPException):
+        resolve_audit_read_scope(
+            AuthenticatedCaller(caller_app="lotus-denied", trust_source="verified_service_jwt"),
+            operation=AuditAccessOperation.LIST_RECORDS,
+        )
+
+    _install_policy(monkeypatch, _denial_policy(all_tenants=True))
+    with pytest.raises(HTTPException):
+        resolve_audit_read_scope(
+            AuthenticatedCaller(caller_app="lotus-denied", trust_source="trusted_http_header"),
+            operation=AuditAccessOperation.LIST_RECORDS,
+        )
+
+    reasons = [event.denial_reason for event in get_audit_store().list_access_events(limit=10)]
+    assert set(reasons) == {
+        AuditAccessDenialReason.CONFLICTING_POLICY,
+        AuditAccessDenialReason.UNVERIFIED_TRUST_SOURCE,
+    }
+
+
+def test_a_refusal_whose_evidence_cannot_be_written_is_not_a_clean_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The denial-path twin of the existing success-path proof.
+
+    A refusal that could not be recorded must not return a tidy 403 as though
+    nothing happened - the entire point of the slice is that refusals leave a
+    trace, so a failure to leave one is a server error.
+    """
+
+    settings.local_header_caller_identity_enabled = False
+    _install_policy(monkeypatch, None)
+
+    class _FailingStore:
+        def save_access_event(self, event: object) -> None:
+            raise RuntimeError("access-event store unavailable")
+
+    monkeypatch.setattr(
+        "app.services.audit_read_authorization.get_audit_store", lambda: _FailingStore()
+    )
+
+    with pytest.raises(RuntimeError):
+        resolve_audit_read_scope(
+            AuthenticatedCaller(caller_app="lotus-denied", trust_source="trusted_http_header"),
+            operation=AuditAccessOperation.LIST_RECORDS,
+        )
+
+
+def test_denial_reasons_survive_the_sql_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Evidence that only survives in memory is not evidence a reviewer can
+    come back to."""
+
+    settings.audit_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-audit-denials.db'}"
+    upgrade_database_to_head(settings.database_url)
+    reset_audit_store_cache()
+    settings.local_header_caller_identity_enabled = False
+    _install_policy(monkeypatch, _denial_policy(all_tenants=True))
+
+    with pytest.raises(HTTPException):
+        resolve_audit_read_scope(
+            AuthenticatedCaller(caller_app="lotus-denied", trust_source="trusted_http_header"),
+            operation=AuditAccessOperation.AGGREGATE_BREAKDOWNS,
+        )
+
+    reset_audit_store_cache()
+    events = list(get_audit_store().list_access_events(limit=10))
+    assert len(events) == 1
+    assert events[0].outcome is AuditAccessOutcome.DENIED
+    assert events[0].denial_reason is AuditAccessDenialReason.UNVERIFIED_TRUST_SOURCE
+    assert events[0].operation is AuditAccessOperation.AGGREGATE_BREAKDOWNS


### PR DESCRIPTION
Issue #167, slice 1 of 3. Records refusals. The read path (S2) and retention (S3) stay separate, as the issue sequences them.

## Control-plane outcome

A refused privileged audit read is on record — who attempted it, from what trust source, what they were attempting, and exactly why it was refused. That is the entry a security reviewer most needs, and it previously left no trace anywhere.

## Invariant

Every decision to grant **or refuse** privileged audit access is durably recorded before the decision takes effect. A refusal whose evidence cannot be written is a server error, never a clean 403.

## One authority

`resolve_audit_read_scope` is the single place that decides audit read scope, so it is the single place that records refusals. It takes the `operation` the caller was attempting; it deliberately does **not** take a scope, because at refusal time no scope has been resolved — which is what the new `AuditReadScopeMode.UNRESOLVED` records, rather than naming a scope the caller never reached.

## The correction that mattered

The issue specified `CONFLICTING_POLICY` and `UNVERIFIED_TRUST_SOURCE` as distinct reasons, but the code collapsed both into one branch:

```python
if policy.allow_audit_read_all_tenants:
    if tenant_ids or not is_privileged_caller_identity_accepted(caller):
        raise HTTPException(403, ...)
```

Non-empty `tenant_ids` is a **configuration mistake** — a policy granting all-tenant access that also carries tenant restrictions. The other half is a **caller presenting an unverified identity for a privileged read**: #161's fence, and the single most security-relevant denial in the set. Recording both under one reason would have filed the security event inside the misconfiguration.

The branch is split. Collapsing it back fails three tests, including the one that asserts the two are distinguishable.

## What changed

- `AuditAccessOutcome.DENIED`, and `AuditAccessDenialReason` with `NO_POLICY`, `INACTIVE_POLICY`, `CONFLICTING_POLICY`, `NO_TENANT_SCOPE`, `MALFORMED_POLICY`, `UNVERIFIED_TRUST_SOURCE`.
- `AuditReadScopeMode.UNRESOLVED` for events written before a scope exists.
- `AuditAccessEvent.denial_reason`, nullable, set only for `DENIED`.
- Migration `0058` adds the nullable column; verified to apply against a real schema, with the column present afterwards.
- All four refusal paths in `resolve_audit_read_scope` record before raising, including the one inside `_normalized_tenant_ids` — the write lives at the boundary rather than in the helper, which is called from two places.

## A third call site the issue did not list

The issue's present-state block named the two audit routes. `routers/observability.py` also resolves audit read scope, for `AGGREGATE_BREAKDOWNS`; without it that path would have kept refusing silently. Found by the type checker rejecting the new required argument, which is the argument for making it required rather than defaulted.

## Evidence

- `test_every_refusal_path_records_exactly_one_denied_event` — parameterised over all six reasons: each produces exactly one `DENIED` event with the matching reason, the attempted operation, the caller and its trust source, `UNRESOLVED` scope, and a still-403 response.
- `test_a_misconfigured_grant_and_an_unverified_caller_are_not_the_same_event` — the split above.
- `test_a_refusal_whose_evidence_cannot_be_written_is_not_a_clean_403` — the denial-path twin of the existing success-path fail-closed proof at `test_audit_tenant_isolation.py:157`. A refusal that leaves no trace defeats the slice.
- `test_denial_reasons_survive_the_sql_store` — full round-trip through the SQL adapter with a real migration. Evidence that only survives in memory is not evidence a reviewer can come back to.

Guard verified by collapsing the split branch back: three tests fail, including the SQL round-trip.

Full local gate: whole suite, `make lint`, `make typecheck` (729 files).

## Deliberately not in this PR

**S2 — the read path.** `list_access_events` is implemented on the repository protocol and both adapters and exposed by no route; privileged-access evidence no operator can read is evidence in name only. It needs its own route, its own authorization (the same privilege the events describe), its own recorded access, and the `PROTECTED_ROUTER_BINDINGS` coverage wiring — enough to be its own bounded change rather than a tail on this one.

**S3 — retention.** Folds into #158 per the issue.
