### PR TITLE
feat(audit): expose the privileged-access ledger to the privilege it describes

### DIFF
--- a/src/app/contracts/audit_access.py
+++ b/src/app/contracts/audit_access.py
@@ -51,6 +51,9 @@ class AuditAccessOperation(str, Enum):
     LIST_RECORDS = "LIST_RECORDS"
     GET_RECORD = "GET_RECORD"
     AGGREGATE_BREAKDOWNS = "AGGREGATE_BREAKDOWNS"
+    # Reading the access-events ledger is itself a privileged audit read, so it
+    # is recorded like any other (issue #167, S2).
+    LIST_ACCESS_EVENTS = "LIST_ACCESS_EVENTS"
 
 
 class AuditAccessOutcome(str, Enum):
@@ -76,6 +79,10 @@ class AuditAccessDenialReason(str, Enum):
     NO_TENANT_SCOPE = "NO_TENANT_SCOPE"
     MALFORMED_POLICY = "MALFORMED_POLICY"
     UNVERIFIED_TRUST_SOURCE = "UNVERIFIED_TRUST_SOURCE"
+    # A caller with a valid restricted-tenant scope reaching for a surface that
+    # requires the all-tenant privilege. Distinct from NO_TENANT_SCOPE, which is
+    # a caller with no usable scope at all.
+    INSUFFICIENT_PRIVILEGE = "INSUFFICIENT_PRIVILEGE"
 
 
 class AuditAccessEvent(BaseModel):
@@ -91,6 +98,20 @@ class AuditAccessEvent(BaseModel):
     )
     returned_record_count: int = Field(ge=0, le=100)
     recorded_at: str = Field(min_length=1, max_length=64)
+
+
+class AuditAccessEventCatalogResponse(BaseModel):
+    """The privileged-access ledger, newest first.
+
+    Bounded like every other audit read. The events describe who read audit
+    records and who was refused; reading them requires the same all-tenant
+    privilege the events themselves describe.
+    """
+
+    service: str = Field(description="Publishing service identity.")
+    version: str = Field(description="Publishing service version.")
+    returned_event_count: int = Field(ge=0, description="Number of events returned.")
+    events: list[AuditAccessEvent] = Field(description="Access events, newest first.")
 
 
 INTERNAL_AGGREGATE_AUDIT_SCOPE = AuditReadScope.all_tenants()

--- a/src/app/routers/audit.py
+++ b/src/app/routers/audit.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 
 from app.config import settings
 from app.contracts.audit_access import (
+    AuditAccessEventCatalogResponse,
     AuditAccessOperation,
     AuditAccessOutcome,
 )
@@ -12,11 +13,56 @@ from app.contracts.api_errors import problem_response
 from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.audit_read_authorization import (
     record_all_tenant_audit_access,
+    require_all_tenant_audit_access,
     resolve_audit_read_scope,
 )
 from app.services.audit_store import get_audit_store
 
 router = APIRouter(prefix="/ai/audit", tags=["audit"])
+
+
+# Registered before the "/{request_id}" detail route below: FastAPI matches in
+# registration order, so a literal path that could also parse as a record id has
+# to come first or it is captured as a lookup for a record named
+# "access-events".
+@router.get(
+    "/access-events",
+    response_model=AuditAccessEventCatalogResponse,
+    operation_id="listAuditAccessEvents",
+    summary="List privileged audit-access events",
+    description=(
+        "Returns the bounded privileged-access ledger, newest first: who read lotus-ai audit "
+        "records, who was refused, and why. Requires the same all-tenant audit privilege the "
+        "events describe, and the read is itself recorded."
+    ),
+    responses={
+        200: {"description": "Access-event ledger returned successfully."},
+        403: problem_response("Caller is not authorized to inspect audit access events."),
+        422: problem_response("Invalid access-event query parameters supplied."),
+        500: problem_response("Unexpected lotus-ai server error."),
+    },
+)
+async def list_audit_access_events(
+    authenticated_caller: AuthenticatedCallerDependency,
+    limit: int = Query(default=100, ge=1, le=100),
+) -> AuditAccessEventCatalogResponse:
+    scope = require_all_tenant_audit_access(
+        authenticated_caller, operation=AuditAccessOperation.LIST_ACCESS_EVENTS
+    )
+    events = list(get_audit_store().list_access_events(limit=limit))
+    record_all_tenant_audit_access(
+        caller=authenticated_caller,
+        scope=scope,
+        operation=AuditAccessOperation.LIST_ACCESS_EVENTS,
+        outcome=AuditAccessOutcome.SUCCEEDED,
+        returned_record_count=len(events),
+    )
+    return AuditAccessEventCatalogResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        returned_event_count=len(events),
+        events=events,
+    )
 
 
 @router.get(

--- a/src/app/services/audit_read_authorization.py
+++ b/src/app/services/audit_read_authorization.py
@@ -64,6 +64,23 @@ def resolve_audit_read_scope(
     return AuditReadScope.restricted(tenant_ids)
 
 
+def require_all_tenant_audit_access(
+    caller: AuthenticatedCaller, *, operation: AuditAccessOperation
+) -> AuditReadScope:
+    """Resolve a scope and require it to be all-tenant.
+
+    Used by surfaces that describe privileged access rather than a tenant's own
+    records. A caller with a perfectly valid restricted scope is refused here,
+    and that refusal is recorded like any other - `INSUFFICIENT_PRIVILEGE`,
+    which is a different event from having no usable scope at all.
+    """
+
+    scope = resolve_audit_read_scope(caller, operation=operation)
+    if scope.mode is not AuditReadScopeMode.ALL_TENANTS:
+        _refuse(caller, operation, AuditAccessDenialReason.INSUFFICIENT_PRIVILEGE)
+    return scope
+
+
 def _refuse(
     caller: AuthenticatedCaller,
     operation: AuditAccessOperation,

--- a/tests/integration/test_audit_tenant_isolation.py
+++ b/tests/integration/test_audit_tenant_isolation.py
@@ -176,3 +176,114 @@ def test_audit_list_applies_the_category_filter_within_the_caller_scope(
     body = response.json()
     assert body["filters_applied"]["category"] == "explain"
     assert all(record["category"] == "explain" for record in body["records"])
+
+
+def test_the_access_event_ledger_is_readable_by_the_privilege_it_describes(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #167 S2: evidence an operator cannot read is evidence in name only.
+
+    The ledger records who read audit records and who was refused, so reading
+    it requires the same all-tenant privilege those events describe — and the
+    read is itself recorded, like every other privileged audit read.
+    """
+
+    monkeypatch.setattr(settings, "local_header_caller_identity_enabled", True)
+    _execute_task(
+        client,
+        caller_app="lotus-manage",
+        tenant_id="tenant-sg-001",
+        correlation_id="corr-access-events-seed",
+    )
+    # A privileged read, so the ledger has something to show.
+    assert (
+        client.get(
+            "/ai/audit", headers={"X-Caller-App": "lotus-platform"}, params={"limit": 10}
+        ).status_code
+        == 200
+    )
+
+    response = client.get(
+        "/ai/audit/access-events",
+        headers={"X-Caller-App": "lotus-platform"},
+        params={"limit": 50},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["returned_event_count"] == len(body["events"])
+    assert body["events"], "the ledger returned nothing despite a recorded privileged read"
+    operations = [event["operation"] for event in body["events"]]
+    assert "LIST_RECORDS" in operations
+    # Newest first.
+    recorded = [event["recorded_at"] for event in body["events"]]
+    assert recorded == sorted(recorded, reverse=True)
+
+    # Reading the ledger is itself privileged access, so it is on the ledger.
+    follow_up = client.get(
+        "/ai/audit/access-events",
+        headers={"X-Caller-App": "lotus-platform"},
+        params={"limit": 50},
+    )
+    assert follow_up.status_code == 200
+    assert "LIST_ACCESS_EVENTS" in [event["operation"] for event in follow_up.json()["events"]]
+
+
+def test_a_restricted_tenant_caller_is_refused_the_ledger_and_recorded(
+    client: TestClient,
+) -> None:
+    """A valid restricted scope is not the privilege this surface requires, and
+    the refusal is itself evidence — recorded as INSUFFICIENT_PRIVILEGE rather
+    than as a caller with no usable scope."""
+
+    response = client.get(
+        "/ai/audit/access-events",
+        headers={"X-Caller-App": "lotus-manage"},
+        params={"limit": 10},
+    )
+
+    assert response.status_code == 403
+    event = get_audit_store().list_access_events(limit=1)[0]
+    assert event.caller_app == "lotus-manage"
+    assert event.outcome.value == "DENIED"
+    assert event.denial_reason is not None
+    assert event.denial_reason.value == "INSUFFICIENT_PRIVILEGE"
+    assert event.operation.value == "LIST_ACCESS_EVENTS"
+    assert event.scope_mode.value == "UNRESOLVED"
+
+
+def test_the_ledger_carries_no_tenant_or_record_identifiers(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ledger describes access, not content. Publishing record or tenant
+    identifiers here would turn an access log into a second, less governed
+    route to the records it describes."""
+
+    monkeypatch.setattr(settings, "local_header_caller_identity_enabled", True)
+    _execute_task(
+        client,
+        caller_app="lotus-manage",
+        tenant_id="tenant-sg-001",
+        correlation_id="corr-access-events-shape",
+    )
+    assert client.get("/ai/audit", headers={"X-Caller-App": "lotus-platform"}).status_code == 200
+
+    body = client.get("/ai/audit/access-events", headers={"X-Caller-App": "lotus-platform"}).json()
+
+    for event in body["events"]:
+        assert "tenant_id" not in event
+        assert "request_id" not in event
+        assert set(event).issubset(
+            {
+                "event_id",
+                "caller_app",
+                "caller_trust_source",
+                "scope_mode",
+                "operation",
+                "outcome",
+                "denial_reason",
+                "returned_record_count",
+                "recorded_at",
+            }
+        )


### PR DESCRIPTION
Issue #167, slice 2 of 3. S1 (recording refusals) merged as `43a3195`. Retention (S3) folds into #158.

## Control-plane outcome

The operator responsible for reviewing privileged audit access can actually read the record of it — who read audit records, who was refused, and why.

## Invariant

Evidence that is written can be read by the party responsible for reviewing it, under the same policy that governs the records it describes. Reading it is itself privileged access, and is recorded as such.

## One authority

`require_all_tenant_audit_access` composes the existing `resolve_audit_read_scope` rather than introducing a second authorization path: the scope is resolved exactly as before, then required to be all-tenant. A refusal there records like any other refusal, through the same `_refuse` seam S1 added.

## What changed

- `AuditAccessOperation.LIST_ACCESS_EVENTS`.
- `AuditAccessDenialReason.INSUFFICIENT_PRIVILEGE` — a caller with a valid restricted-tenant scope reaching for a surface that requires the all-tenant privilege. Distinct from `NO_TENANT_SCOPE`, which is a caller with no usable scope at all; folding them together would describe a legitimate caller as having nothing, which is the wrong story for a reviewer.
- `GET /ai/audit/access-events`, bounded (`limit` 1–100, default 100), newest first, returning `AuditAccessEventCatalogResponse`.
- The successful read is recorded with `returned_record_count` equal to what was returned.

## Route ordering, documented in place

The literal `/access-events` path is registered **before** the `/{request_id}` detail route. FastAPI matches in registration order, so a literal path that could also parse as a record id has to come first or it is captured as a lookup for a record named `access-events`. It works because of ordering alone, so a reorder would break it silently — hence the comment. The integration test would catch it as a non-200.

## Evidence

- `test_the_access_event_ledger_is_readable_by_the_privilege_it_describes` — a privileged caller reads the ledger, sees the `LIST_RECORDS` event that preceded it, gets newest-first ordering, and finds its own `LIST_ACCESS_EVENTS` read in a follow-up listing. That self-consistency is the point of the slice.
- `test_a_restricted_tenant_caller_is_refused_the_ledger_and_recorded` — 403, plus a `DENIED` event carrying `INSUFFICIENT_PRIVILEGE`, the attempted operation, and `UNRESOLVED` scope.
- `test_the_ledger_carries_no_tenant_or_record_identifiers` — the ledger describes access, not content. Publishing record or tenant identifiers here would turn an access log into a second, less governed route to the records it describes; the test pins the exact field set.

## On the protected-route gate

The route is covered by `test_every_published_non_public_operation_refuses_an_unidentified_caller`, and I checked that gate is not vacuous before relying on it: it enumerates every operation from the OpenAPI document itself and asserts each non-public one refuses an unidentified caller, with an assertion that the enumeration is non-empty.

Full local gate: 2184 tests, `make lint`, `make typecheck` (729 files).

## Note for S3 / #158

A `DENIED` event now records a caller who was refused, and being refused *at this endpoint* generates an event about the attempt to read denial events. That is correct and self-consistent, but a caller repeatedly probing writes unbounded rows. The bounded `limit` covers reads; the write side wants a deliberate retention answer rather than a default one.