### PR TITLE
feat(governance): governed actions with distinct-credential approval, first on kill-switch clearance

### DIFF
--- a/alembic/versions/0059_add_governed_actions.py
+++ b/alembic/versions/0059_add_governed_actions.py
@@ -1,0 +1,50 @@
+"""add governed actions table
+
+Revision ID: 0059_add_governed_actions
+Revises: 0058_add_audit_access_denial_reason
+Create Date: 2026-09-02
+
+Issue #157 S1: immutable evidence for governed control-plane actions -
+requester credential, distinct approver credential, action hash, and the
+request/approval/execution instants. First consumer: kill-switch clearance.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0059_add_governed_actions"
+down_revision = "0058_add_audit_access_denial_reason"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_governed_actions",
+        sa.Column("action_id", sa.String(length=64), primary_key=True),
+        sa.Column("action_type", sa.String(length=64), nullable=False, index=True),
+        sa.Column("actor_class", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False, index=True),
+        sa.Column("target", sa.String(length=256), nullable=False, index=True),
+        sa.Column("action_hash", sa.String(length=64), nullable=False),
+        sa.Column("action_payload", sa.JSON(), nullable=False),
+        sa.Column("requester_caller_app", sa.String(length=128), nullable=False),
+        sa.Column("requester_trust_source", sa.String(length=64), nullable=False),
+        sa.Column("requester_key_id", sa.String(length=128), nullable=True),
+        sa.Column("requester_attribution", sa.String(length=256), nullable=True),
+        sa.Column("requested_at", sa.String(length=64), nullable=False),
+        sa.Column("approver_caller_app", sa.String(length=128), nullable=True),
+        sa.Column("approver_trust_source", sa.String(length=64), nullable=True),
+        sa.Column("approver_key_id", sa.String(length=128), nullable=True),
+        sa.Column("approver_attribution", sa.String(length=256), nullable=True),
+        sa.Column("approved_at", sa.String(length=64), nullable=True),
+        sa.Column("executed_at", sa.String(length=64), nullable=True),
+        sa.Column("superseded_by_action_id", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("provider_governed_actions")

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -1,0 +1,107 @@
+"""Governed control-plane actions (issue #157, slice 1).
+
+One reusable pattern for high-impact permissive actions, proven first through
+kill-switch clearance. The risk-direction rule: a safety-increasing action
+(activate a switch, retire a model) takes one verified principal and executes
+immediately; a risk-increasing action (clear a switch, promote a prompt or
+model, enable a provider) takes a verified requester, a verified DISTINCT
+approver, and a hash binding the approval to the exact action requested.
+
+No verified human principal exists in the identity model today - the caller
+credential's ``sub`` names an application - so dual control binds to the
+signing credential (``credential_key_id``). Two steps signed by two different
+key ids are genuinely two different credentials; a single compromised
+credential cannot both request and approve. Claimed operator names are
+recorded as UNVERIFIED ATTRIBUTION, never as approval evidence: the credential
+is the fact, the name is a claim.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GovernedActorClass(str, Enum):
+    """Who a governed action answers to.
+
+    Explicit, never inferred from a name that happens to look like a service.
+    A runtime-originated action (a worker quarantining a poisoned job) is
+    legitimate and has no human approver; recording it as HUMAN_APPROVED with
+    a service string in the approver field is exactly the bypass this exists
+    to close.
+    """
+
+    HUMAN_APPROVED = "HUMAN_APPROVED"
+    SYSTEM_ORIGINATED = "SYSTEM_ORIGINATED"
+
+
+class GovernedActionType(str, Enum):
+    KILL_SWITCH_CLEAR = "KILL_SWITCH_CLEAR"
+
+
+class GovernedActionStatus(str, Enum):
+    PENDING = "PENDING"
+    EXECUTED = "EXECUTED"
+    SUPERSEDED = "SUPERSEDED"
+
+
+class GovernedActionRecord(BaseModel):
+    """Immutable evidence for one governed action, request through execution."""
+
+    model_config = ConfigDict(frozen=True)
+
+    action_id: str = Field(min_length=1, max_length=64)
+    action_type: GovernedActionType
+    actor_class: GovernedActorClass
+    status: GovernedActionStatus
+    target: str = Field(
+        min_length=1,
+        max_length=256,
+        description="The object this action operates on (e.g. a kill-switch id).",
+    )
+    action_hash: str = Field(
+        min_length=64,
+        max_length=64,
+        description=(
+            "SHA-256 over the canonical action payload. Approval binds to this hash, so "
+            "approval of one action can never authorize a modified action."
+        ),
+    )
+    action_payload: dict[str, str | None] = Field(
+        description="The exact hashed payload, retained so the evidence is self-verifying.",
+    )
+    requester_caller_app: str = Field(min_length=1, max_length=128)
+    requester_trust_source: str = Field(min_length=1, max_length=64)
+    requester_key_id: str | None = Field(
+        default=None,
+        max_length=128,
+        description="Signing credential that authenticated the requester; the verified fact.",
+    )
+    requester_attribution: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Caller-claimed operator name. Unverified attribution, not evidence.",
+    )
+    requested_at: str = Field(min_length=1, max_length=64)
+    approver_caller_app: str | None = Field(default=None, max_length=128)
+    approver_trust_source: str | None = Field(default=None, max_length=64)
+    approver_key_id: str | None = Field(
+        default=None,
+        max_length=128,
+        description="Signing credential that authenticated the approver; must differ from the requester's.",
+    )
+    approver_attribution: str | None = Field(default=None, max_length=256)
+    approved_at: str | None = Field(default=None, max_length=64)
+    executed_at: str | None = Field(default=None, max_length=64)
+    superseded_by_action_id: str | None = Field(default=None, max_length=64)
+
+
+class GovernedActionResponse(BaseModel):
+    service: str = Field(description="Publishing service identity.")
+    version: str = Field(description="Publishing service version.")
+    governed_action: GovernedActionRecord = Field(
+        description="The governed-action evidence record."
+    )
+    summary: list[str] = Field(description="Human-readable statements about the action.")

--- a/src/app/contracts/kill_switches.py
+++ b/src/app/contracts/kill_switches.py
@@ -21,6 +21,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from app.contracts.governed_actions import GovernedActionRecord
+
 
 class KillSwitchSemantics(str, Enum):
     HARD_KILL = "HARD_KILL"
@@ -103,11 +105,47 @@ class KillSwitchActivationRequest(BaseModel):
     )
 
 
-class KillSwitchClearRequest(BaseModel):
-    caller_app: str = Field(min_length=1, description="Calling application identity.")
-    reason: str = Field(min_length=1, description="Why this switch is being cleared.")
-    requested_by: str = Field(min_length=1, description="Operator requesting clearance.")
-    approved_by: str = Field(min_length=1, description="Operator approving clearance.")
+class KillSwitchClearIntentRequest(BaseModel):
+    """Step one of governed clearance: a verified requester states the intent.
+
+    Caller identity comes from the authenticated credential, never from the
+    body (issue #157). ``requested_by`` is claimed operator attribution - a
+    recorded claim, not evidence.
+    """
+
+    reason: str = Field(min_length=1, description="Why this switch should be cleared.")
+    requested_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class KillSwitchClearApprovalRequest(BaseModel):
+    """Step two: a distinct verified credential approves the exact pending action."""
+
+    action_id: str = Field(min_length=1, max_length=64, description="Pending governed action id.")
+    action_hash: str = Field(
+        min_length=64,
+        max_length=64,
+        description="Hash of the action being approved, exactly as returned by the request step.",
+    )
+    approved_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class KillSwitchClearApprovalResponse(BaseModel):
+    service: str = Field(description="Service name emitting the response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    store_mode: str = Field(description="Where kill-switch truth lives: memory or sqlalchemy.")
+    activation: KillSwitchActivationRecord = Field(description="The cleared activation.")
+    governed_action: GovernedActionRecord = Field(
+        description="The executed governed-action evidence linking request, approval and clearance.",
+    )
+    summary: list[str] = Field(description="Human-readable statements about the action.")
 
 
 class KillSwitchActionResponse(BaseModel):

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -256,6 +256,32 @@ class ProviderDegradationStateModel(Base):
     updated_at: Mapped[str] = mapped_column(String(64), nullable=False)
 
 
+class GovernedActionModel(Base):
+    """Governed-action evidence: request, approval and execution (issue #157)."""
+
+    __tablename__ = "provider_governed_actions"
+
+    action_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    action_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    actor_class: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    target: Mapped[str] = mapped_column(String(256), nullable=False, index=True)
+    action_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    action_payload: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
+    requester_caller_app: Mapped[str] = mapped_column(String(128), nullable=False)
+    requester_trust_source: Mapped[str] = mapped_column(String(64), nullable=False)
+    requester_key_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    requester_attribution: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    requested_at: Mapped[str] = mapped_column(String(64), nullable=False)
+    approver_caller_app: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    approver_trust_source: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    approver_key_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    approver_attribution: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    approved_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    executed_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    superseded_by_action_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+
 class ProviderOperationsEventModel(Base):
     __tablename__ = "provider_operations_events"
 

--- a/src/app/repositories/memory_provider_operations_repository.py
+++ b/src/app/repositories/memory_provider_operations_repository.py
@@ -6,6 +6,7 @@ from app.contracts.providers import (
     ProviderFailureCategory,
     ProviderQuotaScope,
 )
+from app.contracts.governed_actions import GovernedActionRecord, GovernedActionStatus
 from app.repositories.provider_operations_repository import (
     ProviderBudgetStateRecord,
     ProviderDegradationStateRecord,
@@ -21,6 +22,7 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
         self._budget_states: dict[str, ProviderBudgetStateRecord] = {}
         self._degradation_states: dict[str, ProviderDegradationStateRecord] = {}
         self._event_records: list[ProviderOperationsEventRecord] = []
+        self._governed_actions: dict[str, GovernedActionRecord] = {}
 
     def list_quota_states(self) -> list[ProviderQuotaStateRecord]:
         return [
@@ -169,3 +171,25 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
 
     def list_operations_events(self, *, limit: int) -> list[ProviderOperationsEventRecord]:
         return [deepcopy(record) for record in self._event_records[:limit]]
+
+    def get_governed_action(self, action_id: str) -> GovernedActionRecord | None:
+        record = self._governed_actions.get(action_id)
+        return record.model_copy(deep=True) if record is not None else None
+
+    def get_pending_governed_action(
+        self,
+        *,
+        action_type: str,
+        target: str,
+    ) -> GovernedActionRecord | None:
+        for record in self._governed_actions.values():
+            if (
+                record.action_type.value == action_type
+                and record.target == target
+                and record.status is GovernedActionStatus.PENDING
+            ):
+                return record.model_copy(deep=True)
+        return None
+
+    def upsert_governed_action(self, record: GovernedActionRecord) -> None:
+        self._governed_actions[record.action_id] = record.model_copy(deep=True)

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from app.contracts.access_control import AuthorizationDecision
+from app.contracts.governed_actions import GovernedActionRecord
 from app.contracts.providers import (
     ProviderFailureCategory,
     ProviderOperationsControlActionType,
@@ -130,6 +131,20 @@ class ProviderOperationsRepository(Protocol):
 
     def save_operations_event(self, record: ProviderOperationsEventRecord) -> None:
         """Persist one provider-operations control event record."""
+
+    def get_governed_action(self, action_id: str) -> GovernedActionRecord | None:
+        """Fetch one governed-action evidence record (issue #157)."""
+
+    def get_pending_governed_action(
+        self,
+        *,
+        action_type: str,
+        target: str,
+    ) -> GovernedActionRecord | None:
+        """Fetch the pending governed action for one action type and target, if any."""
+
+    def upsert_governed_action(self, record: GovernedActionRecord) -> None:
+        """Persist one governed-action record by action id."""
 
     def list_operations_events(self, *, limit: int) -> list[ProviderOperationsEventRecord]:
         """List most recent provider-operations control event records."""

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -16,7 +16,9 @@ from app.contracts.providers import (
     ProviderOperationsControlActionType,
     ProviderQuotaScope,
 )
+from app.contracts.governed_actions import GovernedActionRecord
 from app.db.models import (
+    GovernedActionModel,
     ProviderBudgetStateModel,
     ProviderDegradationStateModel,
     ProviderOperationsEventModel,
@@ -364,6 +366,40 @@ class SqlAlchemyProviderOperationsRepository(
             recorded_at=model.recorded_at,
         )
 
+    def get_governed_action(self, action_id: str) -> GovernedActionRecord | None:
+        with self._session_factory() as session:
+            model = session.get(GovernedActionModel, action_id)
+            return _to_governed_action_record(model) if model is not None else None
+
+    def get_pending_governed_action(
+        self,
+        *,
+        action_type: str,
+        target: str,
+    ) -> GovernedActionRecord | None:
+        with self._session_factory() as session:
+            model = session.execute(
+                select(GovernedActionModel)
+                .where(
+                    GovernedActionModel.action_type == action_type,
+                    GovernedActionModel.target == target,
+                    GovernedActionModel.status == "PENDING",
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+            return _to_governed_action_record(model) if model is not None else None
+
+    def upsert_governed_action(self, record: GovernedActionRecord) -> None:
+        with self._session_factory() as session:
+            model = session.get(GovernedActionModel, record.action_id)
+            payload = record.model_dump(mode="json")
+            if model is None:
+                session.add(GovernedActionModel(**payload))
+            else:
+                for field, value in payload.items():
+                    setattr(model, field, value)
+            session.commit()
+
     def _ensure_sqlite_parent_directory(self) -> None:
         prefix = "sqlite:///"
         if not self._database_url.startswith(prefix):
@@ -392,4 +428,10 @@ def _build_legacy_control_authorization() -> AuthorizationDecision:
             "Legacy provider control event predates explicit caller-authorization capture and is "
             "treated as a durable pre-RFC-0012 operator action."
         ),
+    )
+
+
+def _to_governed_action_record(model: GovernedActionModel) -> GovernedActionRecord:
+    return GovernedActionRecord.model_validate(
+        {column: getattr(model, column) for column in GovernedActionRecord.model_fields}
     )

--- a/src/app/routers/kill_switches.py
+++ b/src/app/routers/kill_switches.py
@@ -2,16 +2,21 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.contracts.governed_actions import GovernedActionResponse
 from app.contracts.kill_switches import (
     KillSwitchActionResponse,
     KillSwitchActivationRequest,
-    KillSwitchClearRequest,
+    KillSwitchClearApprovalRequest,
+    KillSwitchClearApprovalResponse,
+    KillSwitchClearIntentRequest,
     KillSwitchStatusResponse,
 )
+from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.kill_switch_control import (
     activate_kill_switch,
+    approve_kill_switch_clearance,
     build_kill_switch_status,
-    clear_kill_switch,
+    request_kill_switch_clearance,
 )
 
 router = APIRouter(prefix="/platform/providers/kill-switches", tags=["platform"])
@@ -63,24 +68,61 @@ async def activate_kill_switch_route(
 
 
 @router.post(
-    "/{switch_id}/clear",
-    response_model=KillSwitchActionResponse,
-    operation_id="clearKillSwitch",
-    summary="Clear a kill switch",
+    "/{switch_id}/clear-requests",
+    response_model=GovernedActionResponse,
+    operation_id="requestKillSwitchClearance",
+    summary="Request clearance of a kill switch",
     description=(
-        "Clears one kill-switch activation so matching live executions may resume. Requires "
-        "provider-control authorization, requester and approver identity, and an operator "
-        "reason; the activation and its clearance remain durably recorded."
+        "Step one of governed clearance (issue #157): records a pending clear intent under "
+        "the requester's verified credential and returns the action hash a distinct verified "
+        "credential must approve. The switch keeps enforcing until the approval executes."
     ),
     responses={
-        200: {"description": "Kill switch cleared."},
-        403: {"description": "Caller is not authorized for provider control."},
+        200: {"description": "Clearance intent recorded and pending approval."},
+        403: {
+            "description": "Caller is not authorized for provider control, or carries no "
+            "verified credential."
+        },
         404: {"description": "No activation exists for the given switch id."},
         409: {"description": "The activation is already cleared, or the store is not durable."},
         500: {"description": "Unexpected server error."},
     },
 )
-async def clear_kill_switch_route(
-    switch_id: str, request: KillSwitchClearRequest
-) -> KillSwitchActionResponse:
-    return clear_kill_switch(switch_id, request)
+async def request_kill_switch_clearance_route(
+    switch_id: str,
+    request: KillSwitchClearIntentRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> GovernedActionResponse:
+    return request_kill_switch_clearance(switch_id, request, authenticated_caller)
+
+
+@router.post(
+    "/{switch_id}/clear-approvals",
+    response_model=KillSwitchClearApprovalResponse,
+    operation_id="approveKillSwitchClearance",
+    summary="Approve and execute a pending kill-switch clearance",
+    description=(
+        "Step two of governed clearance (issue #157): a verified credential DISTINCT from "
+        "the requester's approves the exact pending action hash, which clears the switch and "
+        "records the full request-approval-execution evidence chain."
+    ),
+    responses={
+        200: {"description": "Kill switch cleared under governed approval."},
+        403: {
+            "description": "Caller is not authorized, carries no verified credential, or is "
+            "the same credential that requested the clearance."
+        },
+        404: {"description": "No activation or pending action exists."},
+        409: {
+            "description": "The action hash does not match, the action changed since it was "
+            "requested, the action is not pending, or the store is not durable."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def approve_kill_switch_clearance_route(
+    switch_id: str,
+    request: KillSwitchClearApprovalRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> KillSwitchClearApprovalResponse:
+    return approve_kill_switch_clearance(switch_id, request, authenticated_caller)

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -1,0 +1,249 @@
+"""The governed-action primitive (issue #157, slice 1).
+
+Domains compose three calls: ``submit_governed_action`` records a pending
+intent under the requester's verified credential;
+``approve_and_execute_governed_action`` validates a distinct verified
+credential against the exact action hash, runs the domain's execute callback,
+and persists the completed evidence; ``record_system_originated_action``
+records a runtime action that answers to a service identity and is therefore
+barred from every human-governed action type.
+
+Persistence rides the provider-operations store rather than a new store seam:
+that store already holds the cross-cutting operational control state (quota,
+budget, degradation, control events), and one more mode setting, reset hook
+and readiness probe would be exactly the proliferation the execution board
+bans.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionStatus,
+    GovernedActionType,
+    GovernedActorClass,
+)
+from app.http.authenticated_caller import AuthenticatedCaller
+from app.services.provider_operations_store import get_provider_operations_store
+
+# Action types where dual control applies: the action increases risk, so no
+# single principal may carry it end to end. Safety-increasing actions never
+# appear here - an emergency stop takes one verified principal, immediately.
+HUMAN_GOVERNED_ACTION_TYPES = frozenset({GovernedActionType.KILL_SWITCH_CLEAR})
+
+
+def compute_governed_action_hash(payload: dict[str, str | None]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def submit_governed_action(
+    *,
+    caller: AuthenticatedCaller,
+    action_type: GovernedActionType,
+    target: str,
+    payload: dict[str, str | None],
+    attribution: str | None,
+) -> GovernedActionRecord:
+    """Record a pending intent under the requester's verified credential.
+
+    A prior pending action for the same type and target is superseded rather
+    than mutated: the old hash stops being approvable, and the supersession is
+    itself evidence.
+    """
+
+    _require_verified_governing_credential(caller)
+    repository = get_provider_operations_store()
+    record = GovernedActionRecord(
+        action_id=f"gact_{uuid4().hex[:16]}",
+        action_type=action_type,
+        actor_class=GovernedActorClass.HUMAN_APPROVED,
+        status=GovernedActionStatus.PENDING,
+        target=target,
+        action_hash=compute_governed_action_hash(payload),
+        action_payload=dict(payload),
+        requester_caller_app=caller.caller_app,
+        requester_trust_source=caller.trust_source,
+        requester_key_id=caller.credential_key_id,
+        requester_attribution=attribution,
+        requested_at=_utc_now_iso(),
+    )
+    prior = repository.get_pending_governed_action(action_type=action_type.value, target=target)
+    if prior is not None:
+        repository.upsert_governed_action(
+            prior.model_copy(
+                update={
+                    "status": GovernedActionStatus.SUPERSEDED,
+                    "superseded_by_action_id": record.action_id,
+                }
+            )
+        )
+    repository.upsert_governed_action(record)
+    return record
+
+
+def approve_and_execute_governed_action(
+    *,
+    caller: AuthenticatedCaller,
+    action_id: str,
+    expected_target: str,
+    expected_hash: str,
+    current_payload_builder: Callable[[GovernedActionRecord], dict[str, str | None]],
+    attribution: str | None,
+    execute: Callable[[GovernedActionRecord], None],
+) -> GovernedActionRecord:
+    """Validate a distinct verified approver against the exact action, then execute.
+
+    ``current_payload_builder`` rebuilds the action payload from the live
+    domain state plus the pending record's own requested parameters; if the
+    rebuilt hash no longer matches, the action changed between request and
+    approval and the pending approval is not transferable to it.
+
+    Everything is validated before the domain callback runs; the completed
+    evidence (approver identity, approval and execution instants) persists in
+    one write after the callback succeeds, so a failed execution leaves the
+    action PENDING rather than half-approved.
+    """
+
+    _require_verified_governing_credential(caller)
+    repository = get_provider_operations_store()
+    record = repository.get_governed_action(action_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No governed action exists for `{action_id}`.",
+        )
+    if record.status is not GovernedActionStatus.PENDING:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Governed action `{action_id}` is {record.status.value}; only a PENDING "
+                "action can be approved."
+            ),
+        )
+    if record.actor_class is not GovernedActorClass.HUMAN_APPROVED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A system-originated action has no approval step.",
+        )
+    if record.target != expected_target:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Governed action `{action_id}` targets `{record.target}`, not "
+                f"`{expected_target}`; an approval cannot be redirected."
+            ),
+        )
+    if expected_hash != record.action_hash:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "The supplied action hash does not match the pending action. Approval binds "
+                "to the exact action requested; review the pending action and approve its hash."
+            ),
+        )
+    if compute_governed_action_hash(current_payload_builder(record)) != record.action_hash:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "The action has changed since it was requested. The pending approval is not "
+                "transferable to the changed action; submit a new request."
+            ),
+        )
+    if caller.credential_key_id == record.requester_key_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Approval requires a credential distinct from the requester's. The same "
+                "signing credential cannot both request and approve a governed action."
+            ),
+        )
+
+    execute(record)
+
+    now = _utc_now_iso()
+    executed = record.model_copy(
+        update={
+            "status": GovernedActionStatus.EXECUTED,
+            "approver_caller_app": caller.caller_app,
+            "approver_trust_source": caller.trust_source,
+            "approver_key_id": caller.credential_key_id,
+            "approver_attribution": attribution,
+            "approved_at": now,
+            "executed_at": now,
+        }
+    )
+    repository.upsert_governed_action(executed)
+    return executed
+
+
+def record_system_originated_action(
+    *,
+    service_identity: str,
+    action_type: GovernedActionType,
+    target: str,
+    payload: dict[str, str | None],
+) -> GovernedActionRecord:
+    """Record a runtime action that answers to a service identity.
+
+    A system-originated action is explicitly system-originated: it carries no
+    approver, cannot satisfy a human four-eyes requirement, and is refused
+    outright for human-governed action types - which is what stops the
+    service-identity path becoming the approval bypass.
+    """
+
+    if action_type in HUMAN_GOVERNED_ACTION_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"`{action_type.value}` is a human-governed action type; a system identity "
+                "cannot originate or approve it."
+            ),
+        )
+    record = GovernedActionRecord(
+        action_id=f"gact_{uuid4().hex[:16]}",
+        action_type=action_type,
+        actor_class=GovernedActorClass.SYSTEM_ORIGINATED,
+        status=GovernedActionStatus.EXECUTED,
+        target=target,
+        action_hash=compute_governed_action_hash(payload),
+        action_payload=dict(payload),
+        requester_caller_app=service_identity,
+        requester_trust_source="service_runtime",
+        requested_at=_utc_now_iso(),
+        executed_at=_utc_now_iso(),
+    )
+    get_provider_operations_store().upsert_governed_action(record)
+    return record
+
+
+def _require_verified_governing_credential(caller: AuthenticatedCaller) -> None:
+    """Both steps of a governed action require a verified signing credential.
+
+    Header trust carries no credential at all, so it cannot distinguish two
+    principals - under it, dual control would be one anonymous party talking
+    to itself. Refusing outright is honest; treating it as a weaker principal
+    would make the guarantee unverifiable.
+    """
+
+    if not caller.credential_key_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Governed actions require a verified caller credential; header-trusted "
+                "identity cannot distinguish a requester from an approver."
+            ),
+        )
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()

--- a/src/app/services/kill_switch_control.py
+++ b/src/app/services/kill_switch_control.py
@@ -1,9 +1,13 @@
 """Kill-switch operator actions and enforcement (issue #177, slice 1).
 
-Activation and clearance are governed control-plane actions: PROVIDER_CONTROL
-authorization, requester and approver identity, an operator reason, and (like
-provider-operations resets) a durable store requirement so the control history
-survives restarts and replicas. Enforcement runs at the provider gateway
+Activation and clearance are governed control-plane actions with opposite
+risk directions (issue #157). Activation stops execution: one authorized
+principal, immediately - never a human handoff inside an emergency stop.
+Clearance resumes execution somebody judged unsafe: a verified requester
+records the intent, a DISTINCT verified credential approves the exact action
+hash, and the evidence chain is durable. Both require PROVIDER_CONTROL
+authorization and (like provider-operations resets) a durable store so the
+control history survives restarts and replicas. Enforcement runs at the provider gateway
 preflight, before any other veto: an operator stop outranks quota, budget and
 breaker state, and a hit is recorded as a routing rejection with the bounded
 KILL_SWITCH_ACTIVE category (issue #176).
@@ -22,19 +26,31 @@ from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.access_control import AuthorizationCapabilityType
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionResponse,
+    GovernedActionType,
+)
 from app.contracts.kill_switches import (
     KillSwitchSemantics,
     TARGETLESS_KILL_SWITCH_SCOPES,
     KillSwitchActionResponse,
     KillSwitchActivationRecord,
     KillSwitchActivationRequest,
-    KillSwitchClearRequest,
+    KillSwitchClearApprovalRequest,
+    KillSwitchClearApprovalResponse,
+    KillSwitchClearIntentRequest,
     KillSwitchScope,
     KillSwitchStatusResponse,
 )
 from app.contracts.providers import ProviderExecutionRequest, ProviderFailureCategory
 from app.providers.base import ProviderExecutionError
+from app.http.authenticated_caller import AuthenticatedCaller
 from app.services.access_control_authorization import authorize_request, require_authorized
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
 from app.services.kill_switch_store import get_kill_switch_repository
 from app.services.provider_metrics import record_kill_switch_action
 from app.services.provider_execution_config import resolve_provider_execution_config
@@ -92,16 +108,100 @@ def activate_kill_switch(request: KillSwitchActivationRequest) -> KillSwitchActi
     )
 
 
-def clear_kill_switch(switch_id: str, request: KillSwitchClearRequest) -> KillSwitchActionResponse:
+def request_kill_switch_clearance(
+    switch_id: str,
+    request: KillSwitchClearIntentRequest,
+    caller: AuthenticatedCaller,
+) -> GovernedActionResponse:
+    """Step one of governed clearance: record the intent under the requester's credential."""
+
     require_authorized(
         authorize_request(
-            caller_app=request.caller_app,
+            caller_app=caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
+        )
+    )
+    _require_durable_store()
+    activation = _require_active_activation(switch_id)
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.KILL_SWITCH_CLEAR,
+        target=switch_id,
+        payload=_clearance_payload(activation, request.reason),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Clearance of kill switch `{switch_id}` is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            "The switch keeps enforcing until the approval executes.",
+        ],
+    )
+
+
+def approve_kill_switch_clearance(
+    switch_id: str,
+    request: KillSwitchClearApprovalRequest,
+    caller: AuthenticatedCaller,
+) -> KillSwitchClearApprovalResponse:
+    """Step two: a distinct verified credential approves the exact action, which executes it."""
+
+    require_authorized(
+        authorize_request(
+            caller_app=caller.caller_app,
             capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
         )
     )
     _require_durable_store()
     repository = get_kill_switch_repository()
-    activation = repository.get_activation(switch_id)
+    activation = _require_active_activation(switch_id)
+    cleared_holder: dict[str, KillSwitchActivationRecord] = {}
+
+    def _execute_clearance(record: GovernedActionRecord) -> None:
+        cleared = activation.model_copy(
+            update={
+                "cleared_at": _utc_now_iso(),
+                "cleared_by": f"{caller.caller_app} (credential {caller.credential_key_id})",
+                "clear_reason": record.action_payload.get("clear_reason"),
+            }
+        )
+        repository.upsert_activation(cleared)
+        record_kill_switch_action(
+            action="cleared", scope=cleared.scope.value, semantics=cleared.semantics.value
+        )
+        cleared_holder["activation"] = cleared
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=switch_id,
+        expected_hash=request.action_hash,
+        current_payload_builder=lambda record: _clearance_payload(
+            activation, record.action_payload.get("clear_reason") or ""
+        ),
+        attribution=request.approved_by,
+        execute=_execute_clearance,
+    )
+    return KillSwitchClearApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.kill_switch_store_mode,
+        activation=cleared_holder["activation"],
+        governed_action=executed,
+        summary=[
+            f"Cleared kill switch `{switch_id}` under governed action `{executed.action_id}`.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+        ],
+    )
+
+
+def _require_active_activation(switch_id: str) -> KillSwitchActivationRecord:
+    activation = get_kill_switch_repository().get_activation(switch_id)
     if activation is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -112,27 +212,27 @@ def clear_kill_switch(switch_id: str, request: KillSwitchClearRequest) -> KillSw
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Kill-switch activation `{switch_id}` is already cleared.",
         )
-    cleared = activation.model_copy(
-        update={
-            "cleared_at": _utc_now_iso(),
-            "cleared_by": request.approved_by,
-            "clear_reason": request.reason,
-        }
-    )
-    repository.upsert_activation(cleared)
-    record_kill_switch_action(
-        action="cleared", scope=cleared.scope.value, semantics=cleared.semantics.value
-    )
-    return KillSwitchActionResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        store_mode=settings.kill_switch_store_mode,
-        activation=cleared,
-        summary=[
-            f"Cleared kill switch `{switch_id}`.",
-            f"Requested by `{request.requested_by}` and approved by `{request.approved_by}`.",
-        ],
-    )
+    return activation
+
+
+def _clearance_payload(
+    activation: KillSwitchActivationRecord, reason: str
+) -> dict[str, str | None]:
+    """The exact action the approver signs off on.
+
+    Pins the activation identity (`activated_at`) as well as the switch id, so
+    an approval can never carry over to a re-activation of the same switch.
+    """
+
+    return {
+        "action_type": GovernedActionType.KILL_SWITCH_CLEAR.value,
+        "switch_id": activation.switch_id,
+        "scope": activation.scope.value,
+        "semantics": activation.semantics.value,
+        "target": activation.target,
+        "activated_at": activation.activated_at,
+        "clear_reason": reason,
+    }
 
 
 def build_kill_switch_status() -> KillSwitchStatusResponse:

--- a/src/app/services/runtime_readiness.py
+++ b/src/app/services/runtime_readiness.py
@@ -115,6 +115,7 @@ def get_provider_operations_store_runtime_status() -> StoreRuntimeStatusDescript
         expected_tables=[
             "provider_budget_state",
             "provider_degradation_state",
+            "provider_governed_actions",
             "provider_operations_events",
             "provider_quota_state",
         ],

--- a/tests/integration/test_kill_switch_api_contract.py
+++ b/tests/integration/test_kill_switch_api_contract.py
@@ -9,10 +9,33 @@ from pytest import MonkeyPatch
 
 from app.main import app
 from app.services.kill_switch_store import reset_kill_switch_store_cache
+from tests.support.caller_credentials import (
+    generate_caller_signing_key,
+    mint_caller_credential,
+    public_keys_setting,
+)
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
 
 CONTROL_HEADERS = {"X-Caller-App": "lotus-platform"}
+
+# Three real EdDSA credentials (issue #157): a platform requester, a platform
+# approver under a DISTINCT signing key, and the executing consumer app. The
+# lifecycle runs in verified_service_jwt mode end to end, so what this test
+# proves is the production trust posture, not a header-trust approximation.
+_REQUESTER_KEY = generate_caller_signing_key()
+_APPROVER_KEY = generate_caller_signing_key()
+_MANAGE_KEY = generate_caller_signing_key()
+_PUBLIC_KEYS = public_keys_setting(
+    **{"ops-alpha": _REQUESTER_KEY, "ops-beta": _APPROVER_KEY, "svc-manage": _MANAGE_KEY}
+)
+
+
+def _bearer(signing_key: object, key_id: str, subject: str) -> dict[str, str]:
+    return {
+        "Authorization": "Bearer "
+        + mint_caller_credential(signing_key=signing_key, key_id=key_id, subject=subject)  # type: ignore[arg-type]
+    }
 
 
 def _activation_payload(**overrides: object) -> dict[str, object]:
@@ -68,6 +91,10 @@ def test_kill_switch_lifecycle_enforces_and_restores_live_execution(
     with override_runtime_settings(
         kill_switch_store_mode="sqlalchemy",
         database_url=database_url,
+        caller_trust_mode="verified_service_jwt",
+        caller_jwt_issuer="https://platform.lotus/issuer",
+        caller_jwt_audience="lotus-ai",
+        caller_jwt_public_keys=_PUBLIC_KEYS,
         provider_mode="openai",
         provider_rollout_state="CANARY_ENABLED",
         live_text_provider_id="text.openai",
@@ -98,41 +125,79 @@ def test_kill_switch_lifecycle_enforces_and_restores_live_execution(
                 "expected_output_label": "EXPLANATION_ONLY",
             }
 
-            before = client.post("/ai/tasks/execute", json=execute_payload)
+            manage_headers = _bearer(_MANAGE_KEY, "svc-manage", "lotus-manage")
+            requester_headers = _bearer(_REQUESTER_KEY, "ops-alpha", "lotus-platform")
+            approver_headers = _bearer(_APPROVER_KEY, "ops-beta", "lotus-platform")
+
+            before = client.post("/ai/tasks/execute", json=execute_payload, headers=manage_headers)
             assert before.status_code == 200
 
             activated = client.post(
                 "/platform/providers/kill-switches",
                 json=_activation_payload(),
-                headers=CONTROL_HEADERS,
+                headers=requester_headers,
             )
             assert activated.status_code == 200
             switch_id = activated.json()["activation"]["switch_id"]
             assert activated.json()["store_mode"] == "sqlalchemy"
 
-            refused = client.post("/ai/tasks/execute", json=execute_payload)
+            refused = client.post("/ai/tasks/execute", json=execute_payload, headers=manage_headers)
             assert refused.status_code == 503
             assert "KILL_SWITCH_ACTIVE" in refused.text
             assert switch_id in refused.text
 
             status_body = client.get(
-                "/platform/providers/kill-switches", headers=CONTROL_HEADERS
+                "/platform/providers/kill-switches", headers=requester_headers
             ).json()
             assert status_body["active_count"] == 1
 
-            cleared = client.post(
-                f"/platform/providers/kill-switches/{switch_id}/clear",
+            # Governed clearance, step one: the requester records the intent.
+            # The switch keeps enforcing until a distinct credential approves.
+            pending = client.post(
+                f"/platform/providers/kill-switches/{switch_id}/clear-requests",
+                json={"reason": "Incident resolved.", "requested_by": "ops.primary@lotus"},
+                headers=requester_headers,
+            )
+            assert pending.status_code == 200
+            action = pending.json()["governed_action"]
+            assert action["status"] == "PENDING"
+            assert action["requester_key_id"] == "ops-alpha"
+            still_refused = client.post(
+                "/ai/tasks/execute", json=execute_payload, headers=manage_headers
+            )
+            assert still_refused.status_code == 503
+
+            # The requester's own credential cannot approve its request.
+            self_approval = client.post(
+                f"/platform/providers/kill-switches/{switch_id}/clear-approvals",
                 json={
-                    "caller_app": "lotus-platform",
-                    "reason": "Incident resolved.",
-                    "requested_by": "ops.primary@lotus",
+                    "action_id": action["action_id"],
+                    "action_hash": action["action_hash"],
+                },
+                headers=requester_headers,
+            )
+            assert self_approval.status_code == 403
+
+            # A distinct verified credential approves the exact hash.
+            cleared = client.post(
+                f"/platform/providers/kill-switches/{switch_id}/clear-approvals",
+                json={
+                    "action_id": action["action_id"],
+                    "action_hash": action["action_hash"],
                     "approved_by": "ops.secondary@lotus",
                 },
-                headers=CONTROL_HEADERS,
+                headers=approver_headers,
             )
             assert cleared.status_code == 200
+            evidence = cleared.json()["governed_action"]
+            assert evidence["status"] == "EXECUTED"
+            assert evidence["requester_key_id"] == "ops-alpha"
+            assert evidence["approver_key_id"] == "ops-beta"
+            assert cleared.json()["activation"]["cleared_at"] is not None
 
-            restored = client.post("/ai/tasks/execute", json=execute_payload)
+            restored = client.post(
+                "/ai/tasks/execute", json=execute_payload, headers=manage_headers
+            )
             assert restored.status_code == 200
 
 

--- a/tests/unit/test_governed_action_control.py
+++ b/tests/unit/test_governed_action_control.py
@@ -1,0 +1,213 @@
+"""The governed-action primitive (issue #157, slice 1).
+
+Dual control binds to the signing credential: no verified human principal
+exists in the identity model, so the enforceable fact is that two steps were
+signed by two different credentials - a single compromised credential cannot
+both request and approve. These tests pin that, the hash binding, and the
+actor-class guards that keep the service-identity path from becoming the
+approval bypass.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionStatus,
+    GovernedActionType,
+    GovernedActorClass,
+)
+from app.http.authenticated_caller import AuthenticatedCaller
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    compute_governed_action_hash,
+    record_system_originated_action,
+    submit_governed_action,
+)
+from app.services.provider_operations_store import get_provider_operations_store
+
+REQUESTER = AuthenticatedCaller(
+    caller_app="lotus-platform",
+    trust_source="verified_service_jwt",
+    credential_key_id="ops-key-alpha",
+)
+APPROVER = AuthenticatedCaller(
+    caller_app="lotus-platform",
+    trust_source="verified_service_jwt",
+    credential_key_id="ops-key-beta",
+)
+HEADER_CALLER = AuthenticatedCaller(
+    caller_app="lotus-platform",
+    trust_source="trusted_http_header",
+    credential_key_id=None,
+)
+
+_PAYLOAD: dict[str, str | None] = {
+    "action_type": "KILL_SWITCH_CLEAR",
+    "switch_id": "ksw_test",
+    "clear_reason": "incident resolved",
+}
+
+
+def _submit(**overrides: object) -> GovernedActionRecord:
+    arguments: dict[str, object] = {
+        "caller": REQUESTER,
+        "action_type": GovernedActionType.KILL_SWITCH_CLEAR,
+        "target": "ksw_test",
+        "payload": dict(_PAYLOAD),
+        "attribution": "ops.primary@lotus",
+    }
+    arguments.update(overrides)
+    return submit_governed_action(**arguments)  # type: ignore[arg-type]
+
+
+def _approve(record: GovernedActionRecord, **overrides: object) -> GovernedActionRecord:
+    arguments: dict[str, object] = {
+        "caller": APPROVER,
+        "action_id": record.action_id,
+        "expected_target": record.target,
+        "expected_hash": record.action_hash,
+        "current_payload_builder": lambda pending: dict(pending.action_payload),
+        "attribution": "ops.secondary@lotus",
+        "execute": lambda pending: None,
+    }
+    arguments.update(overrides)
+    return approve_and_execute_governed_action(**arguments)  # type: ignore[arg-type]
+
+
+def test_the_action_hash_is_canonical_and_order_independent() -> None:
+    forward = compute_governed_action_hash({"a": "1", "b": None})
+    reversed_keys = compute_governed_action_hash({"b": None, "a": "1"})
+    assert forward == reversed_keys
+    assert forward != compute_governed_action_hash({"a": "1", "b": "2"})
+
+
+def test_request_and_distinct_approval_produce_complete_evidence() -> None:
+    record = _submit()
+    assert record.status is GovernedActionStatus.PENDING
+    assert record.requester_key_id == "ops-key-alpha"
+    assert record.approver_key_id is None
+
+    executed = _approve(record)
+
+    assert executed.status is GovernedActionStatus.EXECUTED
+    assert executed.requester_key_id == "ops-key-alpha"
+    assert executed.approver_key_id == "ops-key-beta"
+    assert executed.approved_at is not None
+    assert executed.executed_at is not None
+    # The evidence is self-verifying: the stored payload reproduces the hash.
+    assert compute_governed_action_hash(dict(executed.action_payload)) == executed.action_hash
+    persisted = get_provider_operations_store().get_governed_action(record.action_id)
+    assert persisted is not None
+    assert persisted.status is GovernedActionStatus.EXECUTED
+
+
+def test_the_same_credential_cannot_request_and_approve() -> None:
+    record = _submit()
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, caller=REQUESTER)
+    assert exc_info.value.status_code == 403
+    stored = get_provider_operations_store().get_governed_action(record.action_id)
+    assert stored is not None
+    assert stored.status is GovernedActionStatus.PENDING
+
+
+def test_header_trust_cannot_participate_in_governed_actions() -> None:
+    """Header trust carries no credential, so it cannot distinguish a
+    requester from an approver - under it, dual control would be one
+    anonymous party talking to itself."""
+
+    with pytest.raises(HTTPException) as exc_info:
+        _submit(caller=HEADER_CALLER)
+    assert exc_info.value.status_code == 403
+
+    record = _submit()
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, caller=HEADER_CALLER)
+    assert exc_info.value.status_code == 403
+
+
+def test_approval_binds_to_the_exact_hash() -> None:
+    record = _submit()
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, expected_hash="0" * 64)
+    assert exc_info.value.status_code == 409
+
+
+def test_a_changed_action_is_not_approvable() -> None:
+    """The freshness check: the payload is rebuilt from live domain state at
+    approval time, so an approval reviewed against one action can never
+    execute a different one."""
+
+    record = _submit()
+    changed = dict(_PAYLOAD, clear_reason="a different action entirely")
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, current_payload_builder=lambda pending: changed)
+    assert exc_info.value.status_code == 409
+    assert "changed" in exc_info.value.detail
+
+
+def test_an_approval_cannot_be_redirected_to_another_target() -> None:
+    record = _submit()
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, expected_target="ksw_other")
+    assert exc_info.value.status_code == 409
+    assert "cannot be redirected" in exc_info.value.detail
+
+
+def test_a_new_request_supersedes_the_pending_one() -> None:
+    first = _submit()
+    second = _submit(payload=dict(_PAYLOAD, clear_reason="updated reason"))
+
+    superseded = get_provider_operations_store().get_governed_action(first.action_id)
+    assert superseded is not None
+    assert superseded.status is GovernedActionStatus.SUPERSEDED
+    assert superseded.superseded_by_action_id == second.action_id
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(first)
+    assert exc_info.value.status_code == 409
+    assert _approve(second).status is GovernedActionStatus.EXECUTED
+
+
+def test_a_failed_execution_leaves_the_action_pending() -> None:
+    record = _submit()
+
+    def _explode(pending: object) -> None:
+        raise RuntimeError("domain execution failed")
+
+    with pytest.raises(RuntimeError):
+        _approve(record, execute=_explode)
+    stored = get_provider_operations_store().get_governed_action(record.action_id)
+    assert stored is not None
+    assert stored.status is GovernedActionStatus.PENDING
+    assert stored.approver_key_id is None
+
+
+def test_a_system_identity_cannot_originate_a_human_governed_action() -> None:
+    """The actor class is explicit, never inferred from a service-looking
+    string. A human-governed type refuses system origination outright, which
+    is what stops the runtime path becoming the approval bypass."""
+
+    with pytest.raises(HTTPException) as exc_info:
+        record_system_originated_action(
+            service_identity="lotus-ai.async-worker-runtime",
+            action_type=GovernedActionType.KILL_SWITCH_CLEAR,
+            target="ksw_test",
+            payload=dict(_PAYLOAD),
+        )
+    assert exc_info.value.status_code == 403
+    assert "human-governed" in exc_info.value.detail
+
+
+def test_a_system_originated_record_would_have_no_approval_step() -> None:
+    """Pinned at the primitive: even if a SYSTEM_ORIGINATED record reached the
+    store for a human-governed type, approval refuses it - the actor-class
+    guard does not depend on the creation guard alone."""
+
+    record = _submit()
+    forged = record.model_copy(update={"actor_class": GovernedActorClass.SYSTEM_ORIGINATED})
+    get_provider_operations_store().upsert_governed_action(forged)
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(forged)
+    assert exc_info.value.status_code == 409
+    assert "no approval step" in exc_info.value.detail

--- a/tests/unit/test_kill_switch_control.py
+++ b/tests/unit/test_kill_switch_control.py
@@ -12,9 +12,11 @@ from app.config import settings
 from app.contracts.kill_switches import (
     KillSwitchActivationRecord,
     KillSwitchActivationRequest,
-    KillSwitchClearRequest,
+    KillSwitchClearApprovalRequest,
+    KillSwitchClearIntentRequest,
     KillSwitchScope,
 )
+from app.http.authenticated_caller import AuthenticatedCaller
 from app.contracts.providers import (
     ProviderExecutionRequest,
     ProviderFailureCategory,
@@ -22,9 +24,10 @@ from app.contracts.providers import (
 from app.providers.base import ProviderExecutionError
 from app.services.kill_switch_control import (
     activate_kill_switch,
+    approve_kill_switch_clearance,
     build_kill_switch_status,
-    clear_kill_switch,
     enforce_kill_switches,
+    request_kill_switch_clearance,
 )
 from app.services.kill_switch_store import (
     get_kill_switch_repository,
@@ -121,51 +124,147 @@ def test_activation_validates_scope_target_pairing(_durable_store: None) -> None
     assert exc_info.value.status_code == 422
 
 
-def test_activate_status_clear_lifecycle(_durable_store: None) -> None:
+REQUESTER = AuthenticatedCaller(
+    caller_app=CONTROL_CALLER,
+    trust_source="verified_service_jwt",
+    credential_key_id="ops-key-alpha",
+)
+APPROVER = AuthenticatedCaller(
+    caller_app=CONTROL_CALLER,
+    trust_source="verified_service_jwt",
+    credential_key_id="ops-key-beta",
+)
+
+
+def _intent(
+    reason: str = "Incident resolved; provider outputs verified safe.",
+) -> KillSwitchClearIntentRequest:
+    return KillSwitchClearIntentRequest(reason=reason, requested_by="ops.primary@lotus")
+
+
+def test_activate_then_governed_clear_lifecycle(_durable_store: None) -> None:
+    """Issue #157: activation stops execution on one authorized principal,
+    immediately; clearance resumes it only through a verified requester and a
+    DISTINCT verified approver bound to the exact action hash."""
+
     activated = activate_kill_switch(_activation_request())
     assert activated.store_mode == "sqlalchemy"
     switch_id = activated.activation.switch_id
+    assert build_kill_switch_status().active_count == 1
 
-    status_response = build_kill_switch_status()
-    assert status_response.active_count == 1
-    assert status_response.activations[0].switch_id == switch_id
+    pending = request_kill_switch_clearance(switch_id, _intent(), REQUESTER)
+    action = pending.governed_action
+    assert action.status.value == "PENDING"
+    assert action.requester_key_id == "ops-key-alpha"
+    # The switch keeps enforcing until the approval executes.
+    assert build_kill_switch_status().active_count == 1
 
-    cleared = clear_kill_switch(
+    cleared = approve_kill_switch_clearance(
         switch_id,
-        KillSwitchClearRequest(
-            caller_app=CONTROL_CALLER,
-            reason="Incident resolved; provider outputs verified safe.",
-            requested_by="ops.primary@lotus",
+        KillSwitchClearApprovalRequest(
+            action_id=action.action_id,
+            action_hash=action.action_hash,
             approved_by="ops.secondary@lotus",
         ),
+        APPROVER,
     )
     assert cleared.activation.cleared_at is not None
-    assert cleared.activation.cleared_by == "ops.secondary@lotus"
+    assert "ops-key-beta" in str(cleared.activation.cleared_by)
+    assert cleared.governed_action.status.value == "EXECUTED"
+    assert cleared.governed_action.requester_key_id == "ops-key-alpha"
+    assert cleared.governed_action.approver_key_id == "ops-key-beta"
     assert build_kill_switch_status().active_count == 0
 
     with pytest.raises(HTTPException) as exc_info:
-        clear_kill_switch(
+        request_kill_switch_clearance(switch_id, _intent("Duplicate clear."), REQUESTER)
+    assert exc_info.value.status_code == 409
+
+    with pytest.raises(HTTPException) as exc_info:
+        request_kill_switch_clearance("ksw_does_not_exist", _intent(), REQUESTER)
+    assert exc_info.value.status_code == 404
+
+
+def test_no_single_credential_can_resume_stopped_execution(_durable_store: None) -> None:
+    """The target invariant, end to end: the requester approving its own
+    clearance is refused, and the switch keeps refusing execution."""
+
+    activated = activate_kill_switch(_activation_request())
+    switch_id = activated.activation.switch_id
+    pending = request_kill_switch_clearance(switch_id, _intent(), REQUESTER)
+
+    with pytest.raises(HTTPException) as exc_info:
+        approve_kill_switch_clearance(
             switch_id,
-            KillSwitchClearRequest(
-                caller_app=CONTROL_CALLER,
-                reason="Duplicate clear.",
-                requested_by="ops.primary@lotus",
-                approved_by="ops.secondary@lotus",
+            KillSwitchClearApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
             ),
+            REQUESTER,
+        )
+    assert exc_info.value.status_code == 403
+    assert build_kill_switch_status().active_count == 1
+    with pytest.raises(ProviderExecutionError) as enforcement:
+        enforce_kill_switches(_provider_request())
+    assert enforcement.value.category is ProviderFailureCategory.KILL_SWITCH_ACTIVE
+
+
+def test_header_trust_cannot_request_or_approve_clearance(_durable_store: None) -> None:
+    activated = activate_kill_switch(_activation_request())
+    switch_id = activated.activation.switch_id
+    header_caller = AuthenticatedCaller(
+        caller_app=CONTROL_CALLER,
+        trust_source="trusted_http_header",
+        credential_key_id=None,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        request_kill_switch_clearance(switch_id, _intent(), header_caller)
+    assert exc_info.value.status_code == 403
+
+    pending = request_kill_switch_clearance(switch_id, _intent(), REQUESTER)
+    with pytest.raises(HTTPException) as exc_info:
+        approve_kill_switch_clearance(
+            switch_id,
+            KillSwitchClearApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            header_caller,
+        )
+    assert exc_info.value.status_code == 403
+    assert build_kill_switch_status().active_count == 1
+
+
+def test_an_approval_binds_to_the_hash_and_cannot_be_redirected(
+    _durable_store: None,
+) -> None:
+    first = activate_kill_switch(_activation_request())
+    second = activate_kill_switch(
+        _activation_request(target="summarize.v1", reason="Second incident.")
+    )
+    pending = request_kill_switch_clearance(first.activation.switch_id, _intent(), REQUESTER)
+
+    with pytest.raises(HTTPException) as exc_info:
+        approve_kill_switch_clearance(
+            first.activation.switch_id,
+            KillSwitchClearApprovalRequest(
+                action_id=pending.governed_action.action_id, action_hash="0" * 64
+            ),
+            APPROVER,
         )
     assert exc_info.value.status_code == 409
 
     with pytest.raises(HTTPException) as exc_info:
-        clear_kill_switch(
-            "ksw_does_not_exist",
-            KillSwitchClearRequest(
-                caller_app=CONTROL_CALLER,
-                reason="Nothing to clear.",
-                requested_by="ops.primary@lotus",
-                approved_by="ops.secondary@lotus",
+        approve_kill_switch_clearance(
+            second.activation.switch_id,
+            KillSwitchClearApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
             ),
+            APPROVER,
         )
-    assert exc_info.value.status_code == 404
+    assert exc_info.value.status_code == 409
+    assert build_kill_switch_status().active_count == 2
 
 
 def test_enforcement_matches_every_scope_and_only_its_target(

--- a/tests/unit/test_runtime_readiness.py
+++ b/tests/unit/test_runtime_readiness.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.config import settings
 from app.contracts.runtime_readiness import RuntimeReadinessStatus
 from app.db.models import (
+    GovernedActionModel,
     ProviderBudgetStateModel,
     ProviderDegradationStateModel,
     ProviderOperationsEventModel,
@@ -253,6 +254,7 @@ def test_the_provider_operations_probe_names_the_tables_the_repository_uses() ->
     repository_tables = {
         model.__tablename__
         for model in (
+            GovernedActionModel,
             ProviderBudgetStateModel,
             ProviderDegradationStateModel,
             ProviderOperationsEventModel,

--- a/tests/unit/test_sqlalchemy_provider_operations_repository.py
+++ b/tests/unit/test_sqlalchemy_provider_operations_repository.py
@@ -280,3 +280,68 @@ def test_sqlalchemy_provider_operations_repository_sqlite_parent_handling(
     repository._ensure_sqlite_parent_directory()
 
     assert relative_db_path.parent.is_dir()
+
+
+def test_governed_action_round_trip_and_pending_lookup(tmp_path: Path) -> None:
+    """Issue #157: the evidence chain is durable, and the pending lookup that
+    supersession depends on behaves identically to the memory adapter."""
+
+    from app.contracts.governed_actions import (
+        GovernedActionRecord,
+        GovernedActionStatus,
+        GovernedActionType,
+        GovernedActorClass,
+    )
+
+    database_url = f"sqlite:///{tmp_path / 'lotus-ai-governed-actions.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyProviderOperationsRepository(database_url)
+
+    record = GovernedActionRecord(
+        action_id="gact_sql_parity_001",
+        action_type=GovernedActionType.KILL_SWITCH_CLEAR,
+        actor_class=GovernedActorClass.HUMAN_APPROVED,
+        status=GovernedActionStatus.PENDING,
+        target="ksw_sql_parity",
+        action_hash="a" * 64,
+        action_payload={"switch_id": "ksw_sql_parity", "clear_reason": "resolved"},
+        requester_caller_app="lotus-platform",
+        requester_trust_source="verified_service_jwt",
+        requester_key_id="ops-key-alpha",
+        requester_attribution="ops.primary@lotus",
+        requested_at="2026-09-02T08:00:00+00:00",
+    )
+    repository.upsert_governed_action(record)
+
+    assert repository.get_governed_action("gact_sql_parity_001") == record
+    assert (
+        repository.get_pending_governed_action(
+            action_type="KILL_SWITCH_CLEAR", target="ksw_sql_parity"
+        )
+        == record
+    )
+    assert (
+        repository.get_pending_governed_action(action_type="KILL_SWITCH_CLEAR", target="ksw_other")
+        is None
+    )
+
+    executed = record.model_copy(
+        update={
+            "status": GovernedActionStatus.EXECUTED,
+            "approver_caller_app": "lotus-platform",
+            "approver_trust_source": "verified_service_jwt",
+            "approver_key_id": "ops-key-beta",
+            "approved_at": "2026-09-02T08:05:00+00:00",
+            "executed_at": "2026-09-02T08:05:00+00:00",
+        }
+    )
+    repository.upsert_governed_action(executed)
+
+    assert repository.get_governed_action("gact_sql_parity_001") == executed
+    # An executed action is no longer pending.
+    assert (
+        repository.get_pending_governed_action(
+            action_type="KILL_SWITCH_CLEAR", target="ksw_sql_parity"
+        )
+        is None
+    )


### PR DESCRIPTION
Issue #157, slice 1: the governed-action primitive, proven through kill-switch clearance. Remaining domains (prompt promotion, provider enabling, verified requester on activation) follow one bounded PR each on the same primitive.

## Control-plane outcome

**One principal can immediately stop unsafe AI execution, but no single principal can silently resume execution that a governed action stopped.** An operator reviewing a clearance can answer, from one durable record: who requested it, under which verified credential, who approved it, under which *distinct* verified credential, exactly what action was approved, and when it executed.

## Invariant

Dual control applies to the risk-*increasing* direction only. Activation (stops execution) is untouched: one authorized principal, immediately — a human handoff inside an emergency stop would make the platform less safe, not more. Clearance (resumes execution someone judged unsafe) now takes a verified requester, a verified **distinct** approver, and an approval bound to the exact action hash.

## One authority

`governed_action_control` owns the pattern: submit → pending with hash; approve → validate distinct credential + exact hash + unchanged action, execute the domain callback, persist the completed evidence in one write. The kill-switch domain composes it; it does not reimplement any of it, and the next domain won't either. **Not five approval frameworks.**

Persistence rides the provider-operations store — the store that already holds cross-cutting operational control state — rather than a new store seam. One new table (`provider_governed_actions`, migration 0059), no new mode setting, no new reset hook; the readiness probe's model-tied fitness test forced the probe update, exactly as it was built to.

## What dual control means here, stated honestly

**No verified human principal exists in the identity model** — the caller credential's `sub` names an application. So "two humans" cannot be enforced, and this PR does not pretend to. What is enforceable: two steps signed by two different `credential_key_id`s are genuinely two different credentials, so **a single compromised credential cannot both request and approve**. Claimed operator names (`requested_by`, `approved_by`) are recorded as *unverified attribution*, never as approval evidence. Header trust carries no credential at all and is refused outright from both steps — under it, dual control would be one anonymous party talking to itself. Binding a human principal to a credential is follow-on identity work, recorded on the issue.

## The hash binding

The requester's step returns an action hash over `{action_type, switch_id, scope, semantics, target, activated_at, clear_reason}`. The approver approves *that hash*; the server verifies it against the stored pending action **and** against a payload rebuilt from live domain state, so an approval reviewed against one action can never execute a changed one — it refuses with "submit a new request", never mutates the pending approval. `activated_at` in the basis pins the exact activation, so an approval can never carry over to a re-activation. A new request **supersedes** the prior pending one, recorded with `superseded_by_action_id`.

## Actor class, designed now

`HUMAN_APPROVED` vs `SYSTEM_ORIGINATED` is an explicit field, never inferred from a service-looking string. A system identity is refused outright from originating a human-governed action type, and — pinned independently at the approve path — a `SYSTEM_ORIGINATED` record has no approval step even if one reaches the store. `record_system_originated_action` exists for the async-recovery migration (next #157 PR) so runtime quarantine actions become explicitly system-originated instead of writing `approved_by="lotus-ai.async-worker-runtime"`.

## API

- `POST /platform/providers/kill-switches/{id}/clear-requests` → pending governed action + hash (the switch keeps enforcing).
- `POST /platform/providers/kill-switches/{id}/clear-approvals` → validates and executes; response carries the cleared activation **and** the full evidence record.
- The single-call `clear` route, `KillSwitchClearRequest`, and its free-text `approved_by` are **removed**, not preserved beside the governed path.

## Evidence

11 primitive tests + 4 domain-flow tests, including: the target invariant end to end (requester approving its own clearance → 403, switch still refusing execution at the gateway); header trust refused from both steps; wrong hash refused; changed action refused; approval not redirectable to another switch; supersession; a failed domain execution leaves the action PENDING with no approver stamped; and the SQL round-trip of the evidence record with the pending-lookup semantics supersession depends on. Route coverage and OpenAPI contract tests pass with the new routes.

Full local gate: whole suite, `make lint`, `make typecheck` (732 files).

## Known residual, stated

The governed-action evidence persists through the provider-operations store, whose durable mode is derived in the promoted profile; a warn-mode local setup with a memory provider-operations store holds clearance evidence in memory. Same posture as every other provider-operations record, so it is the profile's decision, not a new gap — noted for #158's lifecycle sweep.
