### PR TITLE
feat(governance): govern prompt promotion through distinct-credential approval

### DIFF
--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -39,6 +39,7 @@ class GovernedActorClass(str, Enum):
 
 class GovernedActionType(str, Enum):
     KILL_SWITCH_CLEAR = "KILL_SWITCH_CLEAR"
+    PROMPT_PROMOTE = "PROMPT_PROMOTE"
 
 
 class GovernedActionStatus(str, Enum):

--- a/src/app/contracts/prompts.py
+++ b/src/app/contracts/prompts.py
@@ -7,6 +7,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field, computed_field
 
+from app.contracts.governed_actions import GovernedActionRecord
+
 from app.contracts.access_control import AuthorizationDecision
 from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
 
@@ -152,6 +154,55 @@ class PromptControlActionRequest(BaseModel):
     requested_by: str = Field(description="Operator identity requesting the action.")
     approved_by: str = Field(description="Operator identity approving the action.")
     reason: str = Field(description="Human-readable operator reason for the change.")
+
+
+class PromptPromotionIntentRequest(BaseModel):
+    """Step one of governed promotion: a verified requester states the intent.
+
+    Caller identity comes from the authenticated credential, never from the
+    body (issue #157). ``requested_by`` is claimed operator attribution.
+    """
+
+    task_id: str = Field(description="Task whose candidate prompt should be promoted.")
+    candidate_prompt_version: str = Field(description="Candidate prompt version to promote.")
+    reason: str = Field(min_length=1, description="Why this promotion should happen.")
+    requested_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class PromptPromotionApprovalRequest(BaseModel):
+    """Step two: a distinct verified credential approves the exact pending action."""
+
+    task_id: str = Field(description="Task the pending promotion targets.")
+    action_id: str = Field(min_length=1, max_length=64, description="Pending governed action id.")
+    action_hash: str = Field(
+        min_length=64,
+        max_length=64,
+        description="Hash of the action being approved, exactly as returned by the request step.",
+    )
+    approved_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class PromptPromotionApprovalResponse(BaseModel):
+    service: str = Field(description="Service name emitting the prompt control response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    event: PromptControlEventDescriptor = Field(
+        description="Durable prompt control-plane event that was recorded."
+    )
+    rollout_state: PromptRolloutDescriptor = Field(
+        description="Resulting rollout state after the promotion executed."
+    )
+    governed_action: GovernedActionRecord = Field(
+        description="The executed governed-action evidence linking request, approval and promotion.",
+    )
+    summary: list[str] = Field(description="Human-readable statements about the action.")
 
 
 class PromptControlActionResponse(BaseModel):

--- a/src/app/routers/prompts.py
+++ b/src/app/routers/prompts.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from fastapi import APIRouter, Query
 
 from app.contracts.prompts import (
+    PromptPromotionApprovalRequest,
+    PromptPromotionApprovalResponse,
+    PromptPromotionIntentRequest,
     PromptActivationReadinessResponse,
     PromptControlActionRequest,
     PromptControlActionResponse,
@@ -19,7 +22,10 @@ from app.services.prompt_activation_readiness import build_prompt_activation_rea
 from app.services.prompt_evidence_readiness import build_prompt_evidence_readiness
 from app.services.prompt_governance import build_prompt_governance_status
 from app.services.prompt_governance_status import build_prompt_governance_status_summary
+from app.contracts.governed_actions import GovernedActionResponse
 from app.services.prompt_rollout_control import (
+    approve_prompt_promotion,
+    request_prompt_promotion,
     apply_prompt_control_action,
     build_prompt_control_history,
 )
@@ -90,6 +96,66 @@ async def get_prompt_control_history_route(
     ),
 ) -> PromptControlHistoryResponse:
     return build_prompt_control_history(task_id=task_id, limit=limit)
+
+
+@router.post(
+    "/promote-requests",
+    response_model=GovernedActionResponse,
+    operation_id="requestPromptPromotion",
+    summary="Request promotion of a candidate prompt",
+    description=(
+        "Step one of governed promotion (issue #157): validates the promotion is currently "
+        "executable, then records a pending intent under the requester's verified credential "
+        "and returns the action hash a distinct verified credential must approve. The active "
+        "prompt is unchanged until the approval executes."
+    ),
+    responses={
+        200: {"description": "Promotion intent recorded and pending approval."},
+        403: {
+            "description": "Caller is not authorized for prompt control, or carries no "
+            "verified credential."
+        },
+        404: {"description": "Rollout state or candidate prompt version not found."},
+        409: {"description": "The promotion is not currently executable."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def request_prompt_promotion_route(
+    request: PromptPromotionIntentRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> GovernedActionResponse:
+    return request_prompt_promotion(request, authenticated_caller)
+
+
+@router.post(
+    "/promote-approvals",
+    response_model=PromptPromotionApprovalResponse,
+    operation_id="approvePromptPromotion",
+    summary="Approve and execute a pending prompt promotion",
+    description=(
+        "Step two of governed promotion (issue #157): a verified credential DISTINCT from the "
+        "requester's approves the exact pending action hash, which promotes the candidate and "
+        "records the full request-approval-execution evidence chain."
+    ),
+    responses={
+        200: {"description": "Candidate promoted under governed approval."},
+        403: {
+            "description": "Caller is not authorized, carries no verified credential, or is "
+            "the same credential that requested the promotion."
+        },
+        404: {"description": "No rollout state or pending action exists."},
+        409: {
+            "description": "The action hash does not match, the rollout state changed since "
+            "the request, or the action is not pending."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def approve_prompt_promotion_route(
+    request: PromptPromotionApprovalRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> PromptPromotionApprovalResponse:
+    return approve_prompt_promotion(request, authenticated_caller)
 
 
 @router.post(

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -37,7 +37,9 @@ from app.services.provider_operations_store import get_provider_operations_store
 # Action types where dual control applies: the action increases risk, so no
 # single principal may carry it end to end. Safety-increasing actions never
 # appear here - an emergency stop takes one verified principal, immediately.
-HUMAN_GOVERNED_ACTION_TYPES = frozenset({GovernedActionType.KILL_SWITCH_CLEAR})
+HUMAN_GOVERNED_ACTION_TYPES = frozenset(
+    {GovernedActionType.KILL_SWITCH_CLEAR, GovernedActionType.PROMPT_PROMOTE}
+)
 
 
 def compute_governed_action_hash(payload: dict[str, str | None]) -> str:

--- a/src/app/services/prompt_rollout_control.py
+++ b/src/app/services/prompt_rollout_control.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import cast
 from uuid import uuid4
 
 from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.access_control import AuthorizationCapabilityType, AuthorizationDecision
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionResponse,
+    GovernedActionType,
+)
 from app.contracts.prompts import (
     PromptControlActionRequest,
     PromptControlActionResponse,
@@ -15,11 +21,19 @@ from app.contracts.prompts import (
     PromptControlHistoryResponse,
     PromptDescriptor,
     PromptLifecycleStatus,
+    PromptPromotionApprovalRequest,
+    PromptPromotionApprovalResponse,
+    PromptPromotionIntentRequest,
     PromptRolloutDescriptor,
     PromptRolloutSelectionMode,
 )
+from app.http.authenticated_caller import AuthenticatedCaller
 from app.services.access_control_authorization import authorize_request, require_authorized
 from app.services.eval_approval_gate_summary import build_prompt_approval_gate_summary
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
 from app.services.prompt_rollout_models import PromptRolloutEventRecord, PromptRolloutStateRecord
 from app.services.prompt_store import get_prompt_repository
 
@@ -58,6 +72,21 @@ def apply_prompt_control_action(request: PromptControlActionRequest) -> PromptCo
             task_id=request.task_id,
         )
     )
+    if request.action_type == PromptControlActionType.PROMOTE_CANDIDATE:
+        # Checked after identity and authorization, like every other action
+        # property. Promotion puts a new prompt in front of clients - the
+        # risk-increasing direction - so it is governed: a verified requester
+        # records the intent and a distinct verified credential approves the
+        # exact action (issue #157). Rollback restores the previous active
+        # prompt - the safety direction - and stays immediate on this route.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Prompt promotion is a governed action: submit the intent via "
+                "promote-requests and approve it with a distinct verified credential via "
+                "promote-approvals."
+            ),
+        )
     _require_durable_prompt_control_plane(request.action_type)
     repository = get_prompt_repository()
     rollout_state = repository.get_prompt_rollout_state(request.task_id)
@@ -91,6 +120,191 @@ def apply_prompt_control_action(request: PromptControlActionRequest) -> PromptCo
     )
 
 
+def request_prompt_promotion(
+    request: PromptPromotionIntentRequest,
+    caller: AuthenticatedCaller,
+) -> GovernedActionResponse:
+    """Step one of governed promotion: record the intent under the requester's credential.
+
+    The promote transition is dry-run first, so a pending action is never
+    parked on a promotion that is not currently executable (missing candidate,
+    approval gate not ready, candidate already active).
+    """
+
+    authorization = require_authorized(
+        authorize_request(
+            caller_app=caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PROMPT_CONTROL,
+            task_id=request.task_id,
+        )
+    )
+    _require_durable_prompt_control_plane(PromptControlActionType.PROMOTE_CANDIDATE)
+    rollout_state = _get_required_rollout_state(request.task_id)
+    _build_promote_transition(
+        rollout_state=rollout_state,
+        request=_internal_promote_request(
+            task_id=request.task_id,
+            candidate_prompt_version=request.candidate_prompt_version,
+            reason=request.reason,
+            caller=caller,
+            requested_by=_credential_identity(caller),
+            approved_by="pending-governed-approval",
+        ),
+        authorization=authorization,
+    )
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.PROMPT_PROMOTE,
+        target=request.task_id,
+        payload=_promotion_payload(
+            task_id=request.task_id,
+            candidate_prompt_version=request.candidate_prompt_version,
+            prior_active_prompt_version=rollout_state.active_prompt_version,
+            reason=request.reason,
+        ),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Promotion of `{request.candidate_prompt_version}` for task "
+            f"`{request.task_id}` is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            f"The active prompt remains `{rollout_state.active_prompt_version}` until then.",
+        ],
+    )
+
+
+def approve_prompt_promotion(
+    request: PromptPromotionApprovalRequest,
+    caller: AuthenticatedCaller,
+) -> PromptPromotionApprovalResponse:
+    """Step two: a distinct verified credential approves the exact action, which executes it."""
+
+    authorization = require_authorized(
+        authorize_request(
+            caller_app=caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PROMPT_CONTROL,
+            task_id=request.task_id,
+        )
+    )
+    _require_durable_prompt_control_plane(PromptControlActionType.PROMOTE_CANDIDATE)
+    rollout_state = _get_required_rollout_state(request.task_id)
+    outcome: dict[str, object] = {}
+
+    def _execute_promotion(record: GovernedActionRecord) -> None:
+        internal = _internal_promote_request(
+            task_id=request.task_id,
+            candidate_prompt_version=str(record.action_payload.get("candidate_prompt_version")),
+            reason=str(record.action_payload.get("reason")),
+            caller=caller,
+            requested_by=(f"{record.requester_caller_app} (credential {record.requester_key_id})"),
+            approved_by=_credential_identity(caller),
+        )
+        updated_state, updated_prompts, event = _build_promote_transition(
+            rollout_state=rollout_state,
+            request=internal,
+            authorization=authorization,
+        )
+        get_prompt_repository().save_prompt_rollout_transition(
+            rollout_state=updated_state,
+            updated_prompts=updated_prompts,
+            event=event,
+        )
+        outcome["event"] = event
+        outcome["rollout_state"] = updated_state
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=request.task_id,
+        expected_hash=request.action_hash,
+        current_payload_builder=lambda record: _promotion_payload(
+            task_id=request.task_id,
+            candidate_prompt_version=str(record.action_payload.get("candidate_prompt_version")),
+            prior_active_prompt_version=rollout_state.active_prompt_version,
+            reason=str(record.action_payload.get("reason")),
+        ),
+        attribution=request.approved_by,
+        execute=_execute_promotion,
+    )
+    event = cast(PromptRolloutEventRecord, outcome["event"])
+    updated_state = cast(PromptRolloutStateRecord, outcome["rollout_state"])
+    return PromptPromotionApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        event=_map_control_event(event),
+        rollout_state=_map_rollout_state(updated_state, latest_control_event=event),
+        governed_action=executed,
+        summary=[
+            f"Promoted `{updated_state.active_prompt_version}` for task "
+            f"`{request.task_id}` under governed action `{executed.action_id}`.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+        ],
+    )
+
+
+def _promotion_payload(
+    *,
+    task_id: str,
+    candidate_prompt_version: str,
+    prior_active_prompt_version: str,
+    reason: str,
+) -> dict[str, str | None]:
+    """The exact action the approver signs off on.
+
+    Pins the prior active version: prompt rollout state genuinely can change
+    between request and approval, and an approval reviewed against one active
+    baseline must not execute against another.
+    """
+
+    return {
+        "action_type": GovernedActionType.PROMPT_PROMOTE.value,
+        "task_id": task_id,
+        "candidate_prompt_version": candidate_prompt_version,
+        "prior_active_prompt_version": prior_active_prompt_version,
+        "reason": reason,
+    }
+
+
+def _internal_promote_request(
+    *,
+    task_id: str,
+    candidate_prompt_version: str,
+    reason: str,
+    caller: AuthenticatedCaller,
+    requested_by: str,
+    approved_by: str,
+) -> PromptControlActionRequest:
+    return PromptControlActionRequest(
+        task_id=task_id,
+        action_type=PromptControlActionType.PROMOTE_CANDIDATE,
+        caller_app=caller.caller_app,
+        candidate_prompt_version=candidate_prompt_version,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )
+
+
+def _credential_identity(caller: AuthenticatedCaller) -> str:
+    return f"{caller.caller_app} (credential {caller.credential_key_id})"
+
+
+def _get_required_rollout_state(task_id: str) -> PromptRolloutStateRecord:
+    rollout_state = get_prompt_repository().get_prompt_rollout_state(task_id)
+    if rollout_state is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Prompt rollout state for task_id '{task_id}' was not found.",
+        )
+    return rollout_state
+
+
 def _require_durable_prompt_control_plane(action_type: PromptControlActionType) -> None:
     if settings.prompt_store_mode != "sqlalchemy":
         raise HTTPException(
@@ -119,12 +333,6 @@ def _resolve_transition(
     request: PromptControlActionRequest,
     authorization: AuthorizationDecision,
 ) -> tuple[PromptRolloutStateRecord, list[PromptDescriptor], PromptRolloutEventRecord]:
-    if request.action_type == PromptControlActionType.PROMOTE_CANDIDATE:
-        return _build_promote_transition(
-            rollout_state=rollout_state,
-            request=request,
-            authorization=authorization,
-        )
     if request.action_type == PromptControlActionType.ROLLBACK_TO_PREVIOUS_ACTIVE:
         return _build_rollback_transition(
             rollout_state=rollout_state,

--- a/tests/integration/test_prompt_api_contract.py
+++ b/tests/integration/test_prompt_api_contract.py
@@ -6,6 +6,11 @@ from app.main import app
 from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
+from tests.support.caller_credentials import (
+    generate_caller_signing_key,
+    mint_caller_credential,
+    public_keys_setting,
+)
 
 
 def test_prompt_registry_routes(client: TestClient) -> None:
@@ -49,6 +54,34 @@ def test_prompt_runtime_status_route(client: TestClient) -> None:
     assert any(state["task_id"] == "explain.v1" for state in body["rollout_states"])
 
 
+# Two real EdDSA credentials for the governed promotion flow (issue #157): a
+# requester and an approver under DISTINCT signing keys, both authenticating
+# as the platform control caller.
+_REQUESTER_KEY = generate_caller_signing_key()
+_APPROVER_KEY = generate_caller_signing_key()
+_PUBLIC_KEYS = public_keys_setting(
+    **{"prompt-ops-alpha": _REQUESTER_KEY, "prompt-ops-beta": _APPROVER_KEY}
+)
+_REQUESTER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_REQUESTER_KEY,
+        key_id="prompt-ops-alpha",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+_APPROVER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_APPROVER_KEY,
+        key_id="prompt-ops-beta",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+
+
 def test_prompt_control_routes(client: TestClient) -> None:
     history_response = client.get("/platform/prompts/control-history")
     assert history_response.status_code == 200
@@ -57,6 +90,9 @@ def test_prompt_control_routes(client: TestClient) -> None:
         "ROLLBACK_TO_PREVIOUS_ACTIVE",
     ]
 
+    # Promotion through the single-call route is refused with guidance to the
+    # governed two-step flow (issue #157) - after authorization, like every
+    # other action-shape check.
     blocked_promote_response = client.post(
         "/platform/prompts/control-actions",
         json={
@@ -66,11 +102,24 @@ def test_prompt_control_routes(client: TestClient) -> None:
             "candidate_prompt_version": "foundation.explain.v2",
             "requested_by": "alice@lotus.test",
             "approved_by": "bob@lotus.test",
-            "reason": "Attempt promotion without prompt approval evidence",
+            "reason": "Attempt promotion via the ungoverned route",
         },
     )
     assert blocked_promote_response.status_code == 409
-    assert "SQL-backed prompt rollout state" in blocked_promote_response.json()["detail"]
+    assert "governed action" in blocked_promote_response.json()["detail"]
+    assert "promote-requests" in blocked_promote_response.json()["detail"]
+
+    # The governed request step still requires the durable control plane.
+    blocked_intent_response = client.post(
+        "/platform/prompts/promote-requests",
+        json={
+            "task_id": "explain.v1",
+            "candidate_prompt_version": "foundation.explain.v2",
+            "reason": "Attempt promotion without a durable prompt store",
+        },
+    )
+    assert blocked_intent_response.status_code == 409
+    assert "SQL-backed prompt rollout state" in blocked_intent_response.json()["detail"]
 
 
 def test_prompt_control_routes_support_sql_backed_durable_actions(tmp_path: Path) -> None:
@@ -83,6 +132,10 @@ def test_prompt_control_routes_support_sql_backed_durable_actions(tmp_path: Path
         prompt_store_mode="sqlalchemy",
         evaluation_runtime_store_mode="sqlalchemy",
         database_url=database_url,
+        caller_trust_mode="verified_service_jwt",
+        caller_jwt_issuer="https://platform.lotus/issuer",
+        caller_jwt_audience="lotus-ai",
+        caller_jwt_public_keys=_PUBLIC_KEYS,
     ):
         with TestClient(app) as durable_client:
             for fixture_id in ("prompt_promotion_examples", "prompt_rollback_examples"):
@@ -101,38 +154,66 @@ def test_prompt_control_routes_support_sql_backed_durable_actions(tmp_path: Path
                     )
                 )
 
-            promote_response = durable_client.post(
-                "/platform/prompts/control-actions",
+            # Governed promotion over HTTP (issue #157): the request step
+            # parks the intent under the requester's verified credential and
+            # the active prompt is unchanged until a DISTINCT credential
+            # approves the exact hash.
+            pending_response = durable_client.post(
+                "/platform/prompts/promote-requests",
                 json={
                     "task_id": "explain.v1",
-                    "action_type": "PROMOTE_CANDIDATE",
-                    "caller_app": "lotus-platform",
                     "candidate_prompt_version": "foundation.explain.v2",
-                    "requested_by": "alice@lotus.test",
-                    "approved_by": "bob@lotus.test",
                     "reason": "Approve explanation candidate",
+                    "requested_by": "alice@lotus.test",
                 },
+                headers=_REQUESTER_HEADERS,
+            )
+            assert pending_response.status_code == 200
+            pending_action = pending_response.json()["governed_action"]
+            assert pending_action["status"] == "PENDING"
+            assert pending_action["requester_key_id"] == "prompt-ops-alpha"
+
+            self_approval = durable_client.post(
+                "/platform/prompts/promote-approvals",
+                json={
+                    "task_id": "explain.v1",
+                    "action_id": pending_action["action_id"],
+                    "action_hash": pending_action["action_hash"],
+                },
+                headers=_REQUESTER_HEADERS,
+            )
+            assert self_approval.status_code == 403
+
+            promote_response = durable_client.post(
+                "/platform/prompts/promote-approvals",
+                json={
+                    "task_id": "explain.v1",
+                    "action_id": pending_action["action_id"],
+                    "action_hash": pending_action["action_hash"],
+                    "approved_by": "bob@lotus.test",
+                },
+                headers=_APPROVER_HEADERS,
             )
             assert promote_response.status_code == 200
             assert (
                 promote_response.json()["rollout_state"]["active_prompt_version"]
                 == "foundation.explain.v2"
             )
-            assert (
-                promote_response.json()["rollout_state"]["latest_control_event"]["action_type"]
-                == "PROMOTE_CANDIDATE"
-            )
-            assert (
-                promote_response.json()["event"]["authorization"]["caller_app"] == "lotus-platform"
-            )
+            evidence = promote_response.json()["governed_action"]
+            assert evidence["status"] == "EXECUTED"
+            assert evidence["requester_key_id"] == "prompt-ops-alpha"
+            assert evidence["approver_key_id"] == "prompt-ops-beta"
 
-            runtime_response = durable_client.get("/platform/prompts/runtime-status")
-            assert runtime_response.status_code == 200
+            explain_status = durable_client.get(
+                "/platform/prompts/runtime-status", headers=_REQUESTER_HEADERS
+            )
+            assert explain_status.status_code == 200
             explain_state = next(
                 state
-                for state in runtime_response.json()["rollout_states"]
+                for state in explain_status.json()["rollout_states"]
                 if state["task_id"] == "explain.v1"
             )
+            assert explain_state["active_prompt_version"] == "foundation.explain.v2"
             assert explain_state["latest_control_event"]["action_type"] == "PROMOTE_CANDIDATE"
 
             rollback_response = durable_client.post(
@@ -145,6 +226,7 @@ def test_prompt_control_routes_support_sql_backed_durable_actions(tmp_path: Path
                     "approved_by": "bob@lotus.test",
                     "reason": "Restore known-good prompt",
                 },
+                headers=_REQUESTER_HEADERS,
             )
             assert rollback_response.status_code == 200
             assert (
@@ -153,7 +235,9 @@ def test_prompt_control_routes_support_sql_backed_durable_actions(tmp_path: Path
             )
 
             task_history_response = durable_client.get(
-                "/platform/prompts/control-history", params={"task_id": "explain.v1"}
+                "/platform/prompts/control-history",
+                params={"task_id": "explain.v1"},
+                headers=_REQUESTER_HEADERS,
             )
             assert task_history_response.status_code == 200
             assert len(task_history_response.json()["latest_events"]) == 2
@@ -164,6 +248,13 @@ def test_prompt_control_routes_support_sql_backed_durable_actions(tmp_path: Path
                 task_history_response.json()["latest_events"][0]["authorization"]["caller_app"]
                 == "lotus-platform"
             )
+            # The promotion event records verified credential identities, not
+            # the caller-typed names - those live on the governed action as
+            # unverified attribution.
+            promotion_event = task_history_response.json()["latest_events"][1]
+            assert promotion_event["action_type"] == "PROMOTE_CANDIDATE"
+            assert "prompt-ops-alpha" in promotion_event["requested_by"]
+            assert "prompt-ops-beta" in promotion_event["approved_by"]
 
 
 def test_prompt_control_history_route_rejects_oversized_limit(client: TestClient) -> None:

--- a/tests/integration/test_task_api_contract.py
+++ b/tests/integration/test_task_api_contract.py
@@ -8,6 +8,7 @@ from app.main import app
 from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
+from tests.support.governed_control import promote_prompt_for_test
 
 
 def test_task_execute_contract(client: TestClient) -> None:
@@ -223,19 +224,13 @@ def test_task_execute_contract_reflects_promoted_prompt_lineage(tmp_path: Path) 
                     )
                 )
 
-            promote_response = durable_client.post(
-                "/platform/prompts/control-actions",
-                json={
-                    "task_id": "explain.v1",
-                    "action_type": "PROMOTE_CANDIDATE",
-                    "caller_app": "lotus-platform",
-                    "candidate_prompt_version": "foundation.explain.v2",
-                    "requested_by": "alice@lotus.test",
-                    "approved_by": "bob@lotus.test",
-                    "reason": "Promote reviewed prompt candidate",
-                },
+            # Promotion is governed (issue #157): setup runs the two-step
+            # flow in process, since header trust cannot approve anything.
+            promote_prompt_for_test(
+                task_id="explain.v1",
+                candidate_prompt_version="foundation.explain.v2",
+                reason="Promote reviewed prompt candidate",
             )
-            assert promote_response.status_code == 200
 
             response = durable_client.post(
                 "/ai/tasks/execute",

--- a/tests/support/governed_control.py
+++ b/tests/support/governed_control.py
@@ -1,0 +1,60 @@
+"""Two-step governed-action helpers for tests (issue #157).
+
+Prompt promotion requires a verified requester and a distinct verified
+approver. Tests that need an active prompt as *setup* use
+``promote_prompt_for_test`` so the two-step flow lives in one place instead of
+being copied into every file; tests about the flow itself call the service
+functions directly.
+"""
+
+from __future__ import annotations
+
+from app.contracts.prompts import (
+    PromptPromotionApprovalRequest,
+    PromptPromotionApprovalResponse,
+    PromptPromotionIntentRequest,
+)
+from app.http.authenticated_caller import AuthenticatedCaller
+from app.services.prompt_rollout_control import (
+    approve_prompt_promotion,
+    request_prompt_promotion,
+)
+
+GOVERNED_REQUESTER = AuthenticatedCaller(
+    caller_app="lotus-platform",
+    trust_source="verified_service_jwt",
+    credential_key_id="ops-key-alpha",
+)
+GOVERNED_APPROVER = AuthenticatedCaller(
+    caller_app="lotus-platform",
+    trust_source="verified_service_jwt",
+    credential_key_id="ops-key-beta",
+)
+
+
+def promote_prompt_for_test(
+    *,
+    task_id: str,
+    candidate_prompt_version: str,
+    reason: str = "Governed promotion for test setup.",
+    requested_by: str = "alice@lotus.test",
+    approved_by: str = "bob@lotus.test",
+) -> PromptPromotionApprovalResponse:
+    pending = request_prompt_promotion(
+        PromptPromotionIntentRequest(
+            task_id=task_id,
+            candidate_prompt_version=candidate_prompt_version,
+            reason=reason,
+            requested_by=requested_by,
+        ),
+        GOVERNED_REQUESTER,
+    )
+    return approve_prompt_promotion(
+        PromptPromotionApprovalRequest(
+            task_id=task_id,
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+            approved_by=approved_by,
+        ),
+        GOVERNED_APPROVER,
+    )

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -10,7 +10,7 @@ from app.contracts.access_control import (
     AuthorizationOutcome,
     TenantPolicyMode,
 )
-from app.contracts.prompts import PromptControlActionRequest, PromptControlActionType
+from app.contracts.prompts import PromptControlActionType
 from app.contracts.evals import EvaluationCaseOutcome
 from app.evals.fixture_manifest import EvaluationFixtureRuntimeCase
 from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
@@ -21,7 +21,6 @@ from app.services.eval_runtime_execution import (
     _execute_fixture_case,
 )
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
-from app.services.prompt_rollout_control import apply_prompt_control_action
 from app.services.prompt_rollout_models import PromptRolloutEventRecord, PromptRolloutStateRecord
 from app.services.prompt_store import get_prompt_repository
 from app.services.provider_operations_store import (
@@ -30,6 +29,7 @@ from app.services.provider_operations_store import (
 )
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
+from tests.support.governed_control import promote_prompt_for_test
 
 
 def _authorization() -> AuthorizationDecision:
@@ -973,16 +973,10 @@ def test_apply_prompt_rollback_for_evaluation_rejects_missing_state_and_versions
                 case_count=1,
             )
         )
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Promote before rollback error coverage",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Promote before rollback error coverage",
         )
 
         repository = get_prompt_repository()

--- a/tests/unit/test_platform_status.py
+++ b/tests/unit/test_platform_status.py
@@ -18,14 +18,14 @@ from app.services.evaluation_runtime_store import (
     get_evaluation_runtime_store,
     reset_evaluation_runtime_store_cache,
 )
-from app.services.prompt_rollout_control import apply_prompt_control_action
 from app.services.prompt_store import reset_prompt_store_cache
 from app.services.provider_degradation_state import record_provider_failure
-from app.contracts.prompts import PromptControlActionRequest, PromptControlActionType
+from app.contracts.prompts import PromptControlActionType
 from app.services.provider_operations_store import reset_provider_operations_store_cache
 from app.services.observability_runtime import build_observability_runtime_status
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.observability import build_healthy_ai_surface_supportability_summary
+from tests.support.governed_control import promote_prompt_for_test
 
 
 def test_resolve_startup_readiness_state_defaults_when_app_state_missing() -> None:
@@ -487,16 +487,10 @@ def test_build_platform_runtime_status_reflects_sql_backed_prompt_rollout_after_
             )
         )
 
-    apply_prompt_control_action(
-        PromptControlActionRequest(
-            task_id="explain.v1",
-            action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-            caller_app="lotus-platform",
-            candidate_prompt_version="foundation.explain.v2",
-            requested_by="alice@lotus.test",
-            approved_by="bob@lotus.test",
-            reason="Promote prompt for restart-survival test",
-        )
+    promote_prompt_for_test(
+        task_id="explain.v1",
+        candidate_prompt_version="foundation.explain.v2",
+        reason="Promote prompt for restart-survival test",
     )
 
     reset_prompt_store_cache()

--- a/tests/unit/test_prompt_rollout_control.py
+++ b/tests/unit/test_prompt_rollout_control.py
@@ -30,6 +30,19 @@ from app.services.prompt_runtime import resolve_runtime_prompt_or_raise
 from app.services.prompt_store import get_prompt_repository, reset_prompt_store_cache
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
+from tests.support.governed_control import promote_prompt_for_test
+import pytest
+from pydantic import ValidationError
+from app.contracts.prompts import (
+    PromptPromotionApprovalRequest,
+    PromptPromotionIntentRequest,
+)
+from app.http.authenticated_caller import AuthenticatedCaller
+from app.services.prompt_rollout_control import (
+    approve_prompt_promotion,
+    request_prompt_promotion,
+)
+from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
 
 
 def _authorization() -> AuthorizationDecision:
@@ -60,16 +73,10 @@ def test_apply_prompt_control_action_promotes_candidate_and_records_history(
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
 
-        response = apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Approve improved explanation candidate",
-            )
+        response = promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Approve improved explanation candidate",
         )
 
         resolved = resolve_runtime_prompt_or_raise("explain.v1")
@@ -94,16 +101,10 @@ def test_apply_prompt_control_action_rolls_back_to_previous_active_version(tmp_p
         database_url=database_url,
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Approve improved explanation candidate",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Approve improved explanation candidate",
         )
 
         response = apply_prompt_control_action(
@@ -160,16 +161,10 @@ def test_apply_prompt_control_action_blocks_promotion_without_durable_prompt_sto
     settings.evaluation_runtime_store_mode = "memory"
 
     try:
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Attempt promotion without runtime-backed prompt evidence",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Attempt promotion without runtime-backed prompt evidence",
         )
     except HTTPException as exc:
         assert exc.status_code == 409
@@ -190,16 +185,10 @@ def test_apply_prompt_control_action_blocks_promotion_without_durable_evaluation
         database_url=database_url,
     ):
         try:
-            apply_prompt_control_action(
-                PromptControlActionRequest(
-                    task_id="explain.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-platform",
-                    candidate_prompt_version="foundation.explain.v2",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
-                    reason="Attempt promotion without durable runtime-backed prompt evidence",
-                )
+            promote_prompt_for_test(
+                task_id="explain.v1",
+                candidate_prompt_version="foundation.explain.v2",
+                reason="Attempt promotion without durable runtime-backed prompt evidence",
             )
         except HTTPException as exc:
             assert exc.status_code == 409
@@ -220,16 +209,10 @@ def test_apply_prompt_control_action_rejects_missing_rollout_state(tmp_path: Pat
         _seed_prompt_approval_gate_pass_sqlalchemy()
 
         try:
-            apply_prompt_control_action(
-                PromptControlActionRequest(
-                    task_id="missing.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-platform",
-                    candidate_prompt_version="foundation.explain.v2",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
-                    reason="Exercise missing rollout state branch",
-                )
+            promote_prompt_for_test(
+                task_id="missing.v1",
+                candidate_prompt_version="foundation.explain.v2",
+                reason="Exercise missing rollout state branch",
             )
         except HTTPException as exc:
             assert exc.status_code == 404
@@ -238,9 +221,13 @@ def test_apply_prompt_control_action_rejects_missing_rollout_state(tmp_path: Pat
             raise AssertionError("Expected missing rollout state to fail")
 
 
-def test_apply_prompt_control_action_rejects_blocked_or_invalid_promotion_shapes(
+def test_promotion_request_dry_runs_the_transition_and_refuses_invalid_shapes(
     tmp_path: Path,
 ) -> None:
+    """The request step validates the promotion is currently executable before
+    parking a pending action, so every refusal the old single call produced
+    still fires - now before anything is recorded (issue #157)."""
+
     database_url = f"sqlite:///{tmp_path / 'prompt-rollout-invalid-promote.db'}"
     upgrade_database_to_head(database_url)
 
@@ -250,15 +237,13 @@ def test_apply_prompt_control_action_rejects_blocked_or_invalid_promotion_shapes
         database_url=database_url,
     ):
         try:
-            apply_prompt_control_action(
-                PromptControlActionRequest(
+            request_prompt_promotion(
+                PromptPromotionIntentRequest(
                     task_id="explain.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-platform",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
+                    candidate_prompt_version="foundation.explain.v2",
                     reason="Exercise blocked approval-gate branch",
-                )
+                ),
+                GOVERNED_REQUESTER,
             )
         except HTTPException as exc:
             assert exc.status_code == 409
@@ -268,53 +253,52 @@ def test_apply_prompt_control_action_rejects_blocked_or_invalid_promotion_shapes
 
         _seed_prompt_approval_gate_pass_sqlalchemy()
 
-        for request, expected_status, expected_detail in (
-            (
-                PromptControlActionRequest(
-                    task_id="explain.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-platform",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
-                    reason="Missing candidate version",
-                ),
-                422,
-                "candidate_prompt_version is required",
-            ),
-            (
-                PromptControlActionRequest(
-                    task_id="explain.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-platform",
-                    candidate_prompt_version="foundation.explain.v1",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
-                    reason="Same active version",
-                ),
-                409,
-                "already matches the active prompt version",
-            ),
-            (
-                PromptControlActionRequest(
-                    task_id="explain.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-platform",
-                    candidate_prompt_version="missing.version",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
-                    reason="Missing candidate prompt",
-                ),
-                404,
-                "was not found",
-            ),
+        # A candidate is required by the contract itself now, not by a branch.
+        with pytest.raises(ValidationError):
+            PromptPromotionIntentRequest(
+                task_id="explain.v1",
+                reason="Missing candidate version",
+            )  # type: ignore[call-arg]
+
+        for candidate, expected_status, expected_detail in (
+            ("foundation.explain.v1", 409, "already matches the active prompt version"),
+            ("missing.version", 404, "was not found"),
         ):
             try:
-                apply_prompt_control_action(request)
+                request_prompt_promotion(
+                    PromptPromotionIntentRequest(
+                        task_id="explain.v1",
+                        candidate_prompt_version=candidate,
+                        reason="Invalid promotion shape",
+                    ),
+                    GOVERNED_REQUESTER,
+                )
             except HTTPException as exc:
                 assert exc.status_code == expected_status
                 assert expected_detail in str(exc.detail)
             else:
-                raise AssertionError("Expected invalid prompt promotion request to fail")
+                raise AssertionError("Expected invalid promotion request to fail")
+
+        # The single-call route no longer promotes at all: promotion is
+        # governed, and the refusal says where to go instead.
+        try:
+            apply_prompt_control_action(
+                PromptControlActionRequest(
+                    task_id="explain.v1",
+                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
+                    caller_app="lotus-platform",
+                    candidate_prompt_version="foundation.explain.v2",
+                    requested_by="alice@lotus.test",
+                    approved_by="bob@lotus.test",
+                    reason="Single-call promotion attempt",
+                )
+            )
+        except HTTPException as exc:
+            assert exc.status_code == 409
+            assert "governed action" in str(exc.detail)
+            assert "promote-requests" in str(exc.detail)
+        else:
+            raise AssertionError("Expected single-call promotion to be refused")
 
 
 def test_apply_prompt_control_action_rejects_non_candidate_prompt_version(tmp_path: Path) -> None:
@@ -356,16 +340,10 @@ def test_apply_prompt_control_action_rejects_non_candidate_prompt_version(tmp_pa
         )
 
         try:
-            apply_prompt_control_action(
-                PromptControlActionRequest(
-                    task_id="explain.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-platform",
-                    candidate_prompt_version="foundation.explain.v2",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
-                    reason="Candidate is retired and not governed candidate",
-                )
+            promote_prompt_for_test(
+                task_id="explain.v1",
+                candidate_prompt_version="foundation.explain.v2",
+                reason="Candidate is retired and not governed candidate",
             )
         except HTTPException as exc:
             assert exc.status_code == 409
@@ -384,16 +362,10 @@ def test_apply_prompt_control_action_rejects_invalid_rollback_shape(tmp_path: Pa
         database_url=database_url,
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Promote before testing invalid rollback request",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Promote before testing invalid rollback request",
         )
 
         try:
@@ -476,7 +448,7 @@ def _seed_prompt_approval_gate_pass_sqlalchemy() -> None:
         )
 
 
-def test_apply_prompt_control_action_blocks_unauthorized_caller(tmp_path: Path) -> None:
+def test_unauthorized_callers_and_credentials_cannot_promote(tmp_path: Path) -> None:
     database_url = f"sqlite:///{tmp_path / 'prompt-rollout-unauthorized.db'}"
     upgrade_database_to_head(database_url)
 
@@ -487,20 +459,110 @@ def test_apply_prompt_control_action_blocks_unauthorized_caller(tmp_path: Path) 
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
 
+        # A caller app without the prompt-control capability is refused.
+        unauthorized = AuthenticatedCaller(
+            caller_app="lotus-manage",
+            trust_source="verified_service_jwt",
+            credential_key_id="ops-key-alpha",
+        )
         try:
-            apply_prompt_control_action(
-                PromptControlActionRequest(
+            request_prompt_promotion(
+                PromptPromotionIntentRequest(
                     task_id="explain.v1",
-                    action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                    caller_app="lotus-workbench",
                     candidate_prompt_version="foundation.explain.v2",
-                    requested_by="alice@lotus.test",
-                    approved_by="bob@lotus.test",
                     reason="Unauthorized promotion attempt",
-                )
+                ),
+                unauthorized,
             )
         except HTTPException as exc:
             assert exc.status_code == 403
             assert "not authorized for prompt control-plane actions" in str(exc.detail)
         else:
-            raise AssertionError("Expected unauthorized prompt control action to fail")
+            raise AssertionError("Expected unauthorized promotion request to fail")
+
+        # The requester's own credential cannot approve its request, and the
+        # active prompt is unchanged afterwards.
+        pending = request_prompt_promotion(
+            PromptPromotionIntentRequest(
+                task_id="explain.v1",
+                candidate_prompt_version="foundation.explain.v2",
+                reason="Self-approval attempt",
+            ),
+            GOVERNED_REQUESTER,
+        )
+        try:
+            approve_prompt_promotion(
+                PromptPromotionApprovalRequest(
+                    task_id="explain.v1",
+                    action_id=pending.governed_action.action_id,
+                    action_hash=pending.governed_action.action_hash,
+                ),
+                GOVERNED_REQUESTER,
+            )
+        except HTTPException as exc:
+            assert exc.status_code == 403
+            assert "distinct" in str(exc.detail)
+        else:
+            raise AssertionError("Expected self-approval to be refused")
+        state = get_prompt_repository().get_prompt_rollout_state("explain.v1")
+        assert state is not None
+        assert state.active_prompt_version == "foundation.explain.v1"
+
+
+def test_a_promotion_approved_against_a_changed_baseline_is_refused(tmp_path: Path) -> None:
+    """The hash pins the prior active version. Prompt rollout state genuinely
+    can change between request and approval - a rollback, another promotion -
+    and an approval reviewed against one baseline must not execute against
+    another."""
+
+    database_url = f"sqlite:///{tmp_path / 'prompt-rollout-changed-baseline.db'}"
+    upgrade_database_to_head(database_url)
+
+    with override_runtime_settings(
+        prompt_store_mode="sqlalchemy",
+        evaluation_runtime_store_mode="sqlalchemy",
+        database_url=database_url,
+    ):
+        _seed_prompt_approval_gate_pass_sqlalchemy()
+        pending = request_prompt_promotion(
+            PromptPromotionIntentRequest(
+                task_id="explain.v1",
+                candidate_prompt_version="foundation.explain.v2",
+                reason="Promotion reviewed against the v1 baseline",
+            ),
+            GOVERNED_REQUESTER,
+        )
+
+        # The baseline changes: the same candidate is promoted and rolled back
+        # through governed flows, leaving the rollout state re-derived.
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Baseline change",
+        )
+        apply_prompt_control_action(
+            PromptControlActionRequest(
+                task_id="explain.v1",
+                action_type=PromptControlActionType.ROLLBACK_TO_PREVIOUS_ACTIVE,
+                caller_app="lotus-platform",
+                requested_by="alice@lotus.test",
+                approved_by="bob@lotus.test",
+                reason="Baseline restored",
+            )
+        )
+
+        try:
+            approve_prompt_promotion(
+                PromptPromotionApprovalRequest(
+                    task_id="explain.v1",
+                    action_id=pending.governed_action.action_id,
+                    action_hash=pending.governed_action.action_hash,
+                ),
+                GOVERNED_APPROVER,
+            )
+        except HTTPException as exc:
+            # Superseded by the intervening governed promotion of the same
+            # target, or refused as changed - either way it cannot execute.
+            assert exc.status_code == 409
+        else:
+            raise AssertionError("Expected approval against a changed baseline to fail")

--- a/tests/unit/test_prompt_runtime.py
+++ b/tests/unit/test_prompt_runtime.py
@@ -37,6 +37,7 @@ from app.services.prompt_runtime import (
 from app.services.prompt_store import get_prompt_repository, reset_prompt_store_cache
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
+from tests.support.governed_control import promote_prompt_for_test
 
 
 def _authorization() -> AuthorizationDecision:
@@ -128,16 +129,10 @@ def test_build_prompt_selection_trace_includes_latest_control_event_after_promot
         database_url=database_url,
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Promote explanation prompt",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Promote explanation prompt",
         )
 
         trace = build_prompt_selection_trace("explain.v1")
@@ -158,16 +153,10 @@ def test_prompt_runtime_selection_survives_sql_store_reinitialization(tmp_path: 
         database_url=database_url,
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Promote explanation prompt",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Promote explanation prompt",
         )
 
         reset_prompt_store_cache()
@@ -199,16 +188,10 @@ def test_prompt_runtime_rollback_lineage_survives_sql_store_reinitialization(
         database_url=database_url,
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Promote explanation prompt",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Promote explanation prompt",
         )
         apply_prompt_control_action(
             PromptControlActionRequest(

--- a/tests/unit/test_task_executor.py
+++ b/tests/unit/test_task_executor.py
@@ -18,15 +18,14 @@ from app.contracts.tasks import (
     TaskInputMode,
 )
 from app.repositories.memory_retrieval_repository import InMemoryRetrievalRepository
-from app.contracts.prompts import PromptControlActionRequest, PromptControlActionType
 from app.services.eval_async_execution import run_next_evaluation_execution_job
 from app.services.eval_run_submission_service import submit_evaluation_run
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
-from app.services.prompt_rollout_control import apply_prompt_control_action
 from app.services.task_executor import execute_task
 from app.services.workflow_pack_run_ledger import WorkflowPackRunStoreUnavailableError
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.support.runtime_settings import override_runtime_settings
+from tests.support.governed_control import promote_prompt_for_test
 
 
 def _request(
@@ -816,16 +815,10 @@ def test_execute_task_reflects_promoted_prompt_selection_in_audit_and_evidence(
         database_url=database_url,
     ):
         _seed_prompt_approval_gate_pass_sqlalchemy()
-        apply_prompt_control_action(
-            PromptControlActionRequest(
-                task_id="explain.v1",
-                action_type=PromptControlActionType.PROMOTE_CANDIDATE,
-                caller_app="lotus-platform",
-                candidate_prompt_version="foundation.explain.v2",
-                requested_by="alice@lotus.test",
-                approved_by="bob@lotus.test",
-                reason="Promote updated explanation prompt",
-            )
+        promote_prompt_for_test(
+            task_id="explain.v1",
+            candidate_prompt_version="foundation.explain.v2",
+            reason="Promote updated explanation prompt",
         )
 
         response = execute_task(


### PR DESCRIPTION
Issue #157, slice 2: prompt promotion onto the governed-action primitive from #256. Provider enabling, verified requester on safety actions, and the async-recovery migration remain, one bounded PR each.

## Control-plane outcome

No single principal can put a new prompt in front of clients. A promotion is requested under one verified credential, approved under a distinct verified credential against the exact action hash, and the durable event history records the verified credential identities — not caller-typed names.

## Invariant

The risk-direction rule, applied to prompts: **promotion** (risk-increasing — a new prompt starts speaking to clients) is governed two-step; **rollback** (safety-restoring — the previous known-good prompt returns) stays immediate on the existing route. No human handoff in front of the safety direction.

## One authority

The same `governed_action_control` primitive from #256 — `PROMPT_PROMOTE` joins the vocabulary and `HUMAN_GOVERNED_ACTION_TYPES`; no prompt-specific approval machinery exists. The domain composes `submit`/`approve_and_execute` exactly as kill-switch clearance does, and the entire existing promote transition (`_build_promote_transition`: approval-gate check, candidate validation, lifecycle flips, event construction) is reused unchanged inside the approve callback. The eval runtime's hermetic fixture path is untouched: it operates on evaluation-scoped store state that is reset afterwards, never production truth — exempt for that reason, noted as duplication.

## Where the freshness rebuild earns its keep

For kill switches the hash-pinned state was immutable while active; for prompts it is not. Rollout state genuinely changes between request and approval — another promotion, a rollback — so the hash pins the **prior active version** and the approve step rebuilds the payload from live state. A new test proves an approval reviewed against one baseline refuses to execute against another (409, via supersession or the changed-action check).

## Dry-run before parking

The request step runs the full promote transition validation (approval gate `RUNTIME_PASS`, candidate exists and is a governed candidate, not already active) and discards the result — so a pending action is never parked on a promotion that is not currently executable. Every refusal the old single call produced still fires, now before anything is recorded.

## API

- `POST /platform/prompts/promote-requests` → pending governed action + hash (active prompt unchanged).
- `POST /platform/prompts/promote-approvals` → validates distinct credential + exact hash + unchanged baseline, executes the promotion, returns rollout state **and** the evidence record.
- `POST /platform/prompts/control-actions` with `PROMOTE_CANDIDATE` refuses with guidance to the governed flow — checked **after** authorization, like every other action-shape property, so the caller-boundary spoof check keeps firing first. Rollback on that route is unchanged.
- The promotion event's `requested_by`/`approved_by` now carry verified credential identities (`lotus-platform (credential prompt-ops-alpha)`); claimed operator names ride the governed action as unverified attribution.

## Evidence

- The HTTP contract test runs the whole governed flow in `verified_service_jwt` mode with two real EdDSA credentials: request under one key, self-approval refused 403, approval under the distinct key promotes, runtime status reflects it, and the durable history's promotion event carries both credential identities.
- Unit: dry-run refusals (blocked gate, candidate==active, missing candidate — same statuses and details as before), unauthorized caller refused, self-approval refused with the active prompt proven unchanged, changed-baseline approval refused, single-call promotion refused with guidance.
- A missing candidate version is now impossible by contract (pydantic) rather than a runtime branch; the test asserts `ValidationError`.

## Test migration, stated honestly

14 setup-style promotions across six files collapsed into one shared `promote_prompt_for_test` helper (two-step through the service). One regex over-application was caught by the tests themselves: the transform erased the *unauthorized* caller identity in a refusal test, turning it into a passing promotion — rewritten by hand with the unauthorized identity restored. The eval fixture promotions inside `eval_runtime_execution` are untouched.

Full local gate: whole suite, `make lint`, `make typecheck` (733 files). No migration — the governed-actions table from #256 carries the new action type.
