### PR TITLE
feat(governance): govern provider-operations resets through distinct-credential approval

### DIFF
--- a/scripts/check_module_budget.py
+++ b/scripts/check_module_budget.py
@@ -31,7 +31,6 @@ OVERSIZED_ALLOWLIST: dict[str, int] = {
     "services/eval_runtime_execution.py": 1471,
     "services/workflow_pack_registry_seed.py": 1365,
     "routers/workflow_packs.py": 1250,
-    "contracts/providers.py": 1023,
 }
 
 # The readiness modules that survive because they genuinely compute from

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -40,6 +40,7 @@ class GovernedActorClass(str, Enum):
 class GovernedActionType(str, Enum):
     KILL_SWITCH_CLEAR = "KILL_SWITCH_CLEAR"
     PROMPT_PROMOTE = "PROMPT_PROMOTE"
+    PROVIDER_OPERATIONS_RESET = "PROVIDER_OPERATIONS_RESET"
 
 
 class GovernedActionStatus(str, Enum):

--- a/src/app/contracts/provider_operations.py
+++ b/src/app/contracts/provider_operations.py
@@ -1,0 +1,142 @@
+"""Provider-operations control-plane contracts (issues #152, #157).
+
+Split from ``contracts/providers.py`` when the module-budget ratchet fired:
+the reset-control vocabulary is its own governed surface, and every reset is a
+permissive action carried by the governed-action primitive.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from app.contracts.access_control import AuthorizationDecision
+from app.contracts.governed_actions import GovernedActionRecord
+from app.contracts.providers import ProviderQuotaScope
+
+
+class ProviderOperationsControlActionType(str, Enum):
+    RESET_ALL_QUOTAS = "RESET_ALL_QUOTAS"
+    RESET_QUOTA_SCOPE = "RESET_QUOTA_SCOPE"
+    RESET_BUDGET = "RESET_BUDGET"
+    RESET_DEGRADATION = "RESET_DEGRADATION"
+    RESET_ALL_PROVIDER_OPERATIONS = "RESET_ALL_PROVIDER_OPERATIONS"
+
+
+class ProviderOperationsResetIntentRequest(BaseModel):
+    """Step one of a governed reset: a verified requester states the intent.
+
+    Every reset action is permissive - it re-opens a spending envelope or
+    resumes traffic past the breaker's health protection - so all of them are
+    governed (issue #157). Caller identity comes from the authenticated
+    credential, never from the body.
+    """
+
+    action_type: ProviderOperationsControlActionType = Field(
+        description="Requested provider-operations reset action."
+    )
+    scope: ProviderQuotaScope | None = Field(
+        default=None,
+        description="Quota scope targeted by the action when resetting one quota scope.",
+    )
+    scope_key: str | None = Field(
+        default=None,
+        description="Quota scope key targeted by the action when resetting one quota scope.",
+    )
+    reason: str = Field(min_length=1, description="Why this reset should happen.")
+    requested_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class ProviderOperationsResetApprovalRequest(BaseModel):
+    """Step two: a distinct verified credential approves the exact pending reset.
+
+    The approver restates the action type (and scope for targeted quota
+    resets) so an approval cannot be redirected to a different reset shape.
+    """
+
+    action_type: ProviderOperationsControlActionType = Field(
+        description="The reset action being approved; must match the pending action."
+    )
+    scope: ProviderQuotaScope | None = Field(default=None)
+    scope_key: str | None = Field(default=None)
+    action_id: str = Field(min_length=1, max_length=64, description="Pending governed action id.")
+    action_hash: str = Field(
+        min_length=64,
+        max_length=64,
+        description="Hash of the action being approved, exactly as returned by the request step.",
+    )
+    approved_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class ProviderOperationsResetApprovalResponse(BaseModel):
+    service: str = Field(description="Service name emitting the response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    provider_mode: str = Field(description="Configured provider mode at execution time.")
+    event: ProviderOperationsControlEventDescriptor = Field(
+        description="Durable provider-operations event recorded for the executed reset."
+    )
+    governed_action: GovernedActionRecord = Field(
+        description="The executed governed-action evidence linking request, approval and reset.",
+    )
+    summary: list[str] = Field(description="Human-readable statements about the action.")
+
+
+class ProviderOperationsControlEventDescriptor(BaseModel):
+    event_id: str = Field(
+        description="Stable identifier for the recorded provider-operations action."
+    )
+    action_type: ProviderOperationsControlActionType = Field(
+        description="Type of provider-operations control action that was recorded."
+    )
+    scope: ProviderQuotaScope | None = Field(
+        default=None,
+        description="Quota scope targeted by the action when the action resets a specific quota scope.",
+    )
+    scope_key: str | None = Field(
+        default=None,
+        description="Scope key targeted by the action when applicable.",
+    )
+    reason: str = Field(description="Operator-provided reason for the provider-operations action.")
+    requested_by: str = Field(description="Operator or system identity that requested the action.")
+    approved_by: str = Field(description="Approver identity recorded for the action.")
+    affected_record_count: int = Field(
+        description="Number of provider-operations state records affected by the action."
+    )
+    authorization: AuthorizationDecision = Field(
+        description="Typed caller-authorization decision recorded for the provider control action."
+    )
+    recorded_at: str = Field(description="Timestamp when the action was recorded.")
+
+
+class ProviderOperationsControlHistoryResponse(BaseModel):
+    service: str = Field(
+        description="Service name emitting the provider-operations control history view."
+    )
+    version: str = Field(description="Current lotus-ai service version.")
+    provider_mode: str = Field(description="Configured text-generation provider mode.")
+    control_plane_store_mode: str = Field(
+        description="Configured provider-operations store mode backing control-plane truth."
+    )
+    reset_actions_supported: bool = Field(
+        description="Whether governed provider-operations reset actions are currently supported."
+    )
+    supported_action_types: list[ProviderOperationsControlActionType] = Field(
+        description="Supported provider-operations control action types."
+    )
+    latest_events: list[ProviderOperationsControlEventDescriptor] = Field(
+        default_factory=list,
+        description="Most recent recorded provider-operations control-plane actions.",
+    )
+    notes: list[str] = Field(
+        default_factory=list,
+        description="Human-readable notes describing reset and rollover semantics for the provider control plane.",
+    )

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-from app.contracts.access_control import AuthorizationDecision
+
 from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
 
 
@@ -206,14 +206,6 @@ class ProviderQuotaScope(str, Enum):
     TENANT = "TENANT"
 
 
-class ProviderOperationsControlActionType(str, Enum):
-    RESET_ALL_QUOTAS = "RESET_ALL_QUOTAS"
-    RESET_QUOTA_SCOPE = "RESET_QUOTA_SCOPE"
-    RESET_BUDGET = "RESET_BUDGET"
-    RESET_DEGRADATION = "RESET_DEGRADATION"
-    RESET_ALL_PROVIDER_OPERATIONS = "RESET_ALL_PROVIDER_OPERATIONS"
-
-
 class ProviderQuotaDescriptor(BaseModel):
     scope: ProviderQuotaScope = Field(description="Quota scope this policy entry applies to.")
     scope_key: str = Field(
@@ -355,103 +347,6 @@ class ProviderOperationsStatusResponse(BaseModel):
     summary: list[str] = Field(
         default_factory=list,
         description="Human-readable summary of the current provider operations posture.",
-    )
-
-
-class ProviderOperationsControlEventDescriptor(BaseModel):
-    event_id: str = Field(
-        description="Stable identifier for the recorded provider-operations action."
-    )
-    action_type: ProviderOperationsControlActionType = Field(
-        description="Type of provider-operations control action that was recorded."
-    )
-    scope: ProviderQuotaScope | None = Field(
-        default=None,
-        description="Quota scope targeted by the action when the action resets a specific quota scope.",
-    )
-    scope_key: str | None = Field(
-        default=None,
-        description="Scope key targeted by the action when applicable.",
-    )
-    reason: str = Field(description="Operator-provided reason for the provider-operations action.")
-    requested_by: str = Field(description="Operator or system identity that requested the action.")
-    approved_by: str = Field(description="Approver identity recorded for the action.")
-    affected_record_count: int = Field(
-        description="Number of provider-operations state records affected by the action."
-    )
-    authorization: AuthorizationDecision = Field(
-        description="Typed caller-authorization decision recorded for the provider control action."
-    )
-    recorded_at: str = Field(description="Timestamp when the action was recorded.")
-
-
-class ProviderOperationsControlHistoryResponse(BaseModel):
-    service: str = Field(
-        description="Service name emitting the provider-operations control history view."
-    )
-    version: str = Field(description="Current lotus-ai service version.")
-    provider_mode: str = Field(description="Configured text-generation provider mode.")
-    control_plane_store_mode: str = Field(
-        description="Configured provider-operations store mode backing control-plane truth."
-    )
-    reset_actions_supported: bool = Field(
-        description="Whether governed provider-operations reset actions are currently supported."
-    )
-    supported_action_types: list[ProviderOperationsControlActionType] = Field(
-        description="Supported provider-operations control action types."
-    )
-    latest_events: list[ProviderOperationsControlEventDescriptor] = Field(
-        default_factory=list,
-        description="Most recent recorded provider-operations control-plane actions.",
-    )
-    notes: list[str] = Field(
-        default_factory=list,
-        description="Human-readable notes describing reset and rollover semantics for the provider control plane.",
-    )
-
-
-class ProviderOperationsControlActionRequest(BaseModel):
-    action_type: ProviderOperationsControlActionType = Field(
-        description="Requested provider-operations control action."
-    )
-    caller_app: str = Field(
-        min_length=1,
-        description="Caller application identity authorized to issue the provider-operations action.",
-    )
-    scope: ProviderQuotaScope | None = Field(
-        default=None,
-        description="Quota scope targeted by the action when resetting one quota scope.",
-    )
-    scope_key: str | None = Field(
-        default=None,
-        description="Quota scope key targeted by the action when resetting one quota scope.",
-    )
-    requested_by: str = Field(
-        min_length=1,
-        description="Operator or system identity requesting the provider-operations action.",
-    )
-    approved_by: str = Field(
-        min_length=1,
-        description="Approver identity authorizing the provider-operations action.",
-    )
-    reason: str = Field(
-        min_length=1,
-        description="Human-readable reason for the provider-operations action.",
-    )
-
-
-class ProviderOperationsControlActionResponse(BaseModel):
-    service: str = Field(
-        description="Service name emitting the provider-operations control action response."
-    )
-    version: str = Field(description="Current lotus-ai service version.")
-    provider_mode: str = Field(description="Configured text-generation provider mode.")
-    event: ProviderOperationsControlEventDescriptor = Field(
-        description="Recorded provider-operations control-plane event."
-    )
-    summary: list[str] = Field(
-        default_factory=list,
-        description="Human-readable summary of the applied provider-operations action.",
     )
 
 

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -7,9 +7,9 @@ from app.contracts.access_control import AuthorizationDecision
 from app.contracts.governed_actions import GovernedActionRecord
 from app.contracts.providers import (
     ProviderFailureCategory,
-    ProviderOperationsControlActionType,
     ProviderQuotaScope,
 )
+from app.contracts.provider_operations import ProviderOperationsControlActionType
 
 
 @dataclass(frozen=True)

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -13,9 +13,9 @@ from app.contracts.access_control import (
 )
 from app.contracts.providers import (
     ProviderFailureCategory,
-    ProviderOperationsControlActionType,
     ProviderQuotaScope,
 )
+from app.contracts.provider_operations import ProviderOperationsControlActionType
 from app.contracts.governed_actions import GovernedActionRecord
 from app.db.models import (
     GovernedActionModel,

--- a/src/app/routers/providers.py
+++ b/src/app/routers/providers.py
@@ -2,21 +2,25 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.contracts.governed_actions import GovernedActionResponse
 from app.contracts.providers import (
     ProviderActivationReadinessResponse,
-    RoutingPostureResponse,
     ProviderBudgetPolicyResponse,
     ProviderCatalogResponse,
     ProviderEvidenceReadinessResponse,
     ProviderGovernanceStatusResponse,
-    ProviderOperationsControlActionRequest,
-    ProviderOperationsControlActionResponse,
-    ProviderOperationsControlHistoryResponse,
     ProviderOperationsStatusResponse,
     ProviderOperatorProfileResponse,
     ProviderPolicyResponse,
     ProviderQuotaPolicyResponse,
     ProviderRunbookReadinessResponse,
+    RoutingPostureResponse,
+)
+from app.contracts.provider_operations import (
+    ProviderOperationsControlHistoryResponse,
+    ProviderOperationsResetApprovalRequest,
+    ProviderOperationsResetApprovalResponse,
+    ProviderOperationsResetIntentRequest,
 )
 from app.contracts.rate_cards import RateCardCatalogueResponse
 from app.http.authenticated_caller import AuthenticatedCallerDependency
@@ -26,7 +30,8 @@ from app.services.provider_catalog import build_provider_catalog
 from app.services.provider_evidence_readiness import build_provider_evidence_readiness
 from app.services.provider_governance_status import build_provider_governance_status
 from app.services.provider_operations_control import (
-    apply_provider_operations_control_action,
+    approve_provider_operations_reset,
+    request_provider_operations_reset,
     build_provider_operations_control_history,
 )
 from app.services.provider_operations_status import build_provider_operations_status
@@ -209,28 +214,63 @@ async def get_provider_operations_control_history_route() -> (
 
 
 @router.post(
-    "/control-plane-actions/reset",
-    response_model=ProviderOperationsControlActionResponse,
-    operation_id="applyProviderOperationsControlAction",
-    summary="Apply a lotus-ai provider operations control-plane reset action",
+    "/control-plane-actions/reset-requests",
+    response_model=GovernedActionResponse,
+    operation_id="requestProviderOperationsReset",
+    summary="Request a provider operations reset",
     description=(
-        "Applies one governed provider-operations reset action and records durable operator "
-        "reason and approval metadata for later review."
+        "Step one of a governed reset (issue #157): records a pending reset intent under the "
+        "requester's verified credential and returns the action hash a distinct verified "
+        "credential must approve. Every reset is permissive - it re-opens a spending envelope "
+        "or resumes traffic past breaker protection - so no provider-operations state changes "
+        "until the approval executes."
     ),
     responses={
-        200: {"description": "Provider operations control-plane action applied successfully."},
-        409: {
-            "description": "Durable provider-operations control actions are not currently supported."
+        200: {"description": "Reset intent recorded and pending approval."},
+        403: {
+            "description": "Caller is not authorized for provider control, or carries no "
+            "verified credential."
         },
-        422: {"description": "Invalid provider-operations control action request."},
+        409: {"description": "Durable provider-operations control actions are not supported."},
+        422: {"description": "Invalid reset shape."},
         500: {"description": "Unexpected server error."},
     },
 )
-async def apply_provider_operations_control_action_route(
-    request: ProviderOperationsControlActionRequest,
-    _authenticated_caller: AuthenticatedCallerDependency,
-) -> ProviderOperationsControlActionResponse:
-    return apply_provider_operations_control_action(request)
+async def request_provider_operations_reset_route(
+    request: ProviderOperationsResetIntentRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> GovernedActionResponse:
+    return request_provider_operations_reset(request, authenticated_caller)
+
+
+@router.post(
+    "/control-plane-actions/reset-approvals",
+    response_model=ProviderOperationsResetApprovalResponse,
+    operation_id="approveProviderOperationsReset",
+    summary="Approve and execute a pending provider operations reset",
+    description=(
+        "Step two of a governed reset (issue #157): a verified credential DISTINCT from the "
+        "requester's approves the exact pending action hash, which executes the reset and "
+        "records the full request-approval-execution evidence chain."
+    ),
+    responses={
+        200: {"description": "Reset executed under governed approval."},
+        403: {
+            "description": "Caller is not authorized, carries no verified credential, or is "
+            "the same credential that requested the reset."
+        },
+        404: {"description": "No pending action exists."},
+        409: {
+            "description": "The action hash or shape does not match, or the action is not pending."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def approve_provider_operations_reset_route(
+    request: ProviderOperationsResetApprovalRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> ProviderOperationsResetApprovalResponse:
+    return approve_provider_operations_reset(request, authenticated_caller)
 
 
 @router.get(

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -38,7 +38,11 @@ from app.services.provider_operations_store import get_provider_operations_store
 # single principal may carry it end to end. Safety-increasing actions never
 # appear here - an emergency stop takes one verified principal, immediately.
 HUMAN_GOVERNED_ACTION_TYPES = frozenset(
-    {GovernedActionType.KILL_SWITCH_CLEAR, GovernedActionType.PROMPT_PROMOTE}
+    {
+        GovernedActionType.KILL_SWITCH_CLEAR,
+        GovernedActionType.PROMPT_PROMOTE,
+        GovernedActionType.PROVIDER_OPERATIONS_RESET,
+    }
 )
 
 

--- a/src/app/services/provider_operations_control.py
+++ b/src/app/services/provider_operations_control.py
@@ -1,22 +1,35 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import cast
 from uuid import uuid4
 
 from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.access_control import AuthorizationCapabilityType
-from app.contracts.providers import (
-    ProviderOperationsControlActionRequest,
-    ProviderOperationsControlActionResponse,
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionResponse,
+    GovernedActionType,
+)
+from app.contracts.providers import ProviderQuotaScope
+from app.contracts.provider_operations import (
     ProviderOperationsControlActionType,
     ProviderOperationsControlEventDescriptor,
     ProviderOperationsControlHistoryResponse,
+    ProviderOperationsResetApprovalRequest,
+    ProviderOperationsResetApprovalResponse,
+    ProviderOperationsResetIntentRequest,
 )
+from app.http.authenticated_caller import AuthenticatedCaller
 from app.repositories.provider_operations_repository import ProviderOperationsEventRecord
 from app.repositories.provider_operations_repository import ProviderOperationsRepository
 from app.services.access_control_authorization import authorize_request, require_authorized
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
 from app.services.provider_budget_policy import _BUDGET_KEY
 from app.services.provider_operations_store import get_provider_operations_store
 
@@ -49,15 +62,169 @@ def build_provider_operations_control_history(
     )
 
 
-def apply_provider_operations_control_action(
-    request: ProviderOperationsControlActionRequest,
-) -> ProviderOperationsControlActionResponse:
-    authorization = require_authorized(
+def request_provider_operations_reset(
+    request: ProviderOperationsResetIntentRequest,
+    caller: AuthenticatedCaller,
+) -> GovernedActionResponse:
+    """Step one of a governed reset: record the intent under the requester's credential.
+
+    The reset shape is validated first, so a pending action is never parked on
+    a malformed reset.
+    """
+
+    require_authorized(
         authorize_request(
-            caller_app=request.caller_app,
+            caller_app=caller.caller_app,
             capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
         )
     )
+    _require_durable_reset_plane()
+    _validate_reset_shape(
+        action_type=request.action_type, scope=request.scope, scope_key=request.scope_key
+    )
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.PROVIDER_OPERATIONS_RESET,
+        target=_reset_target(
+            action_type=request.action_type, scope=request.scope, scope_key=request.scope_key
+        ),
+        payload=_reset_payload(
+            action_type=request.action_type,
+            scope=request.scope,
+            scope_key=request.scope_key,
+            reason=request.reason,
+        ),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Reset `{request.action_type.value}` is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            "No provider-operations state changes until the approval executes.",
+        ],
+    )
+
+
+def approve_provider_operations_reset(
+    request: ProviderOperationsResetApprovalRequest,
+    caller: AuthenticatedCaller,
+) -> ProviderOperationsResetApprovalResponse:
+    """Step two: a distinct verified credential approves the exact reset, which executes it."""
+
+    authorization = require_authorized(
+        authorize_request(
+            caller_app=caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
+        )
+    )
+    _require_durable_reset_plane()
+    outcome: dict[str, object] = {}
+
+    def _execute_reset(record: GovernedActionRecord) -> None:
+        action_type = ProviderOperationsControlActionType(
+            str(record.action_payload.get("action_type"))
+        )
+        raw_scope = record.action_payload.get("scope")
+        scope = ProviderQuotaScope(raw_scope) if raw_scope else None
+        scope_key = record.action_payload.get("scope_key")
+        repository = get_provider_operations_store()
+        affected_record_count = _apply_control_action(
+            repository=repository,
+            action_type=action_type,
+            scope=scope,
+            scope_key=scope_key,
+        )
+        event = ProviderOperationsEventRecord(
+            event_id=f"provider_ops_evt_{uuid4().hex[:12]}",
+            action_type=action_type,
+            scope=scope,
+            scope_key=scope_key,
+            reason=str(record.action_payload.get("reason")),
+            requested_by=(f"{record.requester_caller_app} (credential {record.requester_key_id})"),
+            approved_by=f"{caller.caller_app} (credential {caller.credential_key_id})",
+            affected_record_count=affected_record_count,
+            authorization=authorization,
+            recorded_at=_utcnow(),
+        )
+        repository.save_operations_event(event)
+        outcome["event"] = event
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=_reset_target(
+            action_type=request.action_type, scope=request.scope, scope_key=request.scope_key
+        ),
+        expected_hash=request.action_hash,
+        current_payload_builder=lambda record: _reset_payload(
+            action_type=ProviderOperationsControlActionType(
+                str(record.action_payload.get("action_type"))
+            ),
+            scope=(
+                ProviderQuotaScope(str(record.action_payload.get("scope")))
+                if record.action_payload.get("scope")
+                else None
+            ),
+            scope_key=record.action_payload.get("scope_key"),
+            reason=str(record.action_payload.get("reason")),
+        ),
+        attribution=request.approved_by,
+        execute=_execute_reset,
+    )
+    event = cast(ProviderOperationsEventRecord, outcome["event"])
+    return ProviderOperationsResetApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        provider_mode=settings.provider_mode,
+        event=_to_event_descriptor(event),
+        governed_action=executed,
+        summary=[
+            f"Applied provider-operations reset `{event.action_type.value}` under governed "
+            f"action `{executed.action_id}`.",
+            f"Affected provider-operations record count: {event.affected_record_count}.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+        ],
+    )
+
+
+def _reset_target(
+    *,
+    action_type: ProviderOperationsControlActionType,
+    scope: ProviderQuotaScope | None,
+    scope_key: str | None,
+) -> str:
+    """One pending action per exact reset shape.
+
+    A pending targeted quota reset must not be superseded by an unrelated
+    budget reset, so the target carries the full shape.
+    """
+
+    if scope is not None and scope_key is not None:
+        return f"{action_type.value}:{scope.value}:{scope_key}"
+    return action_type.value
+
+
+def _reset_payload(
+    *,
+    action_type: ProviderOperationsControlActionType,
+    scope: ProviderQuotaScope | None,
+    scope_key: object,
+    reason: str,
+) -> dict[str, str | None]:
+    return {
+        "action_type": action_type.value,
+        "scope": scope.value if scope is not None else None,
+        "scope_key": str(scope_key) if scope_key is not None else None,
+        "reason": reason,
+    }
+
+
+def _require_durable_reset_plane() -> None:
     if not _reset_actions_supported():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -67,51 +234,25 @@ def apply_provider_operations_control_action(
             ),
         )
 
-    _validate_control_action_request(request)
-    repository = get_provider_operations_store()
-    affected_record_count = _apply_control_action(repository=repository, request=request)
-    event = ProviderOperationsEventRecord(
-        event_id=f"provider_ops_evt_{uuid4().hex[:12]}",
-        action_type=request.action_type,
-        scope=request.scope,
-        scope_key=request.scope_key,
-        reason=request.reason,
-        requested_by=request.requested_by,
-        approved_by=request.approved_by,
-        affected_record_count=affected_record_count,
-        authorization=authorization,
-        recorded_at=_utcnow(),
-    )
-    repository.save_operations_event(event)
-    return ProviderOperationsControlActionResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        provider_mode=settings.provider_mode,
-        event=_to_event_descriptor(event),
-        summary=[
-            f"Applied provider-operations action `{request.action_type.value}`.",
-            f"Affected provider-operations record count: {affected_record_count}.",
-            f"Action requested by `{request.requested_by}` and approved by `{request.approved_by}`.",
-        ],
-    )
-
 
 def _apply_control_action(
     *,
     repository: ProviderOperationsRepository,
-    request: ProviderOperationsControlActionRequest,
+    action_type: ProviderOperationsControlActionType,
+    scope: ProviderQuotaScope | None,
+    scope_key: object,
 ) -> int:
-    if request.action_type == ProviderOperationsControlActionType.RESET_ALL_QUOTAS:
+    if action_type == ProviderOperationsControlActionType.RESET_ALL_QUOTAS:
         return repository.reset_quota_states()
-    if request.action_type == ProviderOperationsControlActionType.RESET_QUOTA_SCOPE:
-        return repository.reset_quota_states(scope=request.scope, scope_key=request.scope_key)
-    if request.action_type == ProviderOperationsControlActionType.RESET_BUDGET:
+    if action_type == ProviderOperationsControlActionType.RESET_QUOTA_SCOPE:
+        return repository.reset_quota_states(scope=scope, scope_key=str(scope_key))
+    if action_type == ProviderOperationsControlActionType.RESET_BUDGET:
         return repository.reset_budget_state(budget_key=_BUDGET_KEY)
-    if request.action_type == ProviderOperationsControlActionType.RESET_DEGRADATION:
+    if action_type == ProviderOperationsControlActionType.RESET_DEGRADATION:
         # Degradation state is keyed per provider identity (issue #176, S3);
         # the operator reset clears every candidate's counters.
         return repository.reset_degradation_states()
-    if request.action_type == ProviderOperationsControlActionType.RESET_ALL_PROVIDER_OPERATIONS:
+    if action_type == ProviderOperationsControlActionType.RESET_ALL_PROVIDER_OPERATIONS:
         return (
             repository.reset_quota_states()
             + repository.reset_budget_state(budget_key=_BUDGET_KEY)
@@ -120,9 +261,14 @@ def _apply_control_action(
     raise RuntimeError("Unsupported provider-operations control action.")
 
 
-def _validate_control_action_request(request: ProviderOperationsControlActionRequest) -> None:
-    if request.action_type == ProviderOperationsControlActionType.RESET_QUOTA_SCOPE:
-        if request.scope is None or request.scope_key is None:
+def _validate_reset_shape(
+    *,
+    action_type: ProviderOperationsControlActionType,
+    scope: ProviderQuotaScope | None,
+    scope_key: str | None,
+) -> None:
+    if action_type == ProviderOperationsControlActionType.RESET_QUOTA_SCOPE:
+        if scope is None or scope_key is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=(
@@ -131,11 +277,11 @@ def _validate_control_action_request(request: ProviderOperationsControlActionReq
             )
         return
 
-    if request.scope is not None or request.scope_key is not None:
+    if scope is not None or scope_key is not None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(
-                f"{request.action_type.value} does not accept `scope` or `scope_key`; use RESET_QUOTA_SCOPE for targeted quota resets."
+                f"{action_type.value} does not accept `scope` or `scope_key`; use RESET_QUOTA_SCOPE for targeted quota resets."
             ),
         )
 

--- a/tests/integration/test_provider_api_contract.py
+++ b/tests/integration/test_provider_api_contract.py
@@ -22,6 +22,11 @@ from app.services.eval_run_submission_service import submit_evaluation_run
 from app.contracts.evals import EvaluationRunSubmissionRequest
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.unit.test_task_executor import _request
+from tests.support.caller_credentials import (
+    generate_caller_signing_key,
+    mint_caller_credential,
+    public_keys_setting,
+)
 
 
 def _budget_response(cost: float | None, *, stubbed: bool = False) -> ProviderExecutionResponse:
@@ -279,6 +284,39 @@ def test_provider_operations_status_route_reports_durable_sql_backed_circuit_sta
     assert body["degradation_status"]["upstream_error_failure_count"] == 1
 
 
+# Two real EdDSA credentials for the governed reset flow (issue #157).
+_REQUESTER_KEY = generate_caller_signing_key()
+_APPROVER_KEY = generate_caller_signing_key()
+_PUBLIC_KEYS = public_keys_setting(
+    **{"provider-ops-alpha": _REQUESTER_KEY, "provider-ops-beta": _APPROVER_KEY}
+)
+_REQUESTER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_REQUESTER_KEY,
+        key_id="provider-ops-alpha",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+_APPROVER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_APPROVER_KEY,
+        key_id="provider-ops-beta",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+
+
+def _verified_control_settings() -> None:
+    settings.caller_trust_mode = "verified_service_jwt"
+    settings.caller_jwt_issuer = "https://platform.lotus/issuer"
+    settings.caller_jwt_audience = "lotus-ai"
+    settings.caller_jwt_public_keys = _PUBLIC_KEYS
+
+
 def test_provider_operations_control_action_route_resets_durable_sql_backed_state(
     client: TestClient, tmp_path: Path
 ) -> None:
@@ -302,15 +340,47 @@ def test_provider_operations_control_action_route_resets_durable_sql_backed_stat
     record_provider_spend(_budget_response(0.75))
     record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
 
-    response = client.post(
-        "/platform/providers/control-plane-actions/reset",
+    _verified_control_settings()
+
+    # Governed reset over HTTP (issue #157): the request step parks the intent
+    # and no provider-operations state changes until a DISTINCT verified
+    # credential approves the exact hash.
+    pending = client.post(
+        "/platform/providers/control-plane-actions/reset-requests",
         json={
             "action_type": "RESET_ALL_PROVIDER_OPERATIONS",
-            "caller_app": "lotus-platform",
-            "requested_by": "ops.user@lotus",
-            "approved_by": "approver.user@lotus",
             "reason": "Clear durable provider controls after reviewed recovery.",
+            "requested_by": "ops.user@lotus",
         },
+        headers=_REQUESTER_HEADERS,
+    )
+    assert pending.status_code == 200
+    action = pending.json()["governed_action"]
+    assert action["status"] == "PENDING"
+    # The failure recorded above is still counted: nothing was reset yet.
+    quota_pending = client.get("/platform/providers/quota-policy", headers=_REQUESTER_HEADERS)
+    assert quota_pending.json()["quotas"][0]["current_request_count"] == 1
+
+    self_approval = client.post(
+        "/platform/providers/control-plane-actions/reset-approvals",
+        json={
+            "action_type": "RESET_ALL_PROVIDER_OPERATIONS",
+            "action_id": action["action_id"],
+            "action_hash": action["action_hash"],
+        },
+        headers=_REQUESTER_HEADERS,
+    )
+    assert self_approval.status_code == 403
+
+    response = client.post(
+        "/platform/providers/control-plane-actions/reset-approvals",
+        json={
+            "action_type": "RESET_ALL_PROVIDER_OPERATIONS",
+            "action_id": action["action_id"],
+            "action_hash": action["action_hash"],
+            "approved_by": "approver.user@lotus",
+        },
+        headers=_APPROVER_HEADERS,
     )
 
     assert response.status_code == 200
@@ -318,10 +388,16 @@ def test_provider_operations_control_action_route_resets_durable_sql_backed_stat
     assert body["event"]["action_type"] == "RESET_ALL_PROVIDER_OPERATIONS"
     assert body["event"]["affected_record_count"] == 3
     assert body["event"]["authorization"]["caller_app"] == "lotus-platform"
+    assert body["governed_action"]["requester_key_id"] == "provider-ops-alpha"
+    assert body["governed_action"]["approver_key_id"] == "provider-ops-beta"
+    assert "provider-ops-alpha" in body["event"]["requested_by"]
+    assert "provider-ops-beta" in body["event"]["approved_by"]
 
-    quota_response = client.get("/platform/providers/quota-policy")
-    budget_response = client.get("/platform/providers/budget-policy")
-    history_response = client.get("/platform/providers/control-plane-actions")
+    quota_response = client.get("/platform/providers/quota-policy", headers=_REQUESTER_HEADERS)
+    budget_response = client.get("/platform/providers/budget-policy", headers=_REQUESTER_HEADERS)
+    history_response = client.get(
+        "/platform/providers/control-plane-actions", headers=_REQUESTER_HEADERS
+    )
 
     assert quota_response.status_code == 200
     assert budget_response.status_code == 200
@@ -427,14 +503,12 @@ def test_provider_control_action_route_blocks_unauthorized_caller(
     upgrade_database_to_head(settings.database_url)
 
     response = client.post(
-        "/platform/providers/control-plane-actions/reset",
+        "/platform/providers/control-plane-actions/reset-requests",
         json={
             "action_type": "RESET_BUDGET",
-            "caller_app": "lotus-workbench",
-            "requested_by": "ops.user@lotus",
-            "approved_by": "approver.user@lotus",
             "reason": "Unauthorized budget reset attempt.",
         },
+        headers={"X-Caller-App": "lotus-workbench"},
     )
 
     assert response.status_code == 403

--- a/tests/unit/test_memory_provider_operations_repository.py
+++ b/tests/unit/test_memory_provider_operations_repository.py
@@ -6,9 +6,9 @@ from app.contracts.access_control import (
 )
 from app.contracts.providers import (
     ProviderFailureCategory,
-    ProviderOperationsControlActionType,
     ProviderQuotaScope,
 )
+from app.contracts.provider_operations import ProviderOperationsControlActionType
 from app.repositories.memory_provider_operations_repository import (
     InMemoryProviderOperationsRepository,
 )

--- a/tests/unit/test_openapi_contract.py
+++ b/tests/unit/test_openapi_contract.py
@@ -565,10 +565,12 @@ def test_governed_endpoints_define_explicit_operation_ids() -> None:
     assert spec["paths"]["/platform/providers/control-plane-actions"]["get"]["operationId"] == (
         "getProviderOperationsControlHistory"
     )
-    assert (
-        spec["paths"]["/platform/providers/control-plane-actions/reset"]["post"]["operationId"]
-        == "applyProviderOperationsControlAction"
-    )
+    assert spec["paths"]["/platform/providers/control-plane-actions/reset-requests"]["post"][
+        "operationId"
+    ] == ("requestProviderOperationsReset")
+    assert spec["paths"]["/platform/providers/control-plane-actions/reset-approvals"]["post"][
+        "operationId"
+    ] == ("approveProviderOperationsReset")
     assert spec["paths"]["/platform/providers/activation-readiness"]["get"]["operationId"] == (
         "getProviderActivationReadiness"
     )

--- a/tests/unit/test_provider_operations_control.py
+++ b/tests/unit/test_provider_operations_control.py
@@ -7,16 +7,23 @@ from app.contracts.providers import (
     ProviderAdapterKind,
     ProviderExecutionResponse,
     ProviderFailureCategory,
-    ProviderOperationsControlActionRequest,
-    ProviderOperationsControlActionType,
     ProviderQuotaScope,
 )
+from app.contracts.provider_operations import (
+    ProviderOperationsResetApprovalResponse,
+    ProviderOperationsControlActionType,
+    ProviderOperationsResetApprovalRequest,
+    ProviderOperationsResetIntentRequest,
+)
+from app.http.authenticated_caller import AuthenticatedCaller
 from app.services.provider_budget_policy import record_provider_spend
 from app.services.provider_degradation_state import record_provider_failure
 from app.services.provider_operations_control import (
-    apply_provider_operations_control_action,
+    approve_provider_operations_reset,
     build_provider_operations_control_history,
+    request_provider_operations_reset,
 )
+from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
 from app.services.provider_quota_policy import enforce_provider_quota
 from app.services.provider_request_builder import build_provider_execution_request
 from app.services.task_execution_pipeline import validate_task_request
@@ -42,6 +49,36 @@ def _budget_response(cost: float) -> ProviderExecutionResponse:
         stubbed=False,
         message="live response",
         structured_output={},
+    )
+
+
+def _governed_reset(
+    action_type: ProviderOperationsControlActionType,
+    *,
+    scope: ProviderQuotaScope | None = None,
+    scope_key: str | None = None,
+    reason: str = "Clear durable provider controls after reviewed recovery.",
+) -> ProviderOperationsResetApprovalResponse:
+    pending = request_provider_operations_reset(
+        ProviderOperationsResetIntentRequest(
+            action_type=action_type,
+            scope=scope,
+            scope_key=scope_key,
+            reason=reason,
+            requested_by="ops.user@lotus",
+        ),
+        GOVERNED_REQUESTER,
+    )
+    return approve_provider_operations_reset(
+        ProviderOperationsResetApprovalRequest(
+            action_type=action_type,
+            scope=scope,
+            scope_key=scope_key,
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+            approved_by="approver.user@lotus",
+        ),
+        GOVERNED_APPROVER,
     )
 
 
@@ -77,18 +114,17 @@ def test_provider_operations_control_action_resets_durable_state_and_records_eve
     record_provider_spend(_budget_response(0.75))
     record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
 
-    response = apply_provider_operations_control_action(
-        ProviderOperationsControlActionRequest(
-            action_type=ProviderOperationsControlActionType.RESET_ALL_PROVIDER_OPERATIONS,
-            caller_app="lotus-platform",
-            requested_by="ops.user@lotus",
-            approved_by="approver.user@lotus",
-            reason="Clear durable provider controls after reviewed recovery.",
-        )
-    )
+    response = _governed_reset(ProviderOperationsControlActionType.RESET_ALL_PROVIDER_OPERATIONS)
     history = build_provider_operations_control_history()
 
     assert response.event.affected_record_count == 3
+    assert response.governed_action.status.value == "EXECUTED"
+    assert response.governed_action.requester_key_id == "ops-key-alpha"
+    assert response.governed_action.approver_key_id == "ops-key-beta"
+    # The durable event records verified credential identities, not the
+    # caller-typed names.
+    assert "ops-key-alpha" in response.event.requested_by
+    assert "ops-key-beta" in response.event.approved_by
     assert history.reset_actions_supported is True
     assert history.latest_events[0].event_id == response.event.event_id
     assert (
@@ -102,14 +138,12 @@ def test_provider_operations_control_action_rejects_missing_targeted_quota_scope
     settings.database_url = "sqlite:///:memory:"
 
     try:
-        apply_provider_operations_control_action(
-            ProviderOperationsControlActionRequest(
+        request_provider_operations_reset(
+            ProviderOperationsResetIntentRequest(
                 action_type=ProviderOperationsControlActionType.RESET_QUOTA_SCOPE,
-                caller_app="lotus-platform",
-                requested_by="ops.user@lotus",
-                approved_by="approver.user@lotus",
                 reason="Targeted quota reset.",
-            )
+            ),
+            GOVERNED_REQUESTER,
         )
     except HTTPException as exc:
         assert exc.status_code == 422
@@ -119,14 +153,12 @@ def test_provider_operations_control_action_rejects_missing_targeted_quota_scope
 
 def test_provider_operations_control_action_rejects_nondurable_store_mode() -> None:
     try:
-        apply_provider_operations_control_action(
-            ProviderOperationsControlActionRequest(
+        request_provider_operations_reset(
+            ProviderOperationsResetIntentRequest(
                 action_type=ProviderOperationsControlActionType.RESET_BUDGET,
-                caller_app="lotus-platform",
-                requested_by="ops.user@lotus",
-                approved_by="approver.user@lotus",
                 reason="Budget reset on in-memory store should fail.",
-            )
+            ),
+            GOVERNED_REQUESTER,
         )
     except HTTPException as exc:
         assert exc.status_code == 409
@@ -148,16 +180,11 @@ def test_provider_operations_control_action_resets_targeted_quota_scope(tmp_path
     )
     enforce_provider_quota(provider_request)
 
-    response = apply_provider_operations_control_action(
-        ProviderOperationsControlActionRequest(
-            action_type=ProviderOperationsControlActionType.RESET_QUOTA_SCOPE,
-            caller_app="lotus-platform",
-            scope=ProviderQuotaScope.TASK,
-            scope_key="explain.v1",
-            requested_by="ops.user@lotus",
-            approved_by="approver.user@lotus",
-            reason="Targeted task quota reset after review.",
-        )
+    response = _governed_reset(
+        ProviderOperationsControlActionType.RESET_QUOTA_SCOPE,
+        scope=ProviderQuotaScope.TASK,
+        scope_key="explain.v1",
+        reason="Targeted task quota reset after review.",
     )
 
     assert response.event.affected_record_count == 1
@@ -170,18 +197,96 @@ def test_provider_operations_control_action_blocks_unauthorized_caller(tmp_path:
     settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-provider-ops-unauthorized.db'}"
     upgrade_database_to_head(settings.database_url)
 
+    unauthorized = AuthenticatedCaller(
+        caller_app="lotus-workbench",
+        trust_source="verified_service_jwt",
+        credential_key_id="ops-key-alpha",
+    )
     try:
-        apply_provider_operations_control_action(
-            ProviderOperationsControlActionRequest(
+        request_provider_operations_reset(
+            ProviderOperationsResetIntentRequest(
                 action_type=ProviderOperationsControlActionType.RESET_BUDGET,
-                caller_app="lotus-workbench",
-                requested_by="ops.user@lotus",
-                approved_by="approver.user@lotus",
                 reason="Unauthorized budget reset attempt.",
-            )
+            ),
+            unauthorized,
         )
     except HTTPException as exc:
         assert exc.status_code == 403
         assert "not authorized for provider control-plane actions" in str(exc.detail)
     else:
         raise AssertionError("Expected unauthorized provider control action to be rejected.")
+
+
+def test_a_reset_cannot_be_self_approved_and_state_survives(tmp_path: Path) -> None:
+    """The target invariant on the provider domain: the requester's own
+    credential cannot execute the reset, and the state the reset would clear
+    is still there afterwards."""
+
+    settings.provider_operations_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-provider-ops-self.db'}"
+    settings.live_text_degradation_enforced = True
+    settings.live_text_degraded_failure_count_threshold = 1
+    settings.live_text_circuit_open_failure_count_threshold = 2
+    settings.live_text_circuit_open_seconds = 60
+    upgrade_database_to_head(settings.database_url)
+
+    record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
+    pending = request_provider_operations_reset(
+        ProviderOperationsResetIntentRequest(
+            action_type=ProviderOperationsControlActionType.RESET_DEGRADATION,
+            reason="Self-approval attempt.",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    try:
+        approve_provider_operations_reset(
+            ProviderOperationsResetApprovalRequest(
+                action_type=ProviderOperationsControlActionType.RESET_DEGRADATION,
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_REQUESTER,
+        )
+    except HTTPException as exc:
+        assert exc.status_code == 403
+        assert "distinct" in str(exc.detail)
+    else:
+        raise AssertionError("Expected self-approval to be refused.")
+    from app.services.provider_degradation_state import build_provider_degradation_status
+
+    assert build_provider_degradation_status().consecutive_failure_count == 1
+
+
+def test_an_approval_cannot_be_redirected_to_a_different_reset_shape(
+    tmp_path: Path,
+) -> None:
+    """The approver restates the reset shape; approving a degradation clear
+    with a pending budget-reset action refuses rather than executing either."""
+
+    settings.provider_operations_store_mode = "sqlalchemy"
+    settings.database_url = f"sqlite:///{tmp_path / 'lotus-ai-provider-ops-redirect.db'}"
+    upgrade_database_to_head(settings.database_url)
+
+    pending = request_provider_operations_reset(
+        ProviderOperationsResetIntentRequest(
+            action_type=ProviderOperationsControlActionType.RESET_BUDGET,
+            reason="Budget reset pending.",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    try:
+        approve_provider_operations_reset(
+            ProviderOperationsResetApprovalRequest(
+                action_type=ProviderOperationsControlActionType.RESET_DEGRADATION,
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+    except HTTPException as exc:
+        assert exc.status_code == 409
+        assert "cannot be redirected" in str(exc.detail)
+    else:
+        raise AssertionError("Expected shape-redirected approval to be refused.")

--- a/tests/unit/test_sqlalchemy_provider_operations_repository.py
+++ b/tests/unit/test_sqlalchemy_provider_operations_repository.py
@@ -16,7 +16,7 @@ from app.repositories.provider_operations_repository import (
     ProviderOperationsEventRecord,
     ProviderQuotaStateRecord,
 )
-from app.contracts.providers import ProviderOperationsControlActionType
+from app.contracts.provider_operations import ProviderOperationsControlActionType
 from app.repositories.sqlalchemy_provider_operations_repository import (
     SqlAlchemyProviderOperationsRepository,
 )


### PR DESCRIPTION
Issue #157, slice 3: provider-operations resets onto the governed-action primitive. Remaining: verified requester on safety actions, and the async-recovery migration to `SYSTEM_ORIGINATED`.

## Control-plane outcome

No single principal can re-open a spending envelope or resume traffic past breaker protection. Every provider-operations reset is requested under one verified credential and approved under a distinct one against the exact reset shape, and the durable event history records the credential identities.

## Invariant

The risk-direction rule, measured against what actually exists: the steering said "enable provider", but **no runtime enable-provider action exists** — rollout state is configuration, not an API. What exists is five RESET actions, and every one is permissive: quota and budget resets re-open economic envelopes, and `RESET_DEGRADATION` resumes traffic the breaker's own health protection stopped — kill-switch clearance's sibling. All five are therefore governed, and since nothing safety-directional remains on the single-call route, **it is removed outright** rather than left as a refusing stub.

## One authority

Same primitive, third consumer, still no domain approval machinery. `PROVIDER_OPERATIONS_RESET` joins the vocabulary; the approver **restates the reset shape** (action type, and scope/key for targeted quota resets), so an approval cannot be redirected from a pending budget reset to a degradation clear — refused with `cannot be redirected`, tested. One pending action per exact reset shape, so a pending targeted quota reset is not superseded by an unrelated budget reset.

## The ratchet fired, and the answer was a split, not a bump

Adding the reset contracts pushed `contracts/providers.py` past its dated allowlist ceiling (1061 > 1023). Per the ratchet's design, the ceiling was not raised: the provider-operations control vocabulary moved to a new `contracts/provider_operations.py`, `providers.py` dropped to **920 lines — under the default ceiling — and its allowlist entry is deleted**. The dead single-call contracts (`ProviderOperationsControlActionRequest`, `...ActionResponse`) are removed, not moved.

## API

- `POST /platform/providers/control-plane-actions/reset-requests` → pending governed action + hash; no provider-operations state changes.
- `POST /platform/providers/control-plane-actions/reset-approvals` → distinct credential + exact hash + restated shape executes the reset; response carries the event **and** the evidence record.
- `POST /platform/providers/control-plane-actions/reset` is **removed**, with its request/response contracts.

## Evidence

- HTTP flow with two real EdDSA credentials: request parks the intent and a quota counter is proven **still counted** while pending; self-approval refused 403; distinct-credential approval executes with `affected_record_count == 3` and both credential identities on the durable event.
- Unit: all five reset shapes through the governed helper; shape-redirect refused; self-approval refused with the degradation failure count proven intact afterwards; malformed targeted reset refused at the request step before anything is parked; nondurable store refused; unauthorized caller refused.
- OpenAPI operation-id contract updated for both routes; route coverage picks both up from the OpenAPI document.

Full local gate: whole suite, `make lint` (module budget passing at the *lower* bound), `make typecheck` (734 files). No migration — the governed-actions table carries the new type.
