### PR TITLE
feat(routing): capability requirement contract, recorded and visibly unenforced

### DIFF
--- a/src/app/contracts/capability_requirements.py
+++ b/src/app/contracts/capability_requirements.py
@@ -1,0 +1,87 @@
+"""Capability requirements: what a workload needs, never which vendor feature (issue #244, S1).
+
+A consuming Lotus application already cannot name a provider or model — no
+request contract exposes one. What it could not do until now is state
+*requirements*: the workload needs structured output, must answer within a
+latency ceiling, must not exceed a governed cost. This module is that
+vocabulary, deliberately provider-neutral so it survives provider churn:
+``structured_output_required``, never ``openai_json_mode``; ``max_latency_ms``,
+never ``use_fast_model``.
+
+Slice 1 is the contract only. Declared requirements are validated and recorded
+as execution evidence with an explicit ``NOT_ENFORCED`` posture — never
+silently ignored, because a consumer who declares a ceiling must be able to
+see whether anything is holding it. Slice 3 makes them an eligibility filter
+in the existing routing decision and flips the posture.
+
+Dimensions ship only when they have a concrete enforcement story against
+catalogue facts provable from current evidence. Residency, data
+classification, workload criticality and modality are deliberately absent: no
+governed vocabulary for them exists in the platform yet, and inventing one
+here would park dead, unenforceable fields on every request.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# The slice-1 posture: requirements are recorded, visible, and not yet an
+# eligibility filter. Slice 3 introduces the enforced posture alongside the
+# filter itself; this constant is the only value that exists until then.
+REQUIREMENTS_NOT_ENFORCED = "NOT_ENFORCED"
+
+
+class CapabilityRequirements(BaseModel):
+    """Workload requirements declared alongside a task request.
+
+    Every field is optional; at least one must be set — an empty requirements
+    object is a statement that means nothing, and recording it as evidence
+    would be noise wearing a contract's clothes.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    structured_output_required: bool | None = Field(
+        default=None,
+        description=(
+            "The workload requires machine-parseable structured output (the Lotus "
+            "capability, not any vendor's JSON mode)."
+        ),
+    )
+    tool_calling_required: bool | None = Field(
+        default=None,
+        description="The workload requires model-initiated tool calling.",
+    )
+    max_latency_ms: int | None = Field(
+        default=None,
+        ge=100,
+        le=600_000,
+        description="Latency ceiling for the serving execution, in milliseconds.",
+    )
+    max_estimated_cost_usd: float | None = Field(
+        default=None,
+        gt=0,
+        le=1_000,
+        description=(
+            "Ceiling on the governed cost estimate for one execution, in the same "
+            "estimate currency as `estimated_cost_usd` on the response."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _at_least_one_dimension(self) -> CapabilityRequirements:
+        if all(getattr(self, field) is None for field in CapabilityRequirements.model_fields):
+            raise ValueError(
+                "capability requirements must state at least one dimension; omit the "
+                "requirements object entirely when the workload has none"
+            )
+        return self
+
+    def declared_dimensions(self) -> dict[str, bool | int | float]:
+        """The dimensions actually stated, for evidence recording."""
+
+        return {
+            field: value
+            for field in CapabilityRequirements.model_fields
+            if (value := getattr(self, field)) is not None
+        }

--- a/src/app/contracts/tasks.py
+++ b/src/app/contracts/tasks.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from app.contracts.access_control import AuthorizationDecision
 from app.contracts.output_validation import OutputValidationOutcome
+from app.contracts.capability_requirements import CapabilityRequirements
 from app.contracts.evidence import ExecutionEvidenceBundle
 from app.contracts.prompts import PromptSelectionTraceDescriptor
 from app.contracts.providers import ProviderAdapterKind, RoutingDecisionDescriptor
@@ -93,6 +94,14 @@ class TaskExecutionRequest(BaseModel):
     input_mode: TaskInputMode = Field(description="How the task input context is provided.")
     caller: CallerMetadata = Field(description="Calling system metadata.")
     context: TaskContextEnvelope = Field(description="Structured context envelope for execution.")
+    requirements: CapabilityRequirements | None = Field(
+        default=None,
+        description=(
+            "Optional workload requirements (issue #244, S1). Validated and recorded as "
+            "execution evidence with an explicit NOT_ENFORCED posture until capability "
+            "eligibility ships; absent means today's routing behaviour, unchanged."
+        ),
+    )
     expected_output_label: OutputLabel | None = Field(
         default=None,
         description="Optional caller assertion about the expected output label for the task.",

--- a/src/app/services/execution_evidence.py
+++ b/src/app/services/execution_evidence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.contracts.access_control import AuthorizationDecision
+from app.contracts.capability_requirements import REQUIREMENTS_NOT_ENFORCED
 from app.contracts.evidence import ExecutionEvidenceBundle, ExecutionEvidenceDescriptor
 from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.prompts import PromptDescriptor, PromptSelectionTraceDescriptor
@@ -43,7 +44,36 @@ def build_execution_evidence(
             _output_validation_descriptor(output_validation=output_validation),
         ]
     )
+    if request.requirements is not None:
+        descriptors.append(_capability_requirements_descriptor(request=request))
     return ExecutionEvidenceBundle(descriptors=descriptors)
+
+
+def _capability_requirements_descriptor(
+    *, request: TaskExecutionRequest
+) -> ExecutionEvidenceDescriptor:
+    """Declared workload requirements, with their enforcement posture stated.
+
+    Recording a requirement without saying whether anything enforces it would
+    let a consumer believe a ceiling is being held when nothing holds it -
+    the declared-versus-measured defect this platform keeps finding. Slice 3
+    of issue #244 turns these into an eligibility filter and flips the
+    posture; until then the evidence says NOT_ENFORCED, visibly.
+    """
+
+    assert request.requirements is not None
+    return ExecutionEvidenceDescriptor(
+        evidence_type="capability_requirements",
+        summary=(
+            "The caller declared workload capability requirements; they are recorded and "
+            f"{REQUIREMENTS_NOT_ENFORCED}: capability eligibility has not shipped, so no "
+            "routing filter holds them yet."
+        ),
+        attributes={
+            "declared": request.requirements.declared_dimensions(),
+            "requirements_enforcement": REQUIREMENTS_NOT_ENFORCED,
+        },
+    )
 
 
 def _output_validation_descriptor(

--- a/tests/integration/test_task_api_contract.py
+++ b/tests/integration/test_task_api_contract.py
@@ -1034,3 +1034,64 @@ def test_task_execute_contract_guards_against_local_contract_echo_output(
         "invalid_grounded_summary_language"
     )
     assert body["result"]["structured_output"]["talking_points"]
+
+
+def test_declared_capability_requirements_ride_the_response_visibly_unenforced(
+    client: TestClient,
+) -> None:
+    """Issue #244 S1 at the HTTP boundary: a consumer declares what the
+    workload needs — never a provider or a vendor feature — and the response
+    shows the declaration recorded with an explicit NOT_ENFORCED posture, so
+    nobody can mistake a recorded ceiling for a held one."""
+
+    response = client.post(
+        "/ai/tasks/execute",
+        json={
+            "task_id": "explain.v1",
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {
+                "caller_app": "lotus-manage",
+                "correlation_id": "corr-requirements-http",
+                "tenant_id": "tenant-sg-001",
+            },
+            "context": {
+                "summary": "Explain rebalance outcome",
+                "payload": {"status": "BLOCKED"},
+                "source_refs": ["lotus-manage:run:reb_http_1"],
+            },
+            "requirements": {
+                "structured_output_required": True,
+                "max_latency_ms": 2000,
+            },
+            "expected_output_label": "EXPLANATION_ONLY",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    descriptor = next(
+        d
+        for d in body["evidence"]["descriptors"]
+        if d["evidence_type"] == "capability_requirements"
+    )
+    assert descriptor["attributes"]["requirements_enforcement"] == "NOT_ENFORCED"
+    assert descriptor["attributes"]["declared"] == {
+        "structured_output_required": True,
+        "max_latency_ms": 2000,
+    }
+
+    empty = client.post(
+        "/ai/tasks/execute",
+        json={
+            "task_id": "explain.v1",
+            "input_mode": "STRUCTURED_CONTEXT",
+            "caller": {"caller_app": "lotus-manage", "correlation_id": "corr-req-empty"},
+            "context": {
+                "summary": "Explain rebalance outcome",
+                "payload": {"status": "BLOCKED"},
+                "source_refs": ["lotus-manage:run:reb_http_2"],
+            },
+            "requirements": {},
+        },
+    )
+    assert empty.status_code == 422

--- a/tests/unit/test_capability_requirements.py
+++ b/tests/unit/test_capability_requirements.py
@@ -1,0 +1,110 @@
+"""The capability requirement contract (issue #244, S1).
+
+Slice 1 is vocabulary plus honesty: declared requirements are validated and
+recorded as execution evidence with an explicit NOT_ENFORCED posture, and an
+absent requirements object leaves every execution surface byte-identical to
+before the field existed.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.capability_requirements import (
+    REQUIREMENTS_NOT_ENFORCED,
+    CapabilityRequirements,
+)
+from app.contracts.tasks import (
+    CallerMetadata,
+    OutputLabel,
+    TaskContextEnvelope,
+    TaskExecutionRequest,
+    TaskInputMode,
+)
+from app.services.task_executor import execute_task
+
+
+def _request(requirements: CapabilityRequirements | None = None) -> TaskExecutionRequest:
+    return TaskExecutionRequest(
+        task_id="explain.v1",
+        input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+        caller=CallerMetadata(
+            caller_app="lotus-manage",
+            correlation_id="corr-requirements-001",
+            tenant_id="tenant-sg-001",
+        ),
+        context=TaskContextEnvelope(
+            summary="Explain rebalance outcome",
+            payload={"status": "BLOCKED"},
+            source_refs=["lotus-manage:run:reb_001"],
+        ),
+        requirements=requirements,
+        expected_output_label=OutputLabel.EXPLANATION_ONLY,
+    )
+
+
+def test_an_empty_requirements_object_is_refused() -> None:
+    """An empty object is a statement that means nothing; the contract makes
+    'no requirements' spellable only by omission."""
+
+    with pytest.raises(ValidationError) as exc_info:
+        CapabilityRequirements()
+    assert "at least one dimension" in str(exc_info.value)
+
+
+def test_dimension_bounds_are_enforced() -> None:
+    with pytest.raises(ValidationError):
+        CapabilityRequirements(max_latency_ms=10)
+    with pytest.raises(ValidationError):
+        CapabilityRequirements(max_estimated_cost_usd=0)
+    with pytest.raises(ValidationError):
+        CapabilityRequirements(max_estimated_cost_usd=1_000_000)
+
+
+def test_declared_dimensions_reports_only_what_was_stated() -> None:
+    requirements = CapabilityRequirements(structured_output_required=True, max_latency_ms=2_000)
+    assert requirements.declared_dimensions() == {
+        "structured_output_required": True,
+        "max_latency_ms": 2_000,
+    }
+
+
+def test_absent_requirements_leave_the_execution_unchanged() -> None:
+    """The additive guarantee: without the field, nothing about the response
+    or its evidence differs from before the contract existed."""
+
+    response = execute_task(_request())
+
+    assert response.status.value == "COMPLETED"
+    evidence_types = [d.evidence_type for d in response.evidence.descriptors]
+    assert "capability_requirements" not in evidence_types
+    assert len(response.evidence.descriptors) == 8
+
+
+def test_declared_requirements_are_recorded_with_an_explicit_unenforced_posture() -> None:
+    """Recording a requirement without stating whether anything enforces it
+    would let a consumer believe a ceiling is held when nothing holds it."""
+
+    response = execute_task(
+        _request(
+            CapabilityRequirements(
+                structured_output_required=True,
+                max_latency_ms=2_000,
+                max_estimated_cost_usd=0.25,
+            )
+        )
+    )
+
+    assert response.status.value == "COMPLETED"
+    descriptor = next(
+        d for d in response.evidence.descriptors if d.evidence_type == "capability_requirements"
+    )
+    assert descriptor.attributes["requirements_enforcement"] == REQUIREMENTS_NOT_ENFORCED
+    assert descriptor.attributes["declared"] == {
+        "structured_output_required": True,
+        "max_latency_ms": 2_000,
+        "max_estimated_cost_usd": 0.25,
+    }
+    assert "NOT_ENFORCED" in descriptor.summary
+    # Requirements never grant or change routing in this slice: the serving
+    # identity is exactly what it would have been without them.
+    assert response.audit.provider_id == "text.stub"


### PR DESCRIPTION
Issue #244, slice 1 of the capability-driven routing programme. Slice 2 (catalogue capability dimensions) and slice 3 (eligibility in the existing routing decision) follow as their own bounded PRs.

## Control-plane outcome

A consuming Lotus application can state what its workload **needs** — structured output, a latency ceiling, a governed cost ceiling — in a provider-neutral vocabulary that survives provider churn, and can see on the response exactly what was recorded and whether anything enforces it yet.

## Invariant

A declared requirement is never silently ignored. Present requirements are recorded as a `capability_requirements` evidence descriptor with an explicit `requirements_enforcement: NOT_ENFORCED` posture on the response itself; absent requirements leave every execution surface **byte-identical** to before the field existed (asserted by descriptor count). Slice 3 flips the posture when the filter exists — a consumer who declares early is safe and *visibly* unenforced.

This is deliberate defence against the declared-versus-measured defect class this platform keeps finding (static readiness constants, the readiness probe that never ran): a recorded ceiling must not look like a held one.

## One authority

The vocabulary lives in one contract module (`contracts/capability_requirements.py`); the recording rides the existing execution-evidence bundle — the same seam that carries the output-validation verdict (#231) — so it reaches the run record and every projection with no new field, ledger, or migration.

## Vocabulary discipline

- `structured_output_required = true`, **not** `openai_json_mode = true`; `max_latency_ms`, **not** `use_fast_model` — workload needs, never vendor features.
- Four dimensions ship, each with a concrete enforcement story against catalogue facts provable from current evidence: structured output (strict-JSON packs run today), tool calling (provably UNKNOWN/NOT_SUPPORTED today), latency ceiling (timeouts exist), estimated-cost ceiling (rate-card estimates exist).
- **Residency, data classification, workload criticality and modality are deliberately absent**: measured, no governed vocabulary for them exists anywhere in the platform, and inventing enums here would park dead, unenforceable fields on every request — the speculative capability population this programme bans. They join additively when their vocabulary exists with an enforcement story.
- An **empty requirements object is refused** (422): "no requirements" is spellable only by omission, so the evidence stream cannot fill with meaningless declarations.
- The cost ceiling is `max_estimated_cost_usd` — it bounds the same non-authoritative estimate the response carries, never financial truth.

## Evidence

- Contract: empty object refused; dimension bounds enforced; `declared_dimensions()` reports only what was stated.
- Service: absent requirements → descriptor count unchanged (8); declared requirements → descriptor with the exact declared dims, `NOT_ENFORCED` posture, and the serving identity proven unchanged by the declaration.
- HTTP: the declaration and posture ride the response body a consumer actually reads; the empty object 422s at the boundary.

Full local gate: 2,208 tests, `make lint`, `make typecheck` (736 files). Purely additive — no migration, no behaviour change without the field.