### PR TITLE
feat(catalogue): seed capability facts from approval evidence, and never un-assess

### DIFF
--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -43,6 +43,7 @@ from app.providers.configured_workflow_run_model_risk_inventory import (
 )
 from app.services.access_control_authorization import authorize_request, require_authorized
 from app.services.model_catalogue_store import get_model_catalogue_repository
+from app.services.output_contracts import output_contract_exists
 from app.services.provider_execution_config import resolve_provider_execution_config
 
 _LIVE_TEXT_MODES = frozenset(
@@ -175,6 +176,17 @@ def build_seed_model_catalogue_entries() -> list[ModelCatalogueEntry]:
             lifecycle_state=ModelLifecycleState.APPROVED,
             revision_pinned=True,
             modalities=["text"],
+            # Provable from the approval evidence itself (issue #244, S2): a
+            # pack-approved model has produced output that the deterministic
+            # validator held to the pack's strict-JSON schema contract. No
+            # other capability dimension has in-repo evidence, so no other
+            # dimension is seeded - unknown stays unknown, and configuration
+            # alone (the settings rows above) proves nothing.
+            supports_structured_output=(
+                True
+                if any(output_contract_exists(pack_id) for pack_id in approved.workflow_pack_ids)
+                else None
+            ),
             approved_workflow_pack_ids=list(approved.workflow_pack_ids),
             approval_evidence_refs=[approved.approval_ref],
             approved_from_utc=approved.approved_from_utc,
@@ -185,6 +197,35 @@ def build_seed_model_catalogue_entries() -> list[ModelCatalogueEntry]:
         )
 
     return [entries[entry_id] for entry_id in sorted(entries)]
+
+
+_CAPABILITY_DIMENSIONS = (
+    "supports_structured_output",
+    "supports_tool_calling",
+    "supports_streaming",
+    "context_window_tokens",
+    "max_output_tokens",
+)
+
+
+def _preserve_assessed_capabilities(
+    *, candidate: ModelCatalogueEntry, existing: ModelCatalogueEntry
+) -> ModelCatalogueEntry:
+    """Unknown never overwrites known (issue #244, S2).
+
+    Null on a capability dimension means *not assessed*. A seed row that has
+    no evidence for a dimension must not erase an assessment that already
+    exists - reconciling the catalogue with configuration would otherwise
+    quietly un-assess facts every startup. The seed may add facts it can
+    prove; it may never subtract ones it cannot.
+    """
+
+    preserved = {
+        dimension: getattr(existing, dimension)
+        for dimension in _CAPABILITY_DIMENSIONS
+        if getattr(candidate, dimension) is None and getattr(existing, dimension) is not None
+    }
+    return candidate.model_copy(update=preserved) if preserved else candidate
 
 
 def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
@@ -210,6 +251,7 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
             # but never out of an operator-terminal state: a retired model
             # stays retired until an operator explicitly transitions it.
             candidate = candidate.model_copy(update={"lifecycle_state": existing.lifecycle_state})
+        candidate = _preserve_assessed_capabilities(candidate=candidate, existing=existing)
         if candidate.model_dump(exclude=_SEED_MANAGED_EXCLUDES) == existing.model_dump(
             exclude=_SEED_MANAGED_EXCLUDES
         ):

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -547,3 +547,71 @@ def test_drift_observations_survive_a_store_restart_in_sqlalchemy_mode(
     assert set(by_observed) == {"qwen3:8b-q4-2026-03", "qwen3:8b-q5-2026-06"}
     assert by_observed["qwen3:8b-q4-2026-03"].observation_count == 2
     assert by_observed["qwen3:8b-q5-2026-06"].observation_count == 1
+
+
+def test_capability_facts_are_seeded_only_from_approval_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #244 S2: a pack-approved model has provably produced output the
+    deterministic validator held to the pack's strict-JSON schema contract,
+    so structured-output support is a fact. Configuration alone proves
+    nothing, and no other dimension has in-repo evidence - unknown stays
+    unknown rather than becoming an optimistic default."""
+
+    monkeypatch.setattr(settings, "provider_mode", "openai")
+    monkeypatch.setattr(settings, "provider_rollout_state", "CANARY_ENABLED")
+    monkeypatch.setattr(settings, "live_text_provider_id", "text.openai")
+    monkeypatch.setattr(settings, "live_text_model_id", "gpt-5.4")
+    monkeypatch.setattr(settings, "live_text_provider_api_key", "secret")
+    monkeypatch.setattr(settings, "workflow_run_model_risk_inventory_json", APPROVED_INVENTORY_JSON)
+
+    entries = {entry.model_family: entry for entry in build_seed_model_catalogue_entries()}
+
+    approved = entries["gpt-5.2"]
+    assert approved.supports_structured_output is True
+    assert approved.supports_tool_calling is None
+    assert approved.supports_streaming is None
+    assert approved.context_window_tokens is None
+
+    configured = entries["gpt-5.4"]
+    assert configured.supports_structured_output is None
+    assert configured.supports_tool_calling is None
+
+
+def test_reseeding_never_unassesses_a_known_capability_fact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Null means not assessed. The seed may add facts it can prove; it must
+    never subtract ones it cannot - otherwise every startup reconcile would
+    quietly erase operator assessments back to unknown."""
+
+    monkeypatch.setattr(settings, "provider_mode", "openai")
+    monkeypatch.setattr(settings, "provider_rollout_state", "CANARY_ENABLED")
+    monkeypatch.setattr(settings, "live_text_provider_id", "text.openai")
+    monkeypatch.setattr(settings, "live_text_model_id", "gpt-5.4")
+    monkeypatch.setattr(settings, "live_text_provider_api_key", "secret")
+    monkeypatch.setattr(settings, "workflow_run_model_risk_inventory_json", "[]")
+
+    first = ensure_model_catalogue_seeded()
+    assert first.created_count == 1
+    repository = get_model_catalogue_repository()
+    [entry] = repository.list_entries()
+    assert entry.supports_tool_calling is None
+
+    # An operator assessment lands on the row the seed knows nothing about.
+    upsert_model_catalogue_entry(
+        entry.model_copy(
+            update={
+                "supports_tool_calling": False,
+                "supports_structured_output": True,
+                "context_window_tokens": 128_000,
+            }
+        )
+    )
+
+    report = ensure_model_catalogue_seeded()
+    [reconciled] = repository.list_entries()
+    assert reconciled.supports_tool_calling is False
+    assert reconciled.supports_structured_output is True
+    assert reconciled.context_window_tokens == 128_000
+    assert report.updated_count == 0


### PR DESCRIPTION
Issue #244, slice 2: catalogue capability dimensions, seeded only from provable evidence. Slice 3 (eligibility in the existing routing decision) follows.

## Control-plane outcome

The catalogue can answer "does this model support structured output?" with a fact backed by evidence, "not assessed" stated honestly, and never an optimistic default — and an assessment, once made, cannot be silently erased by a startup reconcile.

## Invariant

**Unknown never silently becomes supported, and known never silently becomes unknown.** Null on a capability dimension means *not assessed*; the seed may add facts it can prove and may never subtract ones it cannot.

## Measured before building

The catalogue **already carried** the capability dimensions this slice's programme text describes — `supports_structured_output` / `supports_tool_calling` / `supports_streaming` as nullable booleans with null-means-not-assessed semantics, plus `modalities`, `context_window_tokens`, `max_output_tokens` — but the seeder never populated any of them, and nothing reads them yet. So this slice is not "add capability dimensions"; it is the two rules that make the existing dimensions trustworthy.

## Rule 1 — seed only what the evidence proves

An inventory-**approved** model was approved for named workflow packs; every pack family has a JSON Schema output contract (`contracts/ai-task-outputs/<pack>.v1.json`); the deterministic validator holds pack-bound output to that contract with strict-JSON posture (#156). So a pack-approved model has *provably produced schema-valid structured output* — `supports_structured_output=True` is derived from exactly that chain (`output_contract_exists` over the approved pack ids), anchored to the approval evidence already on the row.

Nothing else is seeded, stated in code with reasons: configuration alone (the settings-seeded rows) proves nothing, so those rows stay unassessed; no tool-calling or streaming path exists in the platform, so neither SUPPORTED nor NOT_SUPPORTED is provable and both stay null; context-window and output-token facts have no in-repo evidence source. Vendor documentation is not in-repo evidence.

## Rule 2 — reseeding never un-assesses

`ensure_model_catalogue_seeded` reconciles the store with configuration on every startup. Without protection, a null-seeded dimension would overwrite an operator's assessment back to unknown on the next boot — a silent fact-erasure loop. `_preserve_assessed_capabilities` carries every assessed dimension through the reconcile (the same discipline the reconcile already applies to operator lifecycle transitions), and the reconcile reports the row `unchanged`.

## Evidence

- `test_capability_facts_are_seeded_only_from_approval_evidence`: the inventory-approved row gets `supports_structured_output=True` and nothing else; the settings-configured row gets nothing at all.
- `test_reseeding_never_unassesses_a_known_capability_fact`: an operator assessment (`supports_tool_calling=False`, `context_window_tokens=128000`) survives a reseed byte-for-byte, reported unchanged. Removing the preservation call makes this test fail — the guard is load-bearing, not decorative.

Full local gate: whole suite, `make lint`, `make typecheck` (736 files). No migration — the columns already existed; this slice makes them honest.
