### PR TITLE
feat(routing): capability eligibility in the existing routing decision

### DIFF
--- a/src/app/contracts/capability_requirements.py
+++ b/src/app/contracts/capability_requirements.py
@@ -29,6 +29,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 # eligibility filter. Slice 3 introduces the enforced posture alongside the
 # filter itself; this constant is the only value that exists until then.
 REQUIREMENTS_NOT_ENFORCED = "NOT_ENFORCED"
+REQUIREMENTS_ENFORCED = "ENFORCED"
+REQUIREMENTS_PARTIALLY_ENFORCED = "PARTIALLY_ENFORCED"
 
 
 class CapabilityRequirements(BaseModel):

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -4,6 +4,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from app.contracts.capability_requirements import CapabilityRequirements
+
 
 from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
 
@@ -48,6 +50,12 @@ class ProviderFailureCategory(str, Enum):
     MODEL_LIFECYCLE_INELIGIBLE = "MODEL_LIFECYCLE_INELIGIBLE"
     KILL_SWITCH_ACTIVE = "KILL_SWITCH_ACTIVE"
     CIRCUIT_OPEN = "CIRCUIT_OPEN"
+    # Capability eligibility (issue #244, S3). Distinct reasons on purpose: a
+    # capability the catalogue proves absent and one it has never assessed are
+    # different operator stories, and unknown failing closed must be visible
+    # as unknown - not laundered into a confident NOT_SUPPORTED.
+    CAPABILITY_NOT_SUPPORTED = "CAPABILITY_NOT_SUPPORTED"
+    CAPABILITY_UNKNOWN = "CAPABILITY_UNKNOWN"
     PROVIDER_TIMEOUT = "PROVIDER_TIMEOUT"
     PROVIDER_RATE_LIMITED = "PROVIDER_RATE_LIMITED"
     PROVIDER_UPSTREAM_ERROR = "PROVIDER_UPSTREAM_ERROR"
@@ -109,6 +117,20 @@ class RoutingDecisionDescriptor(BaseModel):
     strategy: RoutingStrategy = Field(description="Routing strategy the policy applied.")
     candidates: list[RoutingCandidateDescriptor] = Field(
         description="Every candidate the policy considered for this execution.",
+    )
+    requirements_enforced_dimensions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Declared capability-requirement dimensions this decision enforced as "
+            "eligibility or execution constraints (issue #244, S3)."
+        ),
+    )
+    requirements_unenforced_dimensions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Declared dimensions no filter holds yet; recorded so a declared ceiling "
+            "can never silently pass for a held one."
+        ),
     )
     selected_provider_id: str | None = Field(
         default=None,
@@ -617,6 +639,10 @@ class ProviderOperatorProfileResponse(BaseModel):
 
 class ProviderExecutionRequest(BaseModel):
     task_id: str = Field(description="Bounded lotus-ai task identifier being executed.")
+    requirements: CapabilityRequirements | None = Field(
+        default=None,
+        description="Declared workload requirements; None routes exactly as before (issue #244).",
+    )
     caller_app: str = Field(description="Calling Lotus application or platform component.")
     requested_by: str | None = Field(
         default=None,

--- a/src/app/services/execution_evidence.py
+++ b/src/app/services/execution_evidence.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from app.contracts.access_control import AuthorizationDecision
-from app.contracts.capability_requirements import REQUIREMENTS_NOT_ENFORCED
+from app.contracts.capability_requirements import (
+    REQUIREMENTS_ENFORCED,
+    REQUIREMENTS_NOT_ENFORCED,
+    REQUIREMENTS_PARTIALLY_ENFORCED,
+)
 from app.contracts.evidence import ExecutionEvidenceBundle, ExecutionEvidenceDescriptor
 from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.prompts import PromptDescriptor, PromptSelectionTraceDescriptor
@@ -45,33 +49,55 @@ def build_execution_evidence(
         ]
     )
     if request.requirements is not None:
-        descriptors.append(_capability_requirements_descriptor(request=request))
+        descriptors.append(
+            _capability_requirements_descriptor(
+                request=request, provider_execution=provider_execution
+            )
+        )
     return ExecutionEvidenceBundle(descriptors=descriptors)
 
 
 def _capability_requirements_descriptor(
-    *, request: TaskExecutionRequest
+    *, request: TaskExecutionRequest, provider_execution: ProviderExecutionResponse
 ) -> ExecutionEvidenceDescriptor:
     """Declared workload requirements, with their enforcement posture stated.
 
     Recording a requirement without saying whether anything enforces it would
     let a consumer believe a ceiling is being held when nothing holds it -
-    the declared-versus-measured defect this platform keeps finding. Slice 3
-    of issue #244 turns these into an eligibility filter and flips the
-    posture; until then the evidence says NOT_ENFORCED, visibly.
+    the declared-versus-measured defect this platform keeps finding. The
+    posture derives from the routing decision that actually ran (issue #244,
+    S3): a decision that enforced every declared dimension reports ENFORCED, a
+    partial one names both halves, and an execution with no routing decision
+    (the stub path) honestly reports NOT_ENFORCED rather than borrowing a
+    guarantee no filter provided.
     """
 
     assert request.requirements is not None
+    declared = request.requirements.declared_dimensions()
+    decision = getattr(provider_execution, "routing_decision", None)
+    enforced = list(decision.requirements_enforced_dimensions) if decision is not None else []
+    unenforced = (
+        list(decision.requirements_unenforced_dimensions)
+        if decision is not None and enforced
+        else sorted(declared)
+    )
+    if not enforced:
+        posture = REQUIREMENTS_NOT_ENFORCED
+    elif unenforced:
+        posture = REQUIREMENTS_PARTIALLY_ENFORCED
+    else:
+        posture = REQUIREMENTS_ENFORCED
     return ExecutionEvidenceDescriptor(
         evidence_type="capability_requirements",
         summary=(
-            "The caller declared workload capability requirements; they are recorded and "
-            f"{REQUIREMENTS_NOT_ENFORCED}: capability eligibility has not shipped, so no "
-            "routing filter holds them yet."
+            f"The caller declared workload capability requirements; enforcement is {posture} "
+            "for this execution, with the enforced and unenforced dimensions listed."
         ),
         attributes={
-            "declared": request.requirements.declared_dimensions(),
-            "requirements_enforcement": REQUIREMENTS_NOT_ENFORCED,
+            "declared": declared,
+            "requirements_enforcement": posture,
+            "enforced_dimensions": enforced,
+            "unenforced_dimensions": unenforced,
         },
     )
 

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -42,6 +42,7 @@ from app.providers.configured_workflow_run_model_risk_inventory import (
     ConfiguredWorkflowRunModelRiskInventory,
 )
 from app.services.access_control_authorization import authorize_request, require_authorized
+from app.contracts.capability_requirements import CapabilityRequirements
 from app.services.model_catalogue_store import get_model_catalogue_repository
 from app.services.output_contracts import output_contract_exists
 from app.services.provider_execution_config import resolve_provider_execution_config
@@ -264,6 +265,59 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
         updated_count=updated,
         unchanged_count=unchanged,
     )
+
+
+# Requirement dimensions the routing decision enforces (issue #244, S3): the
+# two catalogue-backed capability gates plus the latency ceiling, which is
+# enforced by tightening the execution timeout before any candidate runs. The
+# estimated-cost ceiling is declared-only until a pre-execution bound exists,
+# and the routing decision says so.
+ENFORCED_REQUIREMENT_DIMENSIONS = frozenset(
+    {"structured_output_required", "tool_calling_required", "max_latency_ms"}
+)
+
+_CAPABILITY_FACT_BY_REQUIREMENT = {
+    "structured_output_required": "supports_structured_output",
+    "tool_calling_required": "supports_tool_calling",
+}
+
+
+def enforce_capability_requirements(
+    *,
+    requirements: CapabilityRequirements | None,
+    entry: ModelCatalogueEntry,
+) -> None:
+    """Reject a candidate whose catalogue entry cannot satisfy the workload.
+
+    Unknown fails closed, and fails closed AS unknown: a fact the catalogue
+    has never assessed refuses with CAPABILITY_UNKNOWN, distinctly from a
+    fact it proves absent (CAPABILITY_NOT_SUPPORTED). Laundering unknown into
+    a confident answer in either direction is how capability claims rot.
+    """
+
+    if requirements is None:
+        return
+    for requirement_field, fact_field in _CAPABILITY_FACT_BY_REQUIREMENT.items():
+        if getattr(requirements, requirement_field) is not True:
+            continue
+        fact = getattr(entry, fact_field)
+        if fact is True:
+            continue
+        if fact is False:
+            raise ProviderExecutionError(
+                category=ProviderFailureCategory.CAPABILITY_NOT_SUPPORTED,
+                message=(
+                    f"Candidate `{entry.entry_id}` does not support the required "
+                    f"capability `{requirement_field}`."
+                ),
+            )
+        raise ProviderExecutionError(
+            category=ProviderFailureCategory.CAPABILITY_UNKNOWN,
+            message=(
+                f"Candidate `{entry.entry_id}` has no assessed catalogue fact for the "
+                f"required capability `{requirement_field}`; unknown is not eligibility."
+            ),
+        )
 
 
 def bind_live_text_model_catalogue_entry() -> ModelCatalogueEntry:

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -30,8 +30,11 @@ from app.services.provider_execution_config import (
     resolve_provider_execution_config,
 )
 from app.services.kill_switch_control import enforce_kill_switches
+from app.contracts.capability_requirements import CapabilityRequirements
 from app.services.model_catalogue import (
+    ENFORCED_REQUIREMENT_DIMENSIONS,
     bind_live_text_model_catalogue_entry,
+    enforce_capability_requirements,
     record_model_revision_drift,
 )
 from app.services.provider_policy import require_supported_text_generation_mode
@@ -71,6 +74,7 @@ class ProviderGatewayUnavailableError(HTTPException):
 
 
 def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecutionResponse:
+    request = _apply_latency_ceiling(request)
     config = resolve_provider_execution_config()
     mode = require_supported_text_generation_mode()
     live_execution_state = build_provider_live_execution_state(task_id=request.task_id)
@@ -101,6 +105,9 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             enforce_provider_budget()
             enforce_provider_degradation_preflight()
             catalogue_entry = bind_live_text_model_catalogue_entry()
+            enforce_capability_requirements(
+                requirements=request.requirements, entry=catalogue_entry
+            )
         except ProviderExecutionError as exc:
             # A preflight veto is a candidate rejection: the decision records
             # the one configured candidate as rejected with the bounded
@@ -108,6 +115,7 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             raise ProviderGatewayUnavailableError(
                 detail=f"{exc.category.value}: {exc.message}",
                 routing_decision=_build_rejected_routing_decision(
+                    requirements=request.requirements,
                     mode_value=mode.value,
                     category=exc.category,
                     config=config,
@@ -129,6 +137,10 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
                 observed_model_id=getattr(response, "model_id", None),
             )
         response.routing_decision = _build_fixed_routing_decision(
+            # Enforcement is only claimable where the gates actually ran: the
+            # capability check needs a catalogue bind and the latency ceiling
+            # bounds a provider wait, neither of which exists on the stub path.
+            requirements=request.requirements if mode in LIVE_TEXT_MODES else None,
             mode_value=mode.value,
             selected_provider_id=response.provider_id,
             catalogue_entry=catalogue_entry,
@@ -147,6 +159,7 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             raise ProviderGatewayUnavailableError(
                 detail=f"{exc.category.value}: {exc.message}",
                 routing_decision=_build_fixed_routing_decision(
+                    requirements=request.requirements,
                     mode_value=mode.value,
                     selected_provider_id=config.provider_id or "provider.unavailable",
                     catalogue_entry=catalogue_entry,
@@ -192,6 +205,7 @@ def _execute_ordered_fallback(
         raise ProviderGatewayUnavailableError(
             detail=f"{ProviderFailureCategory.INVALID_LIVE_CONFIGURATION.value}: {detail}",
             routing_decision=_build_ordered_routing_decision(
+                requirements=request.requirements,
                 mode_value=mode.value,
                 candidates=[(config, ProviderFailureCategory.INVALID_LIVE_CONFIGURATION)],
                 serving_config=None,
@@ -221,6 +235,7 @@ def _execute_ordered_fallback(
         eligible.append(index)
     if not eligible:
         raise _ordered_refusal(
+            requirements=request.requirements,
             error=veto_errors[-1],
             mode_value=mode.value,
             candidates=candidates,
@@ -235,6 +250,7 @@ def _execute_ordered_fallback(
         for index in eligible:
             rejections[index] = exc.category
         raise _ordered_refusal(
+            requirements=request.requirements,
             error=exc,
             mode_value=mode.value,
             candidates=candidates,
@@ -251,6 +267,9 @@ def _execute_ordered_fallback(
             try:
                 enforce_provider_degradation_preflight()
                 catalogue_entry = bind_live_text_model_catalogue_entry()
+                enforce_capability_requirements(
+                    requirements=request.requirements, entry=catalogue_entry
+                )
             except ProviderExecutionError as exc:
                 rejections[index] = exc.category
                 attempt_errors.append(exc)
@@ -276,6 +295,7 @@ def _execute_ordered_fallback(
                 observed_model_id=getattr(response, "model_id", None),
             )
             response.routing_decision = _build_ordered_routing_decision(
+                requirements=request.requirements,
                 mode_value=mode.value,
                 candidates=[
                     (item, rejections.get(position)) for position, item in enumerate(candidates)
@@ -291,6 +311,7 @@ def _execute_ordered_fallback(
 
     # Every eligible candidate either returned above or appended its error.
     raise _ordered_refusal(
+        requirements=request.requirements,
         error=attempt_errors[-1],
         mode_value=mode.value,
         candidates=candidates,
@@ -302,6 +323,7 @@ def _execute_ordered_fallback(
 def _ordered_refusal(
     *,
     error: ProviderExecutionError,
+    requirements: CapabilityRequirements | None,
     mode_value: str,
     candidates: list[ProviderExecutionConfig],
     rejections: dict[int, ProviderFailureCategory],
@@ -310,6 +332,7 @@ def _ordered_refusal(
     return ProviderGatewayUnavailableError(
         detail=f"{error.category.value}: {error.message}",
         routing_decision=_build_ordered_routing_decision(
+            requirements=requirements,
             mode_value=mode_value,
             candidates=[
                 (candidate, rejections.get(index)) for index, candidate in enumerate(candidates)
@@ -338,6 +361,7 @@ def _candidate_entry_identity(
 
 def _build_ordered_routing_decision(
     *,
+    requirements: CapabilityRequirements | None,
     mode_value: str,
     candidates: list[tuple[ProviderExecutionConfig, ProviderFailureCategory | None]],
     serving_config: ProviderExecutionConfig | None,
@@ -373,11 +397,14 @@ def _build_ordered_routing_decision(
             "Ordered-fallback policy: the primary candidate was rejected at preflight and "
             "the alternate candidate served; a preflight rejection is not a fallback."
         )
+    enforced_dimensions, unenforced_dimensions = _requirement_enforcement_split(requirements)
     return RoutingDecisionDescriptor(
         policy_id=ROUTING_POLICY_ORDERED_FALLBACK,
         policy_version=ROUTING_POLICY_VERSION_V1,
         strategy=RoutingStrategy.ORDERED_FALLBACK,
         candidates=descriptors,
+        requirements_enforced_dimensions=enforced_dimensions,
+        requirements_unenforced_dimensions=unenforced_dimensions,
         selected_provider_id=serving_config.provider_id if serving_config is not None else None,
         selected_model_catalogue_entry_id=(
             serving_entry.entry_id if serving_entry is not None else None
@@ -388,22 +415,56 @@ def _build_ordered_routing_decision(
     )
 
 
+def _apply_latency_ceiling(request: ProviderExecutionRequest) -> ProviderExecutionRequest:
+    """Enforce a declared latency ceiling by tightening the execution timeout.
+
+    Request-scoped, applied before any candidate runs: the transport cannot
+    wait longer than the ceiling, which is what makes `max_latency_ms`
+    genuinely ENFORCED rather than recorded (issue #244, S3).
+    """
+
+    requirements = request.requirements
+    if requirements is None or requirements.max_latency_ms is None:
+        return request
+    if requirements.max_latency_ms >= request.timeout_ms:
+        return request
+    return request.model_copy(update={"timeout_ms": requirements.max_latency_ms})
+
+
+def _requirement_enforcement_split(
+    requirements: CapabilityRequirements | None,
+) -> tuple[list[str], list[str]]:
+    """Declared dimensions split into what this decision enforces and what it
+    does not - so a declared ceiling can never silently pass for a held one."""
+
+    if requirements is None:
+        return ([], [])
+    declared = requirements.declared_dimensions()
+    enforced = sorted(set(declared) & ENFORCED_REQUIREMENT_DIMENSIONS)
+    unenforced = sorted(set(declared) - ENFORCED_REQUIREMENT_DIMENSIONS)
+    return (enforced, unenforced)
+
+
 def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _build_rejected_routing_decision(
     *,
+    requirements: CapabilityRequirements | None,
     mode_value: str,
     category: ProviderFailureCategory,
     config: ProviderExecutionConfig,
 ) -> RoutingDecisionDescriptor:
     provider_id = config.provider_id or "provider.unavailable"
     entry_id, model_revision = _candidate_entry_identity(config)
+    enforced_dimensions, unenforced_dimensions = _requirement_enforcement_split(requirements)
     return RoutingDecisionDescriptor(
         policy_id=ROUTING_POLICY_FIXED_CONFIGURED_MODE,
         policy_version=ROUTING_POLICY_VERSION_V1,
         strategy=RoutingStrategy.FIXED,
+        requirements_enforced_dimensions=enforced_dimensions,
+        requirements_unenforced_dimensions=unenforced_dimensions,
         candidates=[
             RoutingCandidateDescriptor(
                 provider_id=provider_id,
@@ -425,16 +486,20 @@ def _build_rejected_routing_decision(
 
 def _build_fixed_routing_decision(
     *,
+    requirements: CapabilityRequirements | None,
     mode_value: str,
     selected_provider_id: str,
     catalogue_entry: ModelCatalogueEntry | None,
     decided_at: str,
 ) -> RoutingDecisionDescriptor:
     entry_id = catalogue_entry.entry_id if catalogue_entry is not None else None
+    enforced_dimensions, unenforced_dimensions = _requirement_enforcement_split(requirements)
     return RoutingDecisionDescriptor(
         policy_id=ROUTING_POLICY_FIXED_CONFIGURED_MODE,
         policy_version=ROUTING_POLICY_VERSION_V1,
         strategy=RoutingStrategy.FIXED,
+        requirements_enforced_dimensions=enforced_dimensions,
+        requirements_unenforced_dimensions=unenforced_dimensions,
         candidates=[
             RoutingCandidateDescriptor(
                 provider_id=selected_provider_id,

--- a/src/app/services/provider_request_builder.py
+++ b/src/app/services/provider_request_builder.py
@@ -12,6 +12,7 @@ def build_provider_execution_request(
     config = resolve_provider_execution_config()
     return ProviderExecutionRequest(
         task_id=context.capability.task_id,
+        requirements=context.request.requirements,
         caller_app=context.request.caller.caller_app,
         requested_by=context.request.caller.requested_by,
         tenant_id=context.request.caller.tenant_id,

--- a/tests/unit/test_execution_evidence.py
+++ b/tests/unit/test_execution_evidence.py
@@ -21,6 +21,7 @@ from app.contracts.providers import (
     ProviderAdapterKind,
     ProviderExecutionResponse,
 )
+from app.contracts.evidence import ExecutionEvidenceDescriptor
 from app.contracts.tasks import (
     CallerMetadata,
     CapabilityDescriptor,
@@ -274,3 +275,93 @@ def test_provider_descriptor_omits_catalogue_binding_when_absent() -> None:
     assert "model_catalogue_entry_id" not in descriptor.attributes
     assert "model_revision_pinned" not in descriptor.attributes
     assert "model_version" not in descriptor.attributes
+
+
+def _request_with(**overrides: object) -> TaskExecutionRequest:
+    return TaskExecutionRequest(
+        task_id="explain.v1",
+        input_mode=TaskInputMode.STRUCTURED_CONTEXT,
+        caller=CallerMetadata(caller_app="lotus-manage", correlation_id="corr-req-posture"),
+        context=TaskContextEnvelope(
+            summary="Explain rebalance outcome",
+            payload={"status": "BLOCKED"},
+            source_refs=["lotus-manage:run:reb_001"],
+        ),
+        **overrides,  # type: ignore[arg-type]
+    )
+
+
+def _descriptor_for(request: TaskExecutionRequest, decision: object) -> ExecutionEvidenceDescriptor:
+    from app.services.execution_evidence import _capability_requirements_descriptor
+
+    provider_execution = ProviderExecutionResponse(
+        provider_id="text.openai",
+        provider_mode="openai",
+        adapter_kind=ProviderAdapterKind.OPENAI_LIVE,
+        timeout_ms=4000,
+        retry_count=0,
+        max_output_tokens=512,
+        stubbed=False,
+        message="live response",
+        structured_output={},
+        routing_decision=decision,  # type: ignore[arg-type]
+    )
+    return _capability_requirements_descriptor(
+        request=request, provider_execution=provider_execution
+    )
+
+
+def test_requirements_posture_derives_from_the_routing_decision() -> None:
+    """The evidence says exactly what the decision held: every declared
+    dimension enforced reads ENFORCED, a remainder reads PARTIALLY_ENFORCED
+    with both halves listed, and an execution with no routing decision (stub)
+    reads NOT_ENFORCED with everything listed as unenforced — a recorded
+    ceiling can never pass for a held one (issue #244, S3)."""
+
+    from app.contracts.capability_requirements import CapabilityRequirements
+    from app.contracts.providers import (
+        ROUTING_POLICY_ORDERED_FALLBACK,
+        ROUTING_POLICY_VERSION_V1,
+        RoutingDecisionDescriptor,
+        RoutingStrategy,
+    )
+
+    request = _request_with(
+        requirements=CapabilityRequirements(
+            structured_output_required=True, max_estimated_cost_usd=0.5
+        )
+    )
+
+    def _decision(enforced: list[str], unenforced: list[str]) -> RoutingDecisionDescriptor:
+        return RoutingDecisionDescriptor(
+            policy_id=ROUTING_POLICY_ORDERED_FALLBACK,
+            policy_version=ROUTING_POLICY_VERSION_V1,
+            strategy=RoutingStrategy.ORDERED_FALLBACK,
+            candidates=[],
+            requirements_enforced_dimensions=enforced,
+            requirements_unenforced_dimensions=unenforced,
+            selected_provider_id="text.openai",
+            selected_model_catalogue_entry_id=None,
+            decided_at="2026-09-02T12:00:00Z",
+            selection_reason="test",
+            fallback_path=[],
+        )
+
+    partial = _descriptor_for(
+        request, _decision(["structured_output_required"], ["max_estimated_cost_usd"])
+    )
+    assert partial.attributes["requirements_enforcement"] == "PARTIALLY_ENFORCED"
+    assert partial.attributes["enforced_dimensions"] == ["structured_output_required"]
+    assert partial.attributes["unenforced_dimensions"] == ["max_estimated_cost_usd"]
+
+    full = _descriptor_for(
+        request, _decision(["max_estimated_cost_usd", "structured_output_required"], [])
+    )
+    assert full.attributes["requirements_enforcement"] == "ENFORCED"
+
+    stub = _descriptor_for(request, None)
+    assert stub.attributes["requirements_enforcement"] == "NOT_ENFORCED"
+    assert stub.attributes["unenforced_dimensions"] == [
+        "max_estimated_cost_usd",
+        "structured_output_required",
+    ]

--- a/tests/unit/test_ordered_fallback_routing.py
+++ b/tests/unit/test_ordered_fallback_routing.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.config import settings
+from app.contracts.capability_requirements import CapabilityRequirements
 from app.contracts.kill_switches import KillSwitchActivationRequest, KillSwitchScope
 from app.contracts.providers import (
     ProviderAdapterKind,
@@ -677,3 +678,134 @@ def test_every_evidence_surface_names_the_serving_candidate(
     )
     assert attestation.provider_id == ALTERNATE
     assert attestation.model_id == "claude-sonnet-5"
+
+
+# --- Capability eligibility (issue #244, S3) -------------------------------
+
+
+def _assess_structured_output(provider_id: str, model_id: str, fact: bool) -> None:
+    from app.contracts.model_catalogue import derive_model_catalogue_entry_id
+    from app.services.model_catalogue import ensure_model_catalogue_seeded
+    from app.services.model_catalogue_store import get_model_catalogue_repository
+
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    entry_id = derive_model_catalogue_entry_id(
+        provider_id=provider_id, model_revision=model_id, deployment=None
+    )
+    entry = repository.get_entry(entry_id)
+    assert entry is not None
+    repository.upsert_entry(entry.model_copy(update={"supports_structured_output": fact}))
+
+
+def _requirements(**overrides: object) -> CapabilityRequirements:
+    payload: dict[str, object] = {"structured_output_required": True}
+    payload.update(overrides)
+    return CapabilityRequirements.model_validate(payload)
+
+
+def test_an_unassessed_capability_fails_closed_as_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown is not eligibility, and it refuses AS unknown: the rejection
+    category is CAPABILITY_UNKNOWN, distinct from a fact the catalogue proves
+    absent — laundering unknown into a confident answer in either direction is
+    how capability claims rot."""
+
+    _ordered_fallback_settings()
+    adapter = _install_adapter(monkeypatch, failing={})
+
+    with pytest.raises(ProviderGatewayUnavailableError) as exc_info:
+        execute_text_generation(_request(requirements=_requirements()))
+
+    decision = exc_info.value.routing_decision
+    assert [c.rejection_reason for c in decision.candidates] == [
+        ProviderFailureCategory.CAPABILITY_UNKNOWN,
+        ProviderFailureCategory.CAPABILITY_UNKNOWN,
+    ]
+    assert adapter.executed_provider_ids == []
+    assert decision.requirements_enforced_dimensions == ["structured_output_required"]
+    assert decision.requirements_unenforced_dimensions == []
+
+
+def test_a_proven_absent_capability_refuses_distinctly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _ordered_fallback_settings()
+    _install_adapter(monkeypatch, failing={})
+    _assess_structured_output(PRIMARY, "gpt-5.4", False)
+
+    with pytest.raises(ProviderGatewayUnavailableError) as exc_info:
+        execute_text_generation(_request(requirements=_requirements()))
+
+    decision = exc_info.value.routing_decision
+    assert decision.candidates[0].rejection_reason is (
+        ProviderFailureCategory.CAPABILITY_NOT_SUPPORTED
+    )
+    assert decision.candidates[1].rejection_reason is ProviderFailureCategory.CAPABILITY_UNKNOWN
+
+
+def test_an_assessed_candidate_serves_while_the_unassessed_one_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The eligibility pipeline composes with the existing selection: the
+    primary is rejected on capability grounds and the assessed alternate
+    serves, recorded as a preflight rejection rather than a fallback."""
+
+    _ordered_fallback_settings()
+    adapter = _install_adapter(monkeypatch, failing={})
+    _assess_structured_output(ALTERNATE, "claude-sonnet-5", True)
+
+    response = execute_text_generation(
+        _request(
+            requirements=_requirements(max_estimated_cost_usd=0.50),
+        )
+    )
+
+    assert response.provider_id == ALTERNATE
+    assert adapter.executed_provider_ids == [ALTERNATE]
+    decision = response.routing_decision
+    assert decision is not None
+    assert decision.candidates[0].rejection_reason is ProviderFailureCategory.CAPABILITY_UNKNOWN
+    assert decision.selected_provider_id == ALTERNATE
+    assert decision.fallback_path == []
+    # The decision names what it held and what it did not: the cost ceiling
+    # has no pre-execution bound yet, and saying so is the contract.
+    assert decision.requirements_enforced_dimensions == ["structured_output_required"]
+    assert decision.requirements_unenforced_dimensions == ["max_estimated_cost_usd"]
+
+
+def test_a_declared_latency_ceiling_tightens_the_execution_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """max_latency_ms is genuinely ENFORCED: the transport cannot wait longer
+    than the ceiling, because the request it executes carries the tightened
+    timeout before any candidate runs."""
+
+    _ordered_fallback_settings()
+    seen_timeouts: list[int] = []
+
+    class _TimeoutRecordingAdapter(_DispatchingAdapter):
+        def execute(self, request, *, config):  # type: ignore[no-untyped-def]
+            seen_timeouts.append(request.timeout_ms)
+            return super().execute(request, config=config)
+
+    adapter = _TimeoutRecordingAdapter(failing={})
+    monkeypatch.setattr(
+        "app.services.provider_gateway.resolve_text_generation_adapter",
+        lambda mode: adapter,
+    )
+    _assess_structured_output(PRIMARY, "gpt-5.4", True)
+
+    response = execute_text_generation(
+        _request(
+            timeout_ms=4000,
+            requirements=_requirements(max_latency_ms=1500),
+        )
+    )
+
+    assert response.provider_id == PRIMARY
+    assert seen_timeouts == [1500]
+    decision = response.routing_decision
+    assert decision is not None
+    assert "max_latency_ms" in decision.requirements_enforced_dimensions


### PR DESCRIPTION
Issue #244, slice 3: capability eligibility inside the existing routing decision. With S1 (the requirement contract) and S2 (evidence-seeded catalogue facts) merged, this completes the programme's core: **request requirements → catalogue capability filter → existing selection/fallback**, every exclusion reasoned.

## Control-plane outcome

A workload that requires structured output is served only by a model the catalogue *proves* supports it; a declared latency ceiling is genuinely held by the transport; and every rejection, enforcement, and non-enforcement is on the routing decision an operator reads.

## Invariant

**Every selected candidate was eligible, and unknown is not eligibility.** A capability fact the catalogue has never assessed refuses with `CAPABILITY_UNKNOWN`, distinctly from one it proves absent (`CAPABILITY_NOT_SUPPORTED`) — unknown fails closed *as unknown*, never laundered into a confident answer in either direction.

## One authority — no second routing engine

The filter is one function (`enforce_capability_requirements`) composed into the existing per-candidate preflight, exactly where the catalogue bind already happens; rejections ride the existing `RoutingCandidateDescriptor.rejection_reason` with two new bounded categories. The decision model gains two additive fields — `requirements_enforced_dimensions` / `requirements_unenforced_dimensions` — and no weighted optimisation, scoring, or new strategy exists.

## What "enforced" means, dimension by dimension

- `structured_output_required` / `tool_calling_required`: catalogue-fact gates per candidate. With S2's evidence-only seeding, tool calling is provably unassessed everywhere today, so requiring it refuses `CAPABILITY_UNKNOWN` — which is the truth.
- `max_latency_ms`: enforced by tightening the execution timeout **before any candidate runs** — the transport cannot wait past the ceiling, proven by asserting the timeout the adapter actually receives.
- `max_estimated_cost_usd`: **declared-only until a pre-execution bound exists**, and the decision lists it as unenforced. A recorded ceiling never passes for a held one.

## The stub path claims nothing

The fixed decision builder serves both stub and live executions, and the capability gates only run where a catalogue bind exists. The stub path therefore passes no requirements into the decision, and the evidence posture honestly reads `NOT_ENFORCED` with every declared dimension listed — caught by S1's own posture test during this slice, which is exactly what that test was for.

## Evidence posture completes the S1 promise

The `capability_requirements` evidence descriptor now derives from the decision that actually ran: all declared dimensions enforced → `ENFORCED`; a remainder → `PARTIALLY_ENFORCED` with both halves listed; no decision (stub) → `NOT_ENFORCED`. The S1 posture flip happened exactly as designed, one slice later.

## Evidence

Gateway (real path, adapter fake only at dispatch): unassessed capability → both candidates `CAPABILITY_UNKNOWN`, adapter never invoked, decision lists the enforced split · proven-absent vs unassessed refuse with distinct categories on the same decision · an assessed alternate serves while the unassessed primary is rejected as a preflight (not a fallback), with the cost ceiling visibly unenforced · the adapter receives the tightened timeout (4000 → 1500). Evidence: posture matrix (`ENFORCED` / `PARTIALLY_ENFORCED` / `NOT_ENFORCED`) driven by the decision fields. Requirements absent → all decision fields empty, behaviour byte-identical.

Full local gate: whole suite, `make lint`, `make typecheck` (736 files). Additive contract changes only; no migration.
