### PR TITLE
fix(routing): max_latency_ms is one governed end-to-end execution budget

### DIFF
--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -56,6 +56,11 @@ class ProviderFailureCategory(str, Enum):
     # as unknown - not laundered into a confident NOT_SUPPORTED.
     CAPABILITY_NOT_SUPPORTED = "CAPABILITY_NOT_SUPPORTED"
     CAPABILITY_UNKNOWN = "CAPABILITY_UNKNOWN"
+    # The caller's end-to-end latency budget ran out (issue #244). Distinct
+    # from PROVIDER_TIMEOUT: the provider did nothing wrong - the governed
+    # request deadline was exhausted by earlier attempts, backoff, or
+    # fallback, and no further attempt may start.
+    REQUEST_DEADLINE_EXHAUSTED = "REQUEST_DEADLINE_EXHAUSTED"
     PROVIDER_TIMEOUT = "PROVIDER_TIMEOUT"
     PROVIDER_RATE_LIMITED = "PROVIDER_RATE_LIMITED"
     PROVIDER_UPSTREAM_ERROR = "PROVIDER_UPSTREAM_ERROR"
@@ -642,6 +647,14 @@ class ProviderExecutionRequest(BaseModel):
     requirements: CapabilityRequirements | None = Field(
         default=None,
         description="Declared workload requirements; None routes exactly as before (issue #244).",
+    )
+    execution_deadline_at: float | None = Field(
+        default=None,
+        description=(
+            "Monotonic instant (time.perf_counter seconds) by which the whole execution "
+            "must finish; set once by the gateway from max_latency_ms and never reset "
+            "across retries or fallback. Runtime-only, in-process (issue #244)."
+        ),
     )
     caller_app: str = Field(description="Calling Lotus application or platform component.")
     requested_by: str | None = Field(

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -90,6 +90,7 @@ def execute_openai_compatible_text_request(
         serving_provider_id=serving_provider_id,
         require_api_key=require_api_key,
         retry_limit=request.retry_limit,
+        execution_deadline_at=request.execution_deadline_at,
     )
     output_message = extract_output_text(response_payload)
     message, structured_output = build_structured_output(
@@ -159,6 +160,7 @@ def post_openai_compatible_response(
     serving_provider_id: str,
     require_api_key: bool,
     retry_limit: int = 0,
+    execution_deadline_at: float | None = None,
 ) -> dict[str, Any]:
     """POST one OpenAI-compatible request, labelling every surface it emits
     with ``serving_provider_id``.
@@ -205,15 +207,32 @@ def post_openai_compatible_response(
     backoff_plan = RetryBackoffPlan(
         timeout_seconds=timeout_seconds, retry_limit=bounded_retry_limit
     )
-    deadline_at = time.perf_counter() + backoff_plan.total_deadline_seconds
+    # The retry sequence is bounded by its own plan AND, when the caller
+    # declared max_latency_ms, by the governed execution deadline - whichever
+    # comes first. The governed deadline is never extended here (issue #244).
+    deadline_at = _monotonic() + backoff_plan.total_deadline_seconds
+    if execution_deadline_at is not None:
+        deadline_at = min(deadline_at, execution_deadline_at)
     for attempt_index in range(bounded_retry_limit + 1):
+        if execution_deadline_at is not None:
+            remaining_seconds = execution_deadline_at - _monotonic()
+            if remaining_seconds <= 0:
+                raise ProviderExecutionError(
+                    category=ProviderFailureCategory.REQUEST_DEADLINE_EXHAUSTED,
+                    message=(
+                        "The caller's max_latency_ms budget is exhausted; no further "
+                        "provider attempt may start."
+                    ),
+                )
+            # An attempt may wait only for what remains of the budget.
+            timeout_seconds = min(timeout_seconds, remaining_seconds)
         provider_request = urllib_request.Request(
             endpoint,
             data=body,
             headers=headers,
             method="POST",
         )
-        attempt_started = time.perf_counter()
+        attempt_started = _monotonic()
         try:
             with (
                 provider_attempt_span(
@@ -280,6 +299,15 @@ def post_openai_compatible_response(
             if will_retry:
                 wait_for_retry(retry_decision)
                 continue
+            deadline_stop = _governed_deadline_stop(
+                execution_deadline_at=execution_deadline_at,
+                retryable=retryable,
+                attempt_index=attempt_index,
+                retry_limit=bounded_retry_limit,
+                delay_seconds=retry_decision.delay_seconds,
+            )
+            if deadline_stop is not None:
+                raise deadline_stop from exc
             raise ProviderExecutionError(
                 category=category,
                 message=safe_provider_error_message(
@@ -313,6 +341,15 @@ def post_openai_compatible_response(
             if will_retry:
                 wait_for_retry(retry_decision)
                 continue
+            deadline_stop = _governed_deadline_stop(
+                execution_deadline_at=execution_deadline_at,
+                retryable=True,
+                attempt_index=attempt_index,
+                retry_limit=bounded_retry_limit,
+                delay_seconds=retry_decision.delay_seconds,
+            )
+            if deadline_stop is not None:
+                raise deadline_stop from exc
             raise ProviderExecutionError(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,
                 message=safe_provider_error_message(
@@ -346,6 +383,15 @@ def post_openai_compatible_response(
             if will_retry:
                 wait_for_retry(retry_decision)
                 continue
+            deadline_stop = _governed_deadline_stop(
+                execution_deadline_at=execution_deadline_at,
+                retryable=True,
+                attempt_index=attempt_index,
+                retry_limit=bounded_retry_limit,
+                delay_seconds=retry_decision.delay_seconds,
+            )
+            if deadline_stop is not None:
+                raise deadline_stop from exc
             raise ProviderExecutionError(
                 category=ProviderFailureCategory.PROVIDER_TIMEOUT,
                 message=safe_provider_error_message(
@@ -365,8 +411,45 @@ def post_openai_compatible_response(
 _logger = logging.getLogger("app.provider")
 
 
+def _governed_deadline_stop(
+    *,
+    execution_deadline_at: float | None,
+    retryable: bool,
+    attempt_index: int,
+    retry_limit: int,
+    delay_seconds: float,
+) -> ProviderExecutionError | None:
+    """The error to raise when the governed budget - not the retry plan - is
+    what stopped a retry that was otherwise permitted.
+
+    Distinguishability is the requirement (issue #244): a candidate that
+    stopped because the caller's max_latency_ms ran out must not report a
+    provider condition the provider never caused.
+    """
+
+    if execution_deadline_at is None:
+        return None
+    if not retryable or attempt_index >= retry_limit:
+        return None
+    if _monotonic() + delay_seconds <= execution_deadline_at:
+        return None
+    return ProviderExecutionError(
+        category=ProviderFailureCategory.REQUEST_DEADLINE_EXHAUSTED,
+        message=(
+            "The caller's max_latency_ms budget cannot support another retry; the "
+            "provider attempt sequence stopped at the governed deadline."
+        ),
+    )
+
+
+def _monotonic() -> float:
+    """Seam for the governed-deadline clock; tests replace it."""
+
+    return time.perf_counter()
+
+
 def _attempt_latency_ms(started: float) -> float:
-    return round((time.perf_counter() - started) * 1000.0, 3)
+    return round((_monotonic() - started) * 1000.0, 3)
 
 
 def load_error_payload(exc: error.HTTPError) -> dict[str, Any]:

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -15,6 +15,7 @@ from app.contracts.providers import (
     RoutingDecisionDescriptor,
     RoutingStrategy,
 )
+import time
 from datetime import UTC, datetime
 
 from app.contracts.model_catalogue import ModelCatalogueEntry
@@ -108,6 +109,7 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             enforce_capability_requirements(
                 requirements=request.requirements, entry=catalogue_entry
             )
+            _require_budget_remaining(request)
         except ProviderExecutionError as exc:
             # A preflight veto is a candidate rejection: the decision records
             # the one configured candidate as rejected with the bounded
@@ -124,7 +126,7 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
     adapter = resolve_text_generation_adapter(mode)
     decided_at = _utc_now_iso()
     try:
-        response = adapter.execute(request, config=config)
+        response = adapter.execute(_request_for_attempt(request), config=config)
         if catalogue_entry is not None:
             # Stamp the governed identity the execution was bound to; the
             # transport only knows settings strings and the provider echo.
@@ -265,6 +267,11 @@ def _execute_ordered_fallback(
         candidate = candidates[index]
         with override_provider_execution_config(candidate):
             try:
+                # The governed deadline outranks fallback: an exhausted budget
+                # rejects this candidate without an attempt, and the next
+                # candidate's check rejects it too - the alternate never
+                # starts after exhaustion, and the budget is never reset.
+                _require_budget_remaining(request)
                 enforce_provider_degradation_preflight()
                 catalogue_entry = bind_live_text_model_catalogue_entry()
                 enforce_capability_requirements(
@@ -275,7 +282,7 @@ def _execute_ordered_fallback(
                 attempt_errors.append(exc)
                 continue
             try:
-                response = adapter.execute(request, config=candidate)
+                response = adapter.execute(_request_for_attempt(request), config=candidate)
             except ProviderExecutionError as exc:
                 record_provider_failure(exc.category)
                 rejections[index] = exc.category
@@ -416,19 +423,62 @@ def _build_ordered_routing_decision(
 
 
 def _apply_latency_ceiling(request: ProviderExecutionRequest) -> ProviderExecutionRequest:
-    """Enforce a declared latency ceiling by tightening the execution timeout.
+    """Start the governed end-to-end latency budget (issue #244).
 
-    Request-scoped, applied before any candidate runs: the transport cannot
-    wait longer than the ceiling, which is what makes `max_latency_ms`
-    genuinely ENFORCED rather than recorded (issue #244, S3).
+    `max_latency_ms` is one execution deadline, not an attempt timeout: a
+    single monotonic deadline is stamped here, every later stage receives only
+    the remaining budget, and nothing - retry, backoff sleep, or fallback -
+    resets it. The first attempt's timeout is tightened to the budget; each
+    subsequent attempt is tightened to what remains at its start.
     """
 
     requirements = request.requirements
     if requirements is None or requirements.max_latency_ms is None:
         return request
-    if requirements.max_latency_ms >= request.timeout_ms:
+    return request.model_copy(
+        update={
+            "timeout_ms": min(request.timeout_ms, requirements.max_latency_ms),
+            "execution_deadline_at": _monotonic() + requirements.max_latency_ms / 1000.0,
+        }
+    )
+
+
+def _remaining_budget_ms(request: ProviderExecutionRequest) -> int | None:
+    """Milliseconds left on the governed deadline; None when no budget is set.
+
+    Zero means exhausted: the value is clamped, and callers treat <= 0 as
+    "no further attempt may start".
+    """
+
+    if request.execution_deadline_at is None:
+        return None
+    return int((request.execution_deadline_at - _monotonic()) * 1000.0)
+
+
+def _request_for_attempt(request: ProviderExecutionRequest) -> ProviderExecutionRequest:
+    """The request an individual candidate attempt may execute.
+
+    The attempt timeout is the smaller of the configured timeout and the
+    remaining governed budget, so an attempt can never run past the deadline
+    earlier stages already spent from.
+    """
+
+    remaining = _remaining_budget_ms(request)
+    if remaining is None or remaining >= request.timeout_ms:
         return request
-    return request.model_copy(update={"timeout_ms": requirements.max_latency_ms})
+    return request.model_copy(update={"timeout_ms": max(remaining, 1)})
+
+
+def _require_budget_remaining(request: ProviderExecutionRequest) -> None:
+    remaining = _remaining_budget_ms(request)
+    if remaining is not None and remaining <= 0:
+        raise ProviderExecutionError(
+            category=ProviderFailureCategory.REQUEST_DEADLINE_EXHAUSTED,
+            message=(
+                "The caller's max_latency_ms budget is exhausted; no further provider "
+                "attempt may start."
+            ),
+        )
 
 
 def _requirement_enforcement_split(
@@ -443,6 +493,12 @@ def _requirement_enforcement_split(
     enforced = sorted(set(declared) & ENFORCED_REQUIREMENT_DIMENSIONS)
     unenforced = sorted(set(declared) - ENFORCED_REQUIREMENT_DIMENSIONS)
     return (enforced, unenforced)
+
+
+def _monotonic() -> float:
+    """Seam for the governed-deadline clock; tests replace it."""
+
+    return time.perf_counter()
 
 
 def _utc_now_iso() -> str:

--- a/tests/unit/test_latency_budget.py
+++ b/tests/unit/test_latency_budget.py
@@ -1,0 +1,283 @@
+"""max_latency_ms is one governed end-to-end execution budget (issue #244).
+
+The requirement was previously applied as an individual provider-attempt
+timeout while its evidence said ENFORCED: retries, backoff and ordered
+fallback each started a fresh clock, so total latency could exceed the
+caller's stated maximum. These tests drive the real transport and gateway
+under a fake monotonic clock and a fake sleeper, and pin the invariant for
+every path: **total governed elapsed time never exceeds the requirement**,
+beyond documented clock granularity.
+
+The clock advances only when the fakes say so: each provider attempt costs
+what the fake upstream decides, each backoff sleep costs its full delay, and
+nothing else moves time - so any budget overrun is the runtime's fault, not
+the harness's.
+"""
+
+from __future__ import annotations
+
+from email.message import Message
+from io import BytesIO
+from json import dumps
+from urllib import error
+
+import pytest
+
+from app.config import settings
+from app.contracts.capability_requirements import CapabilityRequirements
+from app.contracts.providers import (
+    ProviderExecutionRequest,
+    ProviderFailureCategory,
+)
+from app.services.provider_gateway import (
+    ProviderGatewayUnavailableError,
+    execute_text_generation,
+)
+from tests.unit.test_ordered_fallback_routing import (
+    ALTERNATE,
+    PRIMARY,
+    _assess_structured_output,
+    _ordered_fallback_settings,
+    _request,
+)
+
+BUDGET_MS = 2_000
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeUpstream:
+    """Scripted provider attempts: each entry is (seconds_spent, outcome).
+
+    outcome "ok" returns a valid payload; "http_503" raises a retryable
+    upstream error; "timeout" raises TimeoutError. Attempts that exceed the
+    scripted duration never happen - the fake IS the elapsed time.
+    """
+
+    def __init__(self, clock: _FakeClock, script: list[tuple[float, str]]) -> None:
+        self.clock = clock
+        self.script = list(script)
+        self.attempt_timeouts: list[float] = []
+
+    def __call__(self, request: object, timeout: float) -> object:
+        self.attempt_timeouts.append(timeout)
+        seconds, outcome = self.script.pop(0)
+        # An attempt can never take longer than the timeout it was given.
+        self.clock.advance(min(seconds, timeout))
+        if outcome == "ok":
+            payload = {
+                "id": "resp_budget",
+                "model": "gpt-5.4",
+                "output_text": "Grounded explanation without figures.",
+                "usage": {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+            }
+
+            class _Response:
+                def __enter__(self) -> "_Response":
+                    return self
+
+                def __exit__(self, *args: object) -> None:
+                    return None
+
+                def read(self) -> bytes:
+                    return dumps(payload).encode("utf-8")
+
+            return _Response()
+        if outcome == "http_503":
+            raise error.HTTPError(
+                url="https://api.test/responses",
+                code=503,
+                msg="Service Unavailable",
+                hdrs=Message(),
+                fp=BytesIO(b"{}"),
+            )
+        raise TimeoutError("scripted timeout")
+
+
+@pytest.fixture()
+def harness(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
+    clock = _FakeClock()
+    monkeypatch.setattr("app.services.provider_gateway._monotonic", clock)
+    monkeypatch.setattr("app.providers.openai_compatible_text_transport._monotonic", clock)
+    # plan_retry consults the real clock unless given one; route it here too.
+    monkeypatch.setattr(
+        "app.services.provider_retry_backoff.time",
+        type("T", (), {"perf_counter": staticmethod(clock), "sleep": None}),
+    )
+    # Backoff sleeps advance the fake clock instead of blocking.
+    monkeypatch.setattr(
+        "app.services.provider_retry_backoff._sleep", lambda seconds: clock.advance(seconds)
+    )
+    # Deterministic jitter.
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+    return clock
+
+
+def _install_upstream(
+    monkeypatch: pytest.MonkeyPatch, clock: _FakeClock, script: list[tuple[float, str]]
+) -> _FakeUpstream:
+    upstream = _FakeUpstream(clock, script)
+    monkeypatch.setattr("urllib.request.urlopen", upstream)
+    return upstream
+
+
+def _budget_request(retry_limit: int = 0) -> ProviderExecutionRequest:
+    return _request(
+        timeout_ms=10_000,
+        retry_limit=retry_limit,
+        requirements=CapabilityRequirements(max_latency_ms=BUDGET_MS),
+    )
+
+
+def _elapsed_ms(clock: _FakeClock, started: float) -> float:
+    return (clock.now - started) * 1000.0
+
+
+def _settings_with_assessed_candidates(retry_limit: int = 0) -> None:
+    _ordered_fallback_settings()
+    settings.provider_retry_limit = retry_limit
+    _assess_structured_output(PRIMARY, "gpt-5.4", True)
+    _assess_structured_output(ALTERNATE, "claude-sonnet-5", True)
+
+
+def test_single_successful_attempt_stays_within_budget(
+    harness: _FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _settings_with_assessed_candidates()
+    _install_upstream(monkeypatch, harness, [(0.5, "ok")])
+    started = harness.now
+
+    response = execute_text_generation(_budget_request())
+
+    assert response.provider_id == PRIMARY
+    assert _elapsed_ms(harness, started) <= BUDGET_MS
+
+
+def test_failed_attempt_then_retry_stays_within_budget(
+    harness: _FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _settings_with_assessed_candidates()
+    upstream = _install_upstream(monkeypatch, harness, [(0.8, "http_503"), (0.5, "ok")])
+    started = harness.now
+
+    response = execute_text_generation(_budget_request(retry_limit=1))
+
+    assert response.provider_id == PRIMARY
+    assert len(upstream.attempt_timeouts) == 2
+    assert _elapsed_ms(harness, started) <= BUDGET_MS
+    # The second attempt received only the remaining budget, not a fresh one.
+    assert upstream.attempt_timeouts[1] < upstream.attempt_timeouts[0]
+
+
+def test_retry_backoff_sleep_counts_against_the_budget(
+    harness: _FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _settings_with_assessed_candidates()
+    upstream = _install_upstream(
+        monkeypatch, harness, [(0.6, "http_503"), (0.6, "http_503"), (0.4, "ok")]
+    )
+    started = harness.now
+
+    response = execute_text_generation(_budget_request(retry_limit=2))
+
+    assert response.provider_id == PRIMARY
+    assert len(upstream.attempt_timeouts) == 3
+    assert _elapsed_ms(harness, started) <= BUDGET_MS
+
+
+def test_primary_failure_then_alternate_shares_one_budget(
+    harness: _FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The budget is never reset when moving from primary to alternate: the
+    alternate's attempt timeout is what the primary left behind."""
+
+    _settings_with_assessed_candidates()
+    upstream = _install_upstream(monkeypatch, harness, [(1.2, "timeout"), (0.5, "ok")])
+    started = harness.now
+
+    response = execute_text_generation(_budget_request())
+
+    assert response.provider_id == ALTERNATE
+    assert _elapsed_ms(harness, started) <= BUDGET_MS
+    assert len(upstream.attempt_timeouts) == 2
+    assert upstream.attempt_timeouts[1] <= (BUDGET_MS / 1000.0) - 1.2 + 0.001
+
+
+def test_multiple_retries_plus_fallback_stay_within_budget(
+    harness: _FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _settings_with_assessed_candidates()
+    upstream = _install_upstream(
+        monkeypatch,
+        harness,
+        [(0.5, "http_503"), (0.5, "timeout"), (0.4, "http_503"), (0.3, "ok")],
+    )
+    started = harness.now
+
+    response = execute_text_generation(_budget_request(retry_limit=1))
+
+    assert response.provider_id == ALTERNATE
+    assert len(upstream.attempt_timeouts) == 4
+    assert _elapsed_ms(harness, started) <= BUDGET_MS
+
+
+def test_deadline_exhaustion_refuses_the_alternate_distinctly(
+    harness: _FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the primary consumes the whole budget, the alternate never starts,
+    and the rejection says the DEADLINE ran out - not that a provider timed
+    out or degraded. Distinguishability is the point: the provider did
+    nothing wrong."""
+
+    _settings_with_assessed_candidates()
+    upstream = _install_upstream(monkeypatch, harness, [(BUDGET_MS / 1000.0, "timeout")])
+    started = harness.now
+
+    with pytest.raises(ProviderGatewayUnavailableError) as exc_info:
+        execute_text_generation(_budget_request())
+
+    decision = exc_info.value.routing_decision
+    assert decision.candidates[0].rejection_reason is ProviderFailureCategory.PROVIDER_TIMEOUT
+    assert decision.candidates[1].rejection_reason is (
+        ProviderFailureCategory.REQUEST_DEADLINE_EXHAUSTED
+    )
+    # Only the primary ever attempted; the alternate was refused pre-attempt.
+    assert len(upstream.attempt_timeouts) == 1
+    assert _elapsed_ms(harness, started) <= BUDGET_MS + 1
+
+
+def test_exhaustion_mid_retry_is_distinct_from_provider_timeout(
+    harness: _FakeClock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retry that no remaining budget can support refuses as deadline
+    exhaustion at the transport, never as another provider condition."""
+
+    _settings_with_assessed_candidates()
+    _install_upstream(
+        monkeypatch,
+        harness,
+        [(1.9, "http_503"), (1.9, "http_503"), (1.9, "http_503")],
+    )
+
+    with pytest.raises(ProviderGatewayUnavailableError) as exc_info:
+        execute_text_generation(_budget_request(retry_limit=2))
+
+    reasons = {c.rejection_reason for c in exc_info.value.routing_decision.candidates}
+    assert ProviderFailureCategory.REQUEST_DEADLINE_EXHAUSTED in reasons
+
+
+def test_no_budget_declared_means_no_deadline_machinery() -> None:
+    """Absent max_latency_ms, nothing changes: no deadline is stamped and the
+    request routes exactly as before the budget existed."""
+
+    request = _request(timeout_ms=4_000)
+    assert request.execution_deadline_at is None

--- a/tests/unit/test_ordered_fallback_routing.py
+++ b/tests/unit/test_ordered_fallback_routing.py
@@ -808,7 +808,10 @@ def test_a_declared_latency_ceiling_tightens_the_execution_timeout(
     )
 
     assert response.provider_id == PRIMARY
-    assert seen_timeouts == [1500]
+    # The attempt timeout is the remaining governed budget at attempt start:
+    # never above the caller's ceiling, allowing real-clock granularity below.
+    assert len(seen_timeouts) == 1
+    assert 1 <= seen_timeouts[0] <= 1500
     decision = response.routing_decision
     assert decision is not None
     assert "max_latency_ms" in decision.requirements_enforced_dimensions


### PR DESCRIPTION
P1 requirement-truth fix (issue #244, per the 2026-09-02 steering): `max_latency_ms` becomes what its evidence already claimed.

## Control-plane outcome

When a caller states `max_latency_ms`, the total governed execution — every attempt, every retry, every backoff sleep, and the fallback — finishes within that budget, or fails closed saying exactly why. The `ENFORCED` claim on the routing decision is now a property the runtime actually enforces.

## The defect, stated plainly

S3 applied the ceiling as an **individual provider-attempt timeout** and reported it enforced. Retries, backoff, and ordered fallback each started a fresh clock, so total latency could materially exceed the caller's stated maximum while the evidence said otherwise. My own S3 test covered only the single-attempt case — the multi-attempt cases were exactly where the claim broke, and they were never tested.

## The model

`max_latency_ms` is the **maximum governed end-to-end execution budget**:

- **One monotonic absolute deadline**, stamped once when execution begins (`_apply_latency_ceiling`), riding the internal request (`execution_deadline_at`), never reset across retries or fallback.
- **Every stage receives only the remaining budget.** Attempt timeout = `min(configured timeout, remaining)` — in the gateway per candidate (`_request_for_attempt`) and again inside the transport per retry iteration.
- **No attempt starts after exhaustion**: the gateway's per-candidate pre-check and the transport's per-iteration pre-check both refuse; the ordered loop's pre-check is what stops the alternate from ever starting on an exhausted budget.
- **Backoff never sleeps past the deadline**: the transport's retry deadline is `min(its own plan deadline, the governed deadline)`, and `plan_retry` already refuses a delay that would cross it — no sleep happens at all.
- **Exhaustion is distinguishable.** New bounded category `REQUEST_DEADLINE_EXHAUSTED`, raised at the gateway pre-check, at the transport pre-check, and — the subtle case — when a retry that the plan would have permitted is refused *because* the governed budget cannot support it (`_governed_deadline_stop`, wired into all three failure paths). A provider that did nothing wrong is never blamed for the caller's budget running out.

## Evidence — fake clock, fake sleeper, real transport and gateway

`test_latency_budget.py` drives the real gateway + transport under a fake monotonic clock (seams in both modules) and a fake sleeper; the clock advances only when the fakes say so, so any overrun is the runtime's fault. The steering's full matrix, each asserting **total elapsed ≤ the requirement**:

- single successful attempt · one failed attempt then retry (second attempt provably receives only the remaining budget) · retry backoff counted against the budget · primary failure then alternate **sharing one budget** (alternate's timeout = what the primary left) · multiple retries plus fallback · **deadline exhaustion before the alternate** — one attempt total, the alternate rejected `REQUEST_DEADLINE_EXHAUSTED` while the primary honestly reports `PROVIDER_TIMEOUT` · mid-retry exhaustion distinct from provider error · no budget declared → no deadline machinery at all.

Documented granularity: the only tolerance is real-clock microseconds between deadline stamping and the first attempt's tightening (the pre-existing S3 test now asserts ≤ ceiling rather than exact equality).

## What did not change

`ENFORCED_REQUIREMENT_DIMENSIONS` still lists `max_latency_ms` — this PR makes the existing claim true rather than re-labelling it. No new subsystem: the deadline rides the existing request, the existing retry plan's `deadline_at` plumbing, and the existing rejection vocabulary. The requirement was not renamed to an attempt timeout because that would have been easier.

Full local gate: whole suite, `make lint`, `make typecheck`, `make migration-smoke`.
