### PR TITLE
feat(catalogue): govern serving promotions through the action primitive (#245 S1)

### DIFF
--- a/alembic/versions/0062_governed_model_promotion.py
+++ b/alembic/versions/0062_governed_model_promotion.py
@@ -1,0 +1,51 @@
+"""governed model promotion
+
+Revision ID: 0062_governed_model_promotion
+Revises: 0061_async_recovery_system_originated
+Create Date: 2026-09-03
+
+Issue #245: lifecycle transitions follow the risk direction. A transition
+that expands serving posture is governed two-step through the primitive; a
+safety or administrative transition takes one verified principal and no
+approver. The approver column becomes nullable so single-principal
+transitions say honestly that no approval existed.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0062_governed_model_promotion"
+down_revision = "0061_async_recovery_system_originated"
+branch_labels = None
+depends_on = None
+
+
+def _lifecycle_events() -> sa.Table:
+    return sa.Table(
+        "model_catalogue_lifecycle_events",
+        sa.MetaData(),
+        sa.Column("event_id", sa.String(64), primary_key=True),
+        sa.Column("entry_id", sa.String(256), nullable=False, index=True),
+        sa.Column("from_state", sa.String(32), nullable=False),
+        sa.Column("to_state", sa.String(32), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("requested_by", sa.String(128), nullable=False),
+        sa.Column("approved_by", sa.String(128), nullable=False),
+        sa.Column("approval_evidence_ref", sa.String(256), nullable=True),
+        sa.Column("recorded_at", sa.String(64), nullable=False, index=True),
+    )
+
+
+def upgrade() -> None:
+    with op.batch_alter_table(
+        "model_catalogue_lifecycle_events", copy_from=_lifecycle_events()
+    ) as batch:
+        batch.alter_column("approved_by", existing_type=sa.String(length=128), nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("model_catalogue_lifecycle_events") as batch:
+        batch.alter_column("approved_by", existing_type=sa.String(length=128), nullable=False)

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -41,6 +41,9 @@ class GovernedActionType(str, Enum):
     KILL_SWITCH_CLEAR = "KILL_SWITCH_CLEAR"
     PROMPT_PROMOTE = "PROMPT_PROMOTE"
     PROVIDER_OPERATIONS_RESET = "PROVIDER_OPERATIONS_RESET"
+    # Serving-posture expansion of a catalogue model (issue #245): eval
+    # evidence enables the decision; a distinct verified credential makes it.
+    MODEL_LIFECYCLE_PROMOTE = "MODEL_LIFECYCLE_PROMOTE"
     # Runtime-originated: a worker quarantining or redriving a poisoned queue
     # job answers to a service identity, not a human approver, and is
     # explicitly SYSTEM_ORIGINATED rather than dressing a service string up

--- a/src/app/contracts/model_catalogue.py
+++ b/src/app/contracts/model_catalogue.py
@@ -18,6 +18,8 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from app.contracts.governed_actions import GovernedActionRecord
+
 
 class ModelLifecycleState(str, Enum):
     DISCOVERED = "DISCOVERED"
@@ -227,6 +229,21 @@ ALLOWED_MODEL_LIFECYCLE_TRANSITIONS: dict[ModelLifecycleState, frozenset[ModelLi
     ModelLifecycleState.RETIRED: frozenset(),
 }
 
+# Transitions INTO these states expand serving posture and are risk-increasing:
+# they require the governed two-step flow (verified requester, distinct
+# verified approver, PASS-verdict eval evidence) rather than the single-call
+# transition route (issue #245). Every other target - taking a model out of
+# service or moving it through evaluation - is a safety or administrative
+# action one verified principal applies immediately.
+MODEL_SERVING_PROMOTION_TARGETS: frozenset[ModelLifecycleState] = frozenset(
+    {
+        ModelLifecycleState.APPROVED,
+        ModelLifecycleState.SHADOW,
+        ModelLifecycleState.CANARY,
+        ModelLifecycleState.PRODUCTION,
+    }
+)
+
 # States an operator has deliberately taken a model OUT of service through.
 # Nothing automatic - including a seeding-authority change - may resurrect
 # a model from these; only an explicit operator transition can.
@@ -243,24 +260,76 @@ class ModelLifecycleTransitionRecord(BaseModel):
     from_state: ModelLifecycleState = Field(description="State before the transition.")
     to_state: ModelLifecycleState = Field(description="State after the transition.")
     reason: str = Field(min_length=1, description="Operator reason recorded with the transition.")
-    requested_by: str = Field(min_length=1, description="Operator who requested the transition.")
-    approved_by: str = Field(min_length=1, description="Operator who approved the transition.")
+    requested_by: str = Field(
+        min_length=1,
+        description="Verified identity that requested the transition (issue #245).",
+    )
+    approved_by: str | None = Field(
+        default=None,
+        description=(
+            "Verified identity that approved a governed serving promotion; null for "
+            "single-principal safety and administrative transitions, where no "
+            "approval existed (issue #245)."
+        ),
+    )
     approval_evidence_ref: str | None = Field(
         default=None,
-        description="Approval evidence reference; required when transitioning to APPROVED.",
+        description=(
+            "Evidence reference recorded with a governed serving promotion "
+            "(`evaluation-run:<run_id>`); null otherwise."
+        ),
     )
     recorded_at: str = Field(description="Instant the transition was recorded (UTC).")
 
 
 class ModelLifecycleTransitionRequest(BaseModel):
-    caller_app: str = Field(min_length=1, description="Calling application identity.")
+    """Single-principal safety or administrative transition.
+
+    Caller identity comes from the authenticated credential, never from the
+    body (issue #245). Serving promotions are refused here and go through the
+    governed two-step promotion flow.
+    """
+
     to_state: ModelLifecycleState = Field(description="Target lifecycle state.")
     reason: str = Field(min_length=1, description="Why this transition is being made.")
-    requested_by: str = Field(min_length=1, description="Operator requesting the transition.")
-    approved_by: str = Field(min_length=1, description="Operator approving the transition.")
-    approval_evidence_ref: str | None = Field(
+
+
+class ModelPromotionIntentRequest(BaseModel):
+    """Step one of governed serving promotion: a verified requester states the intent.
+
+    Eval evidence enables the decision; it does not make the decision - the
+    named run must already exist with a PASS verdict, and a distinct verified
+    credential still has to approve (issue #245).
+    """
+
+    to_state: ModelLifecycleState = Field(
+        description="Serving target (APPROVED, SHADOW, CANARY or PRODUCTION)."
+    )
+    reason: str = Field(min_length=1, description="Why this promotion should happen.")
+    evaluation_run_id: str = Field(
+        min_length=1,
+        description="Existing evaluation run whose PASS verdict backs this promotion.",
+    )
+    requested_by: str | None = Field(
         default=None,
-        description="Approval evidence reference; required when to_state is APPROVED.",
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class ModelPromotionApprovalRequest(BaseModel):
+    """Step two: a distinct verified credential approves the exact pending action."""
+
+    action_id: str = Field(min_length=1, max_length=64, description="Pending governed action id.")
+    action_hash: str = Field(
+        min_length=64,
+        max_length=64,
+        description="Hash of the action being approved, exactly as returned by the request step.",
+    )
+    approved_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
     )
 
 
@@ -272,6 +341,22 @@ class ModelLifecycleTransitionResponse(BaseModel):
     transition: ModelLifecycleTransitionRecord = Field(
         description="The durable transition record this action created.",
     )
+
+
+class ModelPromotionApprovalResponse(BaseModel):
+    """The executed serving promotion with its full governance evidence chain."""
+
+    service: str = Field(description="Service name emitting the response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    store_mode: str = Field(description="Where catalogue truth lives: memory or sqlalchemy.")
+    entry: ModelCatalogueEntry = Field(description="The entry after the promotion.")
+    transition: ModelLifecycleTransitionRecord = Field(
+        description="The durable transition record this promotion created.",
+    )
+    governed_action: GovernedActionRecord = Field(
+        description="The request-approval-execution evidence chain (issue #245).",
+    )
+    summary: list[str] = Field(description="Human-readable account of what executed.")
 
 
 class ModelCatalogueEntryDetailResponse(BaseModel):

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -756,7 +756,9 @@ class ModelCatalogueLifecycleEventModel(Base):
     to_state: Mapped[str] = mapped_column(String(32), nullable=False)
     reason: Mapped[str] = mapped_column(Text, nullable=False)
     requested_by: Mapped[str] = mapped_column(String(128), nullable=False)
-    approved_by: Mapped[str] = mapped_column(String(128), nullable=False)
+    # Null when no approval existed: single-principal safety and
+    # administrative transitions (issue #245).
+    approved_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
     approval_evidence_ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
     recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
 

--- a/src/app/routers/model_catalogue.py
+++ b/src/app/routers/model_catalogue.py
@@ -2,16 +2,23 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.contracts.governed_actions import GovernedActionResponse
 from app.contracts.model_catalogue import (
     ModelCatalogueEntryDetailResponse,
     ModelCatalogueResponse,
     ModelLifecycleTransitionRequest,
     ModelLifecycleTransitionResponse,
+    ModelPromotionApprovalRequest,
+    ModelPromotionApprovalResponse,
+    ModelPromotionIntentRequest,
 )
+from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.model_catalogue import (
     apply_model_lifecycle_transition,
+    approve_model_promotion,
     build_model_catalogue_entry_detail,
     build_model_catalogue_response,
+    request_model_promotion,
 )
 
 router = APIRouter(prefix="/platform/models", tags=["platform"])
@@ -62,19 +69,23 @@ async def get_model_catalogue_entry_detail_route(
     "/catalogue/{entry_id}/lifecycle-transitions",
     response_model=ModelLifecycleTransitionResponse,
     operation_id="applyModelLifecycleTransition",
-    summary="Apply a governed lifecycle transition to a catalogue entry",
+    summary="Apply a single-principal lifecycle transition to a catalogue entry",
     description=(
         "Moves one model-catalogue entry along the governed lifecycle edge table with a "
-        "recorded reason, requester and approver. Promotion to APPROVED requires approval "
-        "evidence. DEGRADED, DEPRECATED and RETIRED entries refuse new live executions at the "
-        "provider gateway. Requires provider-control authorization and the durable catalogue "
-        "store."
+        "recorded reason, under the caller's verified identity (issue #245). Safety and "
+        "administrative targets only: serving promotions (APPROVED, SHADOW, CANARY, "
+        "PRODUCTION) are refused here and go through the governed two-step promotion flow. "
+        "DEGRADED, DEPRECATED and RETIRED entries refuse new live executions at the provider "
+        "gateway. Requires provider-control authorization and the durable catalogue store."
     ),
     responses={
         200: {"description": "Lifecycle transition applied."},
         403: {"description": "Caller is not authorized for provider control."},
         404: {"description": "No entry exists for the given id."},
-        409: {"description": "The durable catalogue store is not configured."},
+        409: {
+            "description": "The durable catalogue store is not configured, or the target "
+            "expands serving posture and requires the governed promotion flow."
+        },
         422: {"description": "The transition is not allowed from the current state."},
         500: {"description": "Unexpected server error."},
     },
@@ -82,5 +93,75 @@ async def get_model_catalogue_entry_detail_route(
 async def apply_model_lifecycle_transition_route(
     entry_id: str,
     request: ModelLifecycleTransitionRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
 ) -> ModelLifecycleTransitionResponse:
-    return apply_model_lifecycle_transition(entry_id, request)
+    return apply_model_lifecycle_transition(entry_id, request, authenticated_caller)
+
+
+@router.post(
+    "/catalogue/{entry_id}/promotion-requests",
+    response_model=GovernedActionResponse,
+    operation_id="requestModelPromotion",
+    summary="Request a serving promotion of a catalogue entry",
+    description=(
+        "Step one of governed serving promotion (issue #245): validates the target, the "
+        "lifecycle edge and the named PASS-verdict evaluation run, then records a pending "
+        "intent under the requester's verified credential and returns the action hash a "
+        "distinct verified credential must approve. Eval evidence enables the decision; it "
+        "does not make the decision. The entry is unchanged until the approval executes."
+    ),
+    responses={
+        200: {"description": "Promotion intent recorded and pending approval."},
+        403: {
+            "description": "Caller is not authorized for provider control, or carries no "
+            "verified credential."
+        },
+        404: {"description": "No entry exists for the given id."},
+        409: {"description": "The durable catalogue store is not configured."},
+        422: {
+            "description": "The target is not a serving promotion, the edge is not allowed, "
+            "or the evaluation run is missing or did not pass."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def request_model_promotion_route(
+    entry_id: str,
+    request: ModelPromotionIntentRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> GovernedActionResponse:
+    return request_model_promotion(entry_id, request, authenticated_caller)
+
+
+@router.post(
+    "/catalogue/{entry_id}/promotion-approvals",
+    response_model=ModelPromotionApprovalResponse,
+    operation_id="approveModelPromotion",
+    summary="Approve and execute a pending serving promotion",
+    description=(
+        "Step two of governed serving promotion (issue #245): a verified credential DISTINCT "
+        "from the requester's approves the exact pending action hash, which re-validates the "
+        "lifecycle edge and eval evidence, executes the promotion, and records the full "
+        "request-approval-execution evidence chain. A lifecycle-state or revision change "
+        "since the request refuses the stale approval."
+    ),
+    responses={
+        200: {"description": "Promotion executed under governed approval."},
+        403: {
+            "description": "Caller is not authorized, carries no verified credential, or is "
+            "the same credential that requested the action."
+        },
+        404: {"description": "No entry or no pending action exists for the given id."},
+        409: {
+            "description": "The durable catalogue store is not configured, the action hash "
+            "does not match, or the entry changed since the request and the approval is stale."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def approve_model_promotion_route(
+    entry_id: str,
+    request: ModelPromotionApprovalRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> ModelPromotionApprovalResponse:
+    return approve_model_promotion(entry_id, request, authenticated_caller)

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -42,6 +42,7 @@ HUMAN_GOVERNED_ACTION_TYPES = frozenset(
         GovernedActionType.KILL_SWITCH_CLEAR,
         GovernedActionType.PROMPT_PROMOTE,
         GovernedActionType.PROVIDER_OPERATIONS_RESET,
+        GovernedActionType.MODEL_LIFECYCLE_PROMOTE,
     }
 )
 

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -15,14 +15,21 @@ seeded field actually changed.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import cast
 from uuid import uuid4
 
 from fastapi import HTTPException, status
 
 from app.config import settings
 from app.contracts.access_control import AuthorizationCapabilityType
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionResponse,
+    GovernedActionType,
+)
 from app.contracts.model_catalogue import (
     ALLOWED_MODEL_LIFECYCLE_TRANSITIONS,
+    MODEL_SERVING_PROMOTION_TARGETS,
     OPERATOR_TERMINAL_LIFECYCLE_STATES,
     ModelCatalogueEntry,
     ModelCatalogueEntryDetailResponse,
@@ -33,6 +40,9 @@ from app.contracts.model_catalogue import (
     ModelLifecycleTransitionRecord,
     ModelLifecycleTransitionRequest,
     ModelLifecycleTransitionResponse,
+    ModelPromotionApprovalRequest,
+    ModelPromotionApprovalResponse,
+    ModelPromotionIntentRequest,
     ModelRevisionDriftObservation,
     derive_model_catalogue_entry_id,
 )
@@ -41,8 +51,15 @@ from app.providers.base import ProviderExecutionError
 from app.providers.configured_workflow_run_model_risk_inventory import (
     ConfiguredWorkflowRunModelRiskInventory,
 )
+from app.http.authenticated_caller import AuthenticatedCaller
 from app.services.access_control_authorization import authorize_request, require_authorized
 from app.contracts.capability_requirements import CapabilityRequirements
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
+from app.services.kill_switch_control import verified_caller_identity
 from app.services.model_catalogue_store import get_model_catalogue_repository
 from app.services.output_contracts import output_contract_exists
 from app.services.provider_execution_config import resolve_provider_execution_config
@@ -361,23 +378,16 @@ def bind_live_text_model_catalogue_entry() -> ModelCatalogueEntry:
     return entry
 
 
-def apply_model_lifecycle_transition(
-    entry_id: str,
-    request: ModelLifecycleTransitionRequest,
-) -> ModelLifecycleTransitionResponse:
-    """Apply one governed lifecycle transition to a catalogue entry.
-
-    The allowed-edge table is the policy; promotion to APPROVED additionally
-    requires approval evidence. The transition and its rationale are recorded
-    durably beside the entry.
-    """
-
+def _require_provider_control_authorization(caller: AuthenticatedCaller) -> None:
     require_authorized(
         authorize_request(
-            caller_app=request.caller_app,
+            caller_app=caller.caller_app,
             capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
         )
     )
+
+
+def _require_durable_catalogue_store() -> None:
     if settings.model_catalogue_store_mode != "sqlalchemy":
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -386,56 +396,273 @@ def apply_model_lifecycle_transition(
                 "sqlalchemy so governed state changes survive restarts."
             ),
         )
-    repository = get_model_catalogue_repository()
-    entry = repository.get_entry(entry_id)
+
+
+def _get_required_catalogue_entry(entry_id: str) -> ModelCatalogueEntry:
+    entry = get_model_catalogue_repository().get_entry(entry_id)
     if entry is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No model-catalogue entry exists for `{entry_id}`.",
         )
+    return entry
+
+
+def _validate_lifecycle_edge(entry: ModelCatalogueEntry, to_state: ModelLifecycleState) -> None:
     allowed = ALLOWED_MODEL_LIFECYCLE_TRANSITIONS[entry.lifecycle_state]
-    if request.to_state not in allowed:
+    if to_state not in allowed:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(
-                f"Transition {entry.lifecycle_state.value} -> {request.to_state.value} is not "
+                f"Transition {entry.lifecycle_state.value} -> {to_state.value} is not "
                 f"allowed; permitted targets: "
                 f"{sorted(state.value for state in allowed) or 'none (terminal state)'}."
             ),
         )
-    if request.to_state is ModelLifecycleState.APPROVED and not request.approval_evidence_ref:
+
+
+def _require_pass_verdict_evaluation_run(run_id: str) -> None:
+    """Promotion evidence must name a real, completed, PASS-verdict eval run.
+
+    Eval evidence enables the decision; it does not make the decision - but a
+    pending approval must never be parked on, or execute against, evidence
+    that does not exist or did not actually pass (issue #245).
+    """
+
+    run = get_evaluation_runtime_store().get_run(run_id=run_id)
+    if run is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="Promotion to APPROVED requires an approval_evidence_ref.",
+            detail=(
+                f"Evaluation run `{run_id}` does not exist; promotion evidence must name "
+                "a real evaluation run."
+            ),
+        )
+    if run.lifecycle_status != "COMPLETED" or run.verdict != "PASS":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Evaluation run `{run_id}` is {run.lifecycle_status} with verdict "
+                f"{run.verdict or 'none'}; promotion requires a COMPLETED run with "
+                "verdict PASS."
+            ),
         )
 
+
+def _record_lifecycle_transition(
+    *,
+    entry: ModelCatalogueEntry,
+    to_state: ModelLifecycleState,
+    reason: str,
+    requested_by: str,
+    approved_by: str | None,
+    approval_evidence_ref: str | None,
+) -> ModelLifecycleTransitionResponse:
+    """Durably apply one already-validated lifecycle state change."""
+
     now = _utc_now_iso()
-    updates: dict[str, object] = {"lifecycle_state": request.to_state, "last_updated_at": now}
-    if request.approval_evidence_ref:
+    updates: dict[str, object] = {"lifecycle_state": to_state, "last_updated_at": now}
+    if approval_evidence_ref:
         updates["approval_evidence_refs"] = [
             *entry.approval_evidence_refs,
-            request.approval_evidence_ref,
+            approval_evidence_ref,
         ]
     updated = entry.model_copy(update=updates)
     transition = ModelLifecycleTransitionRecord(
         event_id=f"mlc_{uuid4().hex[:16]}",
-        entry_id=entry_id,
+        entry_id=entry.entry_id,
         from_state=entry.lifecycle_state,
-        to_state=request.to_state,
-        reason=request.reason,
-        requested_by=request.requested_by,
-        approved_by=request.approved_by,
-        approval_evidence_ref=request.approval_evidence_ref,
+        to_state=to_state,
+        reason=reason,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        approval_evidence_ref=approval_evidence_ref,
         recorded_at=now,
     )
     upsert_model_catalogue_entry(updated)
-    repository.append_lifecycle_event(transition)
+    get_model_catalogue_repository().append_lifecycle_event(transition)
     return ModelLifecycleTransitionResponse(
         service=settings.service_name,
         version=settings.service_version,
         store_mode=settings.model_catalogue_store_mode,
         entry=updated,
         transition=transition,
+    )
+
+
+def apply_model_lifecycle_transition(
+    entry_id: str,
+    request: ModelLifecycleTransitionRequest,
+    caller: AuthenticatedCaller,
+) -> ModelLifecycleTransitionResponse:
+    """Apply one single-principal lifecycle transition to a catalogue entry.
+
+    Safety and administrative targets only: taking a model out of service, or
+    moving it through cataloguing and evaluation, is applied immediately by
+    one verified principal and honestly records that no approval existed.
+    Serving promotions are risk-increasing and refused here with guidance to
+    the governed two-step flow (issue #245).
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    if request.to_state in MODEL_SERVING_PROMOTION_TARGETS:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Transition to {request.to_state.value} expands serving posture and must go "
+                "through the governed two-step promotion flow (issue #245): state the intent "
+                "via promotion-requests, then a distinct verified credential approves via "
+                "promotion-approvals."
+            ),
+        )
+    _validate_lifecycle_edge(entry, request.to_state)
+    return _record_lifecycle_transition(
+        entry=entry,
+        to_state=request.to_state,
+        reason=request.reason,
+        requested_by=verified_caller_identity(caller),
+        approved_by=None,
+        approval_evidence_ref=None,
+    )
+
+
+def _promotion_action_payload(
+    *,
+    entry: ModelCatalogueEntry,
+    to_state: ModelLifecycleState,
+    evaluation_run_id: str,
+    reason: str,
+) -> dict[str, str | None]:
+    """The exact action the approver signs off on.
+
+    Pins the entry's current lifecycle state and exact revision identity: a
+    promotion reviewed against one baseline must not execute against another,
+    so a state or revision change between request and approval refuses the
+    stale approval instead of executing it (issue #245).
+    """
+
+    return {
+        "action_type": GovernedActionType.MODEL_LIFECYCLE_PROMOTE.value,
+        "entry_id": entry.entry_id,
+        "from_state": entry.lifecycle_state.value,
+        "to_state": to_state.value,
+        "provider_id": entry.provider_id,
+        "model_family": entry.model_family,
+        "model_revision": entry.model_revision,
+        "deployment": entry.deployment,
+        "evaluation_run_id": evaluation_run_id,
+        "reason": reason,
+    }
+
+
+def request_model_promotion(
+    entry_id: str,
+    request: ModelPromotionIntentRequest,
+    caller: AuthenticatedCaller,
+) -> GovernedActionResponse:
+    """Step one of governed serving promotion: record the intent under the requester's credential.
+
+    The promotion is fully validated first - serving target, lifecycle edge,
+    and PASS-verdict eval evidence - so a pending action is never parked on a
+    promotion that is not currently executable.
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    if request.to_state not in MODEL_SERVING_PROMOTION_TARGETS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"{request.to_state.value} is not a serving-promotion target; apply it as a "
+                "single-principal transition via lifecycle-transitions."
+            ),
+        )
+    _validate_lifecycle_edge(entry, request.to_state)
+    _require_pass_verdict_evaluation_run(request.evaluation_run_id)
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.MODEL_LIFECYCLE_PROMOTE,
+        target=entry_id,
+        payload=_promotion_action_payload(
+            entry=entry,
+            to_state=request.to_state,
+            evaluation_run_id=request.evaluation_run_id,
+            reason=request.reason,
+        ),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Promotion of `{entry_id}` from {entry.lifecycle_state.value} to "
+            f"{request.to_state.value} is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            f"Eval evidence: run `{request.evaluation_run_id}` (COMPLETED, verdict PASS).",
+        ],
+    )
+
+
+def approve_model_promotion(
+    entry_id: str,
+    request: ModelPromotionApprovalRequest,
+    caller: AuthenticatedCaller,
+) -> ModelPromotionApprovalResponse:
+    """Step two: a distinct verified credential approves the exact action, which executes it."""
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    outcome: dict[str, object] = {}
+
+    def _execute_promotion(record: GovernedActionRecord) -> None:
+        to_state = ModelLifecycleState(str(record.action_payload.get("to_state")))
+        evaluation_run_id = str(record.action_payload.get("evaluation_run_id"))
+        _validate_lifecycle_edge(entry, to_state)
+        _require_pass_verdict_evaluation_run(evaluation_run_id)
+        outcome["response"] = _record_lifecycle_transition(
+            entry=entry,
+            to_state=to_state,
+            reason=str(record.action_payload.get("reason")),
+            requested_by=(f"{record.requester_caller_app} (credential {record.requester_key_id})"),
+            approved_by=verified_caller_identity(caller),
+            approval_evidence_ref=f"evaluation-run:{evaluation_run_id}",
+        )
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=entry_id,
+        expected_hash=request.action_hash,
+        current_payload_builder=lambda record: _promotion_action_payload(
+            entry=entry,
+            to_state=ModelLifecycleState(str(record.action_payload.get("to_state"))),
+            evaluation_run_id=str(record.action_payload.get("evaluation_run_id")),
+            reason=str(record.action_payload.get("reason")),
+        ),
+        attribution=request.approved_by,
+        execute=_execute_promotion,
+    )
+    transition_response = cast(ModelLifecycleTransitionResponse, outcome["response"])
+    return ModelPromotionApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=transition_response.entry,
+        transition=transition_response.transition,
+        governed_action=executed,
+        summary=[
+            f"Promoted `{entry_id}` to {transition_response.entry.lifecycle_state.value} "
+            f"under governed action `{executed.action_id}`.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+            f"Evidence: `{transition_response.transition.approval_evidence_ref}`.",
+        ],
     )
 
 

--- a/tests/integration/test_model_catalogue_api_contract.py
+++ b/tests/integration/test_model_catalogue_api_contract.py
@@ -193,16 +193,18 @@ def test_operator_deprecation_refuses_live_execution_end_to_end(
             transitioned = client.post(
                 "/platform/models/catalogue/text.openai:gpt-5.4/lifecycle-transitions",
                 json={
-                    "caller_app": "lotus-platform",
                     "to_state": "DEPRECATED",
                     "reason": "Vendor end-of-life announced; retire from live service.",
-                    "requested_by": "ops.primary@lotus",
-                    "approved_by": "ops.secondary@lotus",
                 },
                 headers={"X-Caller-App": "lotus-platform"},
             )
             assert transitioned.status_code == 200
             assert transitioned.json()["entry"]["lifecycle_state"] == "DEPRECATED"
+            # Identity comes from the authenticated caller, and the record is
+            # honest that no approval existed (issue #245).
+            transition_record = transitioned.json()["transition"]
+            assert transition_record["requested_by"] == "lotus-platform (trusted_http_header)"
+            assert transition_record["approved_by"] is None
 
             refused = client.post("/ai/tasks/execute", json=execute_payload)
             assert refused.status_code == 503
@@ -223,3 +225,142 @@ def test_operator_deprecation_refuses_live_execution_end_to_end(
                 headers={"X-Caller-App": "lotus-platform"},
             )
             assert unknown.status_code == 404
+
+
+def test_governed_promotion_flow_over_http(tmp_path: Path) -> None:
+    """The governed two-step serving promotion end-to-end (issue #245):
+    verified requester states the intent, a DISTINCT verified credential
+    approves the exact hash, and the transition records the full evidence
+    chain - while the single-call route refuses serving targets."""
+
+    from tests.support.caller_credentials import (
+        generate_caller_signing_key,
+        mint_caller_credential,
+        public_keys_setting,
+    )
+
+    requester_key = generate_caller_signing_key()
+    approver_key = generate_caller_signing_key()
+    requester_headers = {
+        "Authorization": "Bearer "
+        + mint_caller_credential(
+            signing_key=requester_key,
+            key_id="catalogue-ops-alpha",
+            subject="lotus-platform",
+            expires_in_seconds=3600,
+        )
+    }
+    approver_headers = {
+        "Authorization": "Bearer "
+        + mint_caller_credential(
+            signing_key=approver_key,
+            key_id="catalogue-ops-beta",
+            subject="lotus-platform",
+            expires_in_seconds=3600,
+        )
+    }
+
+    database_url = f"sqlite:///{tmp_path / 'catalogue-promotion.db'}"
+    upgrade_database_to_head(database_url)
+
+    with override_runtime_settings(
+        model_catalogue_store_mode="sqlalchemy",
+        database_url=database_url,
+        provider_mode="local_openai_compatible",
+        live_text_provider_id="text.local",
+        live_text_model_id="qwen3:8b",
+        live_text_model_version=None,
+        workflow_run_model_risk_inventory_json="[]",
+        caller_trust_mode="verified_service_jwt",
+        caller_jwt_issuer="https://platform.lotus/issuer",
+        caller_jwt_audience="lotus-ai",
+        caller_jwt_public_keys=public_keys_setting(
+            **{"catalogue-ops-alpha": requester_key, "catalogue-ops-beta": approver_key}
+        ),
+    ):
+        with TestClient(app) as client:
+            from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+            from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+            get_evaluation_runtime_store().save_run(
+                EvaluationRunRecord(
+                    run_id="runtime_promotion_http_001",
+                    fixture_id="model_promotion_examples",
+                    manifest_version="foundation.v1",
+                    lifecycle_status="COMPLETED",
+                    triggered_by="operator-a",
+                    submitted_at="2026-09-03T09:00:00Z",
+                    async_job_id=None,
+                    latest_message="Promotion evidence fixture.",
+                    verdict="PASS",
+                    case_count=3,
+                )
+            )
+            entry_id = "text.local:qwen3:8b"
+            base = f"/platform/models/catalogue/{entry_id}"
+
+            # A catalogue read idempotently seeds the configured identity.
+            seeded = client.get("/platform/models/catalogue", headers=requester_headers)
+            assert seeded.status_code == 200
+
+            evaluating = client.post(
+                f"{base}/lifecycle-transitions",
+                json={"to_state": "EVALUATING", "reason": "Begin evaluation."},
+                headers=requester_headers,
+            )
+            assert evaluating.status_code == 200
+
+            # The single-call route refuses a serving target outright.
+            blocked = client.post(
+                f"{base}/lifecycle-transitions",
+                json={"to_state": "APPROVED", "reason": "Attempt ungoverned promotion."},
+                headers=requester_headers,
+            )
+            assert blocked.status_code == 409
+            assert "promotion-requests" in blocked.json()["detail"]
+
+            pending = client.post(
+                f"{base}/promotion-requests",
+                json={
+                    "to_state": "APPROVED",
+                    "reason": "Passing evaluation evidence supports approval.",
+                    "evaluation_run_id": "runtime_promotion_http_001",
+                    "requested_by": "alice@lotus.test",
+                },
+                headers=requester_headers,
+            )
+            assert pending.status_code == 200
+            action = pending.json()["governed_action"]
+            assert action["status"] == "PENDING"
+
+            # The requester's own credential cannot approve.
+            same_credential = client.post(
+                f"{base}/promotion-approvals",
+                json={"action_id": action["action_id"], "action_hash": action["action_hash"]},
+                headers=requester_headers,
+            )
+            assert same_credential.status_code == 403
+
+            approved = client.post(
+                f"{base}/promotion-approvals",
+                json={
+                    "action_id": action["action_id"],
+                    "action_hash": action["action_hash"],
+                    "approved_by": "bob@lotus.test",
+                },
+                headers=approver_headers,
+            )
+            assert approved.status_code == 200
+            body = approved.json()
+            assert body["entry"]["lifecycle_state"] == "APPROVED"
+            assert (
+                "evaluation-run:runtime_promotion_http_001"
+                in (body["entry"]["approval_evidence_refs"])
+            )
+            assert body["transition"]["requested_by"] == (
+                "lotus-platform (credential catalogue-ops-alpha)"
+            )
+            assert body["transition"]["approved_by"] == (
+                "lotus-platform (credential catalogue-ops-beta)"
+            )
+            assert body["governed_action"]["status"] == "EXECUTED"

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -309,14 +309,67 @@ def test_binding_refuses_an_execution_ineligible_lifecycle_state(
 
 def _transition_request(**overrides: object) -> ModelLifecycleTransitionRequest:
     payload: dict[str, object] = {
-        "caller_app": "lotus-platform",
         "to_state": ModelLifecycleState.EVALUATING,
         "reason": "Begin evaluation for governed promotion.",
-        "requested_by": "ops.primary@lotus",
-        "approved_by": "ops.secondary@lotus",
     }
     payload.update(overrides)
     return ModelLifecycleTransitionRequest.model_validate(payload)
+
+
+def _seed_evaluation_run(
+    run_id: str,
+    *,
+    lifecycle_status: str = "COMPLETED",
+    verdict: str | None = "PASS",
+) -> None:
+    from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id=run_id,
+            fixture_id="model_promotion_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status=lifecycle_status,
+            triggered_by="operator-a",
+            submitted_at="2026-09-03T09:00:00Z",
+            async_job_id=None,
+            latest_message="Promotion evidence fixture.",
+            verdict=verdict,
+            case_count=3,
+        )
+    )
+
+
+def _promote_entry_for_test(
+    entry_id: str, to_state: ModelLifecycleState, evaluation_run_id: str
+) -> object:
+    """Run the full governed two-step promotion as test setup."""
+
+    from app.contracts.model_catalogue import (
+        ModelPromotionApprovalRequest,
+        ModelPromotionIntentRequest,
+    )
+    from app.services.model_catalogue import approve_model_promotion, request_model_promotion
+    from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
+
+    pending = request_model_promotion(
+        entry_id,
+        ModelPromotionIntentRequest(
+            to_state=to_state,
+            reason="Promotion backed by passing evaluation evidence.",
+            evaluation_run_id=evaluation_run_id,
+        ),
+        GOVERNED_REQUESTER,
+    )
+    return approve_model_promotion(
+        entry_id,
+        ModelPromotionApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
 
 
 @pytest.fixture
@@ -338,16 +391,23 @@ def test_lifecycle_transition_requires_authorization_and_durable_store(
 ) -> None:
     from fastapi import HTTPException
 
+    from app.http.authenticated_caller import AuthenticatedCaller
     from app.services.model_catalogue import apply_model_lifecycle_transition
+    from tests.support.governed_control import GOVERNED_REQUESTER
 
+    unauthorized = AuthenticatedCaller(
+        caller_app="lotus-manage",
+        trust_source="verified_service_jwt",
+        credential_key_id="ops-key-alpha",
+    )
     with pytest.raises(HTTPException) as excinfo:
-        apply_model_lifecycle_transition(
-            "text.local:qwen3:8b", _transition_request(caller_app="lotus-manage")
-        )
+        apply_model_lifecycle_transition("text.local:qwen3:8b", _transition_request(), unauthorized)
     assert excinfo.value.status_code == 403
 
     with pytest.raises(HTTPException) as excinfo:
-        apply_model_lifecycle_transition("text.local:qwen3:8b", _transition_request())
+        apply_model_lifecycle_transition(
+            "text.local:qwen3:8b", _transition_request(), GOVERNED_REQUESTER
+        )
     assert excinfo.value.status_code == 409
     assert "LOTUS_AI_MODEL_CATALOGUE_STORE_MODE" in str(excinfo.value.detail)
 
@@ -355,53 +415,62 @@ def test_lifecycle_transition_requires_authorization_and_durable_store(
 def test_lifecycle_transition_walks_the_governed_edge_table(_durable_catalogue: str) -> None:
     from fastapi import HTTPException
 
+    from app.contracts.model_catalogue import ModelPromotionApprovalResponse
     from app.services.model_catalogue import (
         apply_model_lifecycle_transition,
         build_model_catalogue_entry_detail,
     )
+    from tests.support.governed_control import GOVERNED_REQUESTER
 
     entry_id = _durable_catalogue
 
+    # A serving target is refused on the single-principal route BEFORE edge
+    # validation: the risk direction, not the edge table, is the first gate.
     with pytest.raises(HTTPException) as excinfo:
         apply_model_lifecycle_transition(
-            entry_id, _transition_request(to_state=ModelLifecycleState.PRODUCTION)
+            entry_id,
+            _transition_request(to_state=ModelLifecycleState.PRODUCTION),
+            GOVERNED_REQUESTER,
         )
-    assert excinfo.value.status_code == 422
-    assert "not allowed" in str(excinfo.value.detail)
+    assert excinfo.value.status_code == 409
+    assert "promotion-requests" in str(excinfo.value.detail)
 
-    apply_model_lifecycle_transition(entry_id, _transition_request())
-
-    with pytest.raises(HTTPException) as excinfo:
-        apply_model_lifecycle_transition(
-            entry_id, _transition_request(to_state=ModelLifecycleState.APPROVED)
-        )
-    assert excinfo.value.status_code == 422
-    assert "approval_evidence_ref" in str(excinfo.value.detail)
-
-    approved = apply_model_lifecycle_transition(
-        entry_id,
-        _transition_request(
-            to_state=ModelLifecycleState.APPROVED,
-            approval_evidence_ref="mrm-approval-2026-021",
-        ),
+    evaluating = apply_model_lifecycle_transition(
+        entry_id, _transition_request(), GOVERNED_REQUESTER
     )
+    assert evaluating.transition.requested_by == "lotus-platform (credential ops-key-alpha)"
+    # No approval existed, and the record says so honestly.
+    assert evaluating.transition.approved_by is None
+    assert evaluating.transition.approval_evidence_ref is None
+
+    _seed_evaluation_run("run_promotion_001")
+    approved = _promote_entry_for_test(entry_id, ModelLifecycleState.APPROVED, "run_promotion_001")
+    assert isinstance(approved, ModelPromotionApprovalResponse)
     assert approved.entry.lifecycle_state is ModelLifecycleState.APPROVED
-    assert "mrm-approval-2026-021" in approved.entry.approval_evidence_refs
+    assert "evaluation-run:run_promotion_001" in approved.entry.approval_evidence_refs
+    assert approved.transition.requested_by == "lotus-platform (credential ops-key-alpha)"
+    assert approved.transition.approved_by == "lotus-platform (credential ops-key-beta)"
+    assert approved.governed_action.status.value == "EXECUTED"
+
+    production = _promote_entry_for_test(
+        entry_id, ModelLifecycleState.PRODUCTION, "run_promotion_001"
+    )
+    assert isinstance(production, ModelPromotionApprovalResponse)
+    assert production.entry.lifecycle_state is ModelLifecycleState.PRODUCTION
 
     apply_model_lifecycle_transition(
-        entry_id, _transition_request(to_state=ModelLifecycleState.PRODUCTION)
-    )
-    apply_model_lifecycle_transition(
-        entry_id, _transition_request(to_state=ModelLifecycleState.DEPRECATED)
+        entry_id, _transition_request(to_state=ModelLifecycleState.DEPRECATED), GOVERNED_REQUESTER
     )
     retired = apply_model_lifecycle_transition(
-        entry_id, _transition_request(to_state=ModelLifecycleState.RETIRED)
+        entry_id, _transition_request(to_state=ModelLifecycleState.RETIRED), GOVERNED_REQUESTER
     )
     assert retired.entry.lifecycle_state is ModelLifecycleState.RETIRED
 
     with pytest.raises(HTTPException) as excinfo:
         apply_model_lifecycle_transition(
-            entry_id, _transition_request(to_state=ModelLifecycleState.CATALOGUED)
+            entry_id,
+            _transition_request(to_state=ModelLifecycleState.CATALOGUED),
+            GOVERNED_REQUESTER,
         )
     assert excinfo.value.status_code == 422
     assert "terminal" in str(excinfo.value.detail)
@@ -415,6 +484,188 @@ def test_lifecycle_transition_walks_the_governed_edge_table(_durable_catalogue: 
         ModelLifecycleState.RETIRED,
     ]
     assert all(event.reason for event in detail.lifecycle_events)
+
+
+def test_promotion_request_validates_target_edge_and_evidence(_durable_catalogue: str) -> None:
+    """A pending approval is never parked on a promotion that cannot execute:
+    the serving-target shape, the lifecycle edge, and the PASS-verdict eval
+    evidence are all vetted before any intent is recorded (issue #245)."""
+
+    from fastapi import HTTPException
+
+    from app.contracts.model_catalogue import ModelPromotionIntentRequest
+    from app.services.model_catalogue import (
+        apply_model_lifecycle_transition,
+        request_model_promotion,
+    )
+    from tests.support.governed_control import GOVERNED_REQUESTER
+
+    entry_id = _durable_catalogue
+
+    def _intent(
+        to_state: ModelLifecycleState, run_id: str = "run_promotion_ok"
+    ) -> ModelPromotionIntentRequest:
+        return ModelPromotionIntentRequest(
+            to_state=to_state,
+            reason="Promotion backed by evaluation evidence.",
+            evaluation_run_id=run_id,
+        )
+
+    # A non-serving target has no business on the promotion flow.
+    with pytest.raises(HTTPException) as excinfo:
+        request_model_promotion(
+            entry_id, _intent(ModelLifecycleState.DEPRECATED), GOVERNED_REQUESTER
+        )
+    assert excinfo.value.status_code == 422
+    assert "not a serving-promotion target" in str(excinfo.value.detail)
+
+    # The lifecycle edge table still applies on the governed flow.
+    _seed_evaluation_run("run_promotion_ok")
+    with pytest.raises(HTTPException) as excinfo:
+        request_model_promotion(
+            entry_id, _intent(ModelLifecycleState.PRODUCTION), GOVERNED_REQUESTER
+        )
+    assert excinfo.value.status_code == 422
+    assert "not allowed" in str(excinfo.value.detail)
+
+    apply_model_lifecycle_transition(entry_id, _transition_request(), GOVERNED_REQUESTER)
+
+    # Evidence must exist ...
+    with pytest.raises(HTTPException) as excinfo:
+        request_model_promotion(
+            entry_id, _intent(ModelLifecycleState.APPROVED, "run_missing"), GOVERNED_REQUESTER
+        )
+    assert excinfo.value.status_code == 422
+    assert "does not exist" in str(excinfo.value.detail)
+
+    # ... and must actually have passed: a FAIL verdict or an unfinished run
+    # is not promotion evidence.
+    _seed_evaluation_run("run_promotion_fail", verdict="FAIL")
+    with pytest.raises(HTTPException) as excinfo:
+        request_model_promotion(
+            entry_id,
+            _intent(ModelLifecycleState.APPROVED, "run_promotion_fail"),
+            GOVERNED_REQUESTER,
+        )
+    assert excinfo.value.status_code == 422
+    assert "verdict PASS" in str(excinfo.value.detail)
+
+    _seed_evaluation_run("run_promotion_running", lifecycle_status="RUNNING", verdict=None)
+    with pytest.raises(HTTPException) as excinfo:
+        request_model_promotion(
+            entry_id,
+            _intent(ModelLifecycleState.APPROVED, "run_promotion_running"),
+            GOVERNED_REQUESTER,
+        )
+    assert excinfo.value.status_code == 422
+    assert "RUNNING" in str(excinfo.value.detail)
+
+    # A valid intent records PENDING and changes nothing until approval.
+    pending = request_model_promotion(
+        entry_id, _intent(ModelLifecycleState.APPROVED), GOVERNED_REQUESTER
+    )
+    assert pending.governed_action.status.value == "PENDING"
+    entry = get_model_catalogue_repository().get_entry(entry_id)
+    assert entry is not None
+    assert entry.lifecycle_state is ModelLifecycleState.EVALUATING
+
+
+def test_promotion_approval_refuses_a_stale_baseline(_durable_catalogue: str) -> None:
+    """An approval reviewed against one lifecycle baseline must not execute
+    against another: the payload pins the entry's state at request time, and
+    a transition in between refuses the stale approval (issue #245)."""
+
+    from fastapi import HTTPException
+
+    from app.contracts.model_catalogue import (
+        ModelPromotionApprovalRequest,
+        ModelPromotionIntentRequest,
+    )
+    from app.services.model_catalogue import (
+        apply_model_lifecycle_transition,
+        approve_model_promotion,
+        request_model_promotion,
+    )
+    from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
+
+    entry_id = _durable_catalogue
+    apply_model_lifecycle_transition(entry_id, _transition_request(), GOVERNED_REQUESTER)
+    _seed_evaluation_run("run_promotion_stale")
+    pending = request_model_promotion(
+        entry_id,
+        ModelPromotionIntentRequest(
+            to_state=ModelLifecycleState.APPROVED,
+            reason="Promotion backed by evaluation evidence.",
+            evaluation_run_id="run_promotion_stale",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    # The entry moves off the reviewed baseline before the approval lands.
+    apply_model_lifecycle_transition(
+        entry_id,
+        _transition_request(
+            to_state=ModelLifecycleState.CATALOGUED,
+            reason="Evaluation paused; return to catalogued.",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        approve_model_promotion(
+            entry_id,
+            ModelPromotionApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+    assert excinfo.value.status_code == 409
+    assert "submit a new request" in str(excinfo.value.detail)
+
+    entry = get_model_catalogue_repository().get_entry(entry_id)
+    assert entry is not None
+    assert entry.lifecycle_state is ModelLifecycleState.CATALOGUED
+
+
+def test_promotion_approval_requires_a_distinct_credential(_durable_catalogue: str) -> None:
+    from fastapi import HTTPException
+
+    from app.contracts.model_catalogue import (
+        ModelPromotionApprovalRequest,
+        ModelPromotionIntentRequest,
+    )
+    from app.services.model_catalogue import (
+        apply_model_lifecycle_transition,
+        approve_model_promotion,
+        request_model_promotion,
+    )
+    from tests.support.governed_control import GOVERNED_REQUESTER
+
+    entry_id = _durable_catalogue
+    apply_model_lifecycle_transition(entry_id, _transition_request(), GOVERNED_REQUESTER)
+    _seed_evaluation_run("run_promotion_distinct")
+    pending = request_model_promotion(
+        entry_id,
+        ModelPromotionIntentRequest(
+            to_state=ModelLifecycleState.APPROVED,
+            reason="Promotion backed by evaluation evidence.",
+            evaluation_run_id="run_promotion_distinct",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        approve_model_promotion(
+            entry_id,
+            ModelPromotionApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert excinfo.value.status_code == 403
+    assert "distinct" in str(excinfo.value.detail)
 
 
 def test_seed_authority_change_never_resurrects_an_operator_terminal_state(
@@ -523,8 +774,12 @@ def test_lifecycle_transition_on_an_unknown_entry_is_404(_durable_catalogue: str
 
     from app.services.model_catalogue import apply_model_lifecycle_transition
 
+    from tests.support.governed_control import GOVERNED_REQUESTER
+
     with pytest.raises(HTTPException) as excinfo:
-        apply_model_lifecycle_transition("text.unknown:nope", _transition_request())
+        apply_model_lifecycle_transition(
+            "text.unknown:nope", _transition_request(), GOVERNED_REQUESTER
+        )
     assert excinfo.value.status_code == 404
 
 


### PR DESCRIPTION
Issue #245, slice 1: model-lifecycle transitions follow the risk direction, and serving promotion becomes a consumer of the governed-action primitive.

## Control-plane outcome

A transition that **expands serving posture** (`APPROVED`, `SHADOW`, `CANARY`, `PRODUCTION`) now requires a verified requester, a **distinct** verified approving credential, and eval evidence that actually exists and actually passed — bound by hash to the exact entry, baseline state, and revision identity reviewed. A transition that **removes or contains risk** (`CATALOGUED`, `EVALUATING`, `DEGRADED`, `DEPRECATED`, `RETIRED`) is applied immediately by one verified principal, and the record honestly says no approval existed (`approved_by = null`).

**Eval evidence enables the decision; it does not make the decision.** A promotion request must name an existing evaluation run with `lifecycle_status=COMPLETED` and `verdict=PASS`; nothing auto-promotes on a green eval, and the evidence reference (`evaluation-run:<run_id>`) is recorded durably on both the entry and the transition.

## What the anti-patterns looked like before

- `ModelLifecycleTransitionRequest` carried caller-typed `caller_app`, `requested_by`, `approved_by` — free-text identities the issue names as the exact thing to remove.
- "Approval evidence" for `APPROVED` was any non-empty string; nothing checked it referenced anything real.
- The single-call route performed serving promotion with no second credential and no action binding.

## Mechanics (no new machinery)

- `GovernedActionType.MODEL_LIFECYCLE_PROMOTE` joins the existing vocabulary and `HUMAN_GOVERNED_ACTION_TYPES`; the flow is the same `submit_governed_action` / `approve_and_execute_governed_action` primitive every other governed domain composes.
- The action payload pins `entry_id`, `from_state`, `to_state`, full revision identity (provider, family, revision, deployment) and the evaluation run — a lifecycle or revision change between request and approval refuses the stale approval ("submit a new request"), proven by test.
- Request-time validation is dry-run-first (target shape → lifecycle edge → PASS evidence), so a pending action is never parked on a promotion that cannot execute; the approval re-validates edge and evidence before the one-write execute.
- The lifecycle edge table is unchanged and still enforced on both paths.
- Migration `0062` makes `approved_by` nullable on `model_catalogue_lifecycle_events` (with full `copy_from` for offline SQL mode); `make migration-smoke` run locally.

## Evidence

- Edge-walk test now exercises the real production path: single-principal EVALUATING → governed promotion to APPROVED (with PASS-run evidence) → governed promotion to PRODUCTION → single-principal DEPRECATED/RETIRED, asserting requester/approver credential identities and the null approver on single-principal records.
- New tests: promotion-request refuses non-serving targets, illegal edges, missing runs, FAIL verdicts, and unfinished runs; stale-baseline approval refused after an interleaved transition; same-credential approval refused; pending intent changes nothing.
- Integration contract test asserts the HTTP transition records the authenticated caller identity and `approved_by: null`.

Full local gate: lint, typecheck, migration-smoke, whole suite with coverage.

Residual (slice 2, on the issue): capability-scoped degradation — recording a regression against one capability dimension without rewriting the others.
