### PR TITLE
feat(catalogue): capability-scoped degradation with governed restore (#245 S2)

### DIFF
--- a/alembic/versions/0063_capability_degradations.py
+++ b/alembic/versions/0063_capability_degradations.py
@@ -1,0 +1,34 @@
+"""capability degradations
+
+Revision ID: 0063_capability_degradations
+Revises: 0062_governed_model_promotion
+Create Date: 2026-09-03
+
+Issue #245, slice 2: an observed regression scoped to one capability
+dimension degrades exactly that capability - immediately, under one verified
+principal - without rewriting the entry's other evidence. Active
+degradations live on the entry; cleared ones are pinned inside their
+governed restore records.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0063_capability_degradations"
+down_revision = "0062_governed_model_promotion"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "model_catalogue_entries",
+        sa.Column("capability_degradations", sa.JSON(), nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("model_catalogue_entries", "capability_degradations")

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -44,6 +44,10 @@ class GovernedActionType(str, Enum):
     # Serving-posture expansion of a catalogue model (issue #245): eval
     # evidence enables the decision; a distinct verified credential makes it.
     MODEL_LIFECYCLE_PROMOTE = "MODEL_LIFECYCLE_PROMOTE"
+    # Clearing an operator capability degradation re-exposes an
+    # evidence-derived capability fact to requirement routing - risk-increasing,
+    # so it takes the same two-step flow (issue #245, slice 2).
+    MODEL_CAPABILITY_RESTORE = "MODEL_CAPABILITY_RESTORE"
     # Runtime-originated: a worker quarantining or redriving a poisoned queue
     # job answers to a service identity, not a human approver, and is
     # explicitly SYSTEM_ORIGINATED rather than dressing a service string up

--- a/src/app/contracts/model_catalogue.py
+++ b/src/app/contracts/model_catalogue.py
@@ -57,6 +57,23 @@ def derive_model_catalogue_entry_id(
     return f"{base}:{deployment}" if deployment else base
 
 
+class ModelCapabilityDegradation(BaseModel):
+    """One active operator capability degradation on a catalogue entry.
+
+    An observed regression scoped to one capability dimension (issue #245,
+    slice 2): the model stays in service for everything else, and the
+    underlying assessed fact is never rewritten - the degradation overrides
+    it only while present.
+    """
+
+    dimension: str = Field(min_length=1, description="Capability fact field degraded.")
+    reason: str = Field(min_length=1, description="The observed regression.")
+    degraded_by: str = Field(
+        min_length=1, description="Verified identity that degraded the capability."
+    )
+    degraded_at: str = Field(description="Instant the degradation was recorded (UTC).")
+
+
 class ModelCatalogueEntry(BaseModel):
     """One governed catalogue row for an exact model identity."""
 
@@ -125,6 +142,15 @@ class ModelCatalogueEntry(BaseModel):
     supports_streaming: bool | None = Field(
         default=None,
         description="Streaming capability; null means not yet assessed.",
+    )
+    capability_degradations: dict[str, ModelCapabilityDegradation] = Field(
+        default_factory=dict,
+        description=(
+            "Active operator capability degradations keyed by capability fact field "
+            "(issue #245, slice 2). While present, a degradation overrides the "
+            "underlying fact for requirement routing; it never rewrites the fact. "
+            "A cleared degradation is pinned inside the governed restore record."
+        ),
     )
     approved_workflow_pack_ids: list[str] = Field(
         default_factory=list,
@@ -244,6 +270,13 @@ MODEL_SERVING_PROMOTION_TARGETS: frozenset[ModelLifecycleState] = frozenset(
     }
 )
 
+# The capability dimensions requirement routing actually enforces (issue #245,
+# slice 2): only these can be operator-degraded - degrading a dimension no
+# routing decision consults would be a control that controls nothing.
+DEGRADABLE_CAPABILITY_DIMENSIONS: frozenset[str] = frozenset(
+    {"supports_structured_output", "supports_tool_calling"}
+)
+
 # States an operator has deliberately taken a model OUT of service through.
 # Nothing automatic - including a seeding-authority change - may resurrect
 # a model from these; only an explicit operator transition can.
@@ -341,6 +374,84 @@ class ModelLifecycleTransitionResponse(BaseModel):
     transition: ModelLifecycleTransitionRecord = Field(
         description="The durable transition record this action created.",
     )
+
+
+class ModelCapabilityDegradationRequest(BaseModel):
+    """Degrade one capability dimension on a catalogue entry.
+
+    Safety direction: containing an observed regression is applied
+    immediately by one verified principal - no approval step, and the caller
+    identity comes from the authenticated credential (issue #245, slice 2).
+    """
+
+    dimension: str = Field(
+        min_length=1,
+        description="Capability fact field to degrade (e.g. supports_structured_output).",
+    )
+    reason: str = Field(min_length=1, description="The observed regression.")
+
+
+class ModelCapabilityDegradationResponse(BaseModel):
+    service: str = Field(description="Service name emitting the response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    store_mode: str = Field(description="Where catalogue truth lives: memory or sqlalchemy.")
+    entry: ModelCatalogueEntry = Field(description="The entry after the degradation.")
+    degradation: ModelCapabilityDegradation = Field(
+        description="The degradation now active on the entry.",
+    )
+
+
+class ModelCapabilityRestoreIntentRequest(BaseModel):
+    """Step one of governed capability restore: a verified requester states the intent.
+
+    Clearing a degradation re-exposes the underlying evidence-derived fact to
+    requirement routing - risk-increasing, so it takes a distinct verified
+    approver and PASS-verdict eval evidence (issue #245, slice 2).
+    """
+
+    dimension: str = Field(min_length=1, description="Degraded capability fact field.")
+    reason: str = Field(min_length=1, description="Why the regression is considered resolved.")
+    evaluation_run_id: str = Field(
+        min_length=1,
+        description="Existing evaluation run whose PASS verdict backs this restore.",
+    )
+    requested_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class ModelCapabilityRestoreApprovalRequest(BaseModel):
+    """Step two: a distinct verified credential approves the exact pending action."""
+
+    action_id: str = Field(min_length=1, max_length=64, description="Pending governed action id.")
+    action_hash: str = Field(
+        min_length=64,
+        max_length=64,
+        description="Hash of the action being approved, exactly as returned by the request step.",
+    )
+    approved_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class ModelCapabilityRestoreApprovalResponse(BaseModel):
+    """The executed capability restore with its full governance evidence chain."""
+
+    service: str = Field(description="Service name emitting the response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    store_mode: str = Field(description="Where catalogue truth lives: memory or sqlalchemy.")
+    entry: ModelCatalogueEntry = Field(description="The entry after the restore.")
+    governed_action: GovernedActionRecord = Field(
+        description=(
+            "The request-approval-execution evidence chain; its payload pins the "
+            "exact degradation that was cleared (issue #245, slice 2)."
+        ),
+    )
+    summary: list[str] = Field(description="Human-readable account of what executed.")
 
 
 class ModelPromotionApprovalResponse(BaseModel):

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -56,6 +56,11 @@ class ProviderFailureCategory(str, Enum):
     # as unknown - not laundered into a confident NOT_SUPPORTED.
     CAPABILITY_NOT_SUPPORTED = "CAPABILITY_NOT_SUPPORTED"
     CAPABILITY_UNKNOWN = "CAPABILITY_UNKNOWN"
+    # An operator has degraded this capability on the entry after observing a
+    # regression (issue #245, slice 2) - distinct from NOT_SUPPORTED (proven
+    # absent) and UNKNOWN (never assessed): "we turned this off" is a
+    # different operator story from either.
+    CAPABILITY_DEGRADED = "CAPABILITY_DEGRADED"
     # The caller's end-to-end latency budget ran out (issue #244). Distinct
     # from PROVIDER_TIMEOUT: the provider did nothing wrong - the governed
     # request deadline was exhausted by earlier attempts, backoff, or

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -794,6 +794,11 @@ class ModelCatalogueEntryModel(Base):
     supports_structured_output: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     supports_tool_calling: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     supports_streaming: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    # Active operator capability degradations keyed by fact field; cleared
+    # entries live on inside their governed restore records (issue #245).
+    capability_degradations: Mapped[dict[str, dict[str, str]]] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
     approved_workflow_pack_ids: Mapped[list[str]] = mapped_column(JSON, nullable=False)
     approval_evidence_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False)
     approved_from_utc: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/src/app/repositories/sqlalchemy_model_catalogue_repository.py
+++ b/src/app/repositories/sqlalchemy_model_catalogue_repository.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from sqlalchemy import select
 
 from app.contracts.model_catalogue import (
+    ModelCapabilityDegradation,
     ModelCatalogueEntry,
     ModelCatalogueSeedSource,
     ModelLifecycleState,
@@ -59,6 +60,10 @@ class SqlAlchemyModelCatalogueRepository(SqlAlchemyRepositoryBase):
             model.supports_structured_output = entry.supports_structured_output
             model.supports_tool_calling = entry.supports_tool_calling
             model.supports_streaming = entry.supports_streaming
+            model.capability_degradations = {
+                dimension: degradation.model_dump()
+                for dimension, degradation in entry.capability_degradations.items()
+            }
             model.approved_workflow_pack_ids = list(entry.approved_workflow_pack_ids)
             model.approval_evidence_refs = list(entry.approval_evidence_refs)
             model.approved_from_utc = entry.approved_from_utc
@@ -171,6 +176,10 @@ class SqlAlchemyModelCatalogueRepository(SqlAlchemyRepositoryBase):
             supports_structured_output=model.supports_structured_output,
             supports_tool_calling=model.supports_tool_calling,
             supports_streaming=model.supports_streaming,
+            capability_degradations={
+                dimension: ModelCapabilityDegradation.model_validate(payload)
+                for dimension, payload in (model.capability_degradations or {}).items()
+            },
             approved_workflow_pack_ids=list(model.approved_workflow_pack_ids),
             approval_evidence_refs=list(model.approval_evidence_refs),
             approved_from_utc=model.approved_from_utc,

--- a/src/app/routers/model_catalogue.py
+++ b/src/app/routers/model_catalogue.py
@@ -4,6 +4,11 @@ from fastapi import APIRouter
 
 from app.contracts.governed_actions import GovernedActionResponse
 from app.contracts.model_catalogue import (
+    ModelCapabilityDegradationRequest,
+    ModelCapabilityDegradationResponse,
+    ModelCapabilityRestoreApprovalRequest,
+    ModelCapabilityRestoreApprovalResponse,
+    ModelCapabilityRestoreIntentRequest,
     ModelCatalogueEntryDetailResponse,
     ModelCatalogueResponse,
     ModelLifecycleTransitionRequest,
@@ -15,9 +20,12 @@ from app.contracts.model_catalogue import (
 from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.model_catalogue import (
     apply_model_lifecycle_transition,
+    approve_model_capability_restore,
     approve_model_promotion,
     build_model_catalogue_entry_detail,
     build_model_catalogue_response,
+    degrade_model_capability,
+    request_model_capability_restore,
     request_model_promotion,
 )
 
@@ -165,3 +173,105 @@ async def approve_model_promotion_route(
     authenticated_caller: AuthenticatedCallerDependency,
 ) -> ModelPromotionApprovalResponse:
     return approve_model_promotion(entry_id, request, authenticated_caller)
+
+
+@router.post(
+    "/catalogue/{entry_id}/capability-degradations",
+    response_model=ModelCapabilityDegradationResponse,
+    operation_id="degradeModelCapability",
+    summary="Degrade one capability dimension on a catalogue entry",
+    description=(
+        "Records an observed regression scoped to one capability dimension (issue #245, "
+        "slice 2): requirement routing refuses that capability as CAPABILITY_DEGRADED while "
+        "the model stays in service for everything else, and the underlying assessed fact is "
+        "never rewritten. Safety direction: applied immediately by one verified principal, "
+        "no approval step. Requires provider-control authorization and the durable catalogue "
+        "store."
+    ),
+    responses={
+        200: {"description": "Capability degraded immediately."},
+        403: {"description": "Caller is not authorized for provider control."},
+        404: {"description": "No entry exists for the given id."},
+        409: {
+            "description": "The durable catalogue store is not configured, or the capability "
+            "is already degraded."
+        },
+        422: {"description": "The dimension is not one requirement routing enforces."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def degrade_model_capability_route(
+    entry_id: str,
+    request: ModelCapabilityDegradationRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> ModelCapabilityDegradationResponse:
+    return degrade_model_capability(entry_id, request, authenticated_caller)
+
+
+@router.post(
+    "/catalogue/{entry_id}/capability-restore-requests",
+    response_model=GovernedActionResponse,
+    operation_id="requestModelCapabilityRestore",
+    summary="Request restore of a degraded capability",
+    description=(
+        "Step one of governed capability restore (issue #245, slice 2): clearing a "
+        "degradation re-exposes the underlying evidence-derived fact to requirement routing, "
+        "so the restore is validated (active degradation, PASS-verdict evaluation run) and "
+        "recorded as a pending intent a distinct verified credential must approve. The "
+        "capability stays degraded until the approval executes."
+    ),
+    responses={
+        200: {"description": "Restore intent recorded and pending approval."},
+        403: {
+            "description": "Caller is not authorized for provider control, or carries no "
+            "verified credential."
+        },
+        404: {"description": "No entry exists for the given id."},
+        409: {
+            "description": "The durable catalogue store is not configured, or the capability "
+            "is not degraded."
+        },
+        422: {"description": "The evaluation run is missing or did not pass."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def request_model_capability_restore_route(
+    entry_id: str,
+    request: ModelCapabilityRestoreIntentRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> GovernedActionResponse:
+    return request_model_capability_restore(entry_id, request, authenticated_caller)
+
+
+@router.post(
+    "/catalogue/{entry_id}/capability-restore-approvals",
+    response_model=ModelCapabilityRestoreApprovalResponse,
+    operation_id="approveModelCapabilityRestore",
+    summary="Approve and execute a pending capability restore",
+    description=(
+        "Step two of governed capability restore (issue #245, slice 2): a verified credential "
+        "DISTINCT from the requester's approves the exact pending action hash, which clears "
+        "the degradation and records the full request-approval-execution evidence chain with "
+        "the cleared degradation pinned in the payload. A change to the degradation since the "
+        "request refuses the stale approval."
+    ),
+    responses={
+        200: {"description": "Capability restored under governed approval."},
+        403: {
+            "description": "Caller is not authorized, carries no verified credential, or is "
+            "the same credential that requested the action."
+        },
+        404: {"description": "No entry or no pending action exists for the given id."},
+        409: {
+            "description": "The durable catalogue store is not configured, the action hash "
+            "does not match, or the degradation changed since the request."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def approve_model_capability_restore_route(
+    entry_id: str,
+    request: ModelCapabilityRestoreApprovalRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> ModelCapabilityRestoreApprovalResponse:
+    return approve_model_capability_restore(entry_id, request, authenticated_caller)

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -43,6 +43,7 @@ HUMAN_GOVERNED_ACTION_TYPES = frozenset(
         GovernedActionType.PROMPT_PROMOTE,
         GovernedActionType.PROVIDER_OPERATIONS_RESET,
         GovernedActionType.MODEL_LIFECYCLE_PROMOTE,
+        GovernedActionType.MODEL_CAPABILITY_RESTORE,
     }
 )
 

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -29,8 +29,15 @@ from app.contracts.governed_actions import (
 )
 from app.contracts.model_catalogue import (
     ALLOWED_MODEL_LIFECYCLE_TRANSITIONS,
+    DEGRADABLE_CAPABILITY_DIMENSIONS,
     MODEL_SERVING_PROMOTION_TARGETS,
     OPERATOR_TERMINAL_LIFECYCLE_STATES,
+    ModelCapabilityDegradation,
+    ModelCapabilityDegradationRequest,
+    ModelCapabilityDegradationResponse,
+    ModelCapabilityRestoreApprovalRequest,
+    ModelCapabilityRestoreApprovalResponse,
+    ModelCapabilityRestoreIntentRequest,
     ModelCatalogueEntry,
     ModelCatalogueEntryDetailResponse,
     ModelCatalogueResponse,
@@ -238,11 +245,15 @@ def _preserve_assessed_capabilities(
     prove; it may never subtract ones it cannot.
     """
 
-    preserved = {
+    preserved: dict[str, object] = {
         dimension: getattr(existing, dimension)
         for dimension in _CAPABILITY_DIMENSIONS
         if getattr(candidate, dimension) is None and getattr(existing, dimension) is not None
     }
+    # Operator degradations survive reseeding unconditionally: only the
+    # governed restore flow may clear one (issue #245, slice 2).
+    if existing.capability_degradations:
+        preserved["capability_degradations"] = existing.capability_degradations
     return candidate.model_copy(update=preserved) if preserved else candidate
 
 
@@ -317,6 +328,15 @@ def enforce_capability_requirements(
     for requirement_field, fact_field in _CAPABILITY_FACT_BY_REQUIREMENT.items():
         if getattr(requirements, requirement_field) is not True:
             continue
+        degradation = entry.capability_degradations.get(fact_field)
+        if degradation is not None:
+            raise ProviderExecutionError(
+                category=ProviderFailureCategory.CAPABILITY_DEGRADED,
+                message=(
+                    f"Candidate `{entry.entry_id}` has capability `{requirement_field}` "
+                    f"degraded by an operator: {degradation.reason}"
+                ),
+            )
         fact = getattr(entry, fact_field)
         if fact is True:
             continue
@@ -662,6 +682,208 @@ def approve_model_promotion(
             f"Requested under credential `{executed.requester_key_id}` and approved under "
             f"distinct credential `{executed.approver_key_id}`.",
             f"Evidence: `{transition_response.transition.approval_evidence_ref}`.",
+        ],
+    )
+
+
+def degrade_model_capability(
+    entry_id: str,
+    request: ModelCapabilityDegradationRequest,
+    caller: AuthenticatedCaller,
+) -> ModelCapabilityDegradationResponse:
+    """Degrade one capability dimension on a catalogue entry, immediately.
+
+    Safety direction (issue #245, slice 2): containing an observed regression
+    takes one verified principal and no approval step. The underlying
+    assessed fact is never rewritten - the degradation overrides it for
+    requirement routing only while present.
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    if request.dimension not in DEGRADABLE_CAPABILITY_DIMENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"`{request.dimension}` is not a degradable capability dimension; requirement "
+                f"routing enforces: {sorted(DEGRADABLE_CAPABILITY_DIMENSIONS)}."
+            ),
+        )
+    existing = entry.capability_degradations.get(request.dimension)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Capability `{request.dimension}` on `{entry_id}` is already degraded "
+                f"(by {existing.degraded_by} at {existing.degraded_at}); the active "
+                "degradation's provenance is not overwritable."
+            ),
+        )
+    degradation = ModelCapabilityDegradation(
+        dimension=request.dimension,
+        reason=request.reason,
+        degraded_by=verified_caller_identity(caller),
+        degraded_at=_utc_now_iso(),
+    )
+    updated = entry.model_copy(
+        update={
+            "capability_degradations": {
+                **entry.capability_degradations,
+                request.dimension: degradation,
+            },
+            "last_updated_at": degradation.degraded_at,
+        }
+    )
+    upsert_model_catalogue_entry(updated)
+    return ModelCapabilityDegradationResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=updated,
+        degradation=degradation,
+    )
+
+
+def _capability_restore_payload(
+    *,
+    entry: ModelCatalogueEntry,
+    degradation: ModelCapabilityDegradation,
+    evaluation_run_id: str,
+    reason: str,
+) -> dict[str, str | None]:
+    """The exact action the approver signs off on.
+
+    Pins the full degradation being cleared: if the overlay changes between
+    request and approval (re-degraded with a new reason, or already cleared),
+    the stale approval refuses instead of executing (issue #245, slice 2).
+    """
+
+    return {
+        "action_type": GovernedActionType.MODEL_CAPABILITY_RESTORE.value,
+        "entry_id": entry.entry_id,
+        "dimension": degradation.dimension,
+        "degradation_reason": degradation.reason,
+        "degraded_by": degradation.degraded_by,
+        "degraded_at": degradation.degraded_at,
+        "evaluation_run_id": evaluation_run_id,
+        "reason": reason,
+    }
+
+
+def _get_required_capability_degradation(
+    entry: ModelCatalogueEntry, dimension: str
+) -> ModelCapabilityDegradation:
+    degradation = entry.capability_degradations.get(dimension)
+    if degradation is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Capability `{dimension}` on `{entry.entry_id}` is not degraded; "
+                "there is nothing to restore."
+            ),
+        )
+    return degradation
+
+
+def request_model_capability_restore(
+    entry_id: str,
+    request: ModelCapabilityRestoreIntentRequest,
+    caller: AuthenticatedCaller,
+) -> GovernedActionResponse:
+    """Step one of governed capability restore: record the intent under the requester's credential.
+
+    Clearing a degradation re-exposes the underlying evidence-derived fact to
+    requirement routing - risk-increasing, so the restore is validated first
+    (active degradation, PASS-verdict eval evidence) and executes only under
+    a distinct verified approval.
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    degradation = _get_required_capability_degradation(entry, request.dimension)
+    _require_pass_verdict_evaluation_run(request.evaluation_run_id)
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.MODEL_CAPABILITY_RESTORE,
+        target=entry_id,
+        payload=_capability_restore_payload(
+            entry=entry,
+            degradation=degradation,
+            evaluation_run_id=request.evaluation_run_id,
+            reason=request.reason,
+        ),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Restore of capability `{request.dimension}` on `{entry_id}` is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            f"The capability stays degraded ({degradation.reason}) until then.",
+        ],
+    )
+
+
+def approve_model_capability_restore(
+    entry_id: str,
+    request: ModelCapabilityRestoreApprovalRequest,
+    caller: AuthenticatedCaller,
+) -> ModelCapabilityRestoreApprovalResponse:
+    """Step two: a distinct verified credential approves the exact action, which executes it."""
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    outcome: dict[str, object] = {}
+
+    def _execute_restore(record: GovernedActionRecord) -> None:
+        dimension = str(record.action_payload.get("dimension"))
+        _require_pass_verdict_evaluation_run(str(record.action_payload.get("evaluation_run_id")))
+        remaining = {
+            key: value for key, value in entry.capability_degradations.items() if key != dimension
+        }
+        updated = entry.model_copy(
+            update={"capability_degradations": remaining, "last_updated_at": _utc_now_iso()}
+        )
+        upsert_model_catalogue_entry(updated)
+        outcome["entry"] = updated
+
+    def _current_payload(record: GovernedActionRecord) -> dict[str, str | None]:
+        dimension = str(record.action_payload.get("dimension"))
+        return _capability_restore_payload(
+            entry=entry,
+            degradation=_get_required_capability_degradation(entry, dimension),
+            evaluation_run_id=str(record.action_payload.get("evaluation_run_id")),
+            reason=str(record.action_payload.get("reason")),
+        )
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=entry_id,
+        expected_hash=request.action_hash,
+        current_payload_builder=_current_payload,
+        attribution=request.approved_by,
+        execute=_execute_restore,
+    )
+    updated_entry = cast(ModelCatalogueEntry, outcome["entry"])
+    return ModelCapabilityRestoreApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=updated_entry,
+        governed_action=executed,
+        summary=[
+            f"Restored capability `{executed.action_payload.get('dimension')}` on `{entry_id}` "
+            f"under governed action `{executed.action_id}`.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+            "The cleared degradation is pinned inside this action's payload.",
         ],
     )
 

--- a/tests/integration/test_model_catalogue_api_contract.py
+++ b/tests/integration/test_model_catalogue_api_contract.py
@@ -364,3 +364,118 @@ def test_governed_promotion_flow_over_http(tmp_path: Path) -> None:
                 "lotus-platform (credential catalogue-ops-beta)"
             )
             assert body["governed_action"]["status"] == "EXECUTED"
+
+
+def test_capability_degrade_and_governed_restore_over_http(tmp_path: Path) -> None:
+    """Capability-scoped degradation end-to-end (issue #245, slice 2): one
+    verified principal degrades immediately; a DISTINCT verified credential
+    approves the governed restore backed by PASS-verdict eval evidence."""
+
+    from tests.support.caller_credentials import (
+        generate_caller_signing_key,
+        mint_caller_credential,
+        public_keys_setting,
+    )
+
+    requester_key = generate_caller_signing_key()
+    approver_key = generate_caller_signing_key()
+    requester_headers = {
+        "Authorization": "Bearer "
+        + mint_caller_credential(
+            signing_key=requester_key,
+            key_id="capability-ops-alpha",
+            subject="lotus-platform",
+            expires_in_seconds=3600,
+        )
+    }
+    approver_headers = {
+        "Authorization": "Bearer "
+        + mint_caller_credential(
+            signing_key=approver_key,
+            key_id="capability-ops-beta",
+            subject="lotus-platform",
+            expires_in_seconds=3600,
+        )
+    }
+
+    database_url = f"sqlite:///{tmp_path / 'catalogue-capability.db'}"
+    upgrade_database_to_head(database_url)
+
+    with override_runtime_settings(
+        model_catalogue_store_mode="sqlalchemy",
+        database_url=database_url,
+        provider_mode="local_openai_compatible",
+        live_text_provider_id="text.local",
+        live_text_model_id="qwen3:8b",
+        live_text_model_version=None,
+        workflow_run_model_risk_inventory_json="[]",
+        caller_trust_mode="verified_service_jwt",
+        caller_jwt_issuer="https://platform.lotus/issuer",
+        caller_jwt_audience="lotus-ai",
+        caller_jwt_public_keys=public_keys_setting(
+            **{"capability-ops-alpha": requester_key, "capability-ops-beta": approver_key}
+        ),
+    ):
+        with TestClient(app) as client:
+            from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+            from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+            get_evaluation_runtime_store().save_run(
+                EvaluationRunRecord(
+                    run_id="runtime_capability_http_001",
+                    fixture_id="model_promotion_examples",
+                    manifest_version="foundation.v1",
+                    lifecycle_status="COMPLETED",
+                    triggered_by="operator-a",
+                    submitted_at="2026-09-03T10:00:00Z",
+                    async_job_id=None,
+                    latest_message="Capability restore evidence fixture.",
+                    verdict="PASS",
+                    case_count=3,
+                )
+            )
+            base = "/platform/models/catalogue/text.local:qwen3:8b"
+
+            seeded = client.get("/platform/models/catalogue", headers=requester_headers)
+            assert seeded.status_code == 200
+
+            degraded = client.post(
+                f"{base}/capability-degradations",
+                json={
+                    "dimension": "supports_structured_output",
+                    "reason": "Structured output failing contract validation.",
+                },
+                headers=requester_headers,
+            )
+            assert degraded.status_code == 200
+            body = degraded.json()
+            assert body["degradation"]["degraded_by"] == (
+                "lotus-platform (credential capability-ops-alpha)"
+            )
+            assert "supports_structured_output" in body["entry"]["capability_degradations"]
+
+            pending = client.post(
+                f"{base}/capability-restore-requests",
+                json={
+                    "dimension": "supports_structured_output",
+                    "reason": "Provider fixed the regression; run passes again.",
+                    "evaluation_run_id": "runtime_capability_http_001",
+                },
+                headers=requester_headers,
+            )
+            assert pending.status_code == 200
+            action = pending.json()["governed_action"]
+            assert action["status"] == "PENDING"
+
+            approved = client.post(
+                f"{base}/capability-restore-approvals",
+                json={"action_id": action["action_id"], "action_hash": action["action_hash"]},
+                headers=approver_headers,
+            )
+            assert approved.status_code == 200
+            restored = approved.json()
+            assert restored["entry"]["capability_degradations"] == {}
+            assert restored["governed_action"]["status"] == "EXECUTED"
+            assert restored["governed_action"]["action_payload"]["degraded_by"] == (
+                "lotus-platform (credential capability-ops-alpha)"
+            )

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -16,6 +16,7 @@ import pytest
 
 from app.config import settings
 from app.contracts.model_catalogue import (
+    ModelCapabilityDegradationResponse,
     ModelCatalogueSeedReport,
     ModelCatalogueSeedSource,
     ModelLifecycleState,
@@ -870,3 +871,262 @@ def test_reseeding_never_unassesses_a_known_capability_fact(
     assert reconciled.supports_structured_output is True
     assert reconciled.context_window_tokens == 128_000
     assert report.updated_count == 0
+
+
+def _degrade_capability(
+    entry_id: str, dimension: str = "supports_structured_output"
+) -> "ModelCapabilityDegradationResponse":
+    from app.contracts.model_catalogue import ModelCapabilityDegradationRequest
+    from app.services.model_catalogue import degrade_model_capability
+    from tests.support.governed_control import GOVERNED_REQUESTER
+
+    return degrade_model_capability(
+        entry_id,
+        ModelCapabilityDegradationRequest(
+            dimension=dimension,
+            reason="Structured output failing contract validation in production.",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+
+def test_capability_degradation_refuses_requirement_routing_distinctly(
+    _durable_catalogue: str,
+) -> None:
+    """A degraded capability refuses as CAPABILITY_DEGRADED - distinct from
+    NOT_SUPPORTED (proven absent) and UNKNOWN (never assessed) - while the
+    underlying assessed fact is never rewritten (issue #245, slice 2)."""
+
+    from app.contracts.capability_requirements import CapabilityRequirements
+    from app.services.model_catalogue import enforce_capability_requirements
+
+    entry_id = _durable_catalogue
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(entry_id)
+    assert entry is not None
+    repository.upsert_entry(entry.model_copy(update={"supports_structured_output": True}))
+
+    response = _degrade_capability(entry_id)
+    degraded_entry = repository.get_entry(entry_id)
+    assert degraded_entry is not None
+    # The fact is untouched; the degradation overrides it while present.
+    assert degraded_entry.supports_structured_output is True
+    assert degraded_entry.capability_degradations["supports_structured_output"].degraded_by == (
+        "lotus-platform (credential ops-key-alpha)"
+    )
+    assert response.degradation.reason.startswith("Structured output failing")
+
+    requirements = CapabilityRequirements(structured_output_required=True)
+    with pytest.raises(ProviderExecutionError) as excinfo:
+        enforce_capability_requirements(requirements=requirements, entry=degraded_entry)
+    assert excinfo.value.category is ProviderFailureCategory.CAPABILITY_DEGRADED
+
+    # A workload that states no requirements is unaffected.
+    enforce_capability_requirements(requirements=None, entry=degraded_entry)
+
+
+def test_capability_degradation_validates_dimension_and_refuses_overwrite(
+    _durable_catalogue: str,
+) -> None:
+    from fastapi import HTTPException
+
+    from app.contracts.model_catalogue import ModelCapabilityDegradationRequest
+    from app.services.model_catalogue import degrade_model_capability
+    from tests.support.governed_control import GOVERNED_REQUESTER
+
+    entry_id = _durable_catalogue
+
+    with pytest.raises(HTTPException) as excinfo:
+        degrade_model_capability(
+            entry_id,
+            ModelCapabilityDegradationRequest(
+                dimension="supports_streaming",
+                reason="Streaming is not requirement-enforced.",
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert excinfo.value.status_code == 422
+    assert "not a degradable capability dimension" in str(excinfo.value.detail)
+
+    _degrade_capability(entry_id)
+    # The active degradation is not overwritable by a second call.
+    with pytest.raises(HTTPException) as excinfo:
+        _degrade_capability(entry_id)
+    assert excinfo.value.status_code == 409
+    assert "already degraded" in str(excinfo.value.detail)
+
+
+def test_capability_degradation_survives_reseed_and_store_restart(
+    _durable_catalogue: str,
+) -> None:
+    """Only the governed restore flow clears a degradation: reseeding must
+    preserve it, and it must come back from SQL after a restart."""
+
+    from app.services.model_catalogue_store import reset_model_catalogue_store_cache
+
+    entry_id = _durable_catalogue
+    _degrade_capability(entry_id)
+
+    ensure_model_catalogue_seeded()
+    reset_model_catalogue_store_cache()
+
+    entry = get_model_catalogue_repository().get_entry(entry_id)
+    assert entry is not None
+    degradation = entry.capability_degradations["supports_structured_output"]
+    assert degradation.degraded_by == "lotus-platform (credential ops-key-alpha)"
+    assert degradation.degraded_at
+
+
+def test_capability_restore_is_governed_and_pins_the_degradation(
+    _durable_catalogue: str,
+) -> None:
+    from fastapi import HTTPException
+
+    from app.contracts.capability_requirements import CapabilityRequirements
+    from app.contracts.model_catalogue import (
+        ModelCapabilityRestoreApprovalRequest,
+        ModelCapabilityRestoreIntentRequest,
+    )
+    from app.services.model_catalogue import (
+        approve_model_capability_restore,
+        enforce_capability_requirements,
+        request_model_capability_restore,
+    )
+    from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
+
+    entry_id = _durable_catalogue
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(entry_id)
+    assert entry is not None
+    repository.upsert_entry(entry.model_copy(update={"supports_structured_output": True}))
+
+    # Nothing to restore before a degradation exists.
+    with pytest.raises(HTTPException) as excinfo:
+        request_model_capability_restore(
+            entry_id,
+            ModelCapabilityRestoreIntentRequest(
+                dimension="supports_structured_output",
+                reason="Nothing is degraded.",
+                evaluation_run_id="run_restore_001",
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert excinfo.value.status_code == 409
+    assert "not degraded" in str(excinfo.value.detail)
+
+    _degrade_capability(entry_id)
+    _seed_evaluation_run("run_restore_001")
+
+    # Restore evidence must actually have passed.
+    _seed_evaluation_run("run_restore_fail", verdict="FAIL")
+    with pytest.raises(HTTPException) as excinfo:
+        request_model_capability_restore(
+            entry_id,
+            ModelCapabilityRestoreIntentRequest(
+                dimension="supports_structured_output",
+                reason="Provider fixed the regression.",
+                evaluation_run_id="run_restore_fail",
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert excinfo.value.status_code == 422
+
+    pending = request_model_capability_restore(
+        entry_id,
+        ModelCapabilityRestoreIntentRequest(
+            dimension="supports_structured_output",
+            reason="Provider fixed the regression; run passes again.",
+            evaluation_run_id="run_restore_001",
+        ),
+        GOVERNED_REQUESTER,
+    )
+    assert pending.governed_action.status.value == "PENDING"
+    # The capability stays degraded until the approval executes.
+    mid = get_model_catalogue_repository().get_entry(entry_id)
+    assert mid is not None
+    assert "supports_structured_output" in mid.capability_degradations
+
+    executed = approve_model_capability_restore(
+        entry_id,
+        ModelCapabilityRestoreApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert executed.entry.capability_degradations == {}
+    assert executed.governed_action.status.value == "EXECUTED"
+    # The cleared degradation is pinned inside the governed record.
+    pinned_reason = str(executed.governed_action.action_payload["degradation_reason"])
+    assert pinned_reason.startswith("Structured output failing")
+    assert executed.governed_action.action_payload["degraded_by"] == (
+        "lotus-platform (credential ops-key-alpha)"
+    )
+
+    # The evidence-derived fact is effective again.
+    restored = get_model_catalogue_repository().get_entry(entry_id)
+    assert restored is not None
+    enforce_capability_requirements(
+        requirements=CapabilityRequirements(structured_output_required=True), entry=restored
+    )
+
+
+def test_capability_restore_re_request_supersedes_the_prior_intent(
+    _durable_catalogue: str,
+) -> None:
+    """A second restore request for the same entry supersedes the first
+    pending one (the primitive's changed-action rule): the stale intent can
+    never execute, and only the current intent's approval does."""
+
+    from fastapi import HTTPException
+
+    from app.contracts.governed_actions import GovernedActionResponse
+    from app.contracts.model_catalogue import (
+        ModelCapabilityRestoreApprovalRequest,
+        ModelCapabilityRestoreIntentRequest,
+    )
+    from app.services.model_catalogue import (
+        approve_model_capability_restore,
+        request_model_capability_restore,
+    )
+    from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
+
+    entry_id = _durable_catalogue
+    _degrade_capability(entry_id)
+    _seed_evaluation_run("run_restore_stale")
+
+    def _pending() -> GovernedActionResponse:
+        return request_model_capability_restore(
+            entry_id,
+            ModelCapabilityRestoreIntentRequest(
+                dimension="supports_structured_output",
+                reason="Provider fixed the regression.",
+                evaluation_run_id="run_restore_stale",
+            ),
+            GOVERNED_REQUESTER,
+        )
+
+    first = _pending()
+    second = _pending()
+
+    with pytest.raises(HTTPException) as excinfo:
+        approve_model_capability_restore(
+            entry_id,
+            ModelCapabilityRestoreApprovalRequest(
+                action_id=first.governed_action.action_id,
+                action_hash=first.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+    assert excinfo.value.status_code == 409
+    assert "SUPERSEDED" in str(excinfo.value.detail)
+
+    executed = approve_model_capability_restore(
+        entry_id,
+        ModelCapabilityRestoreApprovalRequest(
+            action_id=second.governed_action.action_id,
+            action_hash=second.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert executed.entry.capability_degradations == {}


### PR DESCRIPTION
Issue #245, slice 2 (design note: issue comment): a capability regression makes exactly that capability ineligible — immediately, without rewriting the entry's other evidence — and the routing decision says so distinctly.

## Control-plane outcome

An operator who observes structured output failing on an otherwise-healthy model no longer faces the all-or-nothing choice of entry-level `DEGRADED` (which takes every capability out of service and therefore goes unused while stale claims survive). One verified principal degrades **one capability dimension**, immediately; requirement routing refuses that dimension as `CAPABILITY_DEGRADED` — a third distinct story beside `CAPABILITY_NOT_SUPPORTED` (proven absent) and `CAPABILITY_UNKNOWN` (never assessed): *"we turned this off."*

## Risk direction, same as everywhere

- **Degrade = safety direction**: single verified principal, no approval step, applied immediately. The record carries the verified identity, reason, and instant.
- **Restore = risk-increasing**: clearing the degradation re-exposes the underlying evidence-derived fact to requirement routing, so it takes the governed two-step flow — `GovernedActionType.MODEL_CAPABILITY_RESTORE` through the same primitive, with evidence naming an existing COMPLETED PASS-verdict evaluation run, and the action hash pinning the **exact degradation being cleared** (dimension, reason, who, when). A changed or already-cleared degradation refuses the stale approval; a re-request supersedes the prior pending intent (proven by test).

## Design decisions worth review

- **The fact is never rewritten.** The degradation is an overlay that wins while present; `supports_structured_output=True` (derived from pack-approval evidence) stays true history. Restore removes the overlay only — no capability is ever asserted by the restore itself.
- **No new table, no lost history.** An active degradation lives on the entry (JSON column, migration 0063); a cleared one is pinned verbatim inside its EXECUTED governed-action payload. Every degradation is durably in exactly one of those places.
- **Only enforced dimensions are degradable** (`supports_structured_output`, `supports_tool_calling`): degrading a dimension no routing decision consults would be a control that controls nothing — refused with the enforced list.
- **Reseeding never clears a degradation** — `_preserve_assessed_capabilities` carries the overlay unconditionally; only the governed restore may remove it (proven by reseed + store-restart test).

## Evidence

Unit: degraded capability refuses `CAPABILITY_DEGRADED` while the fact stays `True` and requirement-free workloads are unaffected; non-enforced dimension refused; double-degrade refuses (provenance not overwritable); degradation survives reseed and SQL restart; governed restore validates active degradation + PASS evidence, stays degraded until approval, pins the cleared degradation in the executed record, and re-exposes the fact; re-request supersedes the prior intent and the superseded approval refuses. Integration: JWT HTTP flow across all three routes with distinct requester/approver credentials.

Full local gate: lint, typecheck, migration-smoke, whole suite with coverage.

Residual (recorded on #245, affects slice 1 promotions and restores equally): evidence becomes capability-scoped when the eval manifest declares which capabilities a fixture exercises — a bounded evaluation-side prerequisite, not a reason to weaken the PASS-run requirement meanwhile.
