### PR TITLE
feat(routing): candidate universe as inspectable decision evidence (#244 U1)

### DIFF
--- a/src/app/contracts/provider_catalog.py
+++ b/src/app/contracts/provider_catalog.py
@@ -1,0 +1,174 @@
+"""Provider catalog, policy and operator-profile read-model contracts.
+
+Split from contracts/providers.py when the module budget fired (issue #244,
+U1): the catalog/policy/profile read models are a cohesive family consumed by
+their own services and routes, not by the execution path.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from app.contracts.providers import (
+    ProviderAdapterKind,
+    ProviderCapability,
+    ProviderConfigurationStatusDescriptor,
+    ProviderExecutionMode,
+    ProviderExpansionPolicyDescriptor,
+    ProviderFailureCategory,
+    ProviderLifecycleStatus,
+)
+
+
+class ProviderDescriptor(BaseModel):
+    provider_id: str = Field(description="Stable provider identifier within lotus-ai.")
+    display_name: str = Field(description="Human-readable provider name.")
+    capability: ProviderCapability = Field(
+        description="Primary capability area exposed by the provider."
+    )
+    adapter_kind: ProviderAdapterKind = Field(
+        description="Kind of provider adapter currently registered for this provider path."
+    )
+    lifecycle_status: ProviderLifecycleStatus = Field(
+        description="Current lifecycle state of the provider integration."
+    )
+    runtime_mode: str = Field(description="Configured runtime mode associated with the provider.")
+    enabled_for_execution: bool = Field(
+        description="Whether the provider is currently eligible for live execution."
+    )
+    failure_category_on_use: ProviderFailureCategory | None = Field(
+        default=None,
+        description="Failure category expected if this provider path is selected before it is enabled.",
+    )
+    source_reference: str = Field(
+        description="Repository reference documenting the provider configuration."
+    )
+    notes: str = Field(description="Operational notes describing the current provider posture.")
+
+
+class ProviderCatalogResponse(BaseModel):
+    service: str = Field(description="Service name emitting the provider catalog.")
+    version: str = Field(description="Current lotus-ai service version.")
+    provider_mode: str = Field(description="Configured text-generation provider mode.")
+    embedding_provider_mode: str = Field(description="Configured embedding provider mode.")
+    text_generation_configuration: ProviderConfigurationStatusDescriptor = Field(
+        description="Current rollout and configuration posture for future live text-generation activation."
+    )
+    embedding_configuration: ProviderConfigurationStatusDescriptor = Field(
+        description="Current rollout and configuration posture for future live embedding-provider activation."
+    )
+    runtime_execution_enabled: bool = Field(
+        description="Whether any provider is currently enabled for live execution."
+    )
+    text_generation_runtime_execution_enabled: bool = Field(
+        description="Whether any text-generation provider path is currently enabled for live execution."
+    )
+    embedding_runtime_execution_enabled: bool = Field(
+        description="Whether any embedding provider path is currently enabled for live execution."
+    )
+    expansion_policy: ProviderExpansionPolicyDescriptor = Field(
+        description="Bounded provider-expansion policy describing current provider breadth and future governed slots."
+    )
+    providers: list[ProviderDescriptor] = Field(
+        description="Governed provider catalog exposed by lotus-ai."
+    )
+
+
+class ProviderPolicyDescriptor(BaseModel):
+    capability: ProviderCapability = Field(
+        description="Provider capability governed by the policy."
+    )
+    configured_mode: str = Field(description="Configured runtime mode for the capability.")
+    allowed_modes: list[ProviderExecutionMode] = Field(
+        description="Modes currently supported by lotus-ai for this capability."
+    )
+    selected_provider_id: str = Field(
+        description="Provider identifier currently selected for this capability."
+    )
+    selected_adapter_kind: ProviderAdapterKind = Field(
+        description="Registered adapter kind currently selected for this capability."
+    )
+    live_execution_enabled: bool = Field(
+        description="Whether live execution is currently allowed for this capability."
+    )
+    rejection_category: ProviderFailureCategory = Field(
+        description="Structured failure category used when the configured mode is rejected."
+    )
+    rejection_behavior: str = Field(
+        description="How lotus-ai should behave when the configured mode is unsupported."
+    )
+
+
+class ProviderPolicyResponse(BaseModel):
+    service: str = Field(description="Service name emitting the provider policy response.")
+    version: str = Field(description="Current lotus-ai service version.")
+    text_generation_configuration: ProviderConfigurationStatusDescriptor = Field(
+        description="Current rollout and configuration posture for future live text-generation activation."
+    )
+    embedding_configuration: ProviderConfigurationStatusDescriptor = Field(
+        description="Current rollout and configuration posture for future live embedding-provider activation."
+    )
+    expansion_policy: ProviderExpansionPolicyDescriptor = Field(
+        description="Bounded provider-expansion policy describing how later providers are reviewed without widening execution semantics prematurely."
+    )
+    policies: list[ProviderPolicyDescriptor] = Field(
+        description="Capability-specific provider execution policies."
+    )
+
+
+class ProviderOperatorProfileDescriptor(BaseModel):
+    profile_id: str = Field(description="Stable operator-facing provider profile identifier.")
+    display_name: str = Field(description="Operator-facing label for the provider profile.")
+    provider_mode: str = Field(description="Provider mode activated by this profile.")
+    provider_id: str | None = Field(
+        default=None,
+        description="Expected provider identifier for this profile when one is configured.",
+    )
+    api_base_class: str = Field(
+        description="High-level endpoint class for this profile, such as managed_openai or local_openai_compatible."
+    )
+    docker_profile: str | None = Field(
+        default=None,
+        description="Optional Docker Compose profile name associated with this operator profile.",
+    )
+    use_case: str = Field(
+        description="Human-readable explanation of when operators should choose this profile."
+    )
+    required_settings: list[str] = Field(
+        default_factory=list,
+        description="Configuration settings that must be present for this profile to operate correctly.",
+    )
+    verification_surfaces: list[str] = Field(
+        default_factory=list,
+        description="Primary inspection surfaces operators should use to verify this profile.",
+    )
+
+
+class ProviderOperatorProfileResponse(BaseModel):
+    service: str = Field(description="Service name emitting the provider operator profile view.")
+    version: str = Field(description="Current lotus-ai service version.")
+    selected_profile_id: str = Field(
+        description="Operator profile currently implied by the active provider configuration."
+    )
+    provider_mode: str = Field(description="Configured text-generation provider mode.")
+    current_provider_id: str | None = Field(
+        default=None,
+        description="Configured current provider id for the active text-generation path.",
+    )
+    current_model_id: str | None = Field(
+        default=None,
+        description="Configured current model id for the active text-generation path.",
+    )
+    live_execution_enabled: bool = Field(
+        description="Whether the current provider profile is presently enabled for live execution."
+    )
+    current_readiness_note: str = Field(
+        description="Single operator-facing note describing the current active provider posture."
+    )
+    switching_steps: list[str] = Field(
+        default_factory=list,
+        description="Ordered operator steps to switch and verify the active provider profile.",
+    )
+    profiles: list[ProviderOperatorProfileDescriptor] = Field(
+        description="Supported provider operator profiles exposed by lotus-ai."
+    )

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -114,6 +114,51 @@ class RoutingCandidateDescriptor(BaseModel):
     )
 
 
+class CandidateUniverseSource(str, Enum):
+    """Where the routing candidate enumeration came from (issue #244).
+
+    CONFIGURED: the hand-maintained primary/fallback settings pair.
+    CATALOGUE_DERIVED: derived from governed catalogue evidence bounded by
+    explicit policy - the target architecture; the flip is recorded evidence,
+    never a silent rewire.
+    """
+
+    CONFIGURED = "CONFIGURED"
+    CATALOGUE_DERIVED = "CATALOGUE_DERIVED"
+
+
+class CandidateUniverseExclusionReason(str, Enum):
+    """Why a governed model identity is not in the candidate universe."""
+
+    # A policy-ordered identity has no catalogue entry to earn eligibility with.
+    MODEL_NOT_CATALOGUED = "MODEL_NOT_CATALOGUED"
+    # The entry's lifecycle state refuses new executions.
+    LIFECYCLE_INELIGIBLE = "LIFECYCLE_INELIGIBLE"
+    # The entry is serving-eligible but no policy row lets it serve this mode.
+    POLICY_EXCLUDED = "POLICY_EXCLUDED"
+
+
+class CandidateUniverseExclusionDescriptor(BaseModel):
+    """One reasoned exclusion from the candidate universe (issue #244)."""
+
+    entry_id: str = Field(min_length=1, description="Catalogue entry (or derived identity).")
+    reason: CandidateUniverseExclusionReason = Field(description="Bounded exclusion reason.")
+    detail: str = Field(min_length=1, description="Human-readable account of the exclusion.")
+
+
+class CandidateUniverse(BaseModel):
+    """The ordered candidate universe with every exclusion reasoned (issue #244)."""
+
+    source: CandidateUniverseSource = Field(description="Where the enumeration came from.")
+    candidate_entry_ids: list[str] = Field(
+        description="Ordered catalogue entry ids eligible to serve this execution.",
+    )
+    exclusions: list[CandidateUniverseExclusionDescriptor] = Field(
+        default_factory=list,
+        description="Identities considered and excluded, each with its reason.",
+    )
+
+
 class RoutingDecisionDescriptor(BaseModel):
     """The recorded rationale for one execution's provider/model selection.
 
@@ -164,6 +209,22 @@ class RoutingDecisionDescriptor(BaseModel):
             "settled, in attempt order. Empty under the fixed strategy and when the "
             "primary candidate served; a preflight-rejected candidate is recorded as a "
             "rejection, not a fallback."
+        ),
+    )
+    universe_source: CandidateUniverseSource = Field(
+        default=CandidateUniverseSource.CONFIGURED,
+        description=(
+            "Where the candidate enumeration came from (issue #244): the configured "
+            "settings pair today; CATALOGUE_DERIVED once the derived universe is the "
+            "enumeration."
+        ),
+    )
+    universe_exclusions: list[CandidateUniverseExclusionDescriptor] = Field(
+        default_factory=list,
+        description=(
+            "Governed identities that could not serve this execution and why - "
+            "including serving-eligible catalogue entries no policy row lets serve "
+            "(issue #244)."
         ),
     )
 
@@ -449,32 +510,6 @@ class ProviderConfigurationStatusDescriptor(BaseModel):
     )
 
 
-class ProviderDescriptor(BaseModel):
-    provider_id: str = Field(description="Stable provider identifier within lotus-ai.")
-    display_name: str = Field(description="Human-readable provider name.")
-    capability: ProviderCapability = Field(
-        description="Primary capability area exposed by the provider."
-    )
-    adapter_kind: ProviderAdapterKind = Field(
-        description="Kind of provider adapter currently registered for this provider path."
-    )
-    lifecycle_status: ProviderLifecycleStatus = Field(
-        description="Current lifecycle state of the provider integration."
-    )
-    runtime_mode: str = Field(description="Configured runtime mode associated with the provider.")
-    enabled_for_execution: bool = Field(
-        description="Whether the provider is currently eligible for live execution."
-    )
-    failure_category_on_use: ProviderFailureCategory | None = Field(
-        default=None,
-        description="Failure category expected if this provider path is selected before it is enabled.",
-    )
-    source_reference: str = Field(
-        description="Repository reference documenting the provider configuration."
-    )
-    notes: str = Field(description="Operational notes describing the current provider posture.")
-
-
 class ProviderExpansionRuleDescriptor(BaseModel):
     capability: ProviderCapability = Field(
         description="Provider capability governed by this bounded expansion rule."
@@ -516,134 +551,6 @@ class ProviderExpansionPolicyDescriptor(BaseModel):
     )
     capability_rules: list[ProviderExpansionRuleDescriptor] = Field(
         description="Capability-specific bounded provider expansion rules."
-    )
-
-
-class ProviderCatalogResponse(BaseModel):
-    service: str = Field(description="Service name emitting the provider catalog.")
-    version: str = Field(description="Current lotus-ai service version.")
-    provider_mode: str = Field(description="Configured text-generation provider mode.")
-    embedding_provider_mode: str = Field(description="Configured embedding provider mode.")
-    text_generation_configuration: ProviderConfigurationStatusDescriptor = Field(
-        description="Current rollout and configuration posture for future live text-generation activation."
-    )
-    embedding_configuration: ProviderConfigurationStatusDescriptor = Field(
-        description="Current rollout and configuration posture for future live embedding-provider activation."
-    )
-    runtime_execution_enabled: bool = Field(
-        description="Whether any provider is currently enabled for live execution."
-    )
-    text_generation_runtime_execution_enabled: bool = Field(
-        description="Whether any text-generation provider path is currently enabled for live execution."
-    )
-    embedding_runtime_execution_enabled: bool = Field(
-        description="Whether any embedding provider path is currently enabled for live execution."
-    )
-    expansion_policy: ProviderExpansionPolicyDescriptor = Field(
-        description="Bounded provider-expansion policy describing current provider breadth and future governed slots."
-    )
-    providers: list[ProviderDescriptor] = Field(
-        description="Governed provider catalog exposed by lotus-ai."
-    )
-
-
-class ProviderPolicyDescriptor(BaseModel):
-    capability: ProviderCapability = Field(
-        description="Provider capability governed by the policy."
-    )
-    configured_mode: str = Field(description="Configured runtime mode for the capability.")
-    allowed_modes: list[ProviderExecutionMode] = Field(
-        description="Modes currently supported by lotus-ai for this capability."
-    )
-    selected_provider_id: str = Field(
-        description="Provider identifier currently selected for this capability."
-    )
-    selected_adapter_kind: ProviderAdapterKind = Field(
-        description="Registered adapter kind currently selected for this capability."
-    )
-    live_execution_enabled: bool = Field(
-        description="Whether live execution is currently allowed for this capability."
-    )
-    rejection_category: ProviderFailureCategory = Field(
-        description="Structured failure category used when the configured mode is rejected."
-    )
-    rejection_behavior: str = Field(
-        description="How lotus-ai should behave when the configured mode is unsupported."
-    )
-
-
-class ProviderPolicyResponse(BaseModel):
-    service: str = Field(description="Service name emitting the provider policy response.")
-    version: str = Field(description="Current lotus-ai service version.")
-    text_generation_configuration: ProviderConfigurationStatusDescriptor = Field(
-        description="Current rollout and configuration posture for future live text-generation activation."
-    )
-    embedding_configuration: ProviderConfigurationStatusDescriptor = Field(
-        description="Current rollout and configuration posture for future live embedding-provider activation."
-    )
-    expansion_policy: ProviderExpansionPolicyDescriptor = Field(
-        description="Bounded provider-expansion policy describing how later providers are reviewed without widening execution semantics prematurely."
-    )
-    policies: list[ProviderPolicyDescriptor] = Field(
-        description="Capability-specific provider execution policies."
-    )
-
-
-class ProviderOperatorProfileDescriptor(BaseModel):
-    profile_id: str = Field(description="Stable operator-facing provider profile identifier.")
-    display_name: str = Field(description="Operator-facing label for the provider profile.")
-    provider_mode: str = Field(description="Provider mode activated by this profile.")
-    provider_id: str | None = Field(
-        default=None,
-        description="Expected provider identifier for this profile when one is configured.",
-    )
-    api_base_class: str = Field(
-        description="High-level endpoint class for this profile, such as managed_openai or local_openai_compatible."
-    )
-    docker_profile: str | None = Field(
-        default=None,
-        description="Optional Docker Compose profile name associated with this operator profile.",
-    )
-    use_case: str = Field(
-        description="Human-readable explanation of when operators should choose this profile."
-    )
-    required_settings: list[str] = Field(
-        default_factory=list,
-        description="Configuration settings that must be present for this profile to operate correctly.",
-    )
-    verification_surfaces: list[str] = Field(
-        default_factory=list,
-        description="Primary inspection surfaces operators should use to verify this profile.",
-    )
-
-
-class ProviderOperatorProfileResponse(BaseModel):
-    service: str = Field(description="Service name emitting the provider operator profile view.")
-    version: str = Field(description="Current lotus-ai service version.")
-    selected_profile_id: str = Field(
-        description="Operator profile currently implied by the active provider configuration."
-    )
-    provider_mode: str = Field(description="Configured text-generation provider mode.")
-    current_provider_id: str | None = Field(
-        default=None,
-        description="Configured current provider id for the active text-generation path.",
-    )
-    current_model_id: str | None = Field(
-        default=None,
-        description="Configured current model id for the active text-generation path.",
-    )
-    live_execution_enabled: bool = Field(
-        description="Whether the current provider profile is presently enabled for live execution."
-    )
-    current_readiness_note: str = Field(
-        description="Single operator-facing note describing the current active provider posture."
-    )
-    switching_steps: list[str] = Field(
-        default_factory=list,
-        description="Ordered operator steps to switch and verify the active provider profile.",
-    )
-    profiles: list[ProviderOperatorProfileDescriptor] = Field(
-        description="Supported provider operator profiles exposed by lotus-ai."
     )
 
 

--- a/src/app/routers/model_catalogue.py
+++ b/src/app/routers/model_catalogue.py
@@ -19,11 +19,13 @@ from app.contracts.model_catalogue import (
 )
 from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.model_catalogue import (
+    build_model_catalogue_entry_detail,
+    build_model_catalogue_response,
+)
+from app.services.model_lifecycle_control import (
     apply_model_lifecycle_transition,
     approve_model_capability_restore,
     approve_model_promotion,
-    build_model_catalogue_entry_detail,
-    build_model_catalogue_response,
     degrade_model_capability,
     request_model_capability_restore,
     request_model_promotion,

--- a/src/app/routers/providers.py
+++ b/src/app/routers/providers.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.contracts.governed_actions import GovernedActionResponse
+from app.contracts.provider_catalog import (
+    ProviderCatalogResponse,
+    ProviderOperatorProfileResponse,
+    ProviderPolicyResponse,
+)
 from app.contracts.providers import (
     ProviderActivationReadinessResponse,
     ProviderBudgetPolicyResponse,
-    ProviderCatalogResponse,
     ProviderEvidenceReadinessResponse,
     ProviderGovernanceStatusResponse,
     ProviderOperationsStatusResponse,
-    ProviderOperatorProfileResponse,
-    ProviderPolicyResponse,
     ProviderQuotaPolicyResponse,
     ProviderRunbookReadinessResponse,
     RoutingPostureResponse,

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -15,61 +15,40 @@ seeded field actually changed.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import cast
-from uuid import uuid4
 
 from fastapi import HTTPException, status
 
 from app.config import settings
-from app.contracts.access_control import AuthorizationCapabilityType
-from app.contracts.governed_actions import (
-    GovernedActionRecord,
-    GovernedActionResponse,
-    GovernedActionType,
-)
 from app.contracts.model_catalogue import (
-    ALLOWED_MODEL_LIFECYCLE_TRANSITIONS,
-    DEGRADABLE_CAPABILITY_DIMENSIONS,
-    MODEL_SERVING_PROMOTION_TARGETS,
     OPERATOR_TERMINAL_LIFECYCLE_STATES,
-    ModelCapabilityDegradation,
-    ModelCapabilityDegradationRequest,
-    ModelCapabilityDegradationResponse,
-    ModelCapabilityRestoreApprovalRequest,
-    ModelCapabilityRestoreApprovalResponse,
-    ModelCapabilityRestoreIntentRequest,
     ModelCatalogueEntry,
     ModelCatalogueEntryDetailResponse,
     ModelCatalogueResponse,
     ModelCatalogueSeedReport,
     ModelCatalogueSeedSource,
     ModelLifecycleState,
-    ModelLifecycleTransitionRecord,
-    ModelLifecycleTransitionRequest,
-    ModelLifecycleTransitionResponse,
-    ModelPromotionApprovalRequest,
-    ModelPromotionApprovalResponse,
-    ModelPromotionIntentRequest,
     ModelRevisionDriftObservation,
     derive_model_catalogue_entry_id,
 )
-from app.contracts.providers import ProviderExecutionMode, ProviderFailureCategory
+from app.contracts.providers import (
+    CandidateUniverse,
+    CandidateUniverseExclusionDescriptor,
+    CandidateUniverseExclusionReason,
+    CandidateUniverseSource,
+    ProviderExecutionMode,
+    ProviderFailureCategory,
+)
 from app.providers.base import ProviderExecutionError
 from app.providers.configured_workflow_run_model_risk_inventory import (
     ConfiguredWorkflowRunModelRiskInventory,
 )
-from app.http.authenticated_caller import AuthenticatedCaller
-from app.services.access_control_authorization import authorize_request, require_authorized
 from app.contracts.capability_requirements import CapabilityRequirements
-from app.services.evaluation_runtime_store import get_evaluation_runtime_store
-from app.services.governed_action_control import (
-    approve_and_execute_governed_action,
-    submit_governed_action,
-)
-from app.services.kill_switch_control import verified_caller_identity
 from app.services.model_catalogue_store import get_model_catalogue_repository
 from app.services.output_contracts import output_contract_exists
-from app.services.provider_execution_config import resolve_provider_execution_config
+from app.services.provider_execution_config import (
+    ProviderExecutionConfig,
+    resolve_provider_execution_config,
+)
 
 _LIVE_TEXT_MODES = frozenset(
     {
@@ -357,6 +336,92 @@ def enforce_capability_requirements(
         )
 
 
+def derive_candidate_universe(config: ProviderExecutionConfig) -> CandidateUniverse:
+    """Derive the ordered candidate universe from catalogue evidence bounded by policy.
+
+    The policy bound is the configured primary/fallback identity order (issue
+    #244, U1); the catalogue supplies the evidence each identity must earn
+    eligibility with. Every exclusion is reasoned: a policy identity with no
+    catalogue entry, a policy identity whose lifecycle refuses service, and -
+    the operator question configuration cannot answer - a serving-eligible
+    catalogue entry for this mode that no policy row lets serve.
+
+    U1 consumes this as routing-decision evidence only; the enumeration still
+    comes from configuration, and `source` says so honestly. U2 flips the
+    enumeration to this derivation, and the flip is visible in the decision.
+    """
+
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    policy_order: list[tuple[str | None, str | None, str | None]] = [
+        (config.provider_id, config.model_id, config.model_version),
+        (config.fallback_provider_id, config.fallback_model_id, config.fallback_model_version),
+    ]
+
+    candidate_entry_ids: list[str] = []
+    exclusions: list[CandidateUniverseExclusionDescriptor] = []
+    for provider_id, model_id, model_version in policy_order:
+        if not provider_id or not model_id:
+            continue
+        entry_id = derive_model_catalogue_entry_id(
+            provider_id=provider_id,
+            model_revision=model_version or model_id,
+            deployment=None,
+        )
+        entry = repository.get_entry(entry_id)
+        if entry is None:
+            exclusions.append(
+                CandidateUniverseExclusionDescriptor(
+                    entry_id=entry_id,
+                    reason=CandidateUniverseExclusionReason.MODEL_NOT_CATALOGUED,
+                    detail=(
+                        f"Policy orders `{entry_id}` but no governed catalogue entry exists for it."
+                    ),
+                )
+            )
+            continue
+        if entry.lifecycle_state in _EXECUTION_INELIGIBLE_LIFECYCLE_STATES:
+            exclusions.append(
+                CandidateUniverseExclusionDescriptor(
+                    entry_id=entry_id,
+                    reason=CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE,
+                    detail=(
+                        f"`{entry_id}` is {entry.lifecycle_state.value} and not eligible "
+                        "to serve new executions."
+                    ),
+                )
+            )
+            continue
+        candidate_entry_ids.append(entry_id)
+
+    policy_entry_ids = set(candidate_entry_ids) | {exclusion.entry_id for exclusion in exclusions}
+    for entry in repository.list_entries():
+        if entry.entry_id in policy_entry_ids:
+            continue
+        if entry.provider_mode != config.provider_mode:
+            continue
+        if entry.lifecycle_state in _EXECUTION_INELIGIBLE_LIFECYCLE_STATES:
+            # Out of service by its own lifecycle, not by policy: reporting it
+            # as policy-excluded would misattribute the reason.
+            continue
+        exclusions.append(
+            CandidateUniverseExclusionDescriptor(
+                entry_id=entry.entry_id,
+                reason=CandidateUniverseExclusionReason.POLICY_EXCLUDED,
+                detail=(
+                    f"`{entry.entry_id}` is serving-eligible for mode "
+                    f"`{config.provider_mode}` but no policy row lets it serve."
+                ),
+            )
+        )
+
+    return CandidateUniverse(
+        source=CandidateUniverseSource.CONFIGURED,
+        candidate_entry_ids=candidate_entry_ids,
+        exclusions=exclusions,
+    )
+
+
 def bind_live_text_model_catalogue_entry() -> ModelCatalogueEntry:
     """Resolve the catalogue entry for the configured live-text identity, fail-closed.
 
@@ -396,496 +461,6 @@ def bind_live_text_model_catalogue_entry() -> ModelCatalogueEntry:
             ),
         )
     return entry
-
-
-def _require_provider_control_authorization(caller: AuthenticatedCaller) -> None:
-    require_authorized(
-        authorize_request(
-            caller_app=caller.caller_app,
-            capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
-        )
-    )
-
-
-def _require_durable_catalogue_store() -> None:
-    if settings.model_catalogue_store_mode != "sqlalchemy":
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                "Model lifecycle transitions require LOTUS_AI_MODEL_CATALOGUE_STORE_MODE="
-                "sqlalchemy so governed state changes survive restarts."
-            ),
-        )
-
-
-def _get_required_catalogue_entry(entry_id: str) -> ModelCatalogueEntry:
-    entry = get_model_catalogue_repository().get_entry(entry_id)
-    if entry is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No model-catalogue entry exists for `{entry_id}`.",
-        )
-    return entry
-
-
-def _validate_lifecycle_edge(entry: ModelCatalogueEntry, to_state: ModelLifecycleState) -> None:
-    allowed = ALLOWED_MODEL_LIFECYCLE_TRANSITIONS[entry.lifecycle_state]
-    if to_state not in allowed:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"Transition {entry.lifecycle_state.value} -> {to_state.value} is not "
-                f"allowed; permitted targets: "
-                f"{sorted(state.value for state in allowed) or 'none (terminal state)'}."
-            ),
-        )
-
-
-def _require_pass_verdict_evaluation_run(run_id: str) -> None:
-    """Promotion evidence must name a real, completed, PASS-verdict eval run.
-
-    Eval evidence enables the decision; it does not make the decision - but a
-    pending approval must never be parked on, or execute against, evidence
-    that does not exist or did not actually pass (issue #245).
-    """
-
-    run = get_evaluation_runtime_store().get_run(run_id=run_id)
-    if run is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"Evaluation run `{run_id}` does not exist; promotion evidence must name "
-                "a real evaluation run."
-            ),
-        )
-    if run.lifecycle_status != "COMPLETED" or run.verdict != "PASS":
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"Evaluation run `{run_id}` is {run.lifecycle_status} with verdict "
-                f"{run.verdict or 'none'}; promotion requires a COMPLETED run with "
-                "verdict PASS."
-            ),
-        )
-
-
-def _record_lifecycle_transition(
-    *,
-    entry: ModelCatalogueEntry,
-    to_state: ModelLifecycleState,
-    reason: str,
-    requested_by: str,
-    approved_by: str | None,
-    approval_evidence_ref: str | None,
-) -> ModelLifecycleTransitionResponse:
-    """Durably apply one already-validated lifecycle state change."""
-
-    now = _utc_now_iso()
-    updates: dict[str, object] = {"lifecycle_state": to_state, "last_updated_at": now}
-    if approval_evidence_ref:
-        updates["approval_evidence_refs"] = [
-            *entry.approval_evidence_refs,
-            approval_evidence_ref,
-        ]
-    updated = entry.model_copy(update=updates)
-    transition = ModelLifecycleTransitionRecord(
-        event_id=f"mlc_{uuid4().hex[:16]}",
-        entry_id=entry.entry_id,
-        from_state=entry.lifecycle_state,
-        to_state=to_state,
-        reason=reason,
-        requested_by=requested_by,
-        approved_by=approved_by,
-        approval_evidence_ref=approval_evidence_ref,
-        recorded_at=now,
-    )
-    upsert_model_catalogue_entry(updated)
-    get_model_catalogue_repository().append_lifecycle_event(transition)
-    return ModelLifecycleTransitionResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        store_mode=settings.model_catalogue_store_mode,
-        entry=updated,
-        transition=transition,
-    )
-
-
-def apply_model_lifecycle_transition(
-    entry_id: str,
-    request: ModelLifecycleTransitionRequest,
-    caller: AuthenticatedCaller,
-) -> ModelLifecycleTransitionResponse:
-    """Apply one single-principal lifecycle transition to a catalogue entry.
-
-    Safety and administrative targets only: taking a model out of service, or
-    moving it through cataloguing and evaluation, is applied immediately by
-    one verified principal and honestly records that no approval existed.
-    Serving promotions are risk-increasing and refused here with guidance to
-    the governed two-step flow (issue #245).
-    """
-
-    _require_provider_control_authorization(caller)
-    _require_durable_catalogue_store()
-    entry = _get_required_catalogue_entry(entry_id)
-    if request.to_state in MODEL_SERVING_PROMOTION_TARGETS:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"Transition to {request.to_state.value} expands serving posture and must go "
-                "through the governed two-step promotion flow (issue #245): state the intent "
-                "via promotion-requests, then a distinct verified credential approves via "
-                "promotion-approvals."
-            ),
-        )
-    _validate_lifecycle_edge(entry, request.to_state)
-    return _record_lifecycle_transition(
-        entry=entry,
-        to_state=request.to_state,
-        reason=request.reason,
-        requested_by=verified_caller_identity(caller),
-        approved_by=None,
-        approval_evidence_ref=None,
-    )
-
-
-def _promotion_action_payload(
-    *,
-    entry: ModelCatalogueEntry,
-    to_state: ModelLifecycleState,
-    evaluation_run_id: str,
-    reason: str,
-) -> dict[str, str | None]:
-    """The exact action the approver signs off on.
-
-    Pins the entry's current lifecycle state and exact revision identity: a
-    promotion reviewed against one baseline must not execute against another,
-    so a state or revision change between request and approval refuses the
-    stale approval instead of executing it (issue #245).
-    """
-
-    return {
-        "action_type": GovernedActionType.MODEL_LIFECYCLE_PROMOTE.value,
-        "entry_id": entry.entry_id,
-        "from_state": entry.lifecycle_state.value,
-        "to_state": to_state.value,
-        "provider_id": entry.provider_id,
-        "model_family": entry.model_family,
-        "model_revision": entry.model_revision,
-        "deployment": entry.deployment,
-        "evaluation_run_id": evaluation_run_id,
-        "reason": reason,
-    }
-
-
-def request_model_promotion(
-    entry_id: str,
-    request: ModelPromotionIntentRequest,
-    caller: AuthenticatedCaller,
-) -> GovernedActionResponse:
-    """Step one of governed serving promotion: record the intent under the requester's credential.
-
-    The promotion is fully validated first - serving target, lifecycle edge,
-    and PASS-verdict eval evidence - so a pending action is never parked on a
-    promotion that is not currently executable.
-    """
-
-    _require_provider_control_authorization(caller)
-    _require_durable_catalogue_store()
-    entry = _get_required_catalogue_entry(entry_id)
-    if request.to_state not in MODEL_SERVING_PROMOTION_TARGETS:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"{request.to_state.value} is not a serving-promotion target; apply it as a "
-                "single-principal transition via lifecycle-transitions."
-            ),
-        )
-    _validate_lifecycle_edge(entry, request.to_state)
-    _require_pass_verdict_evaluation_run(request.evaluation_run_id)
-    record = submit_governed_action(
-        caller=caller,
-        action_type=GovernedActionType.MODEL_LIFECYCLE_PROMOTE,
-        target=entry_id,
-        payload=_promotion_action_payload(
-            entry=entry,
-            to_state=request.to_state,
-            evaluation_run_id=request.evaluation_run_id,
-            reason=request.reason,
-        ),
-        attribution=request.requested_by,
-    )
-    return GovernedActionResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        governed_action=record,
-        summary=[
-            f"Promotion of `{entry_id}` from {entry.lifecycle_state.value} to "
-            f"{request.to_state.value} is pending approval.",
-            "A distinct verified credential must approve action "
-            f"`{record.action_id}` with hash `{record.action_hash}`.",
-            f"Eval evidence: run `{request.evaluation_run_id}` (COMPLETED, verdict PASS).",
-        ],
-    )
-
-
-def approve_model_promotion(
-    entry_id: str,
-    request: ModelPromotionApprovalRequest,
-    caller: AuthenticatedCaller,
-) -> ModelPromotionApprovalResponse:
-    """Step two: a distinct verified credential approves the exact action, which executes it."""
-
-    _require_provider_control_authorization(caller)
-    _require_durable_catalogue_store()
-    entry = _get_required_catalogue_entry(entry_id)
-    outcome: dict[str, object] = {}
-
-    def _execute_promotion(record: GovernedActionRecord) -> None:
-        to_state = ModelLifecycleState(str(record.action_payload.get("to_state")))
-        evaluation_run_id = str(record.action_payload.get("evaluation_run_id"))
-        _validate_lifecycle_edge(entry, to_state)
-        _require_pass_verdict_evaluation_run(evaluation_run_id)
-        outcome["response"] = _record_lifecycle_transition(
-            entry=entry,
-            to_state=to_state,
-            reason=str(record.action_payload.get("reason")),
-            requested_by=(f"{record.requester_caller_app} (credential {record.requester_key_id})"),
-            approved_by=verified_caller_identity(caller),
-            approval_evidence_ref=f"evaluation-run:{evaluation_run_id}",
-        )
-
-    executed = approve_and_execute_governed_action(
-        caller=caller,
-        action_id=request.action_id,
-        expected_target=entry_id,
-        expected_hash=request.action_hash,
-        current_payload_builder=lambda record: _promotion_action_payload(
-            entry=entry,
-            to_state=ModelLifecycleState(str(record.action_payload.get("to_state"))),
-            evaluation_run_id=str(record.action_payload.get("evaluation_run_id")),
-            reason=str(record.action_payload.get("reason")),
-        ),
-        attribution=request.approved_by,
-        execute=_execute_promotion,
-    )
-    transition_response = cast(ModelLifecycleTransitionResponse, outcome["response"])
-    return ModelPromotionApprovalResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        store_mode=settings.model_catalogue_store_mode,
-        entry=transition_response.entry,
-        transition=transition_response.transition,
-        governed_action=executed,
-        summary=[
-            f"Promoted `{entry_id}` to {transition_response.entry.lifecycle_state.value} "
-            f"under governed action `{executed.action_id}`.",
-            f"Requested under credential `{executed.requester_key_id}` and approved under "
-            f"distinct credential `{executed.approver_key_id}`.",
-            f"Evidence: `{transition_response.transition.approval_evidence_ref}`.",
-        ],
-    )
-
-
-def degrade_model_capability(
-    entry_id: str,
-    request: ModelCapabilityDegradationRequest,
-    caller: AuthenticatedCaller,
-) -> ModelCapabilityDegradationResponse:
-    """Degrade one capability dimension on a catalogue entry, immediately.
-
-    Safety direction (issue #245, slice 2): containing an observed regression
-    takes one verified principal and no approval step. The underlying
-    assessed fact is never rewritten - the degradation overrides it for
-    requirement routing only while present.
-    """
-
-    _require_provider_control_authorization(caller)
-    _require_durable_catalogue_store()
-    entry = _get_required_catalogue_entry(entry_id)
-    if request.dimension not in DEGRADABLE_CAPABILITY_DIMENSIONS:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=(
-                f"`{request.dimension}` is not a degradable capability dimension; requirement "
-                f"routing enforces: {sorted(DEGRADABLE_CAPABILITY_DIMENSIONS)}."
-            ),
-        )
-    existing = entry.capability_degradations.get(request.dimension)
-    if existing is not None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"Capability `{request.dimension}` on `{entry_id}` is already degraded "
-                f"(by {existing.degraded_by} at {existing.degraded_at}); the active "
-                "degradation's provenance is not overwritable."
-            ),
-        )
-    degradation = ModelCapabilityDegradation(
-        dimension=request.dimension,
-        reason=request.reason,
-        degraded_by=verified_caller_identity(caller),
-        degraded_at=_utc_now_iso(),
-    )
-    updated = entry.model_copy(
-        update={
-            "capability_degradations": {
-                **entry.capability_degradations,
-                request.dimension: degradation,
-            },
-            "last_updated_at": degradation.degraded_at,
-        }
-    )
-    upsert_model_catalogue_entry(updated)
-    return ModelCapabilityDegradationResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        store_mode=settings.model_catalogue_store_mode,
-        entry=updated,
-        degradation=degradation,
-    )
-
-
-def _capability_restore_payload(
-    *,
-    entry: ModelCatalogueEntry,
-    degradation: ModelCapabilityDegradation,
-    evaluation_run_id: str,
-    reason: str,
-) -> dict[str, str | None]:
-    """The exact action the approver signs off on.
-
-    Pins the full degradation being cleared: if the overlay changes between
-    request and approval (re-degraded with a new reason, or already cleared),
-    the stale approval refuses instead of executing (issue #245, slice 2).
-    """
-
-    return {
-        "action_type": GovernedActionType.MODEL_CAPABILITY_RESTORE.value,
-        "entry_id": entry.entry_id,
-        "dimension": degradation.dimension,
-        "degradation_reason": degradation.reason,
-        "degraded_by": degradation.degraded_by,
-        "degraded_at": degradation.degraded_at,
-        "evaluation_run_id": evaluation_run_id,
-        "reason": reason,
-    }
-
-
-def _get_required_capability_degradation(
-    entry: ModelCatalogueEntry, dimension: str
-) -> ModelCapabilityDegradation:
-    degradation = entry.capability_degradations.get(dimension)
-    if degradation is None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"Capability `{dimension}` on `{entry.entry_id}` is not degraded; "
-                "there is nothing to restore."
-            ),
-        )
-    return degradation
-
-
-def request_model_capability_restore(
-    entry_id: str,
-    request: ModelCapabilityRestoreIntentRequest,
-    caller: AuthenticatedCaller,
-) -> GovernedActionResponse:
-    """Step one of governed capability restore: record the intent under the requester's credential.
-
-    Clearing a degradation re-exposes the underlying evidence-derived fact to
-    requirement routing - risk-increasing, so the restore is validated first
-    (active degradation, PASS-verdict eval evidence) and executes only under
-    a distinct verified approval.
-    """
-
-    _require_provider_control_authorization(caller)
-    _require_durable_catalogue_store()
-    entry = _get_required_catalogue_entry(entry_id)
-    degradation = _get_required_capability_degradation(entry, request.dimension)
-    _require_pass_verdict_evaluation_run(request.evaluation_run_id)
-    record = submit_governed_action(
-        caller=caller,
-        action_type=GovernedActionType.MODEL_CAPABILITY_RESTORE,
-        target=entry_id,
-        payload=_capability_restore_payload(
-            entry=entry,
-            degradation=degradation,
-            evaluation_run_id=request.evaluation_run_id,
-            reason=request.reason,
-        ),
-        attribution=request.requested_by,
-    )
-    return GovernedActionResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        governed_action=record,
-        summary=[
-            f"Restore of capability `{request.dimension}` on `{entry_id}` is pending approval.",
-            "A distinct verified credential must approve action "
-            f"`{record.action_id}` with hash `{record.action_hash}`.",
-            f"The capability stays degraded ({degradation.reason}) until then.",
-        ],
-    )
-
-
-def approve_model_capability_restore(
-    entry_id: str,
-    request: ModelCapabilityRestoreApprovalRequest,
-    caller: AuthenticatedCaller,
-) -> ModelCapabilityRestoreApprovalResponse:
-    """Step two: a distinct verified credential approves the exact action, which executes it."""
-
-    _require_provider_control_authorization(caller)
-    _require_durable_catalogue_store()
-    entry = _get_required_catalogue_entry(entry_id)
-    outcome: dict[str, object] = {}
-
-    def _execute_restore(record: GovernedActionRecord) -> None:
-        dimension = str(record.action_payload.get("dimension"))
-        _require_pass_verdict_evaluation_run(str(record.action_payload.get("evaluation_run_id")))
-        remaining = {
-            key: value for key, value in entry.capability_degradations.items() if key != dimension
-        }
-        updated = entry.model_copy(
-            update={"capability_degradations": remaining, "last_updated_at": _utc_now_iso()}
-        )
-        upsert_model_catalogue_entry(updated)
-        outcome["entry"] = updated
-
-    def _current_payload(record: GovernedActionRecord) -> dict[str, str | None]:
-        dimension = str(record.action_payload.get("dimension"))
-        return _capability_restore_payload(
-            entry=entry,
-            degradation=_get_required_capability_degradation(entry, dimension),
-            evaluation_run_id=str(record.action_payload.get("evaluation_run_id")),
-            reason=str(record.action_payload.get("reason")),
-        )
-
-    executed = approve_and_execute_governed_action(
-        caller=caller,
-        action_id=request.action_id,
-        expected_target=entry_id,
-        expected_hash=request.action_hash,
-        current_payload_builder=_current_payload,
-        attribution=request.approved_by,
-        execute=_execute_restore,
-    )
-    updated_entry = cast(ModelCatalogueEntry, outcome["entry"])
-    return ModelCapabilityRestoreApprovalResponse(
-        service=settings.service_name,
-        version=settings.service_version,
-        store_mode=settings.model_catalogue_store_mode,
-        entry=updated_entry,
-        governed_action=executed,
-        summary=[
-            f"Restored capability `{executed.action_payload.get('dimension')}` on `{entry_id}` "
-            f"under governed action `{executed.action_id}`.",
-            f"Requested under credential `{executed.requester_key_id}` and approved under "
-            f"distinct credential `{executed.approver_key_id}`.",
-            "The cleared degradation is pinned inside this action's payload.",
-        ],
-    )
 
 
 def build_model_catalogue_entry_detail(entry_id: str) -> ModelCatalogueEntryDetailResponse:

--- a/src/app/services/model_lifecycle_control.py
+++ b/src/app/services/model_lifecycle_control.py
@@ -1,0 +1,547 @@
+"""Governed lifecycle and capability control on the model catalogue (issue #245).
+
+Split from services/model_catalogue.py when the module budget fired: the
+catalogue module owns identity truth, seeding and eligibility reads; this
+module owns the governed state changes on it - lifecycle transitions, serving
+promotions, capability degradation and its governed restore - every one
+composing the #157 governed-action primitive and the risk-direction rule.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+
+from app.config import settings
+from app.contracts.access_control import AuthorizationCapabilityType
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionResponse,
+    GovernedActionType,
+)
+from app.contracts.model_catalogue import (
+    ALLOWED_MODEL_LIFECYCLE_TRANSITIONS,
+    DEGRADABLE_CAPABILITY_DIMENSIONS,
+    MODEL_SERVING_PROMOTION_TARGETS,
+    ModelCapabilityDegradation,
+    ModelCapabilityDegradationRequest,
+    ModelCapabilityDegradationResponse,
+    ModelCapabilityRestoreApprovalRequest,
+    ModelCapabilityRestoreApprovalResponse,
+    ModelCapabilityRestoreIntentRequest,
+    ModelCatalogueEntry,
+    ModelLifecycleState,
+    ModelLifecycleTransitionRecord,
+    ModelLifecycleTransitionRequest,
+    ModelLifecycleTransitionResponse,
+    ModelPromotionApprovalRequest,
+    ModelPromotionApprovalResponse,
+    ModelPromotionIntentRequest,
+)
+from app.http.authenticated_caller import AuthenticatedCaller
+from app.services.access_control_authorization import authorize_request, require_authorized
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
+from app.services.kill_switch_control import verified_caller_identity
+from app.services.model_catalogue import upsert_model_catalogue_entry
+from app.services.model_catalogue_store import get_model_catalogue_repository
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _require_provider_control_authorization(caller: AuthenticatedCaller) -> None:
+    require_authorized(
+        authorize_request(
+            caller_app=caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
+        )
+    )
+
+
+def _require_durable_catalogue_store() -> None:
+    if settings.model_catalogue_store_mode != "sqlalchemy":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Model lifecycle transitions require LOTUS_AI_MODEL_CATALOGUE_STORE_MODE="
+                "sqlalchemy so governed state changes survive restarts."
+            ),
+        )
+
+
+def _get_required_catalogue_entry(entry_id: str) -> ModelCatalogueEntry:
+    entry = get_model_catalogue_repository().get_entry(entry_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No model-catalogue entry exists for `{entry_id}`.",
+        )
+    return entry
+
+
+def _validate_lifecycle_edge(entry: ModelCatalogueEntry, to_state: ModelLifecycleState) -> None:
+    allowed = ALLOWED_MODEL_LIFECYCLE_TRANSITIONS[entry.lifecycle_state]
+    if to_state not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Transition {entry.lifecycle_state.value} -> {to_state.value} is not "
+                f"allowed; permitted targets: "
+                f"{sorted(state.value for state in allowed) or 'none (terminal state)'}."
+            ),
+        )
+
+
+def _require_pass_verdict_evaluation_run(run_id: str) -> None:
+    """Promotion evidence must name a real, completed, PASS-verdict eval run.
+
+    Eval evidence enables the decision; it does not make the decision - but a
+    pending approval must never be parked on, or execute against, evidence
+    that does not exist or did not actually pass (issue #245).
+    """
+
+    run = get_evaluation_runtime_store().get_run(run_id=run_id)
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Evaluation run `{run_id}` does not exist; promotion evidence must name "
+                "a real evaluation run."
+            ),
+        )
+    if run.lifecycle_status != "COMPLETED" or run.verdict != "PASS":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"Evaluation run `{run_id}` is {run.lifecycle_status} with verdict "
+                f"{run.verdict or 'none'}; promotion requires a COMPLETED run with "
+                "verdict PASS."
+            ),
+        )
+
+
+def _record_lifecycle_transition(
+    *,
+    entry: ModelCatalogueEntry,
+    to_state: ModelLifecycleState,
+    reason: str,
+    requested_by: str,
+    approved_by: str | None,
+    approval_evidence_ref: str | None,
+) -> ModelLifecycleTransitionResponse:
+    """Durably apply one already-validated lifecycle state change."""
+
+    now = _utc_now_iso()
+    updates: dict[str, object] = {"lifecycle_state": to_state, "last_updated_at": now}
+    if approval_evidence_ref:
+        updates["approval_evidence_refs"] = [
+            *entry.approval_evidence_refs,
+            approval_evidence_ref,
+        ]
+    updated = entry.model_copy(update=updates)
+    transition = ModelLifecycleTransitionRecord(
+        event_id=f"mlc_{uuid4().hex[:16]}",
+        entry_id=entry.entry_id,
+        from_state=entry.lifecycle_state,
+        to_state=to_state,
+        reason=reason,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        approval_evidence_ref=approval_evidence_ref,
+        recorded_at=now,
+    )
+    upsert_model_catalogue_entry(updated)
+    get_model_catalogue_repository().append_lifecycle_event(transition)
+    return ModelLifecycleTransitionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=updated,
+        transition=transition,
+    )
+
+
+def apply_model_lifecycle_transition(
+    entry_id: str,
+    request: ModelLifecycleTransitionRequest,
+    caller: AuthenticatedCaller,
+) -> ModelLifecycleTransitionResponse:
+    """Apply one single-principal lifecycle transition to a catalogue entry.
+
+    Safety and administrative targets only: taking a model out of service, or
+    moving it through cataloguing and evaluation, is applied immediately by
+    one verified principal and honestly records that no approval existed.
+    Serving promotions are risk-increasing and refused here with guidance to
+    the governed two-step flow (issue #245).
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    if request.to_state in MODEL_SERVING_PROMOTION_TARGETS:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Transition to {request.to_state.value} expands serving posture and must go "
+                "through the governed two-step promotion flow (issue #245): state the intent "
+                "via promotion-requests, then a distinct verified credential approves via "
+                "promotion-approvals."
+            ),
+        )
+    _validate_lifecycle_edge(entry, request.to_state)
+    return _record_lifecycle_transition(
+        entry=entry,
+        to_state=request.to_state,
+        reason=request.reason,
+        requested_by=verified_caller_identity(caller),
+        approved_by=None,
+        approval_evidence_ref=None,
+    )
+
+
+def _promotion_action_payload(
+    *,
+    entry: ModelCatalogueEntry,
+    to_state: ModelLifecycleState,
+    evaluation_run_id: str,
+    reason: str,
+) -> dict[str, str | None]:
+    """The exact action the approver signs off on.
+
+    Pins the entry's current lifecycle state and exact revision identity: a
+    promotion reviewed against one baseline must not execute against another,
+    so a state or revision change between request and approval refuses the
+    stale approval instead of executing it (issue #245).
+    """
+
+    return {
+        "action_type": GovernedActionType.MODEL_LIFECYCLE_PROMOTE.value,
+        "entry_id": entry.entry_id,
+        "from_state": entry.lifecycle_state.value,
+        "to_state": to_state.value,
+        "provider_id": entry.provider_id,
+        "model_family": entry.model_family,
+        "model_revision": entry.model_revision,
+        "deployment": entry.deployment,
+        "evaluation_run_id": evaluation_run_id,
+        "reason": reason,
+    }
+
+
+def request_model_promotion(
+    entry_id: str,
+    request: ModelPromotionIntentRequest,
+    caller: AuthenticatedCaller,
+) -> GovernedActionResponse:
+    """Step one of governed serving promotion: record the intent under the requester's credential.
+
+    The promotion is fully validated first - serving target, lifecycle edge,
+    and PASS-verdict eval evidence - so a pending action is never parked on a
+    promotion that is not currently executable.
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    if request.to_state not in MODEL_SERVING_PROMOTION_TARGETS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"{request.to_state.value} is not a serving-promotion target; apply it as a "
+                "single-principal transition via lifecycle-transitions."
+            ),
+        )
+    _validate_lifecycle_edge(entry, request.to_state)
+    _require_pass_verdict_evaluation_run(request.evaluation_run_id)
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.MODEL_LIFECYCLE_PROMOTE,
+        target=entry_id,
+        payload=_promotion_action_payload(
+            entry=entry,
+            to_state=request.to_state,
+            evaluation_run_id=request.evaluation_run_id,
+            reason=request.reason,
+        ),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Promotion of `{entry_id}` from {entry.lifecycle_state.value} to "
+            f"{request.to_state.value} is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            f"Eval evidence: run `{request.evaluation_run_id}` (COMPLETED, verdict PASS).",
+        ],
+    )
+
+
+def approve_model_promotion(
+    entry_id: str,
+    request: ModelPromotionApprovalRequest,
+    caller: AuthenticatedCaller,
+) -> ModelPromotionApprovalResponse:
+    """Step two: a distinct verified credential approves the exact action, which executes it."""
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    outcome: dict[str, object] = {}
+
+    def _execute_promotion(record: GovernedActionRecord) -> None:
+        to_state = ModelLifecycleState(str(record.action_payload.get("to_state")))
+        evaluation_run_id = str(record.action_payload.get("evaluation_run_id"))
+        _validate_lifecycle_edge(entry, to_state)
+        _require_pass_verdict_evaluation_run(evaluation_run_id)
+        outcome["response"] = _record_lifecycle_transition(
+            entry=entry,
+            to_state=to_state,
+            reason=str(record.action_payload.get("reason")),
+            requested_by=(f"{record.requester_caller_app} (credential {record.requester_key_id})"),
+            approved_by=verified_caller_identity(caller),
+            approval_evidence_ref=f"evaluation-run:{evaluation_run_id}",
+        )
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=entry_id,
+        expected_hash=request.action_hash,
+        current_payload_builder=lambda record: _promotion_action_payload(
+            entry=entry,
+            to_state=ModelLifecycleState(str(record.action_payload.get("to_state"))),
+            evaluation_run_id=str(record.action_payload.get("evaluation_run_id")),
+            reason=str(record.action_payload.get("reason")),
+        ),
+        attribution=request.approved_by,
+        execute=_execute_promotion,
+    )
+    transition_response = cast(ModelLifecycleTransitionResponse, outcome["response"])
+    return ModelPromotionApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=transition_response.entry,
+        transition=transition_response.transition,
+        governed_action=executed,
+        summary=[
+            f"Promoted `{entry_id}` to {transition_response.entry.lifecycle_state.value} "
+            f"under governed action `{executed.action_id}`.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+            f"Evidence: `{transition_response.transition.approval_evidence_ref}`.",
+        ],
+    )
+
+
+def degrade_model_capability(
+    entry_id: str,
+    request: ModelCapabilityDegradationRequest,
+    caller: AuthenticatedCaller,
+) -> ModelCapabilityDegradationResponse:
+    """Degrade one capability dimension on a catalogue entry, immediately.
+
+    Safety direction (issue #245, slice 2): containing an observed regression
+    takes one verified principal and no approval step. The underlying
+    assessed fact is never rewritten - the degradation overrides it for
+    requirement routing only while present.
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    if request.dimension not in DEGRADABLE_CAPABILITY_DIMENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=(
+                f"`{request.dimension}` is not a degradable capability dimension; requirement "
+                f"routing enforces: {sorted(DEGRADABLE_CAPABILITY_DIMENSIONS)}."
+            ),
+        )
+    existing = entry.capability_degradations.get(request.dimension)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Capability `{request.dimension}` on `{entry_id}` is already degraded "
+                f"(by {existing.degraded_by} at {existing.degraded_at}); the active "
+                "degradation's provenance is not overwritable."
+            ),
+        )
+    degradation = ModelCapabilityDegradation(
+        dimension=request.dimension,
+        reason=request.reason,
+        degraded_by=verified_caller_identity(caller),
+        degraded_at=_utc_now_iso(),
+    )
+    updated = entry.model_copy(
+        update={
+            "capability_degradations": {
+                **entry.capability_degradations,
+                request.dimension: degradation,
+            },
+            "last_updated_at": degradation.degraded_at,
+        }
+    )
+    upsert_model_catalogue_entry(updated)
+    return ModelCapabilityDegradationResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=updated,
+        degradation=degradation,
+    )
+
+
+def _capability_restore_payload(
+    *,
+    entry: ModelCatalogueEntry,
+    degradation: ModelCapabilityDegradation,
+    evaluation_run_id: str,
+    reason: str,
+) -> dict[str, str | None]:
+    """The exact action the approver signs off on.
+
+    Pins the full degradation being cleared: if the overlay changes between
+    request and approval (re-degraded with a new reason, or already cleared),
+    the stale approval refuses instead of executing (issue #245, slice 2).
+    """
+
+    return {
+        "action_type": GovernedActionType.MODEL_CAPABILITY_RESTORE.value,
+        "entry_id": entry.entry_id,
+        "dimension": degradation.dimension,
+        "degradation_reason": degradation.reason,
+        "degraded_by": degradation.degraded_by,
+        "degraded_at": degradation.degraded_at,
+        "evaluation_run_id": evaluation_run_id,
+        "reason": reason,
+    }
+
+
+def _get_required_capability_degradation(
+    entry: ModelCatalogueEntry, dimension: str
+) -> ModelCapabilityDegradation:
+    degradation = entry.capability_degradations.get(dimension)
+    if degradation is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Capability `{dimension}` on `{entry.entry_id}` is not degraded; "
+                "there is nothing to restore."
+            ),
+        )
+    return degradation
+
+
+def request_model_capability_restore(
+    entry_id: str,
+    request: ModelCapabilityRestoreIntentRequest,
+    caller: AuthenticatedCaller,
+) -> GovernedActionResponse:
+    """Step one of governed capability restore: record the intent under the requester's credential.
+
+    Clearing a degradation re-exposes the underlying evidence-derived fact to
+    requirement routing - risk-increasing, so the restore is validated first
+    (active degradation, PASS-verdict eval evidence) and executes only under
+    a distinct verified approval.
+    """
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    degradation = _get_required_capability_degradation(entry, request.dimension)
+    _require_pass_verdict_evaluation_run(request.evaluation_run_id)
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.MODEL_CAPABILITY_RESTORE,
+        target=entry_id,
+        payload=_capability_restore_payload(
+            entry=entry,
+            degradation=degradation,
+            evaluation_run_id=request.evaluation_run_id,
+            reason=request.reason,
+        ),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Restore of capability `{request.dimension}` on `{entry_id}` is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            f"The capability stays degraded ({degradation.reason}) until then.",
+        ],
+    )
+
+
+def approve_model_capability_restore(
+    entry_id: str,
+    request: ModelCapabilityRestoreApprovalRequest,
+    caller: AuthenticatedCaller,
+) -> ModelCapabilityRestoreApprovalResponse:
+    """Step two: a distinct verified credential approves the exact action, which executes it."""
+
+    _require_provider_control_authorization(caller)
+    _require_durable_catalogue_store()
+    entry = _get_required_catalogue_entry(entry_id)
+    outcome: dict[str, object] = {}
+
+    def _execute_restore(record: GovernedActionRecord) -> None:
+        dimension = str(record.action_payload.get("dimension"))
+        _require_pass_verdict_evaluation_run(str(record.action_payload.get("evaluation_run_id")))
+        remaining = {
+            key: value for key, value in entry.capability_degradations.items() if key != dimension
+        }
+        updated = entry.model_copy(
+            update={"capability_degradations": remaining, "last_updated_at": _utc_now_iso()}
+        )
+        upsert_model_catalogue_entry(updated)
+        outcome["entry"] = updated
+
+    def _current_payload(record: GovernedActionRecord) -> dict[str, str | None]:
+        dimension = str(record.action_payload.get("dimension"))
+        return _capability_restore_payload(
+            entry=entry,
+            degradation=_get_required_capability_degradation(entry, dimension),
+            evaluation_run_id=str(record.action_payload.get("evaluation_run_id")),
+            reason=str(record.action_payload.get("reason")),
+        )
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=entry_id,
+        expected_hash=request.action_hash,
+        current_payload_builder=_current_payload,
+        attribution=request.approved_by,
+        execute=_execute_restore,
+    )
+    updated_entry = cast(ModelCatalogueEntry, outcome["entry"])
+    return ModelCapabilityRestoreApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        store_mode=settings.model_catalogue_store_mode,
+        entry=updated_entry,
+        governed_action=executed,
+        summary=[
+            f"Restored capability `{executed.action_payload.get('dimension')}` on `{entry_id}` "
+            f"under governed action `{executed.action_id}`.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+            "The cleared degradation is pinned inside this action's payload.",
+        ],
+    )

--- a/src/app/services/provider_catalog.py
+++ b/src/app/services/provider_catalog.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from app.config import settings
 from app.services.runtime_mode_config import resolve_runtime_mode_config
-from app.contracts.providers import (
-    ProviderCapability,
+from app.contracts.provider_catalog import (
     ProviderCatalogResponse,
     ProviderDescriptor,
+)
+from app.contracts.providers import (
+    ProviderCapability,
     ProviderLifecycleStatus,
 )
 from app.providers.registry import list_registered_provider_descriptors

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -7,6 +7,8 @@ from app.contracts.providers import (
     ROUTING_POLICY_FIXED_CONFIGURED_MODE,
     ROUTING_POLICY_ORDERED_FALLBACK,
     ROUTING_POLICY_VERSION_V1,
+    CandidateUniverse,
+    CandidateUniverseSource,
     ProviderExecutionMode,
     ProviderExecutionRequest,
     ProviderExecutionResponse,
@@ -35,6 +37,7 @@ from app.contracts.capability_requirements import CapabilityRequirements
 from app.services.model_catalogue import (
     ENFORCED_REQUIREMENT_DIMENSIONS,
     bind_live_text_model_catalogue_entry,
+    derive_candidate_universe,
     enforce_capability_requirements,
     record_model_revision_drift,
 )
@@ -219,6 +222,10 @@ def _execute_ordered_fallback(
 
     rejections: dict[int, ProviderFailureCategory] = {}
     candidates = [config, alternate]
+    # Decision evidence only in U1 (issue #244): the enumeration above is
+    # still configuration-shaped, and the universe says so honestly while
+    # recording what the catalogue holds that policy does not let serve.
+    universe = derive_candidate_universe(config)
 
     # Operator kill switches outrank every automatic control, evaluated per
     # candidate: a switch on the primary's provider scope routes to the
@@ -243,6 +250,7 @@ def _execute_ordered_fallback(
             candidates=candidates,
             rejections=rejections,
             fallback_path=[],
+            universe=universe,
         )
 
     try:
@@ -258,6 +266,7 @@ def _execute_ordered_fallback(
             candidates=candidates,
             rejections=rejections,
             fallback_path=[],
+            universe=universe,
         ) from exc
 
     adapter = resolve_text_generation_adapter(mode)
@@ -311,6 +320,7 @@ def _execute_ordered_fallback(
                 serving_entry=catalogue_entry,
                 fallback_path=fallback_path,
                 decided_at=_utc_now_iso(),
+                universe=universe,
             )
             record_provider_spend(response)
             record_successful_provider_execution()
@@ -324,6 +334,7 @@ def _execute_ordered_fallback(
         candidates=candidates,
         rejections=rejections,
         fallback_path=fallback_path,
+        universe=universe,
     )
 
 
@@ -335,6 +346,7 @@ def _ordered_refusal(
     candidates: list[ProviderExecutionConfig],
     rejections: dict[int, ProviderFailureCategory],
     fallback_path: list[str],
+    universe: CandidateUniverse | None = None,
 ) -> ProviderGatewayUnavailableError:
     return ProviderGatewayUnavailableError(
         detail=f"{error.category.value}: {error.message}",
@@ -348,6 +360,7 @@ def _ordered_refusal(
             serving_entry=None,
             fallback_path=fallback_path,
             decided_at=_utc_now_iso(),
+            universe=universe,
         ),
     )
 
@@ -375,6 +388,7 @@ def _build_ordered_routing_decision(
     serving_entry: ModelCatalogueEntry | None,
     fallback_path: list[str],
     decided_at: str,
+    universe: CandidateUniverse | None = None,
 ) -> RoutingDecisionDescriptor:
     descriptors: list[RoutingCandidateDescriptor] = []
     for candidate, rejection in candidates:
@@ -419,6 +433,10 @@ def _build_ordered_routing_decision(
         decided_at=decided_at,
         selection_reason=selection_reason,
         fallback_path=fallback_path,
+        universe_source=(
+            universe.source if universe is not None else CandidateUniverseSource.CONFIGURED
+        ),
+        universe_exclusions=list(universe.exclusions) if universe is not None else [],
     )
 
 

--- a/src/app/services/provider_operator_profile.py
+++ b/src/app/services/provider_operator_profile.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from app.config import settings
-from app.contracts.providers import (
-    ProviderExecutionMode,
+from app.contracts.provider_catalog import (
     ProviderOperatorProfileDescriptor,
     ProviderOperatorProfileResponse,
 )
+from app.contracts.providers import ProviderExecutionMode
 from app.services.provider_live_execution_state import (
     ProviderLiveExecutionState,
     build_provider_live_execution_state,

--- a/src/app/services/provider_policy.py
+++ b/src/app/services/provider_policy.py
@@ -4,13 +4,15 @@ from fastapi import HTTPException, status
 
 from app.config import settings
 from app.services.runtime_mode_config import resolve_runtime_mode_config
+from app.contracts.provider_catalog import (
+    ProviderPolicyDescriptor,
+    ProviderPolicyResponse,
+)
 from app.contracts.providers import (
     ProviderAdapterKind,
     ProviderCapability,
     ProviderExecutionMode,
     ProviderFailureCategory,
-    ProviderPolicyDescriptor,
-    ProviderPolicyResponse,
 )
 from app.providers.registry import resolve_embedding_adapter, resolve_text_generation_adapter
 from app.services.embedding_live_execution_state import build_embedding_live_execution_state

--- a/tests/unit/test_candidate_universe.py
+++ b/tests/unit/test_candidate_universe.py
@@ -1,0 +1,182 @@
+"""The candidate universe is derived from catalogue evidence bounded by policy.
+
+Issue #244, U1: the derivation is routing-decision evidence only - the
+enumeration still comes from configuration, and the universe says so honestly
+while recording what the catalogue holds that policy does not let serve. The
+equivalence proven here is what makes the U2 flip safe.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.contracts.model_catalogue import (
+    ModelCatalogueSeedSource,
+    ModelLifecycleState,
+    derive_model_catalogue_entry_id,
+)
+from app.contracts.providers import (
+    CandidateUniverseExclusionReason,
+    CandidateUniverseSource,
+)
+from app.services.model_catalogue import (
+    derive_candidate_universe,
+    ensure_model_catalogue_seeded,
+)
+from app.services.model_catalogue_store import get_model_catalogue_repository
+from app.services.provider_execution_config import resolve_provider_execution_config
+from tests.unit.test_ordered_fallback_routing import (
+    ALTERNATE,
+    PRIMARY,
+    _install_adapter,
+    _ordered_fallback_settings,
+    _request,
+)
+
+PRIMARY_ENTRY = derive_model_catalogue_entry_id(
+    provider_id=PRIMARY, model_revision="gpt-5.4", deployment=None
+)
+ALTERNATE_ENTRY = derive_model_catalogue_entry_id(
+    provider_id=ALTERNATE, model_revision="claude-sonnet-5", deployment=None
+)
+
+
+def test_derived_universe_matches_the_configured_pair() -> None:
+    """Equivalence: under current configuration the derivation yields exactly
+    the configured primary/fallback order with nothing excluded."""
+
+    _ordered_fallback_settings()
+    universe = derive_candidate_universe(resolve_provider_execution_config())
+
+    assert universe.source is CandidateUniverseSource.CONFIGURED
+    assert universe.candidate_entry_ids == [PRIMARY_ENTRY, ALTERNATE_ENTRY]
+    assert universe.exclusions == []
+
+
+def test_lifecycle_ineligible_policy_identity_is_excluded_with_its_reason() -> None:
+    _ordered_fallback_settings()
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(PRIMARY_ENTRY)
+    assert entry is not None
+    repository.upsert_entry(
+        entry.model_copy(update={"lifecycle_state": ModelLifecycleState.DEPRECATED})
+    )
+
+    universe = derive_candidate_universe(resolve_provider_execution_config())
+
+    assert universe.candidate_entry_ids == [ALTERNATE_ENTRY]
+    assert [e.reason for e in universe.exclusions] == [
+        CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE
+    ]
+    assert "DEPRECATED" in universe.exclusions[0].detail
+
+
+def test_uncatalogued_policy_identity_is_excluded_with_its_reason() -> None:
+    """A policy-ordered identity with no catalogue entry cannot earn
+    eligibility - the derivation says which identity and why."""
+
+    from dataclasses import replace
+
+    _ordered_fallback_settings()
+    config = resolve_provider_execution_config()
+    ghost = replace(
+        config,
+        fallback_provider_id="text.ghost",
+        fallback_model_id="phantom-1",
+        fallback_model_version=None,
+    )
+
+    universe = derive_candidate_universe(ghost)
+
+    assert universe.candidate_entry_ids == [PRIMARY_ENTRY]
+    reasons_by_entry = {e.entry_id: e.reason for e in universe.exclusions}
+    assert reasons_by_entry["text.ghost:phantom-1"] is (
+        CandidateUniverseExclusionReason.MODEL_NOT_CATALOGUED
+    )
+    # The real configured alternate is still catalogued and serving-eligible;
+    # under this policy it is excluded by policy, not misreported as missing.
+    assert reasons_by_entry[ALTERNATE_ENTRY] is (CandidateUniverseExclusionReason.POLICY_EXCLUDED)
+
+
+def test_serving_eligible_entry_outside_policy_is_policy_excluded() -> None:
+    """The operator question configuration cannot answer: a serving-eligible
+    catalogue entry for this mode that no policy row lets serve is recorded
+    as POLICY_EXCLUDED - while an out-of-service non-policy entry is not
+    misattributed to policy."""
+
+    _ordered_fallback_settings()
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    template = repository.get_entry(PRIMARY_ENTRY)
+    assert template is not None
+
+    def _extra(revision: str, state: ModelLifecycleState) -> None:
+        entry_id = derive_model_catalogue_entry_id(
+            provider_id=PRIMARY, model_revision=revision, deployment=None
+        )
+        repository.upsert_entry(
+            template.model_copy(
+                update={
+                    "entry_id": entry_id,
+                    "model_revision": revision,
+                    "lifecycle_state": state,
+                    "seed_source": ModelCatalogueSeedSource.APPROVED_WORKFLOW_RUN_MODEL_INVENTORY,
+                }
+            )
+        )
+
+    _extra("gpt-5.5-preview", ModelLifecycleState.APPROVED)
+    _extra("gpt-4.9-retired", ModelLifecycleState.RETIRED)
+
+    universe = derive_candidate_universe(resolve_provider_execution_config())
+
+    assert universe.candidate_entry_ids == [PRIMARY_ENTRY, ALTERNATE_ENTRY]
+    policy_excluded = [
+        e
+        for e in universe.exclusions
+        if e.reason is CandidateUniverseExclusionReason.POLICY_EXCLUDED
+    ]
+    assert [e.entry_id for e in policy_excluded] == [f"{PRIMARY}:gpt-5.5-preview"]
+    assert all(e.entry_id != f"{PRIMARY}:gpt-4.9-retired" for e in universe.exclusions), (
+        "an out-of-service non-policy entry must not be misattributed to policy"
+    )
+
+
+def test_ordered_routing_decision_carries_universe_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every ordered decision records where its enumeration came from and what
+    the catalogue holds that policy does not let serve."""
+
+    _ordered_fallback_settings()
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    template = repository.get_entry(PRIMARY_ENTRY)
+    assert template is not None
+    shadow_id = derive_model_catalogue_entry_id(
+        provider_id=PRIMARY, model_revision="gpt-5.5-preview", deployment=None
+    )
+    repository.upsert_entry(
+        template.model_copy(
+            update={
+                "entry_id": shadow_id,
+                "model_revision": "gpt-5.5-preview",
+                "lifecycle_state": ModelLifecycleState.APPROVED,
+                "seed_source": ModelCatalogueSeedSource.APPROVED_WORKFLOW_RUN_MODEL_INVENTORY,
+            }
+        )
+    )
+    _install_adapter(monkeypatch, failing={})
+
+    from app.services.provider_gateway import execute_text_generation
+
+    response = execute_text_generation(_request())
+
+    decision = response.routing_decision
+    assert decision is not None
+    assert decision.universe_source is CandidateUniverseSource.CONFIGURED
+    assert [e.entry_id for e in decision.universe_exclusions] == [shadow_id]
+    assert decision.universe_exclusions[0].reason is (
+        CandidateUniverseExclusionReason.POLICY_EXCLUDED
+    )

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -351,7 +351,10 @@ def _promote_entry_for_test(
         ModelPromotionApprovalRequest,
         ModelPromotionIntentRequest,
     )
-    from app.services.model_catalogue import approve_model_promotion, request_model_promotion
+    from app.services.model_lifecycle_control import (
+        approve_model_promotion,
+        request_model_promotion,
+    )
     from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
 
     pending = request_model_promotion(
@@ -393,7 +396,7 @@ def test_lifecycle_transition_requires_authorization_and_durable_store(
     from fastapi import HTTPException
 
     from app.http.authenticated_caller import AuthenticatedCaller
-    from app.services.model_catalogue import apply_model_lifecycle_transition
+    from app.services.model_lifecycle_control import apply_model_lifecycle_transition
     from tests.support.governed_control import GOVERNED_REQUESTER
 
     unauthorized = AuthenticatedCaller(
@@ -417,10 +420,8 @@ def test_lifecycle_transition_walks_the_governed_edge_table(_durable_catalogue: 
     from fastapi import HTTPException
 
     from app.contracts.model_catalogue import ModelPromotionApprovalResponse
-    from app.services.model_catalogue import (
-        apply_model_lifecycle_transition,
-        build_model_catalogue_entry_detail,
-    )
+    from app.services.model_catalogue import build_model_catalogue_entry_detail
+    from app.services.model_lifecycle_control import apply_model_lifecycle_transition
     from tests.support.governed_control import GOVERNED_REQUESTER
 
     entry_id = _durable_catalogue
@@ -495,7 +496,7 @@ def test_promotion_request_validates_target_edge_and_evidence(_durable_catalogue
     from fastapi import HTTPException
 
     from app.contracts.model_catalogue import ModelPromotionIntentRequest
-    from app.services.model_catalogue import (
+    from app.services.model_lifecycle_control import (
         apply_model_lifecycle_transition,
         request_model_promotion,
     )
@@ -582,7 +583,7 @@ def test_promotion_approval_refuses_a_stale_baseline(_durable_catalogue: str) ->
         ModelPromotionApprovalRequest,
         ModelPromotionIntentRequest,
     )
-    from app.services.model_catalogue import (
+    from app.services.model_lifecycle_control import (
         apply_model_lifecycle_transition,
         approve_model_promotion,
         request_model_promotion,
@@ -636,7 +637,7 @@ def test_promotion_approval_requires_a_distinct_credential(_durable_catalogue: s
         ModelPromotionApprovalRequest,
         ModelPromotionIntentRequest,
     )
-    from app.services.model_catalogue import (
+    from app.services.model_lifecycle_control import (
         apply_model_lifecycle_transition,
         approve_model_promotion,
         request_model_promotion,
@@ -773,7 +774,7 @@ def test_memory_lifecycle_events_append_and_list() -> None:
 def test_lifecycle_transition_on_an_unknown_entry_is_404(_durable_catalogue: str) -> None:
     from fastapi import HTTPException
 
-    from app.services.model_catalogue import apply_model_lifecycle_transition
+    from app.services.model_lifecycle_control import apply_model_lifecycle_transition
 
     from tests.support.governed_control import GOVERNED_REQUESTER
 
@@ -877,7 +878,7 @@ def _degrade_capability(
     entry_id: str, dimension: str = "supports_structured_output"
 ) -> "ModelCapabilityDegradationResponse":
     from app.contracts.model_catalogue import ModelCapabilityDegradationRequest
-    from app.services.model_catalogue import degrade_model_capability
+    from app.services.model_lifecycle_control import degrade_model_capability
     from tests.support.governed_control import GOVERNED_REQUESTER
 
     return degrade_model_capability(
@@ -931,7 +932,7 @@ def test_capability_degradation_validates_dimension_and_refuses_overwrite(
     from fastapi import HTTPException
 
     from app.contracts.model_catalogue import ModelCapabilityDegradationRequest
-    from app.services.model_catalogue import degrade_model_capability
+    from app.services.model_lifecycle_control import degrade_model_capability
     from tests.support.governed_control import GOVERNED_REQUESTER
 
     entry_id = _durable_catalogue
@@ -987,9 +988,9 @@ def test_capability_restore_is_governed_and_pins_the_degradation(
         ModelCapabilityRestoreApprovalRequest,
         ModelCapabilityRestoreIntentRequest,
     )
-    from app.services.model_catalogue import (
+    from app.services.model_catalogue import enforce_capability_requirements
+    from app.services.model_lifecycle_control import (
         approve_model_capability_restore,
-        enforce_capability_requirements,
         request_model_capability_restore,
     )
     from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
@@ -1085,7 +1086,7 @@ def test_capability_restore_re_request_supersedes_the_prior_intent(
         ModelCapabilityRestoreApprovalRequest,
         ModelCapabilityRestoreIntentRequest,
     )
-    from app.services.model_catalogue import (
+    from app.services.model_lifecycle_control import (
         approve_model_capability_restore,
         request_model_capability_restore,
     )


### PR DESCRIPTION
Issue #244, candidate-universe U1 (plan: issue comment): the candidate universe becomes a derived, inspectable fact on every routing decision — before U2 makes it the enumeration.

## Control-plane outcome

Every ordered routing decision now answers two questions configuration alone never could: **where did the candidate enumeration come from** (`universe_source` — honestly `CONFIGURED` today), and **what does the governed catalogue hold that could not serve this execution, and why**. Three bounded exclusion reasons: `MODEL_NOT_CATALOGUED` (a policy-ordered identity with no catalogue entry to earn eligibility with), `LIFECYCLE_INELIGIBLE`, and `POLICY_EXCLUDED` — the operator story configuration cannot tell: a serving-eligible catalogue entry no policy row lets serve.

## Why evidence-first

The enumeration is untouched (`candidates = [config, alternate]` exactly as before). `derive_candidate_universe` — catalogue serving-eligibility ∩ the configured policy bound — is proven equivalent to the configured pair by test, and its exclusions ride the decision from day one. U2 flips the enumeration to this derivation with the flip visible in `universe_source`, never a silent rewire. A deliberately-unattributable subtlety pinned by test: an out-of-service non-policy entry is *not* reported as policy-excluded — misattributing a lifecycle refusal to policy would be a false operator story.

## Module-budget ratchet: two forced splits, no ceiling raised

Adding the universe pushed both `contracts/providers.py` (1023) and `services/model_catalogue.py` (1065) over their 1000-line budgets. Per the ratchet's intent, both got real splits:

- `contracts/provider_catalog.py` — the catalog/policy/operator-profile read-model family (ProviderDescriptor, ProviderCatalogResponse, ProviderPolicy*, ProviderOperatorProfile*), consumed by its own services and routes, not the execution path. providers.py → 870 lines.
- `services/model_lifecycle_control.py` — the #245 governed state changes (lifecycle transitions, serving promotions, capability degradation/restore), leaving `model_catalogue.py` to identity truth, seeding and eligibility reads. → 576 + ~550 lines.

Pure moves; no re-exports, no compatibility shims — import sites updated.

## Evidence

Unit (`test_candidate_universe.py`): derived universe == configured pair with zero exclusions (the U2 safety proof); lifecycle-ineligible policy identity excluded with its state named; uncatalogued policy identity excluded as missing while the displaced real alternate is correctly policy-excluded, not misreported; serving-eligible non-policy entry policy-excluded while a retired non-policy entry is not misattributed; end-to-end ordered execution carries `universe_source` and the exclusion on its routing decision. Whole suite (2,240) green — including every pre-existing routing, catalogue, catalog-read and promotion test across the split modules, unchanged.

Full local gate: lint (module budgets now passing with headroom), typecheck, whole suite with coverage. No schema changes.
