### PR TITLE
feat(routing): the derived candidate universe becomes the enumeration (#244 U2)

### DIFF
--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -340,15 +340,15 @@ def derive_candidate_universe(config: ProviderExecutionConfig) -> CandidateUnive
     """Derive the ordered candidate universe from catalogue evidence bounded by policy.
 
     The policy bound is the configured primary/fallback identity order (issue
-    #244, U1); the catalogue supplies the evidence each identity must earn
+    #244); the catalogue supplies the evidence each identity must earn
     eligibility with. Every exclusion is reasoned: a policy identity with no
     catalogue entry, a policy identity whose lifecycle refuses service, and -
     the operator question configuration cannot answer - a serving-eligible
     catalogue entry for this mode that no policy row lets serve.
 
-    U1 consumes this as routing-decision evidence only; the enumeration still
-    comes from configuration, and `source` says so honestly. U2 flips the
-    enumeration to this derivation, and the flip is visible in the decision.
+    Since U2 this derivation IS the ordered enumeration: an identity excluded
+    here never becomes a candidate, and `source` records the flip on every
+    routing decision.
     """
 
     ensure_model_catalogue_seeded()
@@ -416,7 +416,7 @@ def derive_candidate_universe(config: ProviderExecutionConfig) -> CandidateUnive
         )
 
     return CandidateUniverse(
-        source=CandidateUniverseSource.CONFIGURED,
+        source=CandidateUniverseSource.CATALOGUE_DERIVED,
         candidate_entry_ids=candidate_entry_ids,
         exclusions=exclusions,
     )

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -8,6 +8,7 @@ from app.contracts.providers import (
     ROUTING_POLICY_ORDERED_FALLBACK,
     ROUTING_POLICY_VERSION_V1,
     CandidateUniverse,
+    CandidateUniverseExclusionReason,
     CandidateUniverseSource,
     ProviderExecutionMode,
     ProviderExecutionRequest,
@@ -220,12 +221,25 @@ def _execute_ordered_fallback(
             ),
         )
 
-    rejections: dict[int, ProviderFailureCategory] = {}
-    candidates = [config, alternate]
-    # Decision evidence only in U1 (issue #244): the enumeration above is
-    # still configuration-shaped, and the universe says so honestly while
-    # recording what the catalogue holds that policy does not let serve.
+    # The derived universe IS the enumeration (issue #244, U2): the configured
+    # pair supplies policy order and connection material, and the catalogue
+    # decides which of those identities may serve at all. An identity the
+    # catalogue excludes never becomes a candidate - its reasoned exclusion
+    # rides the routing decision instead.
     universe = derive_candidate_universe(config)
+    config_by_entry_id = {
+        _candidate_entry_identity(candidate)[0]: candidate for candidate in (config, alternate)
+    }
+    candidates = [
+        config_by_entry_id[entry_id]
+        for entry_id in universe.candidate_entry_ids
+        if entry_id in config_by_entry_id
+    ]
+    if not candidates:
+        raise _empty_universe_refusal(
+            requirements=request.requirements, mode_value=mode.value, universe=universe
+        )
+    rejections: dict[int, ProviderFailureCategory] = {}
 
     # Operator kill switches outrank every automatic control, evaluated per
     # candidate: a switch on the primary's provider scope routes to the
@@ -365,6 +379,57 @@ def _ordered_refusal(
     )
 
 
+_FAILURE_BY_UNIVERSE_EXCLUSION = {
+    CandidateUniverseExclusionReason.MODEL_NOT_CATALOGUED: (
+        ProviderFailureCategory.MODEL_NOT_CATALOGUED
+    ),
+    CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE: (
+        ProviderFailureCategory.MODEL_LIFECYCLE_INELIGIBLE
+    ),
+    CandidateUniverseExclusionReason.POLICY_EXCLUDED: (
+        ProviderFailureCategory.INVALID_LIVE_CONFIGURATION
+    ),
+}
+
+
+def _empty_universe_refusal(
+    *,
+    requirements: CapabilityRequirements | None,
+    mode_value: str,
+    universe: CandidateUniverse,
+) -> ProviderGatewayUnavailableError:
+    """No policy-ordered identity earned eligibility: refuse with every reason.
+
+    The category comes from the first policy-identity exclusion so the caller
+    sees the primary story; the decision carries all of them.
+    """
+
+    category = next(
+        (
+            _FAILURE_BY_UNIVERSE_EXCLUSION[exclusion.reason]
+            for exclusion in universe.exclusions
+            if exclusion.reason is not CandidateUniverseExclusionReason.POLICY_EXCLUDED
+        ),
+        ProviderFailureCategory.INVALID_LIVE_CONFIGURATION,
+    )
+    detail = "; ".join(exclusion.detail for exclusion in universe.exclusions) or (
+        "the derived candidate universe is empty"
+    )
+    return ProviderGatewayUnavailableError(
+        detail=f"{category.value}: {detail}",
+        routing_decision=_build_ordered_routing_decision(
+            requirements=requirements,
+            mode_value=mode_value,
+            candidates=[],
+            serving_config=None,
+            serving_entry=None,
+            fallback_path=[],
+            decided_at=_utc_now_iso(),
+            universe=universe,
+        ),
+    )
+
+
 def _candidate_entry_identity(
     config: ProviderExecutionConfig,
 ) -> tuple[str | None, str | None]:
@@ -402,7 +467,12 @@ def _build_ordered_routing_decision(
                 rejection_reason=rejection,
             )
         )
-    if serving_config is None:
+    if serving_config is None and not candidates:
+        selection_reason = (
+            "Ordered-fallback policy: the derived candidate universe is empty - every "
+            "policy-ordered identity was excluded (see universe_exclusions); execution refused."
+        )
+    elif serving_config is None:
         selection_reason = (
             "Ordered-fallback policy: every candidate was rejected or failed; execution refused."
         )

--- a/tests/unit/test_candidate_universe.py
+++ b/tests/unit/test_candidate_universe.py
@@ -1,9 +1,9 @@
 """The candidate universe is derived from catalogue evidence bounded by policy.
 
-Issue #244, U1: the derivation is routing-decision evidence only - the
-enumeration still comes from configuration, and the universe says so honestly
-while recording what the catalogue holds that policy does not let serve. The
-equivalence proven here is what makes the U2 flip safe.
+Issue #244, U2: the derivation IS the ordered enumeration - an identity the
+catalogue excludes never becomes a candidate, its reasoned exclusion rides the
+routing decision, and an empty universe refuses with every reason. The
+configured pair supplies policy order and connection material only.
 """
 
 from __future__ import annotations
@@ -48,7 +48,7 @@ def test_derived_universe_matches_the_configured_pair() -> None:
     _ordered_fallback_settings()
     universe = derive_candidate_universe(resolve_provider_execution_config())
 
-    assert universe.source is CandidateUniverseSource.CONFIGURED
+    assert universe.source is CandidateUniverseSource.CATALOGUE_DERIVED
     assert universe.candidate_entry_ids == [PRIMARY_ENTRY, ALTERNATE_ENTRY]
     assert universe.exclusions == []
 
@@ -175,8 +175,85 @@ def test_ordered_routing_decision_carries_universe_evidence(
 
     decision = response.routing_decision
     assert decision is not None
-    assert decision.universe_source is CandidateUniverseSource.CONFIGURED
+    assert decision.universe_source is CandidateUniverseSource.CATALOGUE_DERIVED
     assert [e.entry_id for e in decision.universe_exclusions] == [shadow_id]
     assert decision.universe_exclusions[0].reason is (
         CandidateUniverseExclusionReason.POLICY_EXCLUDED
+    )
+
+
+def test_excluded_identity_never_becomes_a_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The U2 flip: a lifecycle-ineligible primary is not enumerated and not
+    attempted - the alternate serves alone, and the exclusion carries the
+    reason where a candidate rejection used to."""
+
+    _ordered_fallback_settings()
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(PRIMARY_ENTRY)
+    assert entry is not None
+    repository.upsert_entry(
+        entry.model_copy(update={"lifecycle_state": ModelLifecycleState.DEPRECATED})
+    )
+    adapter = _install_adapter(monkeypatch, failing={})
+
+    from app.services.provider_gateway import execute_text_generation
+
+    response = execute_text_generation(_request())
+
+    assert response.provider_id == ALTERNATE
+    assert adapter.executed_provider_ids == [ALTERNATE]
+    decision = response.routing_decision
+    assert decision is not None
+    assert [c.provider_id for c in decision.candidates] == [ALTERNATE]
+    assert [e.entry_id for e in decision.universe_exclusions] == [PRIMARY_ENTRY]
+    assert decision.universe_exclusions[0].reason is (
+        CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE
+    )
+
+
+def test_empty_universe_refuses_with_every_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both policy-ordered identities excluded: no attempt happens, the
+    refusal names the primary story, and the decision carries every reasoned
+    exclusion with zero candidates."""
+
+    from fastapi import HTTPException
+
+    _ordered_fallback_settings()
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    for entry_id in (PRIMARY_ENTRY, ALTERNATE_ENTRY):
+        entry = repository.get_entry(entry_id)
+        assert entry is not None
+        repository.upsert_entry(
+            entry.model_copy(update={"lifecycle_state": ModelLifecycleState.RETIRED})
+        )
+    adapter = _install_adapter(monkeypatch, failing={})
+
+    from app.services.provider_gateway import (
+        ProviderGatewayUnavailableError,
+        execute_text_generation,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        execute_text_generation(_request())
+
+    assert exc_info.value.status_code == 503
+    assert "MODEL_LIFECYCLE_INELIGIBLE" in str(exc_info.value.detail)
+    assert adapter.executed_provider_ids == []
+    assert isinstance(exc_info.value, ProviderGatewayUnavailableError)
+    decision = exc_info.value.routing_decision
+    assert decision.candidates == []
+    assert decision.selected_provider_id is None
+    assert "universe_exclusions" in decision.selection_reason
+    assert sorted(e.entry_id for e in decision.universe_exclusions) == sorted(
+        [PRIMARY_ENTRY, ALTERNATE_ENTRY]
+    )
+    assert all(
+        e.reason is CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE
+        for e in decision.universe_exclusions
     )


### PR DESCRIPTION
Issue #244, candidate-universe U2 (plan: issue comment): the derived universe becomes the ordered enumeration. The flip U1 made inspectable is now real — and visible on every decision.

## Control-plane outcome

The ordered routing path no longer enumerates the configured settings pair; it enumerates **what the governed catalogue lets serve**, in policy order. An identity the catalogue excludes — not catalogued, or lifecycle-ineligible — never becomes a candidate at all: it cannot be attempted, cannot be bound, and its reasoned exclusion rides the decision's `universe_exclusions` where a late per-candidate rejection used to sit. `universe_source` on every ordered decision now reads `CATALOGUE_DERIVED`.

Configuration keeps exactly the two authorities the plan assigned it: **policy order** (primary first, alternate second) and **connection material** — and the pre-existing fail-closed rule for a partial fallback quintet is untouched: ordered strategy still refuses `INVALID_LIVE_CONFIGURATION` outright rather than quietly shrinking the universe.

## The empty-universe refusal

When every policy-ordered identity is excluded, execution refuses before any preflight or attempt with the primary story as its bounded category (`MODEL_LIFECYCLE_INELIGIBLE` / `MODEL_NOT_CATALOGUED`, mapped from the first policy-identity exclusion) and a decision that carries zero candidates, a selection reason pointing at `universe_exclusions`, and every exclusion with its detail. An operator reads *why nothing was eligible*, per identity.

## What deliberately did not change

- Per-candidate runtime controls (kill switches, degradation preflight, catalogue bind, capability-vs-requirements, breaker, quota/budget, governed deadline) are untouched — the universe filters *evidence-based eligibility*; runtime vetoes stay candidate rejections. The bind's own lifecycle fence remains as a TOCTOU backstop between derivation and attempt.
- The fixed strategy is out of scope, exactly as the plan bounded it.
- Policy is still the configured pair; making it a first-class artifact is U3.

## Evidence

New: a lifecycle-ineligible primary is not enumerated and not attempted — the alternate serves alone, with the exclusion carrying the reason (proven down to `adapter.executed_provider_ids`); both identities excluded → 503 with zero candidates, every reasoned exclusion on the decision, and no adapter call. Updated: the U1 equivalence and decision-evidence tests now pin `CATALOGUE_DERIVED`. Unchanged and green: the entire ordered-fallback suite, latency-budget matrix, gateway fixed-path suite — the flip alters no behavior for a healthy universe.

Full local gate: lint, typecheck, whole suite with coverage. No schema changes.
