### PR TITLE
feat(routing): one universe authority for posture and execution (#244 U3)

### DIFF
--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -283,6 +283,15 @@ class RoutingPostureResponse(BaseModel):
         ge=0,
         description="Currently enforcing kill-switch activations (any scope).",
     )
+    candidate_universe: CandidateUniverse | None = Field(
+        default=None,
+        description=(
+            "The derived candidate universe the next ordered execution would enumerate - "
+            "the same derivation the gateway consumes, so this posture can never disagree "
+            "with what routing would actually do (issue #244, U3). Null under the fixed "
+            "strategy, which does not enumerate a universe."
+        ),
+    )
     notes: list[str] = Field(description="Boundary statements this posture ships with.")
 
 

--- a/src/app/services/routing_posture.py
+++ b/src/app/services/routing_posture.py
@@ -28,7 +28,10 @@ from app.contracts.providers import (
     RoutingStrategy,
 )
 from app.services.kill_switch_control import build_kill_switch_status
-from app.services.model_catalogue import ensure_model_catalogue_seeded
+from app.services.model_catalogue import (
+    derive_candidate_universe,
+    ensure_model_catalogue_seeded,
+)
 from app.services.model_catalogue_store import get_model_catalogue_repository
 from app.services.provider_degradation_state import build_provider_degradation_status
 
@@ -78,6 +81,9 @@ def build_routing_posture() -> RoutingPostureResponse:
         quota_enforced=config.enforcement.quota_enforced,
         budget_enforced=config.enforcement.budget_enforced,
         enforcing_kill_switch_count=build_kill_switch_status().active_count,
+        # The same derivation the gateway enumerates from (issue #244, U3):
+        # one authority, so the posture cannot disagree with routing.
+        candidate_universe=derive_candidate_universe(config) if ordered else None,
         notes=notes,
     )
 

--- a/tests/unit/test_candidate_universe.py
+++ b/tests/unit/test_candidate_universe.py
@@ -257,3 +257,28 @@ def test_empty_universe_refuses_with_every_reason(
         e.reason is CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE
         for e in decision.universe_exclusions
     )
+
+
+def test_routing_posture_shows_the_universe_an_execution_would_get() -> None:
+    """One derivation authority (issue #244, U3): the operator posture and the
+    gateway read the same universe, so an identity excluded from posture is
+    exactly the identity an execution would not enumerate."""
+
+    from app.services.routing_posture import build_routing_posture
+
+    _ordered_fallback_settings()
+    ensure_model_catalogue_seeded()
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(PRIMARY_ENTRY)
+    assert entry is not None
+    repository.upsert_entry(
+        entry.model_copy(update={"lifecycle_state": ModelLifecycleState.DEPRECATED})
+    )
+
+    posture = build_routing_posture()
+
+    universe = posture.candidate_universe
+    assert universe is not None
+    assert universe.candidate_entry_ids == [ALTERNATE_ENTRY]
+    assert [e.entry_id for e in universe.exclusions] == [PRIMARY_ENTRY]
+    assert universe.exclusions[0].reason is (CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE)

--- a/tests/unit/test_ordered_fallback_routing.py
+++ b/tests/unit/test_ordered_fallback_routing.py
@@ -445,12 +445,22 @@ def test_routing_posture_names_both_candidates_under_ordered_fallback() -> None:
     assert posture.fallback_candidate.provider_id == ALTERNATE
     assert posture.fallback_candidate.model_catalogue_entry_id == f"{ALTERNATE}:claude-sonnet-5"
     assert posture.fallback_degradation is not None
+    # The posture exposes the same derived universe the gateway enumerates
+    # from - one authority, so the read cannot disagree with routing
+    # (issue #244, U3).
+    assert posture.candidate_universe is not None
+    assert posture.candidate_universe.candidate_entry_ids == [
+        f"{PRIMARY}:gpt-5.4",
+        f"{ALTERNATE}:claude-sonnet-5",
+    ]
+    assert posture.candidate_universe.exclusions == []
 
     settings.routing_strategy = "fixed"
     fixed_posture = build_routing_posture()
     assert fixed_posture.strategy is RoutingStrategy.FIXED
     assert fixed_posture.fallback_candidate is None
     assert fixed_posture.fallback_degradation is None
+    assert fixed_posture.candidate_universe is None
 
 
 def test_real_transport_attributes_the_alternate_identity_end_to_end() -> None:


### PR DESCRIPTION
Issue #244, candidate-universe U3 (plan: issue comment): the policy bound becomes first-class where it matters — as one derivation authority feeding both execution and the operator posture — and the policy-store question gets an explicit recorded answer instead of a speculative table.

## Control-plane outcome

`GET` routing posture now answers the operator question the plan's U3 named: **what universe would the next ordered execution actually enumerate, and what is excluded from it, and why** — `RoutingPostureResponse.candidate_universe`, computed by the *same* `derive_candidate_universe` call the gateway consumes. One authority, so the posture read can never disagree with what routing would do (this module's own charter, now structurally true for the universe too). Null under the fixed strategy, which does not enumerate a universe.

Proven by test: deprecating the primary shows the identical single-candidate universe with the identical `LIFECYCLE_INELIGIBLE` exclusion on the posture read that an execution's routing decision carries.

## The policy-store decision, recorded not built

The plan left "where policy is stored (settings row vs catalogue-adjacent table)" to this slice, with the simplest durable answer. The answer: **policy stays derived from the configured identities, and a policy table is deliberately not built yet** — because connection material (endpoint, credentials) exists only for the configured primary/fallback pair, a policy store today could never legally hold anything beyond what settings already hold. A table whose contents are structurally forced to mirror another surface is a speculative abstraction, not a control. The real prerequisite is generalising connection material beyond the pair; when that exists, policy rows become the governed, risk-directed surface they should be (adding an identity to serving order is risk-increasing — it joins the #157 primitive then). Recorded on #244 with this rationale.

What U3 therefore made first-class is the policy's *effect*: the ordered identity bound is inspectable on every posture read and every routing decision, with its source named.

## Hard requirements vs preferences — already true, stated

Hard requirements fail closed (capability eligibility, #244 S3; latency budget); no preference-ranking machinery exists and none was built — there is no preference input yet to rank by, and building a ranker without one would be the same speculation as the table.

## Evidence

New: posture-vs-execution universe identity under a deprecated primary; ordered posture carries the two-identity universe with zero exclusions and the fixed posture carries null. Whole suite green.

Full local gate: lint, typecheck, whole suite with coverage. No schema changes.
