### PR TITLE
feat(routing): capability posture answers who is eligible and who would serve (#244 S5)

### DIFF
--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -229,6 +229,45 @@ class RoutingDecisionDescriptor(BaseModel):
     )
 
 
+class CapabilityPostureCandidateDescriptor(BaseModel):
+    """One universe candidate's capability eligibility for queried requirements."""
+
+    entry_id: str = Field(min_length=1, description="Catalogue entry assessed.")
+    eligible: bool = Field(description="Whether the entry satisfies the queried requirements.")
+    rejection_reason: ProviderFailureCategory | None = Field(
+        default=None,
+        description=(
+            "Bounded category when ineligible (CAPABILITY_NOT_SUPPORTED, "
+            "CAPABILITY_UNKNOWN or CAPABILITY_DEGRADED); null when eligible."
+        ),
+    )
+    detail: str | None = Field(
+        default=None, description="Human-readable account of the ineligibility; null otherwise."
+    )
+
+
+class CapabilityPostureDescriptor(BaseModel):
+    """Who is eligible for queried capability requirements, and who would serve.
+
+    The answer to the operator question "for capability X: who is eligible,
+    who is excluded and why, who would be selected" (issue #244, S5) -
+    computed with the exact eligibility check the gateway enforces, over the
+    exact universe it would enumerate.
+    """
+
+    requirements: CapabilityRequirements = Field(description="The requirements queried.")
+    candidates: list[CapabilityPostureCandidateDescriptor] = Field(
+        description="Every universe candidate in policy order with its verdict.",
+    )
+    would_select_entry_id: str | None = Field(
+        default=None,
+        description=(
+            "First eligible candidate in policy order - what the next execution with "
+            "these requirements would bind, health permitting; null when none is eligible."
+        ),
+    )
+
+
 class RoutingPostureCandidateDescriptor(BaseModel):
     provider_id: str | None = Field(
         default=None,
@@ -290,6 +329,15 @@ class RoutingPostureResponse(BaseModel):
             "the same derivation the gateway consumes, so this posture can never disagree "
             "with what routing would actually do (issue #244, U3). Null under the fixed "
             "strategy, which does not enumerate a universe."
+        ),
+    )
+    capability_posture: CapabilityPostureDescriptor | None = Field(
+        default=None,
+        description=(
+            "Per-candidate capability eligibility for the queried requirements (issue "
+            "#244, S5): who is eligible, who is excluded and why, and who would be "
+            "selected first. Present only when requirements were queried under the "
+            "ordered strategy."
         ),
     )
     notes: list[str] = Field(description="Boundary statements this posture ships with.")

--- a/src/app/routers/providers.py
+++ b/src/app/routers/providers.py
@@ -24,6 +24,7 @@ from app.contracts.provider_operations import (
     ProviderOperationsResetApprovalResponse,
     ProviderOperationsResetIntentRequest,
 )
+from app.contracts.capability_requirements import CapabilityRequirements
 from app.contracts.rate_cards import RateCardCatalogueResponse
 from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.provider_activation_readiness import build_provider_activation_readiness
@@ -55,17 +56,30 @@ router = APIRouter(prefix="/platform/providers", tags=["platform"])
     description=(
         "Returns the routing policy currently in force, the single candidate the fixed policy "
         "would bind for the next live execution (with its governed catalogue identity, "
-        "lifecycle state and pinning), the circuit-breaker posture, enforcement flags, and the "
-        "count of currently enforcing kill switches. Per-request gates are evaluated per "
-        "execution and recorded on its routing decision."
+        "lifecycle state and pinning), the circuit-breaker posture, enforcement flags, the "
+        "count of currently enforcing kill switches, and - under the ordered strategy - the "
+        "derived candidate universe with every reasoned exclusion. Optional capability "
+        "requirement query parameters add per-candidate eligibility verdicts and the "
+        "candidate the next such execution would select (issue #244, S5), computed with the "
+        "exact check the gateway enforces. Per-request gates are evaluated per execution and "
+        "recorded on its routing decision."
     ),
     responses={
         200: {"description": "Routing posture returned successfully."},
         500: {"description": "Unexpected server error."},
     },
 )
-async def get_routing_posture_route() -> RoutingPostureResponse:
-    return build_routing_posture()
+async def get_routing_posture_route(
+    structured_output_required: bool | None = None,
+    tool_calling_required: bool | None = None,
+) -> RoutingPostureResponse:
+    requirements: CapabilityRequirements | None = None
+    if structured_output_required is not None or tool_calling_required is not None:
+        requirements = CapabilityRequirements(
+            structured_output_required=structured_output_required,
+            tool_calling_required=tool_calling_required,
+        )
+    return build_routing_posture(requirements)
 
 
 @router.get(

--- a/src/app/services/routing_posture.py
+++ b/src/app/services/routing_posture.py
@@ -17,29 +17,39 @@ from app.services.provider_execution_config import (
     derive_fallback_execution_config,
     resolve_provider_execution_config,
 )
+from app.contracts.capability_requirements import CapabilityRequirements
 from app.contracts.model_catalogue import ModelCatalogueEntry, derive_model_catalogue_entry_id
 from app.contracts.providers import (
     ROUTING_POLICY_FIXED_CONFIGURED_MODE,
     ROUTING_POLICY_ORDERED_FALLBACK,
     ROUTING_POLICY_VERSION_V1,
+    CandidateUniverse,
+    CapabilityPostureCandidateDescriptor,
+    CapabilityPostureDescriptor,
     ProviderDegradationStatusDescriptor,
+    ProviderFailureCategory,
     RoutingPostureCandidateDescriptor,
     RoutingPostureResponse,
     RoutingStrategy,
 )
+from app.providers.base import ProviderExecutionError
 from app.services.kill_switch_control import build_kill_switch_status
 from app.services.model_catalogue import (
     derive_candidate_universe,
+    enforce_capability_requirements,
     ensure_model_catalogue_seeded,
 )
 from app.services.model_catalogue_store import get_model_catalogue_repository
 from app.services.provider_degradation_state import build_provider_degradation_status
 
 
-def build_routing_posture() -> RoutingPostureResponse:
+def build_routing_posture(
+    requirements: CapabilityRequirements | None = None,
+) -> RoutingPostureResponse:
     config = resolve_provider_execution_config()
     ordered = config.routing_strategy == "ordered_fallback"
     alternate = derive_fallback_execution_config(config) if ordered else None
+    universe = derive_candidate_universe(config) if ordered else None
     fallback_candidate: RoutingPostureCandidateDescriptor | None = None
     fallback_degradation: ProviderDegradationStatusDescriptor | None = None
     if alternate is not None:
@@ -83,8 +93,65 @@ def build_routing_posture() -> RoutingPostureResponse:
         enforcing_kill_switch_count=build_kill_switch_status().active_count,
         # The same derivation the gateway enumerates from (issue #244, U3):
         # one authority, so the posture cannot disagree with routing.
-        candidate_universe=derive_candidate_universe(config) if ordered else None,
+        candidate_universe=universe,
+        capability_posture=(
+            _build_capability_posture(universe=universe, requirements=requirements)
+            if universe is not None and requirements is not None
+            else None
+        ),
         notes=notes,
+    )
+
+
+def _build_capability_posture(
+    *,
+    universe: CandidateUniverse,
+    requirements: CapabilityRequirements,
+) -> CapabilityPostureDescriptor:
+    """Per-candidate capability eligibility, with the gateway's own check.
+
+    Runs `enforce_capability_requirements` - not a re-derivation of its logic -
+    over the exact universe the next execution would enumerate, so "who is
+    eligible for capability X" can never disagree with what routing enforces
+    (issue #244, S5).
+    """
+
+    repository = get_model_catalogue_repository()
+    candidates: list[CapabilityPostureCandidateDescriptor] = []
+    would_select: str | None = None
+    for entry_id in universe.candidate_entry_ids:
+        entry = repository.get_entry(entry_id)
+        if entry is None:
+            # The universe was derived moments ago; a vanished entry is a
+            # concurrent catalogue change - report it as not catalogued.
+            candidates.append(
+                CapabilityPostureCandidateDescriptor(
+                    entry_id=entry_id,
+                    eligible=False,
+                    rejection_reason=ProviderFailureCategory.MODEL_NOT_CATALOGUED,
+                    detail=f"`{entry_id}` is no longer catalogued.",
+                )
+            )
+            continue
+        try:
+            enforce_capability_requirements(requirements=requirements, entry=entry)
+        except ProviderExecutionError as exc:
+            candidates.append(
+                CapabilityPostureCandidateDescriptor(
+                    entry_id=entry_id,
+                    eligible=False,
+                    rejection_reason=exc.category,
+                    detail=exc.message,
+                )
+            )
+            continue
+        candidates.append(CapabilityPostureCandidateDescriptor(entry_id=entry_id, eligible=True))
+        if would_select is None:
+            would_select = entry_id
+    return CapabilityPostureDescriptor(
+        requirements=requirements,
+        candidates=candidates,
+        would_select_entry_id=would_select,
     )
 
 

--- a/tests/integration/test_provider_api_contract.py
+++ b/tests/integration/test_provider_api_contract.py
@@ -21,6 +21,7 @@ from app.services.eval_async_execution import run_next_evaluation_execution_job
 from app.services.eval_run_submission_service import submit_evaluation_run
 from app.contracts.evals import EvaluationRunSubmissionRequest
 from tests.support.migration_runner import upgrade_database_to_head
+from tests.support.runtime_settings import override_runtime_settings
 from tests.unit.test_task_executor import _request
 from tests.support.caller_credentials import (
     generate_caller_signing_key,
@@ -546,6 +547,46 @@ def test_routing_posture_route_reports_the_fixed_policy(client: TestClient) -> N
     assert body["candidate"]["provider_mode"] == "disabled"
     assert body["enforcing_kill_switch_count"] == 0
     assert body["degradation"]["status"]
+    assert body["candidate_universe"] is None
+    assert body["capability_posture"] is None
+
+
+def test_routing_posture_route_answers_capability_queries(client: TestClient) -> None:
+    """Issue #244, S5 over HTTP: requirement query parameters add per-candidate
+    eligibility verdicts computed over the derived universe."""
+
+    with override_runtime_settings(
+        provider_mode="openai",
+        provider_rollout_state="CANARY_ENABLED",
+        live_text_provider_id="text.openai",
+        live_text_model_id="gpt-5.4",
+        live_text_provider_api_key="secret",
+        live_text_allowed_task_ids="explain.v1",
+        routing_strategy="ordered_fallback",
+        live_text_fallback_provider_id="text.anthropic",
+        live_text_fallback_model_id="claude-sonnet-5",
+        live_text_fallback_api_base="https://alternate.example/v1",
+        live_text_fallback_api_key="secret-alternate",
+        workflow_run_model_risk_inventory_json="[]",
+    ):
+        response = client.get("/platform/providers/routing-posture?structured_output_required=true")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["strategy"] == "ORDERED_FALLBACK"
+        universe = body["candidate_universe"]
+        assert universe is not None
+        assert len(universe["candidate_entry_ids"]) == 2
+        posture = body["capability_posture"]
+        assert posture is not None
+        assert posture["requirements"]["structured_output_required"] is True
+        # Nothing is assessed in this fresh catalogue: unknown fails closed AS
+        # unknown, per candidate, and nothing would be selected.
+        assert [c["rejection_reason"] for c in posture["candidates"]] == [
+            "CAPABILITY_UNKNOWN",
+            "CAPABILITY_UNKNOWN",
+        ]
+        assert posture["would_select_entry_id"] is None
 
 
 def test_rate_card_catalogue_route_reports_the_seeded_default(client: TestClient) -> None:

--- a/tests/unit/test_candidate_universe.py
+++ b/tests/unit/test_candidate_universe.py
@@ -18,6 +18,7 @@ from app.contracts.model_catalogue import (
 from app.contracts.providers import (
     CandidateUniverseExclusionReason,
     CandidateUniverseSource,
+    ProviderFailureCategory,
 )
 from app.services.model_catalogue import (
     derive_candidate_universe,
@@ -282,3 +283,78 @@ def test_routing_posture_shows_the_universe_an_execution_would_get() -> None:
     assert universe.candidate_entry_ids == [ALTERNATE_ENTRY]
     assert [e.entry_id for e in universe.exclusions] == [PRIMARY_ENTRY]
     assert universe.exclusions[0].reason is (CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE)
+
+
+def test_capability_posture_answers_who_is_eligible_and_who_would_serve() -> None:
+    """Issue #244, S5: the posture runs the gateway's own eligibility check
+    over the derived universe - eligible, excluded-with-reason, and the
+    first-eligible selection, per queried capability."""
+
+    from app.contracts.capability_requirements import CapabilityRequirements
+    from app.services.routing_posture import build_routing_posture
+    from tests.unit.test_ordered_fallback_routing import _assess_structured_output
+
+    _ordered_fallback_settings()
+    _assess_structured_output(PRIMARY, "gpt-5.4", True)
+
+    posture = build_routing_posture(CapabilityRequirements(structured_output_required=True))
+
+    capability = posture.capability_posture
+    assert capability is not None
+    assert [c.entry_id for c in capability.candidates] == [PRIMARY_ENTRY, ALTERNATE_ENTRY]
+    assert capability.candidates[0].eligible is True
+    assert capability.candidates[0].rejection_reason is None
+    # The unassessed alternate fails closed AS unknown, never silently.
+    assert capability.candidates[1].eligible is False
+    assert capability.candidates[1].rejection_reason is (ProviderFailureCategory.CAPABILITY_UNKNOWN)
+    assert capability.would_select_entry_id == PRIMARY_ENTRY
+
+    # Without a capability query there is no capability posture.
+    assert build_routing_posture().capability_posture is None
+
+
+def test_capability_posture_reflects_an_operator_degradation() -> None:
+    """A degraded capability shows as CAPABILITY_DEGRADED on the posture with
+    the operator's reason - "we turned this off" is visible, and selection
+    moves (or empties) accordingly."""
+
+    from app.contracts.capability_requirements import CapabilityRequirements
+    from app.services.routing_posture import build_routing_posture
+    from tests.unit.test_ordered_fallback_routing import _assess_structured_output
+
+    _ordered_fallback_settings()
+    _assess_structured_output(PRIMARY, "gpt-5.4", True)
+    _assess_structured_output(ALTERNATE, "claude-sonnet-5", True)
+
+    # The degradation control requires the durable store; write the overlay
+    # directly for this read-model test.
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry(PRIMARY_ENTRY)
+    assert entry is not None
+    from app.contracts.model_catalogue import ModelCapabilityDegradation
+
+    repository.upsert_entry(
+        entry.model_copy(
+            update={
+                "capability_degradations": {
+                    "supports_structured_output": ModelCapabilityDegradation(
+                        dimension="supports_structured_output",
+                        reason="Structured output failing contract validation.",
+                        degraded_by="lotus-platform (credential ops-key-alpha)",
+                        degraded_at="2026-09-03T12:00:00Z",
+                    )
+                }
+            }
+        )
+    )
+
+    posture = build_routing_posture(CapabilityRequirements(structured_output_required=True))
+
+    capability = posture.capability_posture
+    assert capability is not None
+    assert capability.candidates[0].rejection_reason is (
+        ProviderFailureCategory.CAPABILITY_DEGRADED
+    )
+    assert "failing contract validation" in str(capability.candidates[0].detail)
+    assert capability.candidates[1].eligible is True
+    assert capability.would_select_entry_id == ALTERNATE_ENTRY


### PR DESCRIPTION
Issue #244, S5 (the issue's own slice list): the operator capability posture — "for capability X: who is eligible, who is excluded and why, who would be selected" — composed from existing surfaces, exactly as the slice demanded no new readiness API.

## Control-plane outcome

`GET /platform/providers/routing-posture?structured_output_required=true` (and/or `tool_calling_required`) now answers the capability question per candidate: every identity in the derived universe, in policy order, with `eligible` or the bounded reason — `CAPABILITY_NOT_SUPPORTED` (proven absent), `CAPABILITY_UNKNOWN` (never assessed, failing closed AS unknown), or `CAPABILITY_DEGRADED` (an operator turned it off, with their reason) — and `would_select_entry_id`, the first eligible candidate the next such execution would bind, health permitting.

## One check, one universe — no re-derivation

The verdicts come from running `enforce_capability_requirements` itself — the gateway's own eligibility gate — over the exact universe `derive_candidate_universe` gives the gateway. Nothing is re-derived, so the posture structurally cannot disagree with what routing enforces; the posture module's charter ("a posture read must never disagree with what the gateway would actually do") now covers capability eligibility too.

Only the two catalogue-enforced dimensions are queryable; `max_latency_ms` is a runtime budget, not a catalogue fact, and cost stays gated on #232 — the query surface matches exactly what eligibility actually enforces, claiming nothing more.

## Evidence

Unit: assessed primary + unassessed alternate → primary eligible, alternate `CAPABILITY_UNKNOWN`, selection = primary; operator degradation on the primary → `CAPABILITY_DEGRADED` with the operator's reason visible and selection moving to the assessed alternate; no capability query → no capability posture. Integration (HTTP): query parameter flows end-to-end — fresh catalogue reports both candidates `CAPABILITY_UNKNOWN` and a null selection (unknown never launders into eligibility, even on a read); the fixed-strategy posture carries null universe and null capability posture.

Full local gate: lint, typecheck, whole suite with coverage. No schema changes.

With this, #244's five slices all have delivered substance; a closure assessment with per-slice evidence and the recorded residuals (capability-scoped eval evidence, policy store gated on connection-material generalisation, cost gated on #232, ranking strategies deliberately unbuilt) follows on the issue.
