### PR TITLE
fix(governance): gold-standard audit - honest evidence, readable approvals

### DIFF
--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -430,6 +430,23 @@ Before treating retrieval or provider evaluation evidence as approval-ready:
 5. if replay or retry is required, apply the governed async control action first and then verify a new evaluation attempt appears instead of mutating prior case evidence in place
 6. treat `foundation_eval_*` run artifacts as historical baselines only; they do not satisfy current runtime-backed approval posture by themselves
 
+## Governed Actions
+
+One reusable governance pattern covers every high-impact control-plane action; there are no domain-specific approval frameworks. The rule is the **direction of risk**:
+
+- **Safety-increasing actions** (activate a kill switch, roll back a prompt, deprecate/retire a model, degrade a model capability) execute **immediately under one verified principal**. The record carries the verified requester identity derived from the caller credential - never caller-typed free text - and `approved_by` is honestly null: no approval existed. An emergency stop is never blocked on credential availability.
+- **Risk-increasing actions** (clear a kill switch, promote a prompt, reset provider operations, promote a model's serving posture, restore a degraded capability) take the **governed two-step flow**: a verified requester records a pending intent; a DISTINCT verified credential approves the exact pending `action_id` and `action_hash`; the approval executes the action and records the full request-approval-execution evidence chain. Approval binds to the exact action - a changed target, payload, or baseline refuses the stale approval, and a re-request for the same target supersedes the prior pending intent.
+- **System-originated actions** (async queue recovery) are explicitly `SYSTEM_ORIGINATED` under a verified workload identity, restricted to their bounded action types, and structurally incapable of satisfying a human-approval requirement.
+
+Dual-control evidence proves **distinct authenticated credentials**, not verified-human four-eyes: nothing yet binds a platform credential to a verified human principal. That platform identity dependency is tracked explicitly; do not describe the flow as four-eyes in incident reports.
+
+Operator surfaces:
+
+1. `GET /platform/governed-actions` lists the evidence records across every domain, newest first, filterable by `status` and `target` with `limit` 1 through 200 - review a pending action's payload and hash here before approving it, and reconstruct executed chains here afterwards (a cleared capability degradation is pinned only inside its executed restore record)
+2. the two-step route pairs: kill-switch clearance `/platform/providers/kill-switches/{switch_id}/clear-requests|clear-approvals`; prompt promotion `/platform/prompts/promote-requests|promote-approvals`; provider resets `/platform/providers/control-plane-actions/reset-requests|reset-approvals`; model serving promotion `/platform/models/catalogue/{entry_id}/promotion-requests|promotion-approvals` (evidence must name an existing COMPLETED PASS-verdict evaluation run); capability restore `/platform/models/catalogue/{entry_id}/capability-restore-requests|capability-restore-approvals`
+3. single-principal safety routes: kill-switch activation, prompt rollback via `control-actions`, model lifecycle transitions to non-serving states via `/platform/models/catalogue/{entry_id}/lifecycle-transitions`, and capability degradation via `/platform/models/catalogue/{entry_id}/capability-degradations` (requirement routing then refuses that dimension as `CAPABILITY_DEGRADED` while the model keeps serving everything else; only the governed restore clears it, and reseeding never does)
+4. both steps of every two-step flow require verified caller credentials (`LOTUS_AI_CALLER_TRUST_MODE=verified_service_jwt`); header trust cannot distinguish a requester from an approver and is refused
+
 ## Safety Governance Review
 
 Before treating runtime safety enforcement as governed rollout posture:
@@ -485,13 +502,13 @@ Mandatory verification after every mode change:
 
 Runtime semantics under `ordered_fallback`:
 
-1. the candidate order is fixed: configured primary first, configured alternate second; both identities seed governed catalogue rows and pass the same lifecycle and kill-switch fences at bind time
+1. the candidate universe is derived from the governed catalogue, bounded by the configured policy order (primary first, alternate second): both identities seed governed catalogue rows, and an identity the catalogue excludes - not catalogued, or lifecycle-ineligible - never becomes a candidate at all; its reasoned exclusion is recorded in `universe_exclusions` on the routing decision, whose `universe_source` reads `CATALOGUE_DERIVED`. When every policy-ordered identity is excluded, execution refuses before any attempt with each per-identity reason on the decision. The bind-time lifecycle fence remains as a backstop between derivation and attempt
 2. a transient primary failure (`PROVIDER_TIMEOUT`, `PROVIDER_RATE_LIMITED`, `PROVIDER_UPSTREAM_ERROR`, after the primary's own retry budget) triggers one attempt on the alternate within the same execution; the routing decision records the primary's failure category as its rejection and names the failed provider in `fallback_path`
 3. a candidate-scoped preflight veto - a `PROVIDER`/`MODEL_REVISION` kill switch on the primary, or the primary's open circuit breaker - routes to the alternate as a recorded rejection plus selection, with an empty `fallback_path`: a preflight rejection is not a fallback
 4. deterministic failures (configuration, governance) refuse without attempting the alternate
 5. quota counters and the budget envelope are request-scoped and enforced exactly once per execution: a fallback never bypasses or double-charges them, and request-scoped kill-switch scopes (`ALL_LIVE_TEXT`, `TASK`, `TENANT`, `CALLER_APP`) reject both candidates
 6. circuit-breaker bookkeeping is keyed per provider identity (`live_text_generation:<provider_id>`), so the primary's failures never open the alternate's breaker; `RESET_DEGRADATION` and `RESET_ALL_PROVIDER_OPERATIONS` control actions clear every candidate's counters
-7. `GET /platform/providers/routing-posture` names both candidates with their catalogue bindings and per-candidate breaker posture; the serving identity is always stamped on the response and its audit record - there is no silent fallback
+7. `GET /platform/providers/routing-posture` names both candidates with their catalogue bindings and per-candidate breaker posture, and exposes `candidate_universe` - the same derivation the gateway enumerates from, so the posture cannot disagree with routing. Optional capability query parameters (`?structured_output_required=true`, `?tool_calling_required=true`) add per-candidate eligibility verdicts (`CAPABILITY_NOT_SUPPORTED`, `CAPABILITY_UNKNOWN`, `CAPABILITY_DEGRADED`) and `would_select_entry_id`. The serving identity is always stamped on the response and its audit record - there is no silent fallback
 
 ## Durable Provider Operations Recovery
 
@@ -502,7 +519,7 @@ Operator rules:
 1. do not treat a service restart as a quota, spend, or circuit reset
 2. review `/platform/providers/quota-policy`, `/platform/providers/budget-policy`, and `/platform/providers/operations-status` before assuming provider posture has cleared
 3. investigate persistent blocking posture as durable control-plane state, not as stale process memory
-4. use `POST /platform/providers/control-plane-actions/reset` for governed quota, budget, and degradation resets rather than ad hoc table edits
+4. use the governed two-step reset flow (`POST /platform/providers/control-plane-actions/reset-requests` then `/reset-approvals` under a distinct verified credential) for quota, budget, and degradation resets rather than ad hoc table edits
 
 Current recovery expectations:
 
@@ -511,13 +528,14 @@ Current recovery expectations:
 3. circuit-open posture remains durable until the persisted cooldown expires or a governed degradation reset action is applied and recorded
 4. restart alone must not be used as an operational workaround for provider controls
 
-Current governed reset procedure:
+Current governed reset procedure (a reset is risk-increasing - it re-enables spend or traffic another control stopped - so it takes the governed two-step flow; see Governed Actions):
 
 1. inspect `/platform/providers/control-plane-actions` to review recent provider control-plane actions
 2. confirm `/platform/providers/quota-policy`, `/platform/providers/budget-policy`, and `/platform/providers/operations-status` reflect the blocking posture that requires intervention
-3. apply `POST /platform/providers/control-plane-actions/reset` with explicit operator reason, requester, and approver metadata
-4. verify the resulting control-plane event is visible in `/platform/providers/control-plane-actions`
-5. re-check `/platform/providers/quota-policy`, `/platform/providers/budget-policy`, `/platform/providers/operations-status`, and the embedded `provider_operations` block in `/platform/runtime-status`
+3. submit `POST /platform/providers/control-plane-actions/reset-requests` with the exact reset shape and reason under a verified caller credential; the response returns the pending `action_id` and `action_hash`
+4. a DISTINCT verified credential reviews the pending action (`GET /platform/governed-actions?status=PENDING`) and applies `POST /platform/providers/control-plane-actions/reset-approvals` with that exact `action_id` and `action_hash`; identity comes from the Authorization credential, never from body metadata
+5. verify the resulting control-plane event is visible in `/platform/providers/control-plane-actions` and the executed evidence chain in `/platform/governed-actions`
+6. re-check `/platform/providers/quota-policy`, `/platform/providers/budget-policy`, `/platform/providers/operations-status`, and the embedded `provider_operations` block in `/platform/runtime-status`
 
 ## Prompt Activation Governance
 
@@ -538,9 +556,10 @@ Current governed control-action procedure:
 1. inspect `/platform/prompts/control-history?task_id=<task_id>` to review the latest promote or rollback actions for the target task; the route returns newest-first bounded history with `limit` constrained to 1 through 200
 2. inspect `/platform/prompts/runtime-status` to confirm the current active, candidate, and previous-active prompt versions for that task
 3. inspect `/platform/prompts/evidence-readiness` to confirm the prompt approval gate reports `RUNTIME_PASS` before promotion
-4. apply `POST /platform/prompts/control-actions` with explicit requested-by, approved-by, and reason metadata
-5. verify the resulting control-plane event is visible in both `/platform/prompts/control-history` and the task-specific rollout state in `/platform/prompts/runtime-status`
-6. verify post-change task execution and `/ai/audit` records show the expected selected prompt version and latest control event
+4. for a **promotion** (risk-increasing): submit `POST /platform/prompts/promote-requests` under a verified caller credential, then a DISTINCT verified credential approves the exact pending `action_id` and `action_hash` via `POST /platform/prompts/promote-approvals`; the single-call `control-actions` route refuses promotions with guidance to this flow
+5. for a **rollback** (safety direction): apply `POST /platform/prompts/control-actions` with the rollback action and reason; it executes immediately under the single verified caller identity, and the record honestly carries no approver
+6. verify the resulting control-plane event is visible in both `/platform/prompts/control-history` and the task-specific rollout state in `/platform/prompts/runtime-status`, and the governed evidence chain in `/platform/governed-actions`
+7. verify post-change task execution and `/ai/audit` records show the expected selected prompt version and latest control event
 
 Current rollback and incident-response expectations:
 

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -119,3 +119,20 @@ class GovernedActionResponse(BaseModel):
         description="The governed-action evidence record."
     )
     summary: list[str] = Field(description="Human-readable statements about the action.")
+
+
+class GovernedActionHistoryResponse(BaseModel):
+    """Governed-action evidence records, newest requested first.
+
+    The read the approval flow's own refusal guidance presupposes: an approver
+    reviews the exact pending action (payload and hash) before approving it,
+    and an auditor reads the request-approval-execution chain - including
+    evidence that lives nowhere else, such as a capability degradation cleared
+    by an executed restore.
+    """
+
+    service: str = Field(description="Publishing service identity.")
+    version: str = Field(description="Publishing service version.")
+    actions: list[GovernedActionRecord] = Field(
+        description="Matching governed-action records, newest requested first.",
+    )

--- a/src/app/repositories/memory_provider_operations_repository.py
+++ b/src/app/repositories/memory_provider_operations_repository.py
@@ -191,5 +191,21 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
                 return record.model_copy(deep=True)
         return None
 
+    def list_governed_actions(
+        self,
+        *,
+        status: str | None,
+        target: str | None,
+        limit: int,
+    ) -> list[GovernedActionRecord]:
+        records = [
+            record
+            for record in self._governed_actions.values()
+            if (status is None or record.status.value == status)
+            and (target is None or record.target == target)
+        ]
+        records.sort(key=lambda record: record.requested_at, reverse=True)
+        return [record.model_copy(deep=True) for record in records[:limit]]
+
     def upsert_governed_action(self, record: GovernedActionRecord) -> None:
         self._governed_actions[record.action_id] = record.model_copy(deep=True)

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -146,5 +146,14 @@ class ProviderOperationsRepository(Protocol):
     def upsert_governed_action(self, record: GovernedActionRecord) -> None:
         """Persist one governed-action record by action id."""
 
+    def list_governed_actions(
+        self,
+        *,
+        status: str | None,
+        target: str | None,
+        limit: int,
+    ) -> list[GovernedActionRecord]:
+        """List governed-action evidence records, newest requested first."""
+
     def list_operations_events(self, *, limit: int) -> list[ProviderOperationsEventRecord]:
         """List most recent provider-operations control event records."""

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -389,6 +389,22 @@ class SqlAlchemyProviderOperationsRepository(
             ).scalar_one_or_none()
             return _to_governed_action_record(model) if model is not None else None
 
+    def list_governed_actions(
+        self,
+        *,
+        status: str | None,
+        target: str | None,
+        limit: int,
+    ) -> list[GovernedActionRecord]:
+        with self._session_factory() as session:
+            query = select(GovernedActionModel)
+            if status is not None:
+                query = query.where(GovernedActionModel.status == status)
+            if target is not None:
+                query = query.where(GovernedActionModel.target == target)
+            query = query.order_by(GovernedActionModel.requested_at.desc()).limit(limit)
+            return [_to_governed_action_record(model) for model in session.execute(query).scalars()]
+
     def upsert_governed_action(self, record: GovernedActionRecord) -> None:
         with self._session_factory() as session:
             model = session.get(GovernedActionModel, record.action_id)

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
+
+from app.contracts.governed_actions import (
+    GovernedActionHistoryResponse,
+    GovernedActionStatus,
+)
+from app.services.governed_action_control import build_governed_action_history
 
 from app.contracts.app_capability_rollouts import (
     AppCapabilityRolloutCatalogGovernanceStatusResponse,
@@ -110,6 +116,34 @@ router = APIRouter(prefix="/platform", tags=["platform"])
 )
 async def get_platform_runtime_status_route(request: Request) -> PlatformRuntimeStatusResponse:
     return build_platform_runtime_status(request.app.state)
+
+
+@router.get(
+    "/governed-actions",
+    response_model=GovernedActionHistoryResponse,
+    operation_id="getGovernedActionHistory",
+    summary="Get governed-action evidence records",
+    description=(
+        "Returns governed-action evidence records across every domain that composes the "
+        "governed-action primitive (kill-switch clearance, prompt promotion, provider "
+        "resets, model promotions, capability restores, system-originated recovery), "
+        "newest requested first. This is the read the approval flow presupposes: an "
+        "approver reviews the exact pending action - payload and hash - before approving "
+        "it, and an auditor reconstructs the request-approval-execution chain, including "
+        "evidence pinned only here such as a capability degradation cleared by an "
+        "executed restore. Filterable by status and target."
+    ),
+    responses={
+        200: {"description": "Governed-action records returned successfully."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def get_governed_action_history_route(
+    status: GovernedActionStatus | None = None,
+    target: str | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+) -> GovernedActionHistoryResponse:
+    return build_governed_action_history(status_filter=status, target=target, limit=limit)
 
 
 @router.get(

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -25,7 +25,9 @@ from uuid import uuid4
 
 from fastapi import HTTPException, status
 
+from app.config import settings
 from app.contracts.governed_actions import (
+    GovernedActionHistoryResponse,
     GovernedActionRecord,
     GovernedActionStatus,
     GovernedActionType,
@@ -251,6 +253,32 @@ def _require_verified_governing_credential(caller: AuthenticatedCaller) -> None:
                 "identity cannot distinguish a requester from an approver."
             ),
         )
+
+
+def build_governed_action_history(
+    *,
+    status_filter: GovernedActionStatus | None = None,
+    target: str | None = None,
+    limit: int = 50,
+) -> GovernedActionHistoryResponse:
+    """Read governed-action evidence, newest requested first (issue #157).
+
+    A pure read over the existing store: the approver reviews the exact
+    pending action before approving its hash, and the auditor reconstructs
+    the request-approval-execution chain - including evidence pinned only
+    here, such as a capability degradation cleared by an executed restore.
+    """
+
+    records = get_provider_operations_store().list_governed_actions(
+        status=status_filter.value if status_filter is not None else None,
+        target=target,
+        limit=limit,
+    )
+    return GovernedActionHistoryResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        actions=records,
+    )
 
 
 def _utc_now_iso() -> str:

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -478,15 +478,19 @@ def _build_ordered_routing_decision(
         )
     elif fallback_path:
         selection_reason = (
-            "Ordered-fallback policy: the primary candidate failed and the alternate "
-            "candidate served; the fallback path names the failed provider(s)."
+            "Ordered-fallback policy: an earlier candidate failed and a later candidate "
+            "served; the fallback path names the failed provider(s)."
         )
     elif serving_config is candidates[0][0]:
-        selection_reason = "Ordered-fallback policy: the primary candidate served."
+        # "First enumerated", not "primary": the universe may have excluded
+        # the configured primary, and the evidence must not claim it served.
+        selection_reason = (
+            "Ordered-fallback policy: the first candidate in the enumerated universe served."
+        )
     else:
         selection_reason = (
-            "Ordered-fallback policy: the primary candidate was rejected at preflight and "
-            "the alternate candidate served; a preflight rejection is not a fallback."
+            "Ordered-fallback policy: an earlier candidate was rejected at preflight and "
+            "a later candidate served; a preflight rejection is not a fallback."
         )
     enforced_dimensions, unenforced_dimensions = _requirement_enforcement_split(requirements)
     return RoutingDecisionDescriptor(

--- a/tests/integration/test_governed_action_api_contract.py
+++ b/tests/integration/test_governed_action_api_contract.py
@@ -1,0 +1,43 @@
+"""API contract for the governed-action evidence read (issue #157).
+
+The approval flow's own guidance - "review the pending action and approve its
+hash" - presupposes this read: a distinct approver inspects the exact pending
+payload and hash before approving, and an auditor reads the evidence chain.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.services.governed_action_control import record_system_originated_action
+from app.contracts.governed_actions import GovernedActionType
+
+
+def test_governed_action_history_route(client: TestClient) -> None:
+    record_system_originated_action(
+        service_identity="worker-alpha-01",
+        action_type=GovernedActionType.ASYNC_QUEUE_RECOVERY,
+        target="asyncjob_http_contract",
+        payload={"action": "QUARANTINE_QUEUED_JOB", "reason": "poisoned payload"},
+    )
+
+    response = client.get("/platform/governed-actions")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["service"] == "lotus-ai"
+    actions = {action["target"]: action for action in body["actions"]}
+    listed = actions["asyncjob_http_contract"]
+    assert listed["actor_class"] == "SYSTEM_ORIGINATED"
+    assert listed["status"] == "EXECUTED"
+    assert listed["action_hash"]
+    assert listed["action_payload"]["action"] == "QUARANTINE_QUEUED_JOB"
+
+    filtered = client.get(
+        "/platform/governed-actions",
+        params={"status": "PENDING", "target": "asyncjob_http_contract"},
+    )
+    assert filtered.status_code == 200
+    assert filtered.json()["actions"] == []
+
+    bounded = client.get("/platform/governed-actions", params={"limit": 500})
+    assert bounded.status_code == 422

--- a/tests/unit/test_candidate_universe.py
+++ b/tests/unit/test_candidate_universe.py
@@ -213,6 +213,10 @@ def test_excluded_identity_never_becomes_a_candidate(
     assert decision.universe_exclusions[0].reason is (
         CandidateUniverseExclusionReason.LIFECYCLE_INELIGIBLE
     )
+    # Evidence honesty: the configured primary did NOT serve - the selection
+    # reason must describe the enumeration, never claim the primary served.
+    assert "primary" not in decision.selection_reason
+    assert "first candidate in the enumerated universe served" in decision.selection_reason
 
 
 def test_empty_universe_refuses_with_every_reason(

--- a/tests/unit/test_governed_action_control.py
+++ b/tests/unit/test_governed_action_control.py
@@ -234,3 +234,37 @@ def test_a_system_originated_action_records_workload_identity_without_approval()
     assert record.approver_key_id is None
     persisted = get_provider_operations_store().get_governed_action(record.action_id)
     assert persisted == record
+
+
+def test_governed_action_history_lists_newest_first_with_filters() -> None:
+    """The read the approval flow presupposes (issue #157): pending actions
+    are reviewable before approval, and the evidence chain is readable across
+    every composing domain - with status and target filters."""
+
+    from app.services.governed_action_control import build_governed_action_history
+
+    pending = _submit()
+    executed = record_system_originated_action(
+        service_identity="worker-alpha-01",
+        action_type=GovernedActionType.ASYNC_QUEUE_RECOVERY,
+        target="asyncjob_listed",
+        payload={"action": "QUARANTINE_QUEUED_JOB", "reason": "poisoned payload"},
+    )
+
+    everything = build_governed_action_history()
+    assert {record.action_id for record in everything.actions} == {
+        pending.action_id,
+        executed.action_id,
+    }
+
+    pending_only = build_governed_action_history(status_filter=GovernedActionStatus.PENDING)
+    assert [record.action_id for record in pending_only.actions] == [pending.action_id]
+    # The pending record carries what the approver must review: the exact
+    # payload and the hash approval binds to.
+    assert pending_only.actions[0].action_hash == pending.action_hash
+    assert pending_only.actions[0].action_payload == pending.action_payload
+
+    targeted = build_governed_action_history(target="asyncjob_listed")
+    assert [record.action_id for record in targeted.actions] == [executed.action_id]
+
+    assert build_governed_action_history(target="no-such-target").actions == []

--- a/tests/unit/test_ordered_fallback_routing.py
+++ b/tests/unit/test_ordered_fallback_routing.py
@@ -155,7 +155,7 @@ def test_primary_serves_when_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
     assert all(candidate.rejection_reason is None for candidate in decision.candidates)
     assert decision.selected_provider_id == PRIMARY
     assert decision.fallback_path == []
-    assert "primary candidate served" in decision.selection_reason
+    assert "first candidate in the enumerated universe served" in decision.selection_reason
 
 
 def test_transient_primary_failure_falls_back_to_the_alternate(
@@ -183,7 +183,7 @@ def test_transient_primary_failure_falls_back_to_the_alternate(
     )
     assert decision.candidates[1].rejection_reason is None
     assert decision.fallback_path == [PRIMARY]
-    assert "alternate" in decision.selection_reason
+    assert "a later candidate served" in decision.selection_reason
 
     # Failure bookkeeping is keyed per provider: the primary's failure never
     # touches the alternate's breaker state.

--- a/tests/unit/test_provider_degradation_state.py
+++ b/tests/unit/test_provider_degradation_state.py
@@ -29,6 +29,32 @@ def test_provider_degradation_status_reports_documented_only_by_default() -> Non
     assert status.consecutive_failure_count == 0
 
 
+def test_breaker_never_counts_failures_the_provider_did_not_cause() -> None:
+    """The caller's exhausted latency budget - and every other non-provider
+    condition - must not accumulate breaker strikes against an innocent
+    provider (issue #244). Only provider-fault categories are tracked; this
+    pins that a widened tracked set cannot land silently."""
+
+    settings.live_text_degradation_enforced = True
+    settings.live_text_degraded_failure_count_threshold = 1
+    settings.live_text_circuit_open_failure_count_threshold = 2
+    settings.live_text_circuit_open_seconds = 60
+
+    for category in (
+        ProviderFailureCategory.REQUEST_DEADLINE_EXHAUSTED,
+        ProviderFailureCategory.CAPABILITY_UNKNOWN,
+        ProviderFailureCategory.KILL_SWITCH_ACTIVE,
+        ProviderFailureCategory.BUDGET_EXCEEDED,
+    ):
+        record_provider_failure(category)
+
+    status = build_provider_degradation_status()
+
+    assert status.consecutive_failure_count == 0
+    assert status.status != "DEGRADED_UPSTREAM"
+    assert status.status != "CIRCUIT_OPEN"
+
+
 def test_provider_degradation_status_reports_degraded_after_threshold() -> None:
     settings.live_text_degradation_enforced = True
     settings.live_text_degraded_failure_count_threshold = 2


### PR DESCRIPTION
Gold-standard audit of the #157/#245/#244 programme: four gaps found, all fixed here. Everything else checked clean — audit persistence carries the universe fields (full JSON dump), the breaker's tracked-category filter already protects innocent providers, no stale identity fields survive in docs examples, and no test pinned the wording this PR corrects.

## 1 · Routing evidence must not claim the primary served when it didn't (fix)

Under a filtered universe (`candidates = [alternate]`), the ordered decision's `selection_reason` still said *"the primary candidate served"* — describing the **alternate** as the primary in durable audit evidence. Reworded to enumeration-honest language ("the first candidate in the enumerated universe served" / "an earlier candidate … a later candidate"), and the excluded-primary test now pins that the reason never claims "primary".

## 2 · Breaker innocence pinned (test)

`REQUEST_DEADLINE_EXHAUSTED` — the caller's budget running out — must never accumulate breaker strikes against a provider that did nothing wrong. The filter already exists (`_tracked_failure_categories`), but nothing pinned it: a one-line widening could silently start punishing innocent providers. New test drives deadline-exhaustion, capability, kill-switch and budget categories through `record_provider_failure` and asserts zero strikes.

## 3 · The read the approval flow presupposes (small feat)

The primitive's own refusal guidance says *"review the pending action and approve its hash"* — but no API could show a pending action. An approver had to trust an out-of-band hash; an auditor could not reconstruct the chain; and a cleared capability degradation (pinned only inside its executed restore record) was durably stored but unreadable.

`GET /platform/governed-actions` — one read over the existing store, newest requested first, filterable by `status` and `target`, `limit` 1–200. No new store, no new subsystem: `list_governed_actions` on the existing repository protocol plus both adapters, one contract, one route on the existing platform router behind the same registered-caller gate. This is the composed operator read the goal file's own rule permits: the question genuinely could not be answered from any existing surface.

## 4 · Runbook truth (docs)

The operator runbook instructed flows the governance slices deliberately removed — an operator following it would hit a removed route or a refusal:

- the governed reset procedure said `POST …/control-plane-actions/reset` (removed); now documents the two-step `reset-requests`/`reset-approvals` flow with review via `/platform/governed-actions`
- the prompt procedure said to apply promotions via `control-actions` "with requested-by, approved-by metadata" (refused; identity no longer comes from the body); now documents `promote-requests`/`promote-approvals` for promotion and single-principal `control-actions` for rollback
- the ordered-fallback semantics described the pre-U2 world (bind-time fences as the enumeration mechanism); now describes the catalogue-derived universe, `universe_exclusions`, the empty-universe refusal, and the capability-posture query
- a new **Governed Actions** section documents the risk-direction rule, all five two-step route pairs, the single-principal safety routes, the supersede rule, the verified-credential requirement — and states explicitly that dual-control evidence proves distinct credentials, **not** verified-human four-eyes.

Full local gate: lint, typecheck, whole suite with coverage. No schema changes.
