### PR TITLE
fix(catalogue): structured-output evidence no broader than its proof

### DIFF
--- a/alembic/versions/0064_scoped_structured_output_evidence.py
+++ b/alembic/versions/0064_scoped_structured_output_evidence.py
@@ -1,0 +1,37 @@
+"""scoped structured output evidence
+
+Revision ID: 0064_scoped_structured_output_evidence
+Revises: 0063_capability_degradations
+Create Date: 2026-09-03
+
+Issue #244 correction: the seeder used to set the model-global
+supports_structured_output fact from pack approval plus output-contract
+existence - evidence that only proves effective structured output for that
+pack's governed scope. No production assessment path exists, so every stored
+True is seed-derived and over-broad; reset the fact to unknown. Scoped
+eligibility now consults the fields that actually carry the evidence
+(approved_workflow_pack_ids plus the execution's output-contract key), and
+the global fact stays unknown until an assessment proves it.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0064_scoped_structured_output_evidence"
+down_revision = "0063_capability_degradations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("UPDATE model_catalogue_entries SET supports_structured_output = NULL"))
+
+
+def downgrade() -> None:
+    # The over-broad claim is deliberately not restorable: downgrading the
+    # schema does not re-manufacture evidence. Reseeding under the old code
+    # would repopulate it.
+    pass

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -634,6 +634,14 @@ class ProviderExecutionRequest(BaseModel):
         default=None,
         description="Optional tenant or environment ownership marker for the provider request.",
     )
+    output_contract_key: str | None = Field(
+        default=None,
+        description=(
+            "Output-contract key deterministic validation will hold this execution's "
+            "structured output to (binding pack id, else task id); the governed capability "
+            "scope for scoped structured-output eligibility evidence (issue #244)."
+        ),
+    )
     prompt_version: str = Field(description="Resolved prompt version for this execution.")
     system_instructions: str = Field(
         description="Resolved system instructions for the executing task prompt."

--- a/src/app/routers/providers.py
+++ b/src/app/routers/providers.py
@@ -72,6 +72,7 @@ router = APIRouter(prefix="/platform/providers", tags=["platform"])
 async def get_routing_posture_route(
     structured_output_required: bool | None = None,
     tool_calling_required: bool | None = None,
+    output_contract_key: str | None = None,
 ) -> RoutingPostureResponse:
     requirements: CapabilityRequirements | None = None
     if structured_output_required is not None or tool_calling_required is not None:
@@ -79,7 +80,7 @@ async def get_routing_posture_route(
             structured_output_required=structured_output_required,
             tool_calling_required=tool_calling_required,
         )
-    return build_routing_posture(requirements)
+    return build_routing_posture(requirements, output_contract_key=output_contract_key)
 
 
 @router.get(

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -180,17 +180,13 @@ def build_seed_model_catalogue_entries() -> list[ModelCatalogueEntry]:
             lifecycle_state=ModelLifecycleState.APPROVED,
             revision_pinned=True,
             modalities=["text"],
-            # Provable from the approval evidence itself (issue #244, S2): a
-            # pack-approved model has produced output that the deterministic
-            # validator held to the pack's strict-JSON schema contract. No
-            # other capability dimension has in-repo evidence, so no other
-            # dimension is seeded - unknown stays unknown, and configuration
-            # alone (the settings rows above) proves nothing.
-            supports_structured_output=(
-                True
-                if any(output_contract_exists(pack_id) for pack_id in approved.workflow_pack_ids)
-                else None
-            ),
+            # No capability dimension is seeded: pack approval plus an output
+            # contract proves effective structured output only for THAT pack's
+            # governed scope, never the model-global claim a seeded fact would
+            # make. The scoped evidence is consulted at eligibility time from
+            # the fields that carry it (approved_workflow_pack_ids + the
+            # execution's output-contract key); the model-global fact stays
+            # unknown until an assessment actually proves it (issue #244).
             approved_workflow_pack_ids=list(approved.workflow_pack_ids),
             approval_evidence_refs=[approved.approval_ref],
             approved_from_utc=approved.approved_from_utc,
@@ -289,10 +285,30 @@ _CAPABILITY_FACT_BY_REQUIREMENT = {
 }
 
 
+def scoped_structured_output_evidence(
+    entry: ModelCatalogueEntry, output_contract_key: str | None
+) -> bool:
+    """Effective Lotus structured-output evidence, exactly as broad as it is.
+
+    The entry is approved for the governed scope being executed AND
+    deterministic validation holds that scope's output to a strict-JSON
+    contract. That proves the requirement for THIS scope only - it is never
+    widened into a model-global capability claim (issue #244 correction:
+    pack approval plus contract existence must not seed a global fact).
+    """
+
+    if not output_contract_key:
+        return False
+    return output_contract_key in entry.approved_workflow_pack_ids and output_contract_exists(
+        output_contract_key
+    )
+
+
 def enforce_capability_requirements(
     *,
     requirements: CapabilityRequirements | None,
     entry: ModelCatalogueEntry,
+    output_contract_key: str | None = None,
 ) -> None:
     """Reject a candidate whose catalogue entry cannot satisfy the workload.
 
@@ -300,6 +316,11 @@ def enforce_capability_requirements(
     has never assessed refuses with CAPABILITY_UNKNOWN, distinctly from a
     fact it proves absent (CAPABILITY_NOT_SUPPORTED). Laundering unknown into
     a confident answer in either direction is how capability claims rot.
+
+    Eligibility accepts evidence at either honest scope: an assessed
+    model-global fact, or scoped effective evidence for exactly the governed
+    scope this execution validates under. An operator degradation overrides
+    both while present.
     """
 
     if requirements is None:
@@ -327,11 +348,21 @@ def enforce_capability_requirements(
                     f"capability `{requirement_field}`."
                 ),
             )
+        if requirement_field == "structured_output_required" and scoped_structured_output_evidence(
+            entry, output_contract_key
+        ):
+            continue
         raise ProviderExecutionError(
             category=ProviderFailureCategory.CAPABILITY_UNKNOWN,
             message=(
-                f"Candidate `{entry.entry_id}` has no assessed catalogue fact for the "
-                f"required capability `{requirement_field}`; unknown is not eligibility."
+                f"Candidate `{entry.entry_id}` has no applicable evidence for the "
+                f"required capability `{requirement_field}`"
+                + (
+                    f" in governed scope `{output_contract_key}`"
+                    if requirement_field == "structured_output_required" and output_contract_key
+                    else ""
+                )
+                + "; unknown is not eligibility."
             ),
         )
 

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -111,7 +111,9 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             enforce_provider_degradation_preflight()
             catalogue_entry = bind_live_text_model_catalogue_entry()
             enforce_capability_requirements(
-                requirements=request.requirements, entry=catalogue_entry
+                requirements=request.requirements,
+                entry=catalogue_entry,
+                output_contract_key=request.output_contract_key,
             )
             _require_budget_remaining(request)
         except ProviderExecutionError as exc:
@@ -298,7 +300,9 @@ def _execute_ordered_fallback(
                 enforce_provider_degradation_preflight()
                 catalogue_entry = bind_live_text_model_catalogue_entry()
                 enforce_capability_requirements(
-                    requirements=request.requirements, entry=catalogue_entry
+                    requirements=request.requirements,
+                    entry=catalogue_entry,
+                    output_contract_key=request.output_contract_key,
                 )
             except ProviderExecutionError as exc:
                 rejections[index] = exc.category

--- a/src/app/services/provider_request_builder.py
+++ b/src/app/services/provider_request_builder.py
@@ -8,11 +8,13 @@ from app.services.task_execution_models import TaskExecutionContext
 def build_provider_execution_request(
     *,
     context: TaskExecutionContext,
+    output_contract_key: str | None = None,
 ) -> ProviderExecutionRequest:
     config = resolve_provider_execution_config()
     return ProviderExecutionRequest(
         task_id=context.capability.task_id,
         requirements=context.request.requirements,
+        output_contract_key=output_contract_key,
         caller_app=context.request.caller.caller_app,
         requested_by=context.request.caller.requested_by,
         tenant_id=context.request.caller.tenant_id,

--- a/src/app/services/routing_posture.py
+++ b/src/app/services/routing_posture.py
@@ -45,6 +45,7 @@ from app.services.provider_degradation_state import build_provider_degradation_s
 
 def build_routing_posture(
     requirements: CapabilityRequirements | None = None,
+    output_contract_key: str | None = None,
 ) -> RoutingPostureResponse:
     config = resolve_provider_execution_config()
     ordered = config.routing_strategy == "ordered_fallback"
@@ -95,7 +96,11 @@ def build_routing_posture(
         # one authority, so the posture cannot disagree with routing.
         candidate_universe=universe,
         capability_posture=(
-            _build_capability_posture(universe=universe, requirements=requirements)
+            _build_capability_posture(
+                universe=universe,
+                requirements=requirements,
+                output_contract_key=output_contract_key,
+            )
             if universe is not None and requirements is not None
             else None
         ),
@@ -107,13 +112,17 @@ def _build_capability_posture(
     *,
     universe: CandidateUniverse,
     requirements: CapabilityRequirements,
+    output_contract_key: str | None = None,
 ) -> CapabilityPostureDescriptor:
     """Per-candidate capability eligibility, with the gateway's own check.
 
     Runs `enforce_capability_requirements` - not a re-derivation of its logic -
     over the exact universe the next execution would enumerate, so "who is
     eligible for capability X" can never disagree with what routing enforces
-    (issue #244, S5).
+    (issue #244, S5). Without a governed scope the answer is the model-global
+    question (honest UNKNOWN unless assessed); with `output_contract_key` it
+    is the scoped question an execution of that contract would get, and the
+    eligible verdict names which evidence made it so.
     """
 
     repository = get_model_catalogue_repository()
@@ -134,7 +143,11 @@ def _build_capability_posture(
             )
             continue
         try:
-            enforce_capability_requirements(requirements=requirements, entry=entry)
+            enforce_capability_requirements(
+                requirements=requirements,
+                entry=entry,
+                output_contract_key=output_contract_key,
+            )
         except ProviderExecutionError as exc:
             candidates.append(
                 CapabilityPostureCandidateDescriptor(
@@ -145,7 +158,19 @@ def _build_capability_posture(
                 )
             )
             continue
-        candidates.append(CapabilityPostureCandidateDescriptor(entry_id=entry_id, eligible=True))
+        # Name the evidence that made the verdict, at its honest scope.
+        if requirements.structured_output_required is True and (
+            entry.supports_structured_output is not True
+        ):
+            basis = (
+                "effective Lotus structured-output evidence scoped to output contract "
+                f"`{output_contract_key}`"
+            )
+        else:
+            basis = "assessed model-global capability facts"
+        candidates.append(
+            CapabilityPostureCandidateDescriptor(entry_id=entry_id, eligible=True, detail=basis)
+        )
         if would_select is None:
             would_select = entry_id
     return CapabilityPostureDescriptor(

--- a/src/app/services/task_execution_pipeline.py
+++ b/src/app/services/task_execution_pipeline.py
@@ -50,7 +50,9 @@ def resolve_task_execution(
     elif context.capability.category == TaskCategory.KNOWLEDGE_ANSWER:
         provider_execution = execute_knowledge_answer(context=context)
     else:
-        provider_request = build_provider_execution_request(context=context)
+        provider_request = build_provider_execution_request(
+            context=context, output_contract_key=contract_key
+        )
         provider_execution = execute_text_generation(provider_request)
     # Deterministic output validation runs on the provider's actual output,
     # BEFORE safety redaction: redaction must never be able to erase a

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -806,14 +806,20 @@ def test_drift_observations_survive_a_store_restart_in_sqlalchemy_mode(
     assert by_observed["qwen3:8b-q5-2026-06"].observation_count == 1
 
 
-def test_capability_facts_are_seeded_only_from_approval_evidence(
+def test_seeding_never_widens_scoped_evidence_into_a_global_capability_fact(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Issue #244 S2: a pack-approved model has provably produced output the
-    deterministic validator held to the pack's strict-JSON schema contract,
-    so structured-output support is a fact. Configuration alone proves
-    nothing, and no other dimension has in-repo evidence - unknown stays
-    unknown rather than becoming an optimistic default."""
+    """Issue #244 correction: pack approval plus an output contract proves
+    effective structured output only for that pack's governed scope - never
+    the model-global claim a seeded fact would make. No capability dimension
+    is seeded; the scoped evidence is consulted at eligibility time, and the
+    global fact stays unknown until an assessment proves it."""
+
+    from app.contracts.capability_requirements import CapabilityRequirements
+    from app.services.model_catalogue import (
+        enforce_capability_requirements,
+        scoped_structured_output_evidence,
+    )
 
     monkeypatch.setattr(settings, "provider_mode", "openai")
     monkeypatch.setattr(settings, "provider_rollout_state", "CANARY_ENABLED")
@@ -825,7 +831,7 @@ def test_capability_facts_are_seeded_only_from_approval_evidence(
     entries = {entry.model_family: entry for entry in build_seed_model_catalogue_entries()}
 
     approved = entries["gpt-5.2"]
-    assert approved.supports_structured_output is True
+    assert approved.supports_structured_output is None
     assert approved.supports_tool_calling is None
     assert approved.supports_streaming is None
     assert approved.context_window_tokens is None
@@ -833,6 +839,51 @@ def test_capability_facts_are_seeded_only_from_approval_evidence(
     configured = entries["gpt-5.4"]
     assert configured.supports_structured_output is None
     assert configured.supports_tool_calling is None
+
+    # The evidence still counts - at exactly its own scope. advisor_brief.pack
+    # is approved for this entry and validated against a strict-JSON contract,
+    # so an execution of THAT scope is eligible...
+    requirements = CapabilityRequirements(structured_output_required=True)
+    assert scoped_structured_output_evidence(approved, "advisor_brief.pack") is True
+    enforce_capability_requirements(
+        requirements=requirements, entry=approved, output_contract_key="advisor_brief.pack"
+    )
+
+    # ...while any other scope, no scope, or an unapproved entry fails closed
+    # as unknown - the evidence is never widened.
+    for entry, scope in (
+        (approved, "some_other.pack"),
+        (approved, None),
+        (configured, "advisor_brief.pack"),
+    ):
+        assert scoped_structured_output_evidence(entry, scope) is False
+        with pytest.raises(ProviderExecutionError) as excinfo:
+            enforce_capability_requirements(
+                requirements=requirements, entry=entry, output_contract_key=scope
+            )
+        assert excinfo.value.category is ProviderFailureCategory.CAPABILITY_UNKNOWN
+
+    # An operator degradation outranks scoped evidence exactly as it outranks
+    # the global fact.
+    from app.contracts.model_catalogue import ModelCapabilityDegradation
+
+    degraded = approved.model_copy(
+        update={
+            "capability_degradations": {
+                "supports_structured_output": ModelCapabilityDegradation(
+                    dimension="supports_structured_output",
+                    reason="Contract validation failing in production.",
+                    degraded_by="lotus-platform (credential ops-key-alpha)",
+                    degraded_at="2026-09-03T12:00:00Z",
+                )
+            }
+        }
+    )
+    with pytest.raises(ProviderExecutionError) as excinfo:
+        enforce_capability_requirements(
+            requirements=requirements, entry=degraded, output_contract_key="advisor_brief.pack"
+        )
+    assert excinfo.value.category is ProviderFailureCategory.CAPABILITY_DEGRADED
 
 
 def test_reseeding_never_unassesses_a_known_capability_fact(


### PR DESCRIPTION
Steering correction (P1): **capability evidence must be no broader than the evidence that proves it.** The catalogue seeded `supports_structured_output = true` from pack approval plus output-contract existence — evidence that proves effective structured output only for *that pack's governed scope*, never the model-global claim a seeded fact makes.

## The rule, implemented exactly as stated

If a request requires structured output, candidate eligibility now finds **applicable evidence at an honest scope**:

- **Assessed model-global fact** (`supports_structured_output is True`) → eligible. No production path writes this yet; it stays the slot a real assessment fills.
- **Scoped effective evidence** → eligible for exactly this execution: the entry is approved for the governed scope being executed (`output_contract_key ∈ approved_workflow_pack_ids`) AND deterministic validation holds that scope's output to a strict-JSON contract. The same two facts the old seed used — consulted at their true scope instead of widened into a global claim.
- **Explicit negative fact** → `CAPABILITY_NOT_SUPPORTED`. **Operator degradation** → `CAPABILITY_DEGRADED`, outranking both evidence classes (pinned by test).
- **Anything else** → `CAPABILITY_UNKNOWN`, with the refusal naming the governed scope it found no evidence in.

No new registry, no per-pack capability dimensions: the evidence lives in fields the catalogue already carries, and the governed scope rides the execution request as `output_contract_key` — stamped from the same `binding pack_id else task_id` resolution deterministic validation already uses, so eligibility and validation see one scope.

## What this changes in behaviour

A structured-output-requiring execution of an approved pack with a contract is eligible exactly as before — via honestly-scoped evidence now. A structured-output requirement on any *other* scope (a different pack, a plain task, no scope) no longer rides the widened claim: it fails closed as `CAPABILITY_UNKNOWN` until real evidence exists. That narrowing is the point.

**Migration 0064** resets stored `supports_structured_output` to NULL: the seeder was the only production writer, so every stored `true` is the over-broad claim. The downgrade deliberately does not restore it — a schema downgrade does not re-manufacture evidence.

## Operator visibility

The capability posture accepts the same scope (`?output_contract_key=`): without it, the answer is the model-global question (honest UNKNOWN unless assessed); with it, the scoped question an execution would get — and an eligible verdict now **names its evidence basis** ("assessed model-global capability facts" vs "effective Lotus structured-output evidence scoped to output contract `X`"), so the explanation is exactly as strong as the evidence behind it.

## Evidence

The rewritten seed test proves the full matrix: nothing seeded globally; the approved pack scope eligible via `scoped_structured_output_evidence` and the real enforcement path; other scope / no scope / unapproved entry each `CAPABILITY_UNKNOWN`; degradation outranks scoped evidence. Existing S3/ordered/posture/latency suites green unchanged (they assess the global fact explicitly). Full local gate: lint, typecheck, migration-smoke, whole suite with coverage.

Closes the capability-scoped evidence truth gap recorded on the #244/#245 closures, per the steering: elevated and closed before any wider requirement dimensions.
