### PR TITLE
feat(identity): bound credential lifetime, require iat/typ, carry jti (#233)

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import model_validator
+from pydantic import PrivateAttr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Promoted-profile hardening (issue #153 S2): protection defaults applied only
@@ -21,6 +21,25 @@ PROMOTED_PROFILE_DEFAULTS: dict[str, object] = {
     "readiness_probe_policy": "degrade",
     "startup_readiness_policy": "enforce",
 }
+
+# The promoted defaults that are PROTECTIONS (issue #233): for each of these,
+# any explicit divergence from the promoted value is a weakening - the
+# booleans only weaken to False, the store modes to per-process memory, the
+# policies to non-blocking postures. Explicit override still wins, but it must
+# be loud: a startup finding names every protection an operator overrode.
+# The tuning values (retry limit, breaker thresholds/window) are deliberately
+# not here - a different threshold is a choice, not a disabled protection.
+PROMOTED_PROTECTION_FIELDS: frozenset[str] = frozenset(
+    {
+        "live_text_quota_enforced",
+        "live_text_budget_enforced",
+        "live_text_degradation_enforced",
+        "provider_operations_store_mode",
+        "workflow_pack_admission_store_mode",
+        "readiness_probe_policy",
+        "startup_readiness_policy",
+    }
+)
 
 
 class Settings(BaseSettings):
@@ -118,6 +137,9 @@ class Settings(BaseSettings):
     caller_jwt_issuer: str | None = None
     caller_jwt_audience: str | None = None
     caller_jwt_public_keys: str = ""
+    # Maximum accepted credential validity window (exp - iat), issue #233: a
+    # leaked token must not replay for an issuer-chosen unbounded lifetime.
+    caller_jwt_max_lifetime_seconds: int = 3600
     http_allowed_hosts: str = "*"
     http_cors_allowed_origins: str = (
         "http://localhost,http://localhost:3000,http://127.0.0.1,http://127.0.0.1:3000"
@@ -135,13 +157,38 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="LOTUS_AI_", extra="ignore")
 
+    _promoted_protection_overrides: list[str] = PrivateAttr(default_factory=list)
+
+    @property
+    def promoted_protection_overrides(self) -> list[str]:
+        """Protections an operator explicitly weakened below the promoted default.
+
+        Captured at construction, where ``model_fields_set`` is authoritative
+        about what the operator actually set (issue #233): a pre-existing
+        explicit weakening must not silently keep weaker posture. Empty
+        outside the promoted profile.
+        """
+
+        return list(self._promoted_protection_overrides)
+
     @model_validator(mode="after")
     def _apply_runtime_profile_defaults(self) -> "Settings":
         if self.runtime_profile != "promoted":
             return self
+        overrides: list[str] = []
         for field_name, promoted_value in PROMOTED_PROFILE_DEFAULTS.items():
             if field_name not in self.model_fields_set:
                 setattr(self, field_name, promoted_value)
+            elif (
+                field_name in PROMOTED_PROTECTION_FIELDS
+                and getattr(self, field_name) != promoted_value
+            ):
+                overrides.append(
+                    f"promoted override: {field_name} is explicitly weakened to "
+                    f"{getattr(self, field_name)!r} (promoted default {promoted_value!r}); "
+                    "this protection is operator-overridden"
+                )
+        self._promoted_protection_overrides = overrides
         return self
 
 

--- a/src/app/contracts/access_control.py
+++ b/src/app/contracts/access_control.py
@@ -117,6 +117,14 @@ class AuthorizationDecision(BaseModel):
             "never reach authorization."
         ),
     )
+    caller_credential_token_id: str | None = Field(
+        default=None,
+        description=(
+            "Issuer-assigned token id (jti) of the verifying credential when it carried "
+            "one; recorded so a future revocation list can name exactly this token "
+            "(issue #233). Null under header trust or when the issuer minted no jti."
+        ),
+    )
     capability_type: AuthorizationCapabilityType = Field(
         description="Capability class evaluated by the access-control layer."
     )

--- a/src/app/http/authenticated_caller.py
+++ b/src/app/http/authenticated_caller.py
@@ -30,6 +30,13 @@ class AuthenticatedCaller(BaseModel):
             "null under header trust."
         ),
     )
+    credential_token_id: str | None = Field(
+        default=None,
+        description=(
+            "Issuer-assigned token id (jti) of the verifying credential when it "
+            "carried one; recorded for future revocation lists (issue #233)."
+        ),
+    )
 
 
 def is_privileged_caller_identity_accepted(caller: AuthenticatedCaller) -> bool:
@@ -83,6 +90,7 @@ def _resolve_authenticated_caller(
             caller_app=credential.subject,
             trust_source=CALLER_TRUST_MODE_VERIFIED_JWT,
             credential_key_id=credential.key_id,
+            credential_token_id=credential.token_id,
         )
     if not caller_app:
         raise HTTPException(

--- a/src/app/http/caller_credential.py
+++ b/src/app/http/caller_credential.py
@@ -72,6 +72,12 @@ class VerifiedCallerCredential:
 
     subject: str
     key_id: str
+    # Optional issuer-assigned token id (jti), carried for future revocation
+    # lists and recorded on the authorization decision (issue #233).
+    token_id: str | None = None
+
+
+_MAX_TOKEN_ID_LENGTH = 128
 
 
 def verify_caller_credential(authorization: str | None) -> VerifiedCallerCredential:
@@ -89,6 +95,9 @@ def verify_caller_credential(authorization: str | None) -> VerifiedCallerCredent
     algorithm = header.get("alg")
     if algorithm != "EdDSA":
         raise _credential_invalid(f"credential algorithm '{algorithm}' is not EdDSA")
+    token_type = header.get("typ")
+    if token_type != "JWT":
+        raise _credential_invalid("credential header must declare typ JWT")
     key_id = header.get("kid")
     if not isinstance(key_id, str) or not key_id:
         raise _credential_invalid("credential does not name a key id")
@@ -118,6 +127,20 @@ def verify_caller_credential(authorization: str | None) -> VerifiedCallerCredent
         raise _credential_invalid("credential does not carry a numeric expiry")
     if now >= float(expiry):
         raise _credential_invalid("credential has expired")
+    issued_at = payload.get("iat")
+    if not isinstance(issued_at, (int, float)):
+        raise _credential_invalid("credential does not carry a numeric issued-at claim")
+    if float(issued_at) > now:
+        raise _credential_invalid("credential is issued in the future")
+    # Bound the issuer-chosen validity window (issue #233): a leaked token must
+    # not replay for an unbounded lifetime. With iat required and not in the
+    # future, bounding exp-iat also bounds exp-now - the remaining lifetime can
+    # never exceed the issued lifetime.
+    max_lifetime = settings.caller_jwt_max_lifetime_seconds
+    if float(expiry) - float(issued_at) > max_lifetime:
+        raise _credential_invalid(
+            f"credential lifetime exceeds the accepted maximum of {max_lifetime} seconds"
+        )
     not_before = payload.get("nbf")
     if not_before is not None:
         if not isinstance(not_before, (int, float)):
@@ -125,10 +148,20 @@ def verify_caller_credential(authorization: str | None) -> VerifiedCallerCredent
         if now < float(not_before):
             raise _credential_invalid("credential is not valid yet")
 
+    token_id = payload.get("jti")
+    if token_id is not None:
+        if not isinstance(token_id, str) or not token_id.strip():
+            raise _credential_invalid("credential token id must be a non-empty string")
+        if len(token_id) > _MAX_TOKEN_ID_LENGTH:
+            raise _credential_invalid(
+                f"credential token id exceeds {_MAX_TOKEN_ID_LENGTH} characters"
+            )
+        token_id = token_id.strip()
+
     subject = payload.get("sub")
     if not isinstance(subject, str) or not subject.strip():
         raise _credential_invalid("credential does not carry a caller subject")
-    return VerifiedCallerCredential(subject=subject.strip(), key_id=key_id)
+    return VerifiedCallerCredential(subject=subject.strip(), key_id=key_id, token_id=token_id)
 
 
 def _extract_bearer_token(authorization: str | None) -> str:

--- a/src/app/services/access_control_authorization.py
+++ b/src/app/services/access_control_authorization.py
@@ -52,7 +52,10 @@ def authorize_request(
     authenticated_caller = get_authenticated_caller()
     if authenticated_caller is not None and authenticated_caller.credential_key_id is not None:
         return decision.model_copy(
-            update={"caller_credential_key_id": authenticated_caller.credential_key_id}
+            update={
+                "caller_credential_key_id": authenticated_caller.credential_key_id,
+                "caller_credential_token_id": authenticated_caller.credential_token_id,
+            }
         )
     return decision
 

--- a/src/app/services/startup_policy.py
+++ b/src/app/services/startup_policy.py
@@ -61,6 +61,9 @@ def evaluate_startup_readiness() -> StartupReadinessEvaluation:
 
     findings.extend(_caller_identity_findings())
     findings.extend(_provider_protection_findings())
+    # Explicit operator weakenings of promoted protections, captured at
+    # settings construction (issue #233): override wins, but never silently.
+    findings.extend(settings.promoted_protection_overrides)
 
     return _evaluation_for(findings)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         "artifact_object_store_root": settings.artifact_object_store_root,
         "startup_readiness_policy": settings.startup_readiness_policy,
         "readiness_probe_policy": settings.readiness_probe_policy,
+        "caller_jwt_max_lifetime_seconds": settings.caller_jwt_max_lifetime_seconds,
         "local_header_caller_identity_enabled": settings.local_header_caller_identity_enabled,
         "caller_trust_mode": settings.caller_trust_mode,
         "caller_jwt_issuer": settings.caller_jwt_issuer,

--- a/tests/support/caller_credentials.py
+++ b/tests/support/caller_credentials.py
@@ -40,7 +40,9 @@ def mint_caller_credential(
     audience: str = TEST_AUDIENCE,
     expires_in_seconds: int = 300,
     extra_claims: dict[str, Any] | None = None,
+    omit_claims: tuple[str, ...] = (),
     algorithm: str = "EdDSA",
+    token_type: str | None = "JWT",
 ) -> str:
     now = time.time()
     payload: dict[str, Any] = {
@@ -52,7 +54,11 @@ def mint_caller_credential(
     }
     if extra_claims:
         payload.update(extra_claims)
-    header = {"alg": algorithm, "typ": "JWT", "kid": key_id}
+    for claim in omit_claims:
+        payload.pop(claim, None)
+    header: dict[str, Any] = {"alg": algorithm, "kid": key_id}
+    if token_type is not None:
+        header["typ"] = token_type
     signing_input = f"{_b64url(header)}.{_b64url(payload)}"
     signature = signing_key.sign(signing_input.encode("ascii"))
     return f"{signing_input}.{_b64url_bytes(signature)}"

--- a/tests/unit/test_caller_credential_verification.py
+++ b/tests/unit/test_caller_credential_verification.py
@@ -281,7 +281,11 @@ def test_evaluation_condition_promoted_profile_end_to_end(tmp_path: Path) -> Non
         accepted = client.post(
             "/ai/tasks/execute",
             json=payload,
-            headers={"Authorization": _bearer(subject="lotus-manage")},
+            headers={
+                "Authorization": _bearer(
+                    subject="lotus-manage", extra_claims={"jti": "tok-149-e2e"}
+                )
+            },
         )
         assert accepted.status_code == 200
         assert accepted.json()["status"] == "COMPLETED"
@@ -293,6 +297,9 @@ def test_evaluation_condition_promoted_profile_end_to_end(tmp_path: Path) -> Non
     assert record.authorization.caller_identity_source == "verified_service_jwt"
     assert record.authorization.caller_identity_bound is True
     assert record.authorization.caller_credential_key_id == "platform_2026_08"
+    # The issuer-assigned token id rides the decision so a future revocation
+    # list can name exactly this token (issue #233).
+    assert record.authorization.caller_credential_token_id == "tok-149-e2e"
 
 
 def test_public_key_parsing_rejects_each_malformation() -> None:
@@ -341,3 +348,73 @@ def test_startup_findings_cover_the_caller_trust_posture() -> None:
     # Header mode outside promoted carries none either.
     settings.caller_trust_mode = "header"
     assert not [f for f in evaluate_startup_readiness().findings if "caller identity" in f]
+
+
+def test_credential_lifetime_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #233: a leaked token must not replay for an issuer-chosen
+    unbounded lifetime. The accepted window (exp - iat) is bounded by
+    configuration; with iat required and never in the future, that also
+    bounds the remaining lifetime."""
+
+    _verified_mode_settings()
+
+    # The exact boundary is accepted; one second past it is not.
+    at_limit = _resolve_authenticated_caller(
+        x_caller_app=None, authorization=_bearer(expires_in_seconds=3600)
+    )
+    assert at_limit.caller_app == "lotus-advise"
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_caller_credential(_bearer(expires_in_seconds=3601))
+    _assert_credential_invalid(exc_info)
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert "lifetime exceeds" in detail["detail"]
+
+
+def test_missing_future_and_non_numeric_issued_at_are_rejected() -> None:
+    _verified_mode_settings()
+    import time as _time
+
+    for overrides in (
+        {"omit_claims": ("iat",)},
+        {"extra_claims": {"iat": "yesterday"}},
+        {"extra_claims": {"iat": int(_time.time()) + 600}},
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            verify_caller_credential(_bearer(**overrides))
+        _assert_credential_invalid(exc_info)
+
+
+def test_credential_header_must_declare_typ_jwt() -> None:
+    _verified_mode_settings()
+    for token_type in (None, "JOSE"):
+        with pytest.raises(HTTPException) as exc_info:
+            verify_caller_credential(_bearer(token_type=token_type))
+        _assert_credential_invalid(exc_info)
+        detail = exc_info.value.detail
+        assert isinstance(detail, dict)
+        assert "typ JWT" in detail["detail"]
+
+
+def test_token_id_is_carried_when_present_and_validated() -> None:
+    """An optional jti is verified in shape, carried on the identity, and
+    absent stays honestly None - the future revocation surface (issue #233)."""
+
+    _verified_mode_settings()
+
+    with_jti = verify_caller_credential(_bearer(extra_claims={"jti": "tok-42"}))
+    assert with_jti.token_id == "tok-42"
+
+    without_jti = verify_caller_credential(_bearer())
+    assert without_jti.token_id is None
+
+    for bad_jti in ("", "   ", 123, "x" * 129):
+        with pytest.raises(HTTPException) as exc_info:
+            verify_caller_credential(_bearer(extra_claims={"jti": bad_jti}))
+        _assert_credential_invalid(exc_info)
+
+    caller = _resolve_authenticated_caller(
+        x_caller_app=None, authorization=_bearer(extra_claims={"jti": "tok-77"})
+    )
+    assert caller.credential_token_id == "tok-77"

--- a/tests/unit/test_runtime_profile.py
+++ b/tests/unit/test_runtime_profile.py
@@ -1,5 +1,7 @@
 """Runtime profile derives protection defaults (issue #153, S2)."""
 
+import pytest
+
 from app.config import PROMOTED_PROFILE_DEFAULTS, Settings, settings
 from app.services.startup_policy import _provider_protection_findings
 
@@ -75,3 +77,58 @@ def test_local_profile_and_stub_mode_produce_no_protection_findings() -> None:
         "workflow-pack admission store: per-process memory leases cannot bound "
         "queue admission across replicas in the promoted profile"
     ]
+
+
+def test_explicitly_weakened_protections_are_captured_loudly() -> None:
+    """Issue #233: explicit override still wins, but never silently - every
+    protection field explicitly weaker than the promoted default is captured
+    at construction, where model_fields_set is authoritative."""
+
+    weakened = Settings(
+        runtime_profile="promoted",
+        startup_readiness_policy="warn",
+        provider_operations_store_mode="memory",
+        live_text_budget_enforced=False,
+    )
+    captured = weakened.promoted_protection_overrides
+    assert len(captured) == 3
+    assert any("startup_readiness_policy" in finding for finding in captured)
+    assert any("provider_operations_store_mode" in finding for finding in captured)
+    assert any("live_text_budget_enforced" in finding for finding in captured)
+    assert all("explicitly weakened" in finding for finding in captured)
+
+    # An explicit value EQUAL to the promoted default is not a weakening, a
+    # weakened tuning value is not a protection override, and outside the
+    # promoted profile nothing is captured.
+    assert (
+        Settings(
+            runtime_profile="promoted",
+            startup_readiness_policy="enforce",
+            provider_retry_limit=0,
+        ).promoted_protection_overrides
+        == []
+    )
+    assert Settings(runtime_profile="local").promoted_protection_overrides == []
+
+
+def test_startup_readiness_surfaces_promoted_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The captured overrides ride the startup findings, so a weakened
+    startup policy is loud even though - by the operator's own choice - it
+    no longer blocks."""
+
+    from app.services.startup_policy import evaluate_startup_readiness
+
+    monkeypatch.setattr(
+        settings,
+        "_promoted_protection_overrides",
+        [
+            "promoted override: startup_readiness_policy is explicitly weakened to "
+            "'warn' (promoted default 'enforce'); this protection is operator-overridden"
+        ],
+    )
+
+    evaluation = evaluate_startup_readiness()
+
+    assert any("promoted override: startup_readiness_policy" in f for f in evaluation.findings)


### PR DESCRIPTION
Closes #233 — both findings from the #149/#153 adversarial review, exactly as accepted.

## 1 · Credential hardening: a leaked token's blast radius is now bounded

The verifier accepted an issuer-chosen validity window and ignored `iat`/`typ`/`jti`. Now:

- **`iat` required** (numeric) and never in the future.
- **Lifetime bounded**: `exp − iat` must not exceed `LOTUS_AI_CALLER_JWT_MAX_LIFETIME_SECONDS` (default 3600). With `iat` required and not in the future, bounding the issued window also bounds the remaining window (`exp − now`) — the second bound follows mathematically rather than being dead code; stated in the verifier comment. The exact boundary is accepted, one second past it refused (both pinned — bands never break on their edge).
- **`typ` must declare `JWT`** — missing or different refuses.
- **Optional `jti` accepted and validated** (non-empty string, ≤128 chars), carried as `credential_token_id` on the authenticated caller and **stamped on the authorization decision** beside the key id — so a future revocation list can name exactly this token, and the audit trail already records it end-to-end (proven by extending the existing promoted-profile e2e: the audit record now asserts `caller_credential_token_id`).

Every failure stays a bounded 401 `CALLER_CREDENTIAL_INVALID` with no header-trust fallback, unchanged.

## 2 · Promoted overrides are loud

The promoted profile fills only fields the operator did not set — explicit choices win, by design. But an explicit weakening (e.g. `LOTUS_AI_STARTUP_READINESS_POLICY=warn`) kept weaker posture with nothing naming it. Now every **protection** field explicitly weaker than its promoted default becomes a startup finding: the three enforcement flags, the two durable store modes, and both readiness policies (`PROMOTED_PROTECTION_FIELDS` — tuning values like retry limit and breaker thresholds deliberately excluded: a different threshold is a choice, not a disabled protection).

Explicitness is captured **at settings construction inside the promoted validator**, where `model_fields_set` is authoritative — not re-derived later from mutable global state (which the test harness legitimately pollutes). The captured findings ride the normal startup-readiness evaluation, so a weakened startup policy is loud in the logs and on the readiness surface even though — by the operator's own explicit choice — it no longer blocks.

## Evidence

Acceptance criteria verbatim: oversized-lifetime and missing-iat credentials rejected in tests (plus future-iat, non-numeric-iat, boundary-accepted, typ matrix, jti shape matrix); a promoted run with an explicitly weakened protection lists it as a finding (capture matrix: weakened protections listed, equal-to-default explicit values and weakened tuning values not listed, non-promoted empty; wiring proven through `evaluate_startup_readiness`). Full local gate: lint, typecheck, whole suite with coverage. New setting registered in the conftest snapshot. No schema changes.
