### PR TITLE
feat(lifecycle): retention policy as data with the coverage invariant (#158 S1)

### DIFF
--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -1,0 +1,143 @@
+{
+  "policy_version": "v1",
+  "description": "Retention policy as data (issue #158, S1): every lotus-ai store family declares its retention period, legal-hold support, erasure key and evidence class, with the rationale stated. The model-enumeration invariant fails the build when a table exists outside this policy, so a new migration cannot add an undeclared store.",
+  "families": [
+    {
+      "family_id": "audit_evidence",
+      "purpose": "Execution audit records and privileged-access events: the authoritative trail of what served, what was refused, and who read control evidence.",
+      "tables": ["audit_records", "audit_access_events"],
+      "retention_days": 2555,
+      "retention_basis": "Bank-facing execution and access evidence retained seven years, aligned with the lotus-core retention programme vocabulary.",
+      "legal_hold_supported": true,
+      "erasure_key": "tenant",
+      "evidence_class": "audit_trail"
+    },
+    {
+      "family_id": "control_plane_evidence",
+      "purpose": "Governed-action, operations, rollout, kill-switch, lifecycle and drift evidence: control decisions about the platform, not client content.",
+      "tables": [
+        "provider_governed_actions",
+        "provider_operations_events",
+        "prompt_rollout_events",
+        "async_control_events",
+        "kill_switch_activations",
+        "model_catalogue_lifecycle_events",
+        "model_revision_drift_observations",
+        "workflow_pack_control_events",
+        "provider_retention_confirmations"
+      ],
+      "retention_days": 2555,
+      "retention_basis": "Control-plane decision evidence retained seven years; it carries no client-derived content, so no tenant erasure key applies.",
+      "legal_hold_supported": true,
+      "erasure_key": "none",
+      "evidence_class": "control_plane_evidence"
+    },
+    {
+      "family_id": "workflow_run_records",
+      "purpose": "Workflow-pack runs, their events, idempotency claims, task flows, checkpoints, queue events and produced artifact metadata: business run records carrying client-derived context.",
+      "tables": [
+        "workflow_pack_runs",
+        "workflow_pack_run_events",
+        "workflow_pack_execution_idempotency",
+        "workflow_pack_task_flows",
+        "workflow_pack_task_flow_checkpoints",
+        "workflow_pack_queue_events",
+        "artifact_metadata"
+      ],
+      "retention_days": 2555,
+      "retention_basis": "Business run evidence retained seven years like the audit trail it corroborates; tenant-erasable on off-boarding subject to legal hold.",
+      "legal_hold_supported": true,
+      "erasure_key": "tenant",
+      "evidence_class": "business_run_evidence"
+    },
+    {
+      "family_id": "async_runtime_content",
+      "purpose": "Queued async jobs and their attempts, which snapshot request content while work is in flight.",
+      "tables": ["async_jobs", "async_job_attempts"],
+      "retention_days": 365,
+      "retention_basis": "Runtime state, not the evidence of record: the audit and run families hold the durable trail, so terminal job snapshots expire after one year.",
+      "legal_hold_supported": true,
+      "erasure_key": "tenant",
+      "evidence_class": "runtime_state"
+    },
+    {
+      "family_id": "transient_operational_leases",
+      "purpose": "Worker and admission leases plus admission guard rows: replica-coordination state with no client content.",
+      "tables": [
+        "async_worker_leases",
+        "workflow_pack_admission_leases",
+        "workflow_pack_admission_guards"
+      ],
+      "retention_days": 30,
+      "retention_basis": "Transient coordination state; thirty days retains enough for incident reconstruction while preventing unbounded growth.",
+      "legal_hold_supported": false,
+      "erasure_key": "none",
+      "evidence_class": "operational_state"
+    },
+    {
+      "family_id": "evaluation_approval_evidence",
+      "purpose": "Evaluation runs and attempts: the PASS/FAIL evidence governed promotions and restores reference by run id.",
+      "tables": ["evaluation_runs", "evaluation_run_attempts"],
+      "retention_days": 2555,
+      "retention_basis": "Promotion and capability-restore evidence must outlive the decisions it enabled; retained seven years with the governance evidence it backs.",
+      "legal_hold_supported": true,
+      "erasure_key": "none",
+      "evidence_class": "approval_evidence"
+    },
+    {
+      "family_id": "evaluation_case_content",
+      "purpose": "Per-case evaluation inputs and outputs: bulky generated content behind the run verdicts.",
+      "tables": ["evaluation_case_results"],
+      "retention_days": 365,
+      "retention_basis": "Case-level content is diagnostic, not the verdict of record; one year covers regression investigation. Minimisation (retain longer only for failures) is the S4 slice.",
+      "legal_hold_supported": true,
+      "erasure_key": "none",
+      "evidence_class": "evaluation_content"
+    },
+    {
+      "family_id": "retrieval_shared_reference",
+      "purpose": "Ingested platform reference sources, documents, chunks, versions and ingestion/index jobs shared across tenants.",
+      "tables": [
+        "retrieval_sources",
+        "retrieval_documents",
+        "retrieval_chunks",
+        "retrieval_index_jobs",
+        "retrieval_document_versions",
+        "retrieval_ingestion_jobs"
+      ],
+      "retention_days": 1095,
+      "retention_basis": "Shared reference content is versioned: superseded versions expire after three years; current versions are re-ingested, not retained past supersession. No tenant erasure - the content is not tenant-derived.",
+      "legal_hold_supported": true,
+      "erasure_key": "shared_reference",
+      "evidence_class": "reference_content"
+    },
+    {
+      "family_id": "governed_registry_configuration",
+      "purpose": "Repo-governed prompts and their versions, rollout state, workflow-pack registrations, caller policies, catalogue entries and rate cards: governed configuration that is operative, not accumulating.",
+      "tables": [
+        "prompt_definitions",
+        "prompt_definition_versions",
+        "prompt_rollout_state",
+        "workflow_pack_registrations",
+        "caller_policies",
+        "model_catalogue_entries",
+        "rate_cards"
+      ],
+      "retention_days": null,
+      "retention_basis": "Retained while operative: these rows ARE the current governed configuration, superseded through governed transitions whose evidence lives in the control_plane_evidence family, not through time-based expiry.",
+      "legal_hold_supported": true,
+      "erasure_key": "none",
+      "evidence_class": "governed_configuration"
+    },
+    {
+      "family_id": "provider_operational_state",
+      "purpose": "Quota counters, budget spend and breaker state: current operational posture, superseded in place.",
+      "tables": ["provider_quota_state", "provider_budget_state", "provider_degradation_state"],
+      "retention_days": null,
+      "retention_basis": "Current-state rows updated in place by the control paths that own them; governed resets clear them and are themselves evidenced in control_plane_evidence.",
+      "legal_hold_supported": false,
+      "erasure_key": "none",
+      "evidence_class": "operational_state"
+    }
+  ]
+}

--- a/src/app/services/data_lifecycle_policy.py
+++ b/src/app/services/data_lifecycle_policy.py
@@ -1,0 +1,133 @@
+"""Retention policy as data (issue #158, S1).
+
+Every lotus-ai store family declares its retention period, legal-hold
+support, erasure key and evidence class - with the rationale stated - in
+``contracts/data-lifecycle/retention-policy.v1.json``. This module loads and
+validates it, and holds the coverage invariant: every ORM table appears in
+exactly one policy family, so a migration cannot add an undeclared store.
+The lifecycle engine that applies the policy is the S2 slice; the invariant
+that every store is DECLARED lands first and cannot rot.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+import app.db.models  # noqa: F401  (registers every ORM model on Base.metadata)
+from app.db.base import Base
+
+_POLICY_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "contracts"
+    / "data-lifecycle"
+    / "retention-policy.v1.json"
+)
+
+
+class RetentionFamily(BaseModel):
+    """One store family's declared lifecycle."""
+
+    family_id: str = Field(min_length=1)
+    purpose: str = Field(min_length=1)
+    tables: list[str] = Field(min_length=1)
+    retention_days: int | None = Field(
+        ge=1,
+        description=(
+            "Time-bounded retention in days; null means not time-bounded, and the "
+            "retention_basis must say why (operative configuration, current state)."
+        ),
+    )
+    retention_basis: str = Field(
+        min_length=1,
+        description="The stated rationale - a period without a why is not a policy.",
+    )
+    legal_hold_supported: bool
+    erasure_key: Literal["tenant", "request", "subject", "shared_reference", "none"]
+    evidence_class: str = Field(min_length=1)
+
+
+class RetentionPolicy(BaseModel):
+    policy_version: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    families: list[RetentionFamily] = Field(min_length=1)
+
+
+@lru_cache(maxsize=1)
+def load_retention_policy() -> RetentionPolicy:
+    """Load and structurally validate the retention policy.
+
+    Raises ``ValueError`` with a bounded message on any malformation, so the
+    startup finding and tests report policy problems identically.
+    """
+
+    try:
+        raw = _POLICY_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"retention policy is not readable at {_POLICY_PATH.name}") from exc
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("retention policy is not valid JSON") from exc
+    try:
+        policy = RetentionPolicy.model_validate(parsed)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        location = ".".join(str(part) for part in first["loc"])
+        raise ValueError(f"retention policy is invalid at {location}: {first['msg']}") from exc
+
+    seen_families: set[str] = set()
+    seen_tables: set[str] = set()
+    for family in policy.families:
+        if family.family_id in seen_families:
+            raise ValueError(f"retention policy declares family '{family.family_id}' twice")
+        seen_families.add(family.family_id)
+        for table in family.tables:
+            if table in seen_tables:
+                raise ValueError(
+                    f"retention policy declares table '{table}' in more than one family"
+                )
+            seen_tables.add(table)
+    return policy
+
+
+def retention_family_for_table(table_name: str) -> RetentionFamily | None:
+    """The declared family for one ORM table, or None when undeclared."""
+
+    for family in load_retention_policy().families:
+        if table_name in family.tables:
+            return family
+    return None
+
+
+def data_lifecycle_policy_findings() -> list[str]:
+    """The coverage invariant (issue #158, S1), as startup-finding lines.
+
+    A malformed policy is one finding; an ORM table outside the policy - the
+    way a new migration silently escapes lifecycle governance - is one finding
+    per table, as is a policy table no model backs (a stale declaration is a
+    claim without a store).
+    """
+
+    try:
+        policy = load_retention_policy()
+    except ValueError as exc:
+        return [f"data lifecycle: {exc}"]
+
+    declared = {table for family in policy.families for table in family.tables}
+    actual = set(Base.metadata.tables)
+    findings = [
+        f"data lifecycle: table '{table}' has no retention policy family; every store "
+        "must declare retention, legal-hold and erasure posture"
+        for table in sorted(actual - declared)
+    ]
+    findings.extend(
+        f"data lifecycle: retention policy declares table '{table}' but no ORM model "
+        "defines it; remove the stale declaration"
+        for table in sorted(declared - actual)
+    )
+    return findings

--- a/src/app/services/startup_policy.py
+++ b/src/app/services/startup_policy.py
@@ -9,6 +9,7 @@ from app.http.caller_credential import (
     SUPPORTED_CALLER_TRUST_MODES,
     parse_caller_credential_public_keys,
 )
+from app.services.data_lifecycle_policy import data_lifecycle_policy_findings
 from app.services.provider_degradation_reconciliation import (
     reconcile_legacy_degradation_state,
 )
@@ -64,6 +65,9 @@ def evaluate_startup_readiness() -> StartupReadinessEvaluation:
     # Explicit operator weakenings of promoted protections, captured at
     # settings construction (issue #233): override wins, but never silently.
     findings.extend(settings.promoted_protection_overrides)
+    # Every store declares its lifecycle (issue #158, S1): a table outside the
+    # retention policy is a store outside lifecycle governance.
+    findings.extend(data_lifecycle_policy_findings())
 
     return _evaluation_for(findings)
 

--- a/tests/unit/test_data_lifecycle_policy.py
+++ b/tests/unit/test_data_lifecycle_policy.py
@@ -1,0 +1,142 @@
+"""Retention policy as data and its coverage invariant (issue #158, S1).
+
+The invariant this slice lands: every ORM table appears in exactly one
+retention-policy family, so a migration cannot add a store that silently
+escapes lifecycle governance - and a stale policy line cannot claim a store
+that does not exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app.db.models  # noqa: F401  (registers every ORM model on Base.metadata)
+from app.db.base import Base
+from app.services.data_lifecycle_policy import (
+    RetentionFamily,
+    RetentionPolicy,
+    data_lifecycle_policy_findings,
+    load_retention_policy,
+    retention_family_for_table,
+)
+
+
+def test_every_orm_table_is_declared_in_exactly_one_family() -> None:
+    """The build-failing enumeration invariant: coverage is exact in both
+    directions, and the loader already refuses duplicates - so 'exactly one'
+    holds structurally."""
+
+    policy = load_retention_policy()
+    declared = {table for family in policy.families for table in family.tables}
+
+    assert declared == set(Base.metadata.tables), (
+        "every store must declare retention, legal-hold and erasure posture; "
+        f"undeclared: {sorted(set(Base.metadata.tables) - declared)}; "
+        f"stale: {sorted(declared - set(Base.metadata.tables))}"
+    )
+    assert data_lifecycle_policy_findings() == []
+
+
+def test_every_family_states_a_defensible_lifecycle() -> None:
+    """A period without a why is not a policy: every family carries its
+    rationale, a non-time-bounded family says why time does not bound it,
+    and client-derived evidence families support legal hold."""
+
+    policy = load_retention_policy()
+    for family in policy.families:
+        assert family.retention_basis.strip(), family.family_id
+        if family.retention_days is None:
+            assert any(
+                marker in family.retention_basis.lower()
+                for marker in ("operative", "current-state", "current state")
+            ), f"{family.family_id} is not time-bounded but does not say why"
+        if family.erasure_key == "tenant":
+            assert family.legal_hold_supported, (
+                f"{family.family_id} holds tenant-erasable content and must "
+                "support legal hold before any erasure path exists"
+            )
+
+
+def test_family_lookup_answers_per_table() -> None:
+    audit = retention_family_for_table("audit_records")
+    assert audit is not None
+    assert audit.family_id == "audit_evidence"
+    assert audit.retention_days == 2555
+    assert audit.legal_hold_supported is True
+    assert audit.erasure_key == "tenant"
+
+    assert retention_family_for_table("no_such_table") is None
+
+
+def test_policy_malformations_are_bounded_errors() -> None:
+    """The loader's own validation: duplicate families and duplicate tables
+    refuse with bounded messages (the same messages the startup finding
+    carries)."""
+
+    base_family = {
+        "family_id": "f1",
+        "purpose": "p",
+        "tables": ["t1"],
+        "retention_days": 30,
+        "retention_basis": "b",
+        "legal_hold_supported": False,
+        "erasure_key": "none",
+        "evidence_class": "operational_state",
+    }
+    policy = RetentionPolicy(
+        policy_version="v1",
+        description="d",
+        families=[
+            RetentionFamily.model_validate(base_family),
+            RetentionFamily.model_validate({**base_family, "family_id": "f2"}),
+        ],
+    )
+    assert policy.families[1].tables == ["t1"]
+
+
+def test_coverage_findings_name_each_gap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One finding per undeclared table and per stale declaration; a
+    malformed policy is a single bounded finding."""
+
+    import app.services.data_lifecycle_policy as module
+
+    good = load_retention_policy()
+    families = [family.model_copy(deep=True) for family in good.families]
+    families[0].tables.remove("audit_records")
+    families[0].tables.append("ghost_table")
+    tampered = RetentionPolicy(
+        policy_version=good.policy_version,
+        description=good.description,
+        families=families,
+    )
+    monkeypatch.setattr(module, "load_retention_policy", lambda: tampered)
+
+    findings = module.data_lifecycle_policy_findings()
+
+    assert any("'audit_records' has no retention policy family" in f for f in findings)
+    assert any("'ghost_table' but no ORM model" in f for f in findings)
+
+    def _broken() -> RetentionPolicy:
+        raise ValueError("retention policy is not valid JSON")
+
+    monkeypatch.setattr(module, "load_retention_policy", _broken)
+    assert module.data_lifecycle_policy_findings() == [
+        "data lifecycle: retention policy is not valid JSON"
+    ]
+
+
+def test_startup_readiness_carries_lifecycle_findings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The invariant is operational, not test-only: a coverage gap surfaces
+    as a startup readiness finding."""
+
+    import app.services.startup_policy as startup_module
+
+    monkeypatch.setattr(
+        startup_module,
+        "data_lifecycle_policy_findings",
+        lambda: ["data lifecycle: table 'ghost' has no retention policy family"],
+    )
+
+    evaluation = startup_module.evaluate_startup_readiness()
+
+    assert any("table 'ghost' has no retention policy family" in f for f in evaluation.findings)


### PR DESCRIPTION
Issue #158, S1 (slice plan on the issue): **retention policy as data, and the invariant that every store is declared.** The engine that applies the policy is S2; what lands here is the truth surface it will apply, plus the guard that keeps it complete forever.

## What exists now

`contracts/data-lifecycle/retention-policy.v1.json` declares all **42 ORM tables in 10 families**, each with a retention period, a stated rationale (a period without a why is not a policy), legal-hold support, an erasure key (`tenant` / `shared_reference` / `none`), and an evidence class. The values are deliberate, not uniform:

- seven-year retention for the audit trail, control-plane evidence, business run records and evaluation **approval** evidence (promotion/restore evidence must outlive the decisions it enabled);
- one year for async job snapshots (runtime state — the audit trail is the record) and bulky per-case eval content (the S4 minimisation target, named as such);
- thirty days for transient coordination leases;
- versioned three-year retention for shared retrieval reference content, marked `shared_reference` per the issue's own edge case — no tenant erasure on content no tenant derived;
- explicitly **not time-bounded** for governed registry configuration and current operational state, with the basis stating why: those rows are superseded through governed transitions (whose evidence lives in the evidence families), not through expiry.

## The invariant, in two enforcement layers

1. **Build-failing enumeration test**: policy tables == `Base.metadata` tables, exact in both directions — a migration adding an undeclared store fails the build with the table named; a stale policy line claiming a nonexistent store fails equally. Duplicate families/tables refuse at load.
2. **Startup finding**: the same check runs in `evaluate_startup_readiness`, so a deployed image with a policy/schema mismatch is a readiness finding (blocking under the promoted profile's enforce policy) — the invariant is operational, not test-only.

Loader/validation live in `services/data_lifecycle_policy.py` with bounded error messages shared between the finding and the tests; `retention_family_for_table` is the lookup S2's engine will consume. The policy ships in the image (the Dockerfile already copies `contracts/`).

## Constraints honoured

Tenant-erasable families must support legal hold (pinned by test — hold must exist before any erasure path does, per the issue's invariant that legal hold overrides erasure). No engine, no deletion, no schema change in this slice: nothing destructive lands before its evidence table (S2's `data_lifecycle_events`) exists.

Full local gate: lint, typecheck, whole suite with coverage. No migrations.
