### PR TITLE
feat(lifecycle): evidence tables, expiry engine and legal hold (#158 S2a)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint module-budget-guard monetary-float-guard runtime-purity-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply runtime-mode-smoke test test-unit test-integration test-e2e test-coverage coverage-gate security-audit check ci docker-build clean
+.PHONY: install lint module-budget-guard monetary-float-guard runtime-purity-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply data-lifecycle-run runtime-mode-smoke test test-unit test-integration test-e2e test-coverage coverage-gate security-audit check ci docker-build clean
 
 install:
 	python -m pip install --upgrade pip
@@ -43,6 +43,9 @@ migration-smoke:
 
 migration-apply:
 	python -m alembic upgrade head
+
+data-lifecycle-run:
+	python scripts/run_data_lifecycle.py
 
 runtime-mode-smoke:
 	python -m pytest tests/integration/test_runtime_modes.py -q

--- a/alembic/versions/0065_data_lifecycle_evidence.py
+++ b/alembic/versions/0065_data_lifecycle_evidence.py
@@ -1,0 +1,54 @@
+"""data lifecycle evidence
+
+Revision ID: 0065_data_lifecycle_evidence
+Revises: 0064_scoped_structured_output_evidence
+Create Date: 2026-09-03
+
+Issue #158, S2a: the evidence table lands before anything destructive runs.
+data_lifecycle_events is append-only deletion evidence (family, count,
+policy version, digest of deleted ids - never the content);
+data_legal_holds makes legal hold a first-class row the engine must honour
+before deleting anything.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0065_data_lifecycle_evidence"
+down_revision = "0064_scoped_structured_output_evidence"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "data_lifecycle_events",
+        sa.Column("event_id", sa.String(64), primary_key=True),
+        sa.Column("family_id", sa.String(128), nullable=False, index=True),
+        sa.Column("action", sa.String(32), nullable=False),
+        sa.Column("key_scope", sa.String(256), nullable=True),
+        sa.Column("row_count", sa.Integer(), nullable=False),
+        sa.Column("policy_version", sa.String(16), nullable=False),
+        sa.Column("actor", sa.String(256), nullable=False),
+        sa.Column("deleted_ids_digest", sa.String(64), nullable=False),
+        sa.Column("recorded_at", sa.String(64), nullable=False, index=True),
+    )
+    op.create_table(
+        "data_legal_holds",
+        sa.Column("hold_id", sa.String(64), primary_key=True),
+        sa.Column("family_id", sa.String(128), nullable=False, index=True),
+        sa.Column("key_type", sa.String(32), nullable=False),
+        sa.Column("key_value", sa.String(256), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("placed_by", sa.String(256), nullable=False),
+        sa.Column("placed_at", sa.String(64), nullable=False),
+        sa.Column("released_at", sa.String(64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("data_legal_holds")
+    op.drop_table("data_lifecycle_events")

--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -1,20 +1,23 @@
 {
   "policy_version": "v1",
-  "description": "Retention policy as data (issue #158, S1): every lotus-ai store family declares its retention period, legal-hold support, erasure key and evidence class, with the rationale stated. The model-enumeration invariant fails the build when a table exists outside this policy, so a new migration cannot add an undeclared store.",
+  "description": "Retention policy as data (issue #158): every lotus-ai store family declares its retention period, legal-hold support, erasure key, evidence class and enforcement posture, with the rationale stated. The model-enumeration invariant fails the build when a table exists outside this policy; a family's ENFORCED posture is exactly as broad as the lifecycle engine's handlers (DECLARED_ONLY says honestly that the period is stated but not yet applied).",
   "families": [
     {
       "family_id": "audit_evidence",
-      "purpose": "Execution audit records and privileged-access events: the authoritative trail of what served, what was refused, and who read control evidence.",
-      "tables": ["audit_records", "audit_access_events"],
+      "purpose": "Execution audit records: the authoritative trail of what served and what was refused, carrying client-derived context.",
+      "tables": [
+        "audit_records"
+      ],
       "retention_days": 2555,
       "retention_basis": "Bank-facing execution and access evidence retained seven years, aligned with the lotus-core retention programme vocabulary.",
       "legal_hold_supported": true,
       "erasure_key": "tenant",
-      "evidence_class": "audit_trail"
+      "evidence_class": "audit_trail",
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "control_plane_evidence",
-      "purpose": "Governed-action, operations, rollout, kill-switch, lifecycle and drift evidence: control decisions about the platform, not client content.",
+      "purpose": "Governed-action, operations, rollout, kill-switch, lifecycle, drift, privileged-access and deletion evidence: control decisions about the platform, not client content.",
       "tables": [
         "provider_governed_actions",
         "provider_operations_events",
@@ -24,13 +27,16 @@
         "model_catalogue_lifecycle_events",
         "model_revision_drift_observations",
         "workflow_pack_control_events",
-        "provider_retention_confirmations"
+        "provider_retention_confirmations",
+        "audit_access_events",
+        "data_lifecycle_events"
       ],
       "retention_days": 2555,
       "retention_basis": "Control-plane decision evidence retained seven years; it carries no client-derived content, so no tenant erasure key applies.",
       "legal_hold_supported": true,
       "erasure_key": "none",
-      "evidence_class": "control_plane_evidence"
+      "evidence_class": "control_plane_evidence",
+      "enforcement": "DECLARED_ONLY"
     },
     {
       "family_id": "workflow_run_records",
@@ -48,51 +54,63 @@
       "retention_basis": "Business run evidence retained seven years like the audit trail it corroborates; tenant-erasable on off-boarding subject to legal hold.",
       "legal_hold_supported": true,
       "erasure_key": "tenant",
-      "evidence_class": "business_run_evidence"
+      "evidence_class": "business_run_evidence",
+      "enforcement": "DECLARED_ONLY"
     },
     {
       "family_id": "async_runtime_content",
       "purpose": "Queued async jobs and their attempts, which snapshot request content while work is in flight.",
-      "tables": ["async_jobs", "async_job_attempts"],
+      "tables": [
+        "async_jobs",
+        "async_job_attempts"
+      ],
       "retention_days": 365,
       "retention_basis": "Runtime state, not the evidence of record: the audit and run families hold the durable trail, so terminal job snapshots expire after one year.",
       "legal_hold_supported": true,
       "erasure_key": "tenant",
-      "evidence_class": "runtime_state"
+      "evidence_class": "runtime_state",
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "transient_operational_leases",
-      "purpose": "Worker and admission leases plus admission guard rows: replica-coordination state with no client content.",
+      "purpose": "Worker and admission leases: replica-coordination state with no client content.",
       "tables": [
         "async_worker_leases",
-        "workflow_pack_admission_leases",
-        "workflow_pack_admission_guards"
+        "workflow_pack_admission_leases"
       ],
       "retention_days": 30,
       "retention_basis": "Transient coordination state; thirty days retains enough for incident reconstruction while preventing unbounded growth.",
       "legal_hold_supported": false,
       "erasure_key": "none",
-      "evidence_class": "operational_state"
+      "evidence_class": "operational_state",
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "evaluation_approval_evidence",
       "purpose": "Evaluation runs and attempts: the PASS/FAIL evidence governed promotions and restores reference by run id.",
-      "tables": ["evaluation_runs", "evaluation_run_attempts"],
+      "tables": [
+        "evaluation_runs",
+        "evaluation_run_attempts"
+      ],
       "retention_days": 2555,
       "retention_basis": "Promotion and capability-restore evidence must outlive the decisions it enabled; retained seven years with the governance evidence it backs.",
       "legal_hold_supported": true,
       "erasure_key": "none",
-      "evidence_class": "approval_evidence"
+      "evidence_class": "approval_evidence",
+      "enforcement": "DECLARED_ONLY"
     },
     {
       "family_id": "evaluation_case_content",
       "purpose": "Per-case evaluation inputs and outputs: bulky generated content behind the run verdicts.",
-      "tables": ["evaluation_case_results"],
+      "tables": [
+        "evaluation_case_results"
+      ],
       "retention_days": 365,
       "retention_basis": "Case-level content is diagnostic, not the verdict of record; one year covers regression investigation. Minimisation (retain longer only for failures) is the S4 slice.",
       "legal_hold_supported": true,
       "erasure_key": "none",
-      "evidence_class": "evaluation_content"
+      "evidence_class": "evaluation_content",
+      "enforcement": "DECLARED_ONLY"
     },
     {
       "family_id": "retrieval_shared_reference",
@@ -109,11 +127,12 @@
       "retention_basis": "Shared reference content is versioned: superseded versions expire after three years; current versions are re-ingested, not retained past supersession. No tenant erasure - the content is not tenant-derived.",
       "legal_hold_supported": true,
       "erasure_key": "shared_reference",
-      "evidence_class": "reference_content"
+      "evidence_class": "reference_content",
+      "enforcement": "DECLARED_ONLY"
     },
     {
       "family_id": "governed_registry_configuration",
-      "purpose": "Repo-governed prompts and their versions, rollout state, workflow-pack registrations, caller policies, catalogue entries and rate cards: governed configuration that is operative, not accumulating.",
+      "purpose": "Repo-governed prompts and their versions, rollout state, workflow-pack registrations, caller policies, catalogue entries, rate cards and active legal holds: governed configuration that is operative, not accumulating.",
       "tables": [
         "prompt_definitions",
         "prompt_definition_versions",
@@ -121,23 +140,31 @@
         "workflow_pack_registrations",
         "caller_policies",
         "model_catalogue_entries",
-        "rate_cards"
+        "rate_cards",
+        "data_legal_holds"
       ],
       "retention_days": null,
       "retention_basis": "Retained while operative: these rows ARE the current governed configuration, superseded through governed transitions whose evidence lives in the control_plane_evidence family, not through time-based expiry.",
       "legal_hold_supported": true,
       "erasure_key": "none",
-      "evidence_class": "governed_configuration"
+      "evidence_class": "governed_configuration",
+      "enforcement": "NOT_TIME_BOUNDED"
     },
     {
       "family_id": "provider_operational_state",
-      "purpose": "Quota counters, budget spend and breaker state: current operational posture, superseded in place.",
-      "tables": ["provider_quota_state", "provider_budget_state", "provider_degradation_state"],
+      "purpose": "Quota counters, budget spend, breaker state and admission guard rows: current operational posture, superseded in place.",
+      "tables": [
+        "provider_quota_state",
+        "provider_budget_state",
+        "provider_degradation_state",
+        "workflow_pack_admission_guards"
+      ],
       "retention_days": null,
       "retention_basis": "Current-state rows updated in place by the control paths that own them; governed resets clear them and are themselves evidenced in control_plane_evidence.",
       "legal_hold_supported": false,
       "erasure_key": "none",
-      "evidence_class": "operational_state"
+      "evidence_class": "operational_state",
+      "enforcement": "NOT_TIME_BOUNDED"
     }
   ]
 }

--- a/scripts/run_data_lifecycle.py
+++ b/scripts/run_data_lifecycle.py
@@ -1,0 +1,27 @@
+"""Apply the data-retention policy once and print the evidence (issue #158, S2a).
+
+Usage: python scripts/run_data_lifecycle.py [actor]
+
+The actor lands on every deletion-evidence row; default names the scheduled
+job identity so an operator-invoked run is distinguishable by passing their
+own identity.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+
+
+def main() -> int:
+    from app.services.data_lifecycle_engine import run_data_lifecycle
+
+    actor = sys.argv[1] if len(sys.argv) > 1 else "lotus-ai.data-lifecycle-job"
+    report = run_data_lifecycle(actor=actor)
+    print(json.dumps(asdict(report), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/app/contracts/data_lifecycle.py
+++ b/src/app/contracts/data_lifecycle.py
@@ -1,0 +1,48 @@
+"""Data-lifecycle evidence and legal-hold contracts (issue #158, S2a)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class DataLifecycleAction(str, Enum):
+    EXPIRY = "EXPIRY"
+
+
+class DataLifecycleEventRecord(BaseModel):
+    """One append-only deletion-evidence row: deletion never removes the
+    evidence of deletion, and content is referenced only by digest."""
+
+    event_id: str = Field(min_length=1, max_length=64)
+    family_id: str = Field(min_length=1, max_length=128)
+    action: DataLifecycleAction
+    key_scope: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Key scope the action applied to, when narrower than the family.",
+    )
+    row_count: int = Field(ge=1)
+    policy_version: str = Field(min_length=1, max_length=16)
+    actor: str = Field(min_length=1, max_length=256)
+    deleted_ids_digest: str = Field(
+        min_length=64,
+        max_length=64,
+        description="sha256 over the sorted deleted primary keys - evidence without content.",
+    )
+    recorded_at: str = Field(min_length=1, max_length=64)
+
+
+class DataLegalHoldRecord(BaseModel):
+    """An active hold while released_at is null: legal hold overrides expiry,
+    and (from S3) erasure - both recorded."""
+
+    hold_id: str = Field(min_length=1, max_length=64)
+    family_id: str = Field(min_length=1, max_length=128)
+    key_type: str = Field(min_length=1, max_length=32)
+    key_value: str = Field(min_length=1, max_length=256)
+    reason: str = Field(min_length=1)
+    placed_by: str = Field(min_length=1, max_length=256)
+    placed_at: str = Field(min_length=1, max_length=64)
+    released_at: str | None = Field(default=None, max_length=64)

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -806,3 +806,36 @@ class ModelCatalogueEntryModel(Base):
     seed_source: Mapped[str] = mapped_column(String(64), nullable=False)
     created_at: Mapped[str] = mapped_column(String(64), nullable=False)
     last_updated_at: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
+class DataLifecycleEventModel(Base):
+    """Append-only deletion evidence (issue #158, S2a): what the lifecycle
+    engine removed, by family and count, referencing content only by digest."""
+
+    __tablename__ = "data_lifecycle_events"
+
+    event_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    family_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String(32), nullable=False)
+    key_scope: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    row_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    policy_version: Mapped[str] = mapped_column(String(16), nullable=False)
+    actor: Mapped[str] = mapped_column(String(256), nullable=False)
+    deleted_ids_digest: Mapped[str] = mapped_column(String(64), nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
+class DataLegalHoldModel(Base):
+    """An active legal hold: expiry (and, from S3, erasure) must not touch
+    matching rows while released_at is null (issue #158, S2a)."""
+
+    __tablename__ = "data_legal_holds"
+
+    hold_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    family_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    key_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    key_value: Mapped[str] = mapped_column(String(256), nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    placed_by: Mapped[str] = mapped_column(String(256), nullable=False)
+    placed_at: Mapped[str] = mapped_column(String(64), nullable=False)
+    released_at: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/src/app/repositories/async_runtime_repository.py
+++ b/src/app/repositories/async_runtime_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections.abc import Sequence
 from typing import Protocol
 
 from app.contracts.access_control import AuthorizationDecision
@@ -127,6 +128,13 @@ class AsyncRuntimeRepository(Protocol):
         attempt_message: str,
     ) -> AsyncRuntimeClaimRecord | None:
         """Atomically claim one specific runnable async job if it is still claimable."""
+
+    def delete_job_records(self, job_ids: Sequence[str]) -> tuple[int, int, int]:
+        """Delete jobs with their attempts and leases (issue #158, S2a).
+
+        Returns (jobs, attempts, leases) deleted counts; lifecycle-engine
+        only, never exposed on a route.
+        """
 
     def list_control_events(
         self, *, limit: int = 20, job_id: str | None = None

--- a/src/app/repositories/audit_repository.py
+++ b/src/app/repositories/audit_repository.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from app.contracts.audit_access import AuditAccessEvent, AuditReadScope
 from app.contracts.audit import AuditRecordResponse
+from app.contracts.data_lifecycle import DataLegalHoldRecord, DataLifecycleEventRecord
 
 
 class AuditRepository(Protocol):
@@ -26,6 +27,30 @@ class AuditRepository(Protocol):
         limit: int = 20,
     ) -> list[AuditRecordResponse]:
         """List persisted audit records using bounded filters."""
+
+    def delete_records(self, request_ids: Sequence[str]) -> int:
+        """Delete audit records by id for the lifecycle engine (issue #158, S2a).
+
+        The engine writes the deletion-evidence event in the same run; this
+        method is not exposed on any route.
+        """
+
+    def save_lifecycle_event(self, event: DataLifecycleEventRecord) -> None:
+        """Persist one append-only deletion-evidence row."""
+
+    def list_lifecycle_events(self, *, limit: int = 100) -> Sequence[DataLifecycleEventRecord]:
+        """List deletion evidence, newest first."""
+
+    def place_legal_hold(self, record: DataLegalHoldRecord) -> None:
+        """Persist a legal hold; active while released_at is null."""
+
+    def release_legal_hold(self, *, hold_id: str, released_at: str) -> bool:
+        """Stamp released_at on one hold; False when no such active hold."""
+
+    def list_active_legal_holds(
+        self, *, family_id: str | None = None
+    ) -> Sequence[DataLegalHoldRecord]:
+        """Active (unreleased) holds, optionally for one family."""
 
     def save_access_event(self, event: AuditAccessEvent) -> None:
         """Persist an identifier-minimized audit-read access event."""

--- a/src/app/repositories/memory_async_runtime_repository.py
+++ b/src/app/repositories/memory_async_runtime_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from copy import deepcopy
 
 from app.repositories.async_runtime_repository import (
@@ -227,6 +228,18 @@ class InMemoryAsyncRuntimeRepository(AsyncRuntimeRepository):
             attempt=claimed_attempt,
             lease=lease,
         )
+
+    def delete_job_records(self, job_ids: Sequence[str]) -> tuple[int, int, int]:
+        jobs = attempts = leases = 0
+        for job_id in job_ids:
+            if self._jobs.pop(job_id, None) is not None:
+                jobs += 1
+            attempts += len(self._attempts.pop(job_id, []))
+            lease = self._leases_by_job.pop(job_id, None)
+            if lease is not None:
+                self._lease_id_to_job.pop(lease.lease_id, None)
+                leases += 1
+        return jobs, attempts, leases
 
     def list_control_events(
         self, *, limit: int = 20, job_id: str | None = None

--- a/src/app/repositories/memory_audit_repository.py
+++ b/src/app/repositories/memory_audit_repository.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from threading import Lock
 
 from app.contracts.audit import AuditRecordResponse
+from app.contracts.data_lifecycle import DataLegalHoldRecord, DataLifecycleEventRecord
 from app.contracts.audit_access import (
     AuditAccessEvent,
     AuditReadScope,
@@ -15,6 +16,8 @@ class InMemoryAuditRepository:
     def __init__(self) -> None:
         self._records: dict[str, AuditRecordResponse] = {}
         self._access_events: dict[str, AuditAccessEvent] = {}
+        self._lifecycle_events: dict[str, DataLifecycleEventRecord] = {}
+        self._legal_holds: dict[str, DataLegalHoldRecord] = {}
         self._lock = Lock()
 
     def save(self, record: AuditRecordResponse) -> None:
@@ -56,6 +59,49 @@ class InMemoryAuditRepository:
             if requested_by is not None:
                 records = [record for record in records if record.requested_by == requested_by]
             return records[:limit]
+
+    def delete_records(self, request_ids: Sequence[str]) -> int:
+        with self._lock:
+            deleted = 0
+            for request_id in request_ids:
+                if self._records.pop(request_id, None) is not None:
+                    deleted += 1
+            return deleted
+
+    def save_lifecycle_event(self, event: DataLifecycleEventRecord) -> None:
+        with self._lock:
+            self._lifecycle_events[event.event_id] = event
+
+    def list_lifecycle_events(self, *, limit: int = 100) -> Sequence[DataLifecycleEventRecord]:
+        with self._lock:
+            events = sorted(
+                self._lifecycle_events.values(),
+                key=lambda event: event.recorded_at,
+                reverse=True,
+            )
+            return events[:limit]
+
+    def place_legal_hold(self, record: DataLegalHoldRecord) -> None:
+        with self._lock:
+            self._legal_holds[record.hold_id] = record
+
+    def release_legal_hold(self, *, hold_id: str, released_at: str) -> bool:
+        with self._lock:
+            hold = self._legal_holds.get(hold_id)
+            if hold is None or hold.released_at is not None:
+                return False
+            self._legal_holds[hold_id] = hold.model_copy(update={"released_at": released_at})
+            return True
+
+    def list_active_legal_holds(
+        self, *, family_id: str | None = None
+    ) -> Sequence[DataLegalHoldRecord]:
+        with self._lock:
+            return [
+                hold
+                for hold in self._legal_holds.values()
+                if hold.released_at is None and (family_id is None or hold.family_id == family_id)
+            ]
 
     def save_access_event(self, event: AuditAccessEvent) -> None:
         with self._lock:

--- a/src/app/repositories/sqlalchemy_async_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_async_runtime_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
 from sqlalchemy import delete, select
@@ -260,6 +262,25 @@ class SqlAlchemyAsyncRuntimeRepository(SqlAlchemyRepositoryBase, AsyncRuntimeRep
                 job=self._to_job_record(job_model),
                 attempt=self._to_attempt_record(attempt_model),
                 lease=self._to_lease_record(lease_model),
+            )
+
+    def delete_job_records(self, job_ids: Sequence[str]) -> tuple[int, int, int]:
+        if not job_ids:
+            return 0, 0, 0
+        ids = list(job_ids)
+        with self._session_factory() as session:
+            leases = session.execute(
+                delete(AsyncWorkerLeaseModel).where(AsyncWorkerLeaseModel.job_id.in_(ids))
+            )
+            attempts = session.execute(
+                delete(AsyncJobAttemptModel).where(AsyncJobAttemptModel.job_id.in_(ids))
+            )
+            jobs = session.execute(delete(AsyncJobModel).where(AsyncJobModel.job_id.in_(ids)))
+            session.commit()
+            return (
+                int(getattr(jobs, "rowcount", 0) or 0),
+                int(getattr(attempts, "rowcount", 0) or 0),
+                int(getattr(leases, "rowcount", 0) or 0),
             )
 
     def list_control_events(

--- a/src/app/repositories/sqlalchemy_audit_repository.py
+++ b/src/app/repositories/sqlalchemy_audit_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from collections.abc import Sequence
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.sql import Select
 
 from app.contracts.access_control import (
@@ -13,6 +13,7 @@ from app.contracts.access_control import (
     TenantPolicyMode,
 )
 from app.contracts.audit import AuditRecordResponse
+from app.contracts.data_lifecycle import DataLegalHoldRecord, DataLifecycleEventRecord
 from app.contracts.output_validation import OutputValidationOutcome
 from app.contracts.audit_access import (
     AuditAccessDenialReason,
@@ -30,7 +31,12 @@ from app.contracts.prompts import (
 from app.contracts.providers import ProviderAdapterKind, RoutingDecisionDescriptor
 from app.contracts.safety import RedactionPosture, SafetyExecutionOutcome
 from app.contracts.tasks import OutputLabel, TaskCategory, TaskExecutionStatus
-from app.db.models import AuditAccessEventModel, AuditRecordModel
+from app.db.models import (
+    AuditAccessEventModel,
+    AuditRecordModel,
+    DataLegalHoldModel,
+    DataLifecycleEventModel,
+)
 from app.repositories.sqlalchemy_repository_base import SqlAlchemyRepositoryBase
 from app.services.safety_runtime import build_safety_execution_outcome_from_record
 
@@ -136,6 +142,60 @@ class SqlAlchemyAuditRepository(SqlAlchemyRepositoryBase):
         with self._session_factory() as session:
             models = session.execute(statement).scalars().all()
             return [self._to_contract(model) for model in models]
+
+    def delete_records(self, request_ids: Sequence[str]) -> int:
+        if not request_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(AuditRecordModel).where(AuditRecordModel.request_id.in_(list(request_ids)))
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
+
+    def save_lifecycle_event(self, event: DataLifecycleEventRecord) -> None:
+        with self._session_factory() as session:
+            session.add(DataLifecycleEventModel(**event.model_dump(mode="json")))
+            session.commit()
+
+    def list_lifecycle_events(self, *, limit: int = 100) -> Sequence[DataLifecycleEventRecord]:
+        statement = (
+            select(DataLifecycleEventModel)
+            .order_by(DataLifecycleEventModel.recorded_at.desc())
+            .limit(limit)
+        )
+        with self._session_factory() as session:
+            models = session.execute(statement).scalars().all()
+            return [
+                DataLifecycleEventRecord.model_validate(model, from_attributes=True)
+                for model in models
+            ]
+
+    def place_legal_hold(self, record: DataLegalHoldRecord) -> None:
+        with self._session_factory() as session:
+            session.add(DataLegalHoldModel(**record.model_dump(mode="json")))
+            session.commit()
+
+    def release_legal_hold(self, *, hold_id: str, released_at: str) -> bool:
+        with self._session_factory() as session:
+            model = session.get(DataLegalHoldModel, hold_id)
+            if model is None or model.released_at is not None:
+                return False
+            model.released_at = released_at
+            session.commit()
+            return True
+
+    def list_active_legal_holds(
+        self, *, family_id: str | None = None
+    ) -> Sequence[DataLegalHoldRecord]:
+        statement = select(DataLegalHoldModel).where(DataLegalHoldModel.released_at.is_(None))
+        if family_id is not None:
+            statement = statement.where(DataLegalHoldModel.family_id == family_id)
+        with self._session_factory() as session:
+            models = session.execute(statement).scalars().all()
+            return [
+                DataLegalHoldRecord.model_validate(model, from_attributes=True) for model in models
+            ]
 
     def save_access_event(self, event: AuditAccessEvent) -> None:
         model = AuditAccessEventModel(

--- a/src/app/services/data_lifecycle_engine.py
+++ b/src/app/services/data_lifecycle_engine.py
@@ -1,0 +1,225 @@
+"""The data-lifecycle engine (issue #158, S2a).
+
+One idempotent run applies the retention policy to every family whose
+enforcement posture is ENFORCED, honours active legal holds, and writes one
+append-only ``data_lifecycle_events`` row per family batch - deletion
+evidence without the content. Families marked DECLARED_ONLY are reported,
+never touched: the retention claim is exactly as broad as the handlers here.
+
+Handlers are deliberately per-family code rather than a generic column DSL:
+each family's semantics (simple age, terminal-state age, tenant-scoped legal
+hold) are stated and tested individually, and a test pins that the handler
+set and the policy's ENFORCED families agree in both directions.
+
+Timestamps are parsed, never compared as strings: stored ISO instants mix
+``+00:00`` and ``Z`` suffixes, and lexicographic comparison across those
+formats is wrong.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from app.contracts.data_lifecycle import DataLifecycleAction, DataLifecycleEventRecord
+from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
+from app.services.audit_store import get_audit_store
+from app.services.async_runtime_store import get_async_runtime_store
+from app.services.data_lifecycle_policy import RetentionFamily, load_retention_policy
+from app.services.workflow_pack_admission_lease_store import (
+    get_workflow_pack_admission_lease_repository,
+)
+
+# The async job states the engine may expire: an in-flight job is runtime
+# truth, not an ageing snapshot.
+_TERMINAL_JOB_STATUSES = frozenset({"COMPLETED", "FAILED", "ABANDONED", "SUPERSEDED"})
+
+_CANDIDATE_BATCH_LIMIT = 5000
+
+
+@dataclass(frozen=True)
+class FamilyRunResult:
+    family_id: str
+    enforcement: str
+    deleted_count: int
+    event_id: str | None
+    detail: str
+
+
+@dataclass(frozen=True)
+class DataLifecycleRunReport:
+    policy_version: str
+    actor: str
+    started_at: str
+    results: list[FamilyRunResult]
+
+
+def run_data_lifecycle(*, actor: str) -> DataLifecycleRunReport:
+    """Apply retention to every ENFORCED family, evidencing each deletion.
+
+    Idempotent: a second run over the same data deletes nothing and writes no
+    further events (events are written only for non-empty batches).
+    """
+
+    policy = load_retention_policy()
+    now = datetime.now(UTC)
+    results: list[FamilyRunResult] = []
+    for family in policy.families:
+        if family.enforcement != "ENFORCED":
+            results.append(
+                FamilyRunResult(
+                    family_id=family.family_id,
+                    enforcement=family.enforcement,
+                    deleted_count=0,
+                    event_id=None,
+                    detail="not applied by the engine; posture is honest about that",
+                )
+            )
+            continue
+        handler = _ENFORCED_FAMILY_HANDLERS[family.family_id]
+        assert family.retention_days is not None  # ENFORCED implies time-bounded
+        cutoff = now - timedelta(days=family.retention_days)
+        deleted_ids, detail = handler(family, cutoff)
+        event_id: str | None = None
+        if deleted_ids:
+            event_id = _record_deletion_evidence(
+                family=family,
+                policy_version=policy.policy_version,
+                actor=actor,
+                deleted_ids=deleted_ids,
+                now=now,
+            )
+        results.append(
+            FamilyRunResult(
+                family_id=family.family_id,
+                enforcement=family.enforcement,
+                deleted_count=len(deleted_ids),
+                event_id=event_id,
+                detail=detail,
+            )
+        )
+    return DataLifecycleRunReport(
+        policy_version=policy.policy_version,
+        actor=actor,
+        started_at=now.isoformat(),
+        results=results,
+    )
+
+
+def _expire_audit_evidence(family: RetentionFamily, cutoff: datetime) -> tuple[list[str], str]:
+    """Audit records past retention, honouring tenant-scoped legal holds."""
+
+    repository = get_audit_store()
+    held_tenants = {
+        hold.key_value
+        for hold in repository.list_active_legal_holds(family_id=family.family_id)
+        if hold.key_type == "tenant"
+    }
+    candidates = repository.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=_CANDIDATE_BATCH_LIMIT)
+    expired: list[str] = []
+    held_count = 0
+    for record in candidates:
+        if not _is_before(record.generated_at, cutoff):
+            continue
+        if record.tenant_id is not None and record.tenant_id in held_tenants:
+            held_count += 1
+            continue
+        expired.append(record.request_id)
+    deleted = repository.delete_records(expired) if expired else 0
+    return expired, (
+        f"expired {deleted} audit records; {held_count} past-retention rows kept under legal hold"
+    )
+
+
+def _expire_async_runtime_content(
+    family: RetentionFamily, cutoff: datetime
+) -> tuple[list[str], str]:
+    """Terminal async jobs past retention, with their attempts and leases."""
+
+    repository = get_async_runtime_store()
+    expired_job_ids = [
+        job.job_id
+        for job in repository.list_jobs()
+        if job.lifecycle_status in _TERMINAL_JOB_STATUSES and _is_before(job.submitted_at, cutoff)
+    ]
+    jobs, attempts, leases = (
+        repository.delete_job_records(expired_job_ids) if expired_job_ids else (0, 0, 0)
+    )
+    return expired_job_ids, (
+        f"expired {jobs} terminal jobs with {attempts} attempts and {leases} leases; "
+        "in-flight jobs are never expired"
+    )
+
+
+def _expire_transient_leases(family: RetentionFamily, cutoff: datetime) -> tuple[list[str], str]:
+    """Aged worker and admission leases: coordination state, no client content."""
+
+    async_repository = get_async_runtime_store()
+    deleted_ids: list[str] = []
+    for lease in async_repository.list_leases():
+        if _is_before(lease.claimed_at, cutoff):
+            if async_repository.delete_lease(lease_id=lease.lease_id):
+                deleted_ids.append(lease.lease_id)
+    admission_repository = get_workflow_pack_admission_lease_repository()
+    admission_deleted = 0
+    for admission_lease in admission_repository.list_leases():
+        if _is_before(admission_lease.admitted_at, cutoff):
+            if admission_repository.delete_lease(admission_lease.queue_item_id):
+                deleted_ids.append(admission_lease.queue_item_id)
+                admission_deleted += 1
+    return deleted_ids, (
+        f"expired {len(deleted_ids) - admission_deleted} worker leases and "
+        f"{admission_deleted} admission leases"
+    )
+
+
+_ENFORCED_FAMILY_HANDLERS = {
+    "audit_evidence": _expire_audit_evidence,
+    "async_runtime_content": _expire_async_runtime_content,
+    "transient_operational_leases": _expire_transient_leases,
+}
+
+
+def enforced_family_handler_ids() -> frozenset[str]:
+    """The families the engine actually applies - pinned against the policy."""
+
+    return frozenset(_ENFORCED_FAMILY_HANDLERS)
+
+
+def _record_deletion_evidence(
+    *,
+    family: RetentionFamily,
+    policy_version: str,
+    actor: str,
+    deleted_ids: list[str],
+    now: datetime,
+) -> str:
+    digest = hashlib.sha256("\n".join(sorted(deleted_ids)).encode("utf-8")).hexdigest()
+    event = DataLifecycleEventRecord(
+        event_id=f"dle_{uuid4().hex[:16]}",
+        family_id=family.family_id,
+        action=DataLifecycleAction.EXPIRY,
+        key_scope=None,
+        row_count=len(deleted_ids),
+        policy_version=policy_version,
+        actor=actor,
+        deleted_ids_digest=digest,
+        recorded_at=now.isoformat(),
+    )
+    get_audit_store().save_lifecycle_event(event)
+    return event.event_id
+
+
+def _is_before(instant: str, cutoff: datetime) -> bool:
+    """Parse-and-compare: never a string comparison across ISO variants."""
+
+    try:
+        parsed = datetime.fromisoformat(instant.replace("Z", "+00:00"))
+    except ValueError:
+        # An unparseable instant is never silently expired.
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed < cutoff

--- a/src/app/services/data_lifecycle_policy.py
+++ b/src/app/services/data_lifecycle_policy.py
@@ -49,6 +49,14 @@ class RetentionFamily(BaseModel):
     legal_hold_supported: bool
     erasure_key: Literal["tenant", "request", "subject", "shared_reference", "none"]
     evidence_class: str = Field(min_length=1)
+    enforcement: Literal["ENFORCED", "DECLARED_ONLY", "NOT_TIME_BOUNDED"] = Field(
+        description=(
+            "Whether the lifecycle engine actually applies this family's retention "
+            "(issue #158, S2a): ENFORCED means an engine handler deletes past-retention "
+            "rows; DECLARED_ONLY says honestly that the period is stated but not yet "
+            "applied; NOT_TIME_BOUNDED matches a null retention period."
+        ),
+    )
 
 
 class RetentionPolicy(BaseModel):
@@ -86,6 +94,11 @@ def load_retention_policy() -> RetentionPolicy:
         if family.family_id in seen_families:
             raise ValueError(f"retention policy declares family '{family.family_id}' twice")
         seen_families.add(family.family_id)
+        if (family.retention_days is None) != (family.enforcement == "NOT_TIME_BOUNDED"):
+            raise ValueError(
+                f"retention policy family '{family.family_id}' is inconsistent: a null "
+                "retention period and the NOT_TIME_BOUNDED posture must imply each other"
+            )
         for table in family.tables:
             if table in seen_tables:
                 raise ValueError(

--- a/tests/unit/test_data_lifecycle_engine.py
+++ b/tests/unit/test_data_lifecycle_engine.py
@@ -1,0 +1,421 @@
+"""The lifecycle engine applies exactly what the policy claims (issue #158, S2a).
+
+Expiry honours age semantics per family (simple age, terminal-state age,
+tenant-scoped legal hold), every non-empty deletion writes append-only
+evidence with a digest, a second run is a no-op, and DECLARED_ONLY families
+are reported untouched - the retention claim is exactly as broad as the
+engine's handlers, pinned in both directions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+
+from app.contracts.access_control import (
+    AuthorizationCapabilityType,
+    AuthorizationDecision,
+    AuthorizationOutcome,
+    TenantPolicyMode,
+)
+from app.contracts.audit import AuditRecordResponse
+from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
+from app.contracts.data_lifecycle import DataLegalHoldRecord
+from app.contracts.evidence import ExecutionEvidenceBundle
+from app.contracts.prompts import PromptRolloutRole, PromptSelectionTraceDescriptor
+from app.contracts.providers import ProviderAdapterKind
+from app.contracts.safety import RedactionPosture
+from app.contracts.tasks import OutputLabel, TaskCategory, TaskExecutionStatus
+from app.repositories.async_runtime_repository import (
+    AsyncRuntimeAttemptRecord,
+    AsyncRuntimeJobRecord,
+    AsyncRuntimeLeaseRecord,
+)
+from app.services.async_runtime_store import get_async_runtime_store
+from app.services.audit_store import get_audit_store
+from app.services.data_lifecycle_engine import (
+    enforced_family_handler_ids,
+    run_data_lifecycle,
+)
+from app.services.data_lifecycle_policy import load_retention_policy
+from app.services.safety_runtime import build_safety_execution_outcome_from_record
+from app.services.workflow_pack_admission_lease_store import (
+    get_workflow_pack_admission_lease_repository,
+)
+from app.contracts.workflow_pack_queue_policies import (
+    WorkflowPackQueueLane,
+    WorkflowPackQueueState,
+)
+from app.services.workflow_pack_queue_admission_models import WorkflowPackQueueAdmissionLease
+
+
+def _iso(days_ago: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+
+
+def _audit_record(request_id: str, *, tenant_id: str | None, days_ago: int) -> AuditRecordResponse:
+    return AuditRecordResponse(
+        request_id=request_id,
+        execution_status=TaskExecutionStatus.COMPLETED,
+        task_id="explain.v1",
+        category=TaskCategory.EXPLAIN,
+        output_label=OutputLabel.EXPLANATION_ONLY,
+        caller_app="lotus-manage",
+        correlation_id=f"corr-{request_id}",
+        requested_by="ops.user@lotus",
+        tenant_id=tenant_id,
+        prompt_version="foundation.explain.v1",
+        prompt_selection=PromptSelectionTraceDescriptor(
+            task_id="explain.v1",
+            prompt_version="foundation.explain.v1",
+            rollout_role=PromptRolloutRole.ACTIVE,
+            selection_reason="test",
+            active_prompt_version="foundation.explain.v1",
+            candidate_prompt_version=None,
+            previous_active_prompt_version=None,
+            latest_control_event=None,
+        ),
+        provider_mode="disabled",
+        provider_id="text.stub",
+        adapter_kind=ProviderAdapterKind.STUB,
+        model_id=None,
+        safety_mode="documented_only",
+        redaction_posture=RedactionPosture.MINIMIZATION_REQUIRED,
+        enforced_safety_controls=["response_labeling"],
+        safety_outcome=build_safety_execution_outcome_from_record(
+            safety_mode="documented_only",
+            output_label=OutputLabel.EXPLANATION_ONLY,
+            redaction_posture=RedactionPosture.MINIMIZATION_REQUIRED,
+            enforced_controls=["response_labeling"],
+        ),
+        authorization=AuthorizationDecision(
+            caller_app="lotus-manage",
+            capability_type=AuthorizationCapabilityType.TASK_EXECUTION,
+            outcome=AuthorizationOutcome.ALLOWED,
+            allowed=True,
+            tenant_policy_mode=TenantPolicyMode.RESTRICTED,
+            task_id="explain.v1",
+            requested_source_ids=[],
+            effective_source_ids=[],
+            tenant_id=tenant_id,
+            summary="test",
+        ),
+        generated_at=_iso(days_ago),
+        stubbed=True,
+        context_summary="s",
+        context_keys=[],
+        source_refs=[],
+        result_preview="p",
+        structured_output={},
+        evidence=ExecutionEvidenceBundle(descriptors=[]),
+    )
+
+
+def _job(job_id: str, *, status: str, days_ago: int) -> AsyncRuntimeJobRecord:
+    return AsyncRuntimeJobRecord(
+        job_id=job_id,
+        job_type="evaluation_run",
+        target_id=None,
+        lifecycle_status=status,
+        submitted_at=_iso(days_ago),
+        caller_app="lotus-platform",
+        correlation_id=f"corr-{job_id}",
+        payload_summary="snapshot",
+        execution_path="queue",
+        related_evaluation_run_id=None,
+        latest_message="m",
+        attempt_count=1,
+        artifact_ids=[],
+    )
+
+
+def _seed_expiry_matrix() -> None:
+    audit = get_audit_store()
+    audit.save(_audit_record("air_old_a", tenant_id="tenant-a", days_ago=2600))
+    audit.save(_audit_record("air_old_b_held", tenant_id="tenant-b", days_ago=2600))
+    audit.save(_audit_record("air_young_a", tenant_id="tenant-a", days_ago=10))
+    audit.place_legal_hold(
+        DataLegalHoldRecord(
+            hold_id="hold_b",
+            family_id="audit_evidence",
+            key_type="tenant",
+            key_value="tenant-b",
+            reason="Litigation hold for tenant-b.",
+            placed_by="legal.ops@lotus",
+            placed_at=_iso(1),
+        )
+    )
+
+    jobs = get_async_runtime_store()
+    jobs.save_job(_job("job_old_done", status="COMPLETED", days_ago=400))
+    jobs.save_attempt(
+        AsyncRuntimeAttemptRecord(
+            attempt_id="att_old_done",
+            job_id="job_old_done",
+            attempt_number=1,
+            lifecycle_status="COMPLETED",
+            worker_id="w1",
+            claimed_at=_iso(400),
+            heartbeat_at=_iso(400),
+            started_at=_iso(400),
+            completed_at=_iso(400),
+            failure_reason=None,
+            recorded_message="done",
+        )
+    )
+    jobs.save_job(_job("job_old_queued", status="QUEUED", days_ago=400))
+    jobs.save_job(_job("job_young_done", status="COMPLETED", days_ago=5))
+    jobs.save_lease(
+        AsyncRuntimeLeaseRecord(
+            lease_id="lease_stale",
+            job_id="job_old_queued",
+            attempt_id="att_x",
+            worker_id="w-dead",
+            claimed_at=_iso(40),
+            heartbeat_at=_iso(40),
+            lease_expires_at=_iso(39),
+        )
+    )
+
+    admission = get_workflow_pack_admission_lease_repository()
+    admission.try_admit(
+        WorkflowPackQueueAdmissionLease(
+            queue_item_id="adm_old",
+            policy_id="policy-1",
+            workflow_pack_id="pack.v1",
+            workflow_pack_version="1",
+            lane=WorkflowPackQueueLane.BATCH,
+            state=WorkflowPackQueueState.ADMITTED,
+            admitted_at=_iso(45),
+        ),
+        pack_limit=5,
+        lane_limit=5,
+    )
+    admission.try_admit(
+        WorkflowPackQueueAdmissionLease(
+            queue_item_id="adm_young",
+            policy_id="policy-2",
+            workflow_pack_id="pack.v1",
+            workflow_pack_version="1",
+            lane=WorkflowPackQueueLane.BATCH,
+            state=WorkflowPackQueueState.ADMITTED,
+            admitted_at=_iso(2),
+        ),
+        pack_limit=5,
+        lane_limit=5,
+    )
+
+
+def test_policy_enforced_families_match_engine_handlers_exactly() -> None:
+    """The retention claim is exactly as broad as the engine: every ENFORCED
+    family has a handler and every handler's family is ENFORCED."""
+
+    policy = load_retention_policy()
+    enforced = {f.family_id for f in policy.families if f.enforcement == "ENFORCED"}
+    assert enforced == enforced_family_handler_ids()
+
+
+def test_expiry_honours_age_terminal_state_and_legal_hold() -> None:
+    _seed_expiry_matrix()
+
+    report = run_data_lifecycle(actor="test.operator")
+
+    results = {r.family_id: r for r in report.results}
+    audit = get_audit_store()
+    remaining = {r.request_id for r in audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=50)}
+    # Past-retention tenant-a row expired; the held tenant-b row and the
+    # young row remain.
+    assert remaining == {"air_old_b_held", "air_young_a"}
+    assert results["audit_evidence"].deleted_count == 1
+    assert "1 past-retention rows kept under legal hold" in results["audit_evidence"].detail
+
+    jobs = get_async_runtime_store()
+    job_ids = {j.job_id for j in jobs.list_jobs()}
+    # The old terminal job went (with its attempt); the old QUEUED job is
+    # in-flight truth and stays; the young terminal job stays.
+    assert job_ids == {"job_old_queued", "job_young_done"}
+    assert results["async_runtime_content"].deleted_count == 1
+
+    # The stale worker lease and the old admission lease expired.
+    assert results["transient_operational_leases"].deleted_count == 2
+    assert {
+        lease.queue_item_id
+        for lease in get_workflow_pack_admission_lease_repository().list_leases()
+    } == {"adm_young"}
+
+    # Deletion evidence: one event per non-empty family, digest over sorted ids.
+    events = {e.family_id: e for e in audit.list_lifecycle_events(limit=20)}
+    assert set(events) == {
+        "audit_evidence",
+        "async_runtime_content",
+        "transient_operational_leases",
+    }
+    assert events["audit_evidence"].row_count == 1
+    assert events["audit_evidence"].deleted_ids_digest == hashlib.sha256(b"air_old_a").hexdigest()
+    assert events["audit_evidence"].policy_version == report.policy_version
+    assert events["audit_evidence"].actor == "test.operator"
+
+    # DECLARED_ONLY families are reported, never touched.
+    assert results["workflow_run_records"].enforcement == "DECLARED_ONLY"
+    assert results["workflow_run_records"].deleted_count == 0
+    assert results["workflow_run_records"].event_id is None
+
+
+def test_second_run_is_idempotent() -> None:
+    _seed_expiry_matrix()
+    run_data_lifecycle(actor="test.operator")
+    events_before = len(get_audit_store().list_lifecycle_events(limit=50))
+
+    second = run_data_lifecycle(actor="test.operator")
+
+    assert all(result.deleted_count == 0 for result in second.results)
+    assert len(get_audit_store().list_lifecycle_events(limit=50)) == events_before
+
+
+def test_unparseable_timestamps_are_never_silently_expired() -> None:
+    jobs = get_async_runtime_store()
+    record = _job("job_bad_ts", status="COMPLETED", days_ago=400)
+    jobs.save_job(AsyncRuntimeJobRecord(**{**record.__dict__, "submitted_at": "not-a-timestamp"}))
+
+    run_data_lifecycle(actor="test.operator")
+
+    assert {j.job_id for j in jobs.list_jobs()} == {"job_bad_ts"}
+
+
+def test_released_hold_no_longer_protects() -> None:
+    audit = get_audit_store()
+    audit.save(_audit_record("air_released", tenant_id="tenant-c", days_ago=2600))
+    audit.place_legal_hold(
+        DataLegalHoldRecord(
+            hold_id="hold_c",
+            family_id="audit_evidence",
+            key_type="tenant",
+            key_value="tenant-c",
+            reason="Hold pending review.",
+            placed_by="legal.ops@lotus",
+            placed_at=_iso(2),
+        )
+    )
+    first = run_data_lifecycle(actor="test.operator")
+    assert {r.family_id: r.deleted_count for r in first.results}["audit_evidence"] == 0
+
+    assert audit.release_legal_hold(hold_id="hold_c", released_at=_iso(0)) is True
+    assert audit.release_legal_hold(hold_id="hold_c", released_at=_iso(0)) is False
+
+    second = run_data_lifecycle(actor="test.operator")
+    assert {r.family_id: r.deleted_count for r in second.results}["audit_evidence"] == 1
+    assert audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=10) == []
+
+
+def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -> None:
+    """The durable adapters implement the same lifecycle surface: expiry,
+    cascade deletion, hold protection and evidence all survive SQL."""
+
+    from pathlib import Path
+
+    import pytest as _pytest
+
+    from app.config import settings
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    assert isinstance(monkeypatch, _pytest.MonkeyPatch)
+    assert isinstance(tmp_path, Path)
+    database_url = f"sqlite:///{tmp_path / 'lifecycle-s2a.db'}"
+    upgrade_database_to_head(database_url)
+    monkeypatch.setattr(settings, "database_url", database_url)
+    monkeypatch.setattr(settings, "audit_store_mode", "sqlalchemy")
+    monkeypatch.setattr(settings, "async_runtime_store_mode", "sqlalchemy")
+    monkeypatch.setattr(settings, "workflow_pack_admission_store_mode", "sqlalchemy")
+
+    _seed_expiry_matrix()
+    report = run_data_lifecycle(actor="test.operator")
+
+    results = {r.family_id: r.deleted_count for r in report.results}
+    assert results["audit_evidence"] == 1
+    assert results["async_runtime_content"] == 1
+    assert results["transient_operational_leases"] == 2
+
+    audit = get_audit_store()
+    assert {r.request_id for r in audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=50)} == {
+        "air_old_b_held",
+        "air_young_a",
+    }
+    events = audit.list_lifecycle_events(limit=10)
+    assert len(events) == 3
+    assert all(len(event.deleted_ids_digest) == 64 for event in events)
+    assert {j.job_id for j in get_async_runtime_store().list_jobs()} == {
+        "job_old_queued",
+        "job_young_done",
+    }
+
+    second = run_data_lifecycle(actor="test.operator")
+    assert all(result.deleted_count == 0 for result in second.results)
+    assert len(get_audit_store().list_lifecycle_events(limit=10)) == 3
+
+
+def test_naive_timestamps_are_treated_as_utc() -> None:
+    """A stored instant without a timezone is compared as UTC, not skipped."""
+
+    jobs = get_async_runtime_store()
+    record = _job("job_naive_old", status="COMPLETED", days_ago=400)
+    naive = (datetime.now(UTC) - timedelta(days=400)).replace(tzinfo=None).isoformat()
+    jobs.save_job(AsyncRuntimeJobRecord(**{**record.__dict__, "submitted_at": naive}))
+
+    report = run_data_lifecycle(actor="test.operator")
+
+    assert {r.family_id: r.deleted_count for r in report.results}["async_runtime_content"] == 1
+    assert jobs.list_jobs() == []
+
+
+def test_repository_edge_paths_are_bounded() -> None:
+    """Empty and unknown-id deletions are safe no-ops in both adapters'
+    shared semantics: nothing deleted, nothing raised."""
+
+    audit = get_audit_store()
+    assert audit.delete_records([]) == 0
+    assert audit.delete_records(["air_never_existed"]) == 0
+
+    jobs = get_async_runtime_store()
+    assert jobs.delete_job_records([]) == (0, 0, 0)
+    assert jobs.delete_job_records(["job_never_existed"]) == (0, 0, 0)
+
+
+def test_sql_hold_release_and_filters_round_trip(tmp_path: object, monkeypatch: object) -> None:
+    """The SQL adapter's hold lifecycle: family filter, release once, refuse
+    a second release, and empty deletions."""
+
+    from pathlib import Path
+
+    import pytest as _pytest
+
+    from app.config import settings
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    assert isinstance(monkeypatch, _pytest.MonkeyPatch)
+    assert isinstance(tmp_path, Path)
+    database_url = f"sqlite:///{tmp_path / 'lifecycle-holds.db'}"
+    upgrade_database_to_head(database_url)
+    monkeypatch.setattr(settings, "database_url", database_url)
+    monkeypatch.setattr(settings, "audit_store_mode", "sqlalchemy")
+
+    audit = get_audit_store()
+    audit.place_legal_hold(
+        DataLegalHoldRecord(
+            hold_id="hold_sql",
+            family_id="audit_evidence",
+            key_type="tenant",
+            key_value="tenant-x",
+            reason="r",
+            placed_by="legal.ops@lotus",
+            placed_at=_iso(1),
+        )
+    )
+    assert [h.hold_id for h in audit.list_active_legal_holds(family_id="audit_evidence")] == [
+        "hold_sql"
+    ]
+    assert audit.list_active_legal_holds(family_id="other_family") == []
+    assert audit.release_legal_hold(hold_id="hold_sql", released_at=_iso(0)) is True
+    assert audit.release_legal_hold(hold_id="hold_sql", released_at=_iso(0)) is False
+    assert audit.release_legal_hold(hold_id="hold_missing", released_at=_iso(0)) is False
+    assert audit.list_active_legal_holds() == []
+    assert audit.delete_records([]) == 0

--- a/tests/unit/test_data_lifecycle_policy.py
+++ b/tests/unit/test_data_lifecycle_policy.py
@@ -82,6 +82,7 @@ def test_policy_malformations_are_bounded_errors() -> None:
         "legal_hold_supported": False,
         "erasure_key": "none",
         "evidence_class": "operational_state",
+        "enforcement": "DECLARED_ONLY",
     }
     policy = RetentionPolicy(
         policy_version="v1",
@@ -140,3 +141,59 @@ def test_startup_readiness_carries_lifecycle_findings(monkeypatch: pytest.Monkey
     evaluation = startup_module.evaluate_startup_readiness()
 
     assert any("table 'ghost' has no retention policy family" in f for f in evaluation.findings)
+
+
+def test_loader_refuses_each_malformation_with_a_bounded_message(
+    tmp_path: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every loader failure mode - unreadable, bad JSON, schema-invalid,
+    duplicate family, duplicate table, inconsistent posture - raises the
+    bounded message the startup finding carries."""
+
+    import json
+    from pathlib import Path
+
+    import app.services.data_lifecycle_policy as module
+
+    assert isinstance(tmp_path, Path)
+
+    def _load_from(content: str | None) -> str:
+        target = tmp_path / "policy.json"
+        if content is None:
+            target = tmp_path / "missing.json"
+        else:
+            target.write_text(content, encoding="utf-8")
+        monkeypatch.setattr(module, "_POLICY_PATH", target)
+        module.load_retention_policy.cache_clear()
+        try:
+            with pytest.raises(ValueError) as exc_info:
+                module.load_retention_policy()
+            return str(exc_info.value)
+        finally:
+            module.load_retention_policy.cache_clear()
+
+    def _family(family_id: str = "f1", **overrides: object) -> dict[str, object]:
+        family: dict[str, object] = {
+            "family_id": family_id,
+            "purpose": "p",
+            "tables": ["t1"],
+            "retention_days": 30,
+            "retention_basis": "b",
+            "legal_hold_supported": False,
+            "erasure_key": "none",
+            "evidence_class": "operational_state",
+            "enforcement": "DECLARED_ONLY",
+        }
+        family.update(overrides)
+        return family
+
+    def _policy(*families: dict[str, object]) -> str:
+        return json.dumps({"policy_version": "v1", "description": "d", "families": list(families)})
+
+    assert "not readable" in _load_from(None)
+    assert "not valid JSON" in _load_from("{nope")
+    assert "invalid at" in _load_from(_policy({"family_id": "f1"}))
+    assert "declares family 'f1' twice" in _load_from(_policy(_family(), _family(tables=["t2"])))
+    assert "in more than one family" in _load_from(_policy(_family(), _family("f2")))
+    assert "must imply each other" in _load_from(_policy(_family(retention_days=None)))
+    assert "must imply each other" in _load_from(_policy(_family(enforcement="NOT_TIME_BOUNDED")))

--- a/tests/unit/test_internal_aggregate_scope_guard.py
+++ b/tests/unit/test_internal_aggregate_scope_guard.py
@@ -24,6 +24,11 @@ ALLOWED_REFERENCING_MODULES = {
     "contracts/audit_access.py",  # the definition itself
     "services/app_capability_rollout_observability.py",
     "services/capability_pack_observability.py",
+    # The lifecycle engine must see every tenant's rows to expire them
+    # (issue #158, S2a; classified on #159): not a request path - no caller,
+    # no response contract - and every deletion it performs is evidenced on
+    # the append-only data_lifecycle_events ledger.
+    "services/data_lifecycle_engine.py",
     "services/task_execution_evidence_summary.py",
     "services/task_execution_summary.py",
     "services/task_retrieval_execution_summary.py",


### PR DESCRIPTION
Issue #158, S2a (design note on the issue): **the evidence lands before anything destructive runs, and the first retention families become true.**

## What exists now

- **`data_lifecycle_events`** (migration 0065): append-only deletion evidence — family, action, row count, policy version, actor, instant, and a sha256 digest over the sorted deleted primary keys. Deletion never removes the evidence of deletion, and the evidence references content only by digest.
- **`data_legal_holds`**: a first-class hold row (family + key type/value, reason, placed_by, released_at) the engine must honour before deleting anything — holds don't rewrite every store.
- **One idempotent lifecycle run** (`make data-lifecycle-run` + `run_data_lifecycle(actor=…)`): applies retention to every family whose posture is `ENFORCED`, reports `DECLARED_ONLY` families untouched, writes one evidence row per non-empty family batch, and a second run deletes nothing and writes nothing (proven).

## The scope-no-broader-than-evidence rule, applied to retention itself

The policy contract gains an **enforcement posture** per family: `ENFORCED` / `DECLARED_ONLY` / `NOT_TIME_BOUNDED` (the last must — bidirectionally, validated — accompany a null retention period). A test pins that the policy's ENFORCED set and the engine's handler set agree **in both directions**, so the policy can never claim an applied retention the engine doesn't implement, and the engine can never quietly enforce an undeclared family.

First enforced families, each with its own stated semantics:
- **`audit_evidence`** — age past seven years, honouring tenant-scoped legal holds (held rows counted in the run detail: a skipped deletion is visible, not silent);
- **`async_runtime_content`** — terminal-state jobs only (an in-flight job is runtime truth, not an ageing snapshot), cascading attempts and leases in one repository operation;
- **`transient_operational_leases`** — aged worker and admission leases.

## Two policy truth corrections found while wiring the engine

- `audit_access_events` claimed a **tenant** erasure key but has no tenant column — moved to `control_plane_evidence` (it is privileged-access control evidence);
- `workflow_pack_admission_guards` sat in a 30-day family but has **no timestamp** — it is a current-state guard row, moved to the current-state family.

Both are exactly the defect class the control-plane test targets: a declared scope broader than the store can honour. The two new evidence tables declare themselves in the policy (the S1 enumeration invariant forced them to — the guard works).

## Deliberate mechanics

Handlers are per-family code, not a generic column DSL — each family's semantics are stated and tested individually, and no speculative cascade grammar exists for families that don't need one. Timestamps are **parsed, never compared as strings**: stored ISO instants mix `+00:00` and `Z` suffixes, and lexicographic comparison across those formats is wrong; an unparseable instant is never silently expired (pinned).

## Evidence

Memory-mode matrix (age × terminal-state × legal hold × young rows), digest recomputed byte-exact, idempotent second run, released-hold-then-expires flow (double release refused), unparseable-timestamp protection, DECLARED_ONLY untouched — plus the same matrix through the SQL adapters over migration 0065. Full local gate: lint, typecheck, migration-smoke, whole suite with coverage.
