### PR TITLE
feat(lifecycle): the control-plane-evidence family becomes true (#158 S2b)

### DIFF
--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -36,7 +36,7 @@
       "legal_hold_supported": true,
       "erasure_key": "none",
       "evidence_class": "control_plane_evidence",
-      "enforcement": "DECLARED_ONLY"
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "workflow_run_records",

--- a/src/app/provider_retention_confirmations/memory_repository.py
+++ b/src/app/provider_retention_confirmations/memory_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from app.provider_retention_confirmations.repository import (
     ProviderRetentionConfirmationConflictError,
     ProviderRetentionConfirmationRecord,
@@ -21,6 +23,26 @@ class InMemoryProviderRetentionConfirmationRepository:
     ) -> ProviderRetentionConfirmationRecord | None:
         idempotency_key = self._idempotency_key_by_provider_ref.get(provider_confirmation_ref)
         return self._records.get(idempotency_key) if idempotency_key is not None else None
+
+    def list_confirmations(self, *, limit: int) -> list[ProviderRetentionConfirmationRecord]:
+        records = sorted(
+            self._records.values(),
+            key=lambda record: record.envelope.claims.issued_at_utc,
+            reverse=True,
+        )
+        return records[:limit]
+
+    def delete_confirmations(self, confirmation_ids: Sequence[str]) -> int:
+        wanted = set(confirmation_ids)
+        deleted = 0
+        for idempotency_key, record in list(self._records.items()):
+            if record.envelope.claims.confirmation_id in wanted:
+                self._records.pop(idempotency_key, None)
+                self._idempotency_key_by_provider_ref.pop(
+                    record.envelope.claims.provider_confirmation_ref, None
+                )
+                deleted += 1
+        return deleted
 
     def save(
         self, record: ProviderRetentionConfirmationRecord

--- a/src/app/provider_retention_confirmations/repository.py
+++ b/src/app/provider_retention_confirmations/repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -27,6 +29,14 @@ class ProviderRetentionConfirmationRepository(Protocol):
     def get_by_provider_confirmation_ref(
         self, *, provider_confirmation_ref: str
     ) -> ProviderRetentionConfirmationRecord | None: ...
+
+    def list_confirmations(self, *, limit: int) -> list[ProviderRetentionConfirmationRecord]:
+        """List confirmations, newest first (lifecycle engine read)."""
+        ...
+
+    def delete_confirmations(self, confirmation_ids: Sequence[str]) -> int:
+        """Delete confirmation evidence by id (issue #158, S2b)."""
+        ...
 
     def save(
         self, record: ProviderRetentionConfirmationRecord

--- a/src/app/provider_retention_confirmations/sqlalchemy_repository.py
+++ b/src/app/provider_retention_confirmations/sqlalchemy_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import ProviderRetentionConfirmationModel
@@ -47,6 +49,27 @@ class SqlAlchemyProviderRetentionConfirmationRepository(SqlAlchemyRepositoryBase
                 )
             )
             return self._to_record(model) if model is not None else None
+
+    def list_confirmations(self, *, limit: int) -> list[ProviderRetentionConfirmationRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(ProviderRetentionConfirmationModel)
+                .order_by(ProviderRetentionConfirmationModel.recorded_at.desc())
+                .limit(limit)
+            ).all()
+            return [self._to_record(model) for model in models]
+
+    def delete_confirmations(self, confirmation_ids: Sequence[str]) -> int:
+        if not confirmation_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(ProviderRetentionConfirmationModel).where(
+                    ProviderRetentionConfirmationModel.confirmation_id.in_(list(confirmation_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def save(
         self, record: ProviderRetentionConfirmationRecord

--- a/src/app/repositories/async_runtime_repository.py
+++ b/src/app/repositories/async_runtime_repository.py
@@ -141,5 +141,8 @@ class AsyncRuntimeRepository(Protocol):
     ) -> list[AsyncRuntimeControlEventRecord]:
         """List recent async control-plane events, optionally filtered by job."""
 
+    def delete_control_events(self, event_ids: Sequence[str]) -> int:
+        """Delete control events by id for the lifecycle engine (issue #158, S2b)."""
+
     def save_control_event(self, record: AsyncRuntimeControlEventRecord) -> None:
         """Persist one async control-plane event."""

--- a/src/app/repositories/audit_repository.py
+++ b/src/app/repositories/audit_repository.py
@@ -57,3 +57,9 @@ class AuditRepository(Protocol):
 
     def list_access_events(self, *, limit: int = 100) -> Sequence[AuditAccessEvent]:
         """List recent audit-read access events for bounded verification and support."""
+
+    def delete_access_events(self, event_ids: Sequence[str]) -> int:
+        """Delete access events by id for the lifecycle engine (issue #158, S2b)."""
+
+    def delete_lifecycle_events(self, event_ids: Sequence[str]) -> int:
+        """Delete lifecycle events by id for the lifecycle engine (issue #158, S2b)."""

--- a/src/app/repositories/kill_switch_repository.py
+++ b/src/app/repositories/kill_switch_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from typing import Protocol
 
 from app.contracts.kill_switches import KillSwitchActivationRecord
@@ -7,6 +9,10 @@ from app.contracts.kill_switches import KillSwitchActivationRecord
 
 class KillSwitchRepository(Protocol):
     def list_activations(self) -> list[KillSwitchActivationRecord]: ...
+
+    def delete_activations(self, switch_ids: Sequence[str]) -> int:
+        """Delete non-enforcing activation evidence by id (issue #158, S2b)."""
+        ...
 
     def get_activation(self, switch_id: str) -> KillSwitchActivationRecord | None: ...
 

--- a/src/app/repositories/memory_async_runtime_repository.py
+++ b/src/app/repositories/memory_async_runtime_repository.py
@@ -252,6 +252,12 @@ class InMemoryAsyncRuntimeRepository(AsyncRuntimeRepository):
         filtered.sort(key=lambda item: item.recorded_at, reverse=True)
         return filtered[: max(limit, 1)]
 
+    def delete_control_events(self, event_ids: Sequence[str]) -> int:
+        wanted = set(event_ids)
+        before = len(self._control_events)
+        self._control_events = [r for r in self._control_events if r.event_id not in wanted]
+        return before - len(self._control_events)
+
     def save_control_event(self, record: AsyncRuntimeControlEventRecord) -> None:
         self._control_events = [
             existing for existing in self._control_events if existing.event_id != record.event_id

--- a/src/app/repositories/memory_audit_repository.py
+++ b/src/app/repositories/memory_audit_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TypeVar
 from threading import Lock
 
 from app.contracts.audit import AuditRecordResponse
@@ -10,6 +11,9 @@ from app.contracts.audit_access import (
     AuditReadScope,
     AuditReadScopeMode,
 )
+
+
+_V = TypeVar("_V")
 
 
 class InMemoryAuditRepository:
@@ -103,6 +107,14 @@ class InMemoryAuditRepository:
                 if hold.released_at is None and (family_id is None or hold.family_id == family_id)
             ]
 
+    def delete_access_events(self, event_ids: Sequence[str]) -> int:
+        with self._lock:
+            return _pop_all(self._access_events, event_ids)
+
+    def delete_lifecycle_events(self, event_ids: Sequence[str]) -> int:
+        with self._lock:
+            return _pop_all(self._lifecycle_events, event_ids)
+
     def save_access_event(self, event: AuditAccessEvent) -> None:
         with self._lock:
             self._access_events[event.event_id] = event
@@ -115,6 +127,14 @@ class InMemoryAuditRepository:
                 reverse=True,
             )
             return events[:limit]
+
+
+def _pop_all(store: dict[str, _V], keys: Sequence[str]) -> int:
+    deleted = 0
+    for key in keys:
+        if store.pop(key, None) is not None:
+            deleted += 1
+    return deleted
 
 
 def _record_is_in_scope(record: AuditRecordResponse, scope: AuditReadScope) -> bool:

--- a/src/app/repositories/memory_kill_switch_repository.py
+++ b/src/app/repositories/memory_kill_switch_repository.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from app.contracts.kill_switches import KillSwitchActivationRecord
 
 
 class InMemoryKillSwitchRepository:
     def __init__(self) -> None:
         self._activations: dict[str, KillSwitchActivationRecord] = {}
+
+    def delete_activations(self, switch_ids: Sequence[str]) -> int:
+        deleted = 0
+        for switch_id in switch_ids:
+            if self._activations.pop(switch_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def list_activations(self) -> list[KillSwitchActivationRecord]:
         return sorted(

--- a/src/app/repositories/memory_model_catalogue_repository.py
+++ b/src/app/repositories/memory_model_catalogue_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from app.contracts.model_catalogue import (
     ModelCatalogueEntry,
     ModelLifecycleTransitionRecord,
@@ -25,6 +27,29 @@ class InMemoryModelCatalogueRepository:
 
     def append_lifecycle_event(self, event: ModelLifecycleTransitionRecord) -> None:
         self._lifecycle_events.append(event.model_copy(deep=True))
+
+    def list_all_lifecycle_events(self, *, limit: int) -> list[ModelLifecycleTransitionRecord]:
+        events = sorted(self._lifecycle_events, key=lambda e: e.recorded_at, reverse=True)
+        return [event.model_copy(deep=True) for event in events[:limit]]
+
+    def delete_lifecycle_events(self, event_ids: Sequence[str]) -> int:
+        wanted = set(event_ids)
+        before = len(self._lifecycle_events)
+        self._lifecycle_events = [e for e in self._lifecycle_events if e.event_id not in wanted]
+        return before - len(self._lifecycle_events)
+
+    def list_all_drift_observations(self, *, limit: int) -> list[ModelRevisionDriftObservation]:
+        observations = sorted(
+            self._drift_observations.values(), key=lambda o: o.last_observed_at, reverse=True
+        )
+        return [observation.model_copy(deep=True) for observation in observations[:limit]]
+
+    def delete_drift_observations(self, observation_ids: Sequence[str]) -> int:
+        deleted = 0
+        for observation_id in observation_ids:
+            if self._drift_observations.pop(observation_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def list_lifecycle_events(self, entry_id: str) -> list[ModelLifecycleTransitionRecord]:
         return sorted(

--- a/src/app/repositories/memory_prompt_repository.py
+++ b/src/app/repositories/memory_prompt_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.contracts.prompts import (
@@ -60,6 +62,12 @@ class InMemoryPromptRepository(PromptRepository):
         if prompt is None:
             return None
         return deepcopy(prompt)
+
+    def delete_prompt_rollout_events(self, event_ids: Sequence[str]) -> int:
+        wanted = set(event_ids)
+        before = len(self._rollout_events)
+        self._rollout_events = [r for r in self._rollout_events if r.event_id not in wanted]
+        return before - len(self._rollout_events)
 
     def list_prompt_rollout_states(self) -> list[PromptRolloutStateRecord]:
         states = list(self._rollout_states.values())

--- a/src/app/repositories/memory_provider_operations_repository.py
+++ b/src/app/repositories/memory_provider_operations_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.contracts.providers import (
@@ -171,6 +173,19 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
 
     def list_operations_events(self, *, limit: int) -> list[ProviderOperationsEventRecord]:
         return [deepcopy(record) for record in self._event_records[:limit]]
+
+    def delete_operations_events(self, event_ids: Sequence[str]) -> int:
+        wanted = set(event_ids)
+        before = len(self._event_records)
+        self._event_records = [r for r in self._event_records if r.event_id not in wanted]
+        return before - len(self._event_records)
+
+    def delete_governed_actions(self, action_ids: Sequence[str]) -> int:
+        deleted = 0
+        for action_id in action_ids:
+            if self._governed_actions.pop(action_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def get_governed_action(self, action_id: str) -> GovernedActionRecord | None:
         record = self._governed_actions.get(action_id)

--- a/src/app/repositories/memory_workflow_pack_registry_repository.py
+++ b/src/app/repositories/memory_workflow_pack_registry_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from app.contracts.workflow_packs import (
     WorkflowPackControlEventDescriptor,
     WorkflowPackRegistrationDescriptor,
@@ -50,6 +52,13 @@ class InMemoryWorkflowPackRegistryRepository(WorkflowPackRegistryRepository):
             events = [event for event in events if event.version == version]
         events.sort(key=lambda event: event.recorded_at, reverse=True)
         return [event.model_copy(deep=True) for event in events[: max(limit, 1)]]
+
+    def delete_control_events(self, event_ids: Sequence[str]) -> int:
+        deleted = 0
+        for event_id in event_ids:
+            if self._events.pop(event_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def save_control_event(self, event: WorkflowPackControlEventDescriptor) -> None:
         self._events[event.event_id] = event.model_copy(deep=True)

--- a/src/app/repositories/model_catalogue_repository.py
+++ b/src/app/repositories/model_catalogue_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from typing import Protocol
 
 from app.contracts.model_catalogue import (
@@ -20,6 +22,14 @@ class ModelCatalogueRepository(Protocol):
 
     def list_lifecycle_events(self, entry_id: str) -> list[ModelLifecycleTransitionRecord]: ...
 
+    def list_all_lifecycle_events(self, *, limit: int) -> list[ModelLifecycleTransitionRecord]:
+        """List lifecycle events across every entry (lifecycle engine read)."""
+        ...
+
+    def delete_lifecycle_events(self, event_ids: Sequence[str]) -> int:
+        """Delete lifecycle-event evidence by id (issue #158, S2b)."""
+        ...
+
     def get_drift_observation(
         self, observation_id: str
     ) -> ModelRevisionDriftObservation | None: ...
@@ -27,3 +37,11 @@ class ModelCatalogueRepository(Protocol):
     def upsert_drift_observation(self, observation: ModelRevisionDriftObservation) -> None: ...
 
     def list_drift_observations(self, entry_id: str) -> list[ModelRevisionDriftObservation]: ...
+
+    def list_all_drift_observations(self, *, limit: int) -> list[ModelRevisionDriftObservation]:
+        """List drift observations across every entry (lifecycle engine read)."""
+        ...
+
+    def delete_drift_observations(self, observation_ids: Sequence[str]) -> int:
+        """Delete drift-observation evidence by id (issue #158, S2b)."""
+        ...

--- a/src/app/repositories/prompt_repository.py
+++ b/src/app/repositories/prompt_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from typing import Protocol
 
 from app.contracts.prompts import PromptDescriptor
@@ -25,6 +27,10 @@ class PromptRepository(Protocol):
     def list_prompt_rollout_events(
         self, task_id: str | None = None, limit: int = 20
     ) -> list[PromptRolloutEventRecord]: ...
+
+    def delete_prompt_rollout_events(self, event_ids: Sequence[str]) -> int:
+        """Delete rollout-event evidence by id (issue #158, S2b)."""
+        ...
 
     def save_prompt_rollout_transition(
         self,

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections.abc import Sequence
 from typing import Protocol
 
 from app.contracts.access_control import AuthorizationDecision
@@ -154,6 +155,12 @@ class ProviderOperationsRepository(Protocol):
         limit: int,
     ) -> list[GovernedActionRecord]:
         """List governed-action evidence records, newest requested first."""
+
+    def delete_operations_events(self, event_ids: Sequence[str]) -> int:
+        """Delete operations events by id for the lifecycle engine (issue #158, S2b)."""
+
+    def delete_governed_actions(self, action_ids: Sequence[str]) -> int:
+        """Delete non-current governed-action evidence by id (issue #158, S2b)."""
 
     def list_operations_events(self, *, limit: int) -> list[ProviderOperationsEventRecord]:
         """List most recent provider-operations control event records."""

--- a/src/app/repositories/sqlalchemy_async_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_async_runtime_repository.py
@@ -295,6 +295,18 @@ class SqlAlchemyAsyncRuntimeRepository(SqlAlchemyRepositoryBase, AsyncRuntimeRep
             ).all()
             return [self._to_control_event_record(model) for model in models]
 
+    def delete_control_events(self, event_ids: Sequence[str]) -> int:
+        if not event_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(AsyncControlEventModel).where(
+                    AsyncControlEventModel.event_id.in_(list(event_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
+
     def save_control_event(self, record: AsyncRuntimeControlEventRecord) -> None:
         model = AsyncControlEventModel(
             event_id=record.event_id,

--- a/src/app/repositories/sqlalchemy_audit_repository.py
+++ b/src/app/repositories/sqlalchemy_audit_repository.py
@@ -197,6 +197,20 @@ class SqlAlchemyAuditRepository(SqlAlchemyRepositoryBase):
                 DataLegalHoldRecord.model_validate(model, from_attributes=True) for model in models
             ]
 
+    def delete_access_events(self, event_ids: Sequence[str]) -> int:
+        return self._delete_by_ids(AuditAccessEventModel.event_id, event_ids)
+
+    def delete_lifecycle_events(self, event_ids: Sequence[str]) -> int:
+        return self._delete_by_ids(DataLifecycleEventModel.event_id, event_ids)
+
+    def _delete_by_ids(self, column: object, ids: Sequence[str]) -> int:
+        if not ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(delete(column.class_).where(column.in_(list(ids))))  # type: ignore[attr-defined]
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
+
     def save_access_event(self, event: AuditAccessEvent) -> None:
         model = AuditAccessEventModel(
             event_id=event.event_id,

--- a/src/app/repositories/sqlalchemy_kill_switch_repository.py
+++ b/src/app/repositories/sqlalchemy_kill_switch_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.kill_switches import (
     KillSwitchActivationRecord,
@@ -18,6 +20,18 @@ class SqlAlchemyKillSwitchRepository(SqlAlchemyRepositoryBase):
         self._database_url = database_url
         self._ensure_sqlite_parent_directory()
         self._configure_sqlalchemy(database_url)
+
+    def delete_activations(self, switch_ids: Sequence[str]) -> int:
+        if not switch_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(KillSwitchActivationModel).where(
+                    KillSwitchActivationModel.switch_id.in_(list(switch_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def list_activations(self) -> list[KillSwitchActivationRecord]:
         with self._session_factory() as session:

--- a/src/app/repositories/sqlalchemy_model_catalogue_repository.py
+++ b/src/app/repositories/sqlalchemy_model_catalogue_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.model_catalogue import (
     ModelCapabilityDegradation,
@@ -89,6 +91,51 @@ class SqlAlchemyModelCatalogueRepository(SqlAlchemyRepositoryBase):
                 )
             )
             session.commit()
+
+    def list_all_lifecycle_events(self, *, limit: int) -> list[ModelLifecycleTransitionRecord]:
+        with self._session_factory() as session:
+            models = session.execute(
+                select(ModelCatalogueLifecycleEventModel)
+                .order_by(ModelCatalogueLifecycleEventModel.recorded_at.desc())
+                .limit(limit)
+            ).scalars()
+            return [
+                ModelLifecycleTransitionRecord.model_validate(model, from_attributes=True)
+                for model in models
+            ]
+
+    def delete_lifecycle_events(self, event_ids: Sequence[str]) -> int:
+        if not event_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(ModelCatalogueLifecycleEventModel).where(
+                    ModelCatalogueLifecycleEventModel.event_id.in_(list(event_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
+
+    def list_all_drift_observations(self, *, limit: int) -> list[ModelRevisionDriftObservation]:
+        with self._session_factory() as session:
+            models = session.execute(
+                select(ModelRevisionDriftObservationModel)
+                .order_by(ModelRevisionDriftObservationModel.last_observed_at.desc())
+                .limit(limit)
+            ).scalars()
+            return [self._to_drift_observation(model) for model in models]
+
+    def delete_drift_observations(self, observation_ids: Sequence[str]) -> int:
+        if not observation_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(ModelRevisionDriftObservationModel).where(
+                    ModelRevisionDriftObservationModel.observation_id.in_(list(observation_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def list_lifecycle_events(self, entry_id: str) -> list[ModelLifecycleTransitionRecord]:
         with self._session_factory() as session:

--- a/src/app/repositories/sqlalchemy_prompt_repository.py
+++ b/src/app/repositories/sqlalchemy_prompt_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.access_control import (
     AuthorizationCapabilityType,
@@ -88,6 +90,18 @@ class SqlAlchemyPromptRepository(SqlAlchemyRepositoryBase):
             if state is None:
                 return None
             return self._to_rollout_state(state)
+
+    def delete_prompt_rollout_events(self, event_ids: Sequence[str]) -> int:
+        if not event_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(PromptRolloutEventModel).where(
+                    PromptRolloutEventModel.event_id.in_(list(event_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def list_prompt_rollout_events(
         self, task_id: str | None = None, limit: int = 20

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
 from sqlalchemy import delete, select
@@ -365,6 +367,30 @@ class SqlAlchemyProviderOperationsRepository(
             ),
             recorded_at=model.recorded_at,
         )
+
+    def delete_operations_events(self, event_ids: Sequence[str]) -> int:
+        if not event_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(ProviderOperationsEventModel).where(
+                    ProviderOperationsEventModel.event_id.in_(list(event_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
+
+    def delete_governed_actions(self, action_ids: Sequence[str]) -> int:
+        if not action_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(GovernedActionModel).where(
+                    GovernedActionModel.action_id.in_(list(action_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def get_governed_action(self, action_id: str) -> GovernedActionRecord | None:
         with self._session_factory() as session:

--- a/src/app/repositories/sqlalchemy_workflow_pack_registry_repository.py
+++ b/src/app/repositories/sqlalchemy_workflow_pack_registry_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.access_control import (
     AuthorizationCapabilityType,
@@ -62,6 +64,18 @@ class SqlAlchemyWorkflowPackRegistryRepository(
         with self._session_factory() as session:
             session.merge(self._build_registration_model(registration))
             session.commit()
+
+    def delete_control_events(self, event_ids: Sequence[str]) -> int:
+        if not event_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(WorkflowPackControlEventModel).where(
+                    WorkflowPackControlEventModel.event_id.in_(list(event_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def list_control_events(
         self,

--- a/src/app/repositories/workflow_pack_registry_repository.py
+++ b/src/app/repositories/workflow_pack_registry_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from typing import Protocol
 
 from app.contracts.workflow_packs import (
@@ -28,6 +30,9 @@ class WorkflowPackRegistryRepository(Protocol):
         limit: int = 20,
     ) -> list[WorkflowPackControlEventDescriptor]:
         """List persisted workflow-pack control events."""
+
+    def delete_control_events(self, event_ids: Sequence[str]) -> int:
+        """Delete control-event evidence by id (issue #158, S2b)."""
 
     def save_control_event(self, event: WorkflowPackControlEventDescriptor) -> None:
         """Persist one workflow-pack control event."""

--- a/src/app/services/data_lifecycle_engine.py
+++ b/src/app/services/data_lifecycle_engine.py
@@ -28,6 +28,14 @@ from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
 from app.services.audit_store import get_audit_store
 from app.services.async_runtime_store import get_async_runtime_store
 from app.services.data_lifecycle_policy import RetentionFamily, load_retention_policy
+from app.services.kill_switch_store import get_kill_switch_repository
+from app.services.model_catalogue_store import get_model_catalogue_repository
+from app.services.prompt_store import get_prompt_repository
+from app.services.provider_operations_store import get_provider_operations_store
+from app.services.workflow_pack_registry_store import get_workflow_pack_registry_store
+from app.provider_retention_confirmations.store import (
+    get_provider_retention_confirmation_store,
+)
 from app.services.workflow_pack_admission_lease_store import (
     get_workflow_pack_admission_lease_repository,
 )
@@ -175,8 +183,139 @@ def _expire_transient_leases(family: RetentionFamily, cutoff: datetime) -> tuple
     )
 
 
+def _expire_control_plane_evidence(
+    family: RetentionFamily, cutoff: datetime
+) -> tuple[list[str], str]:
+    """Control-plane evidence past retention, with three protective predicates.
+
+    An ENFORCING kill switch is current control state, never expired; a
+    PENDING governed action is a live approval intent, never expired; a drift
+    observation ages on its LAST observation, so a still-recurring drift is
+    never expired. Deleted ids are table-prefixed so the digest cannot
+    collide across tables within the one family event.
+    """
+
+    audit = get_audit_store()
+    ops = get_provider_operations_store()
+    prompts = get_prompt_repository()
+    async_runtime = get_async_runtime_store()
+    kill_switches = get_kill_switch_repository()
+    registry = get_workflow_pack_registry_store()
+    catalogue = get_model_catalogue_repository()
+    confirmations = get_provider_retention_confirmation_store()
+
+    deleted: list[str] = []
+    details: list[str] = []
+
+    def _expire(table: str, rows: list[tuple[str, str]], delete_fn: object) -> None:
+        expired = [pk for pk, instant in rows if _is_before(instant, cutoff)]
+        if expired:
+            count = delete_fn(expired)  # type: ignore[operator]
+            deleted.extend(f"{table}:{pk}" for pk in expired)
+            details.append(f"{table}={count}")
+
+    _expire(
+        "audit_access_events",
+        [
+            (e.event_id, e.recorded_at)
+            for e in audit.list_access_events(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        audit.delete_access_events,
+    )
+    _expire(
+        "data_lifecycle_events",
+        [
+            (e.event_id, e.recorded_at)
+            for e in audit.list_lifecycle_events(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        audit.delete_lifecycle_events,
+    )
+    _expire(
+        "provider_operations_events",
+        [
+            (e.event_id, e.recorded_at)
+            for e in ops.list_operations_events(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        ops.delete_operations_events,
+    )
+    _expire(
+        "provider_governed_actions",
+        [
+            (a.action_id, a.requested_at)
+            for a in ops.list_governed_actions(
+                status=None, target=None, limit=_CANDIDATE_BATCH_LIMIT
+            )
+            if a.status.value != "PENDING"
+        ],
+        ops.delete_governed_actions,
+    )
+    _expire(
+        "prompt_rollout_events",
+        [
+            (e.event_id, e.recorded_at)
+            for e in prompts.list_prompt_rollout_events(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        prompts.delete_prompt_rollout_events,
+    )
+    _expire(
+        "async_control_events",
+        [
+            (e.event_id, e.recorded_at)
+            for e in async_runtime.list_control_events(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        async_runtime.delete_control_events,
+    )
+    _expire(
+        "kill_switch_activations",
+        [
+            (a.switch_id, a.activated_at)
+            for a in kill_switches.list_activations()
+            if a.cleared_at is not None or a.expiry_recorded_at is not None
+        ],
+        kill_switches.delete_activations,
+    )
+    _expire(
+        "workflow_pack_control_events",
+        [
+            (e.event_id, e.recorded_at)
+            for e in registry.list_control_events(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        registry.delete_control_events,
+    )
+    _expire(
+        "model_catalogue_lifecycle_events",
+        [
+            (e.event_id, e.recorded_at)
+            for e in catalogue.list_all_lifecycle_events(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        catalogue.delete_lifecycle_events,
+    )
+    _expire(
+        "model_revision_drift_observations",
+        [
+            (o.observation_id, o.last_observed_at)
+            for o in catalogue.list_all_drift_observations(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        catalogue.delete_drift_observations,
+    )
+    _expire(
+        "provider_retention_confirmations",
+        [
+            (c.envelope.claims.confirmation_id, c.envelope.claims.issued_at_utc)
+            for c in confirmations.list_confirmations(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        confirmations.delete_confirmations,
+    )
+    detail = "; ".join(details) if details else "nothing past retention"
+    return deleted, (
+        f"expired control-plane evidence ({detail}); enforcing switches, pending "
+        "governed actions and recently-observed drift are never expired"
+    )
+
+
 _ENFORCED_FAMILY_HANDLERS = {
     "audit_evidence": _expire_audit_evidence,
+    "control_plane_evidence": _expire_control_plane_evidence,
     "async_runtime_content": _expire_async_runtime_content,
     "transient_operational_leases": _expire_transient_leases,
 }

--- a/tests/unit/test_data_lifecycle_engine.py
+++ b/tests/unit/test_data_lifecycle_engine.py
@@ -323,17 +323,49 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
     database_url = f"sqlite:///{tmp_path / 'lifecycle-s2a.db'}"
     upgrade_database_to_head(database_url)
     monkeypatch.setattr(settings, "database_url", database_url)
-    monkeypatch.setattr(settings, "audit_store_mode", "sqlalchemy")
-    monkeypatch.setattr(settings, "async_runtime_store_mode", "sqlalchemy")
-    monkeypatch.setattr(settings, "workflow_pack_admission_store_mode", "sqlalchemy")
+    for mode_field in (
+        "audit_store_mode",
+        "async_runtime_store_mode",
+        "workflow_pack_admission_store_mode",
+        "kill_switch_store_mode",
+        "prompt_store_mode",
+        "workflow_pack_registry_store_mode",
+        "model_catalogue_store_mode",
+        "provider_operations_store_mode",
+        "provider_retention_confirmation_store_mode",
+    ):
+        monkeypatch.setattr(settings, mode_field, "sqlalchemy")
 
     _seed_expiry_matrix()
+    _seed_control_plane_matrix()
     report = run_data_lifecycle(actor="test.operator")
 
     results = {r.family_id: r.deleted_count for r in report.results}
     assert results["audit_evidence"] == 1
     assert results["async_runtime_content"] == 1
     assert results["transient_operational_leases"] == 2
+    assert results["control_plane_evidence"] == 10
+
+    # The SQL adapters' empty deletions are safe no-ops.
+    from app.provider_retention_confirmations.store import (
+        get_provider_retention_confirmation_store,
+    )
+    from app.services.kill_switch_store import get_kill_switch_repository
+    from app.services.model_catalogue_store import get_model_catalogue_repository
+    from app.services.prompt_store import get_prompt_repository
+    from app.services.provider_operations_store import get_provider_operations_store
+    from app.services.workflow_pack_registry_store import get_workflow_pack_registry_store
+
+    assert get_kill_switch_repository().delete_activations([]) == 0
+    assert get_prompt_repository().delete_prompt_rollout_events([]) == 0
+    assert get_workflow_pack_registry_store().delete_control_events([]) == 0
+    assert get_model_catalogue_repository().delete_lifecycle_events([]) == 0
+    assert get_model_catalogue_repository().delete_drift_observations([]) == 0
+    assert get_provider_operations_store().delete_operations_events([]) == 0
+    assert get_provider_operations_store().delete_governed_actions([]) == 0
+    assert get_provider_retention_confirmation_store().delete_confirmations([]) == 0
+    assert get_audit_store().delete_access_events([]) == 0
+    assert get_audit_store().delete_lifecycle_events([]) == 0
 
     audit = get_audit_store()
     assert {r.request_id for r in audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=50)} == {
@@ -341,7 +373,7 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
         "air_young_a",
     }
     events = audit.list_lifecycle_events(limit=10)
-    assert len(events) == 3
+    assert len(events) == 4
     assert all(len(event.deleted_ids_digest) == 64 for event in events)
     assert {j.job_id for j in get_async_runtime_store().list_jobs()} == {
         "job_old_queued",
@@ -350,7 +382,7 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
 
     second = run_data_lifecycle(actor="test.operator")
     assert all(result.deleted_count == 0 for result in second.results)
-    assert len(get_audit_store().list_lifecycle_events(limit=10)) == 3
+    assert len(get_audit_store().list_lifecycle_events(limit=10)) == 4
 
 
 def test_naive_timestamps_are_treated_as_utc() -> None:
@@ -419,3 +451,331 @@ def test_sql_hold_release_and_filters_round_trip(tmp_path: object, monkeypatch: 
     assert audit.release_legal_hold(hold_id="hold_missing", released_at=_iso(0)) is False
     assert audit.list_active_legal_holds() == []
     assert audit.delete_records([]) == 0
+
+
+def _authz() -> AuthorizationDecision:
+    return AuthorizationDecision(
+        caller_app="lotus-platform",
+        capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
+        outcome=AuthorizationOutcome.ALLOWED,
+        allowed=True,
+        tenant_policy_mode=TenantPolicyMode.OPTIONAL,
+        task_id=None,
+        requested_source_ids=[],
+        effective_source_ids=[],
+        tenant_id=None,
+        summary="test",
+    )
+
+
+def _seed_control_plane_matrix() -> None:
+    from app.contracts.audit_access import (
+        AuditAccessEvent,
+        AuditAccessOperation,
+        AuditAccessOutcome,
+        AuditReadScopeMode,
+    )
+    from app.contracts.governed_actions import (
+        GovernedActionRecord,
+        GovernedActionStatus,
+        GovernedActionType,
+        GovernedActorClass,
+    )
+    from app.contracts.kill_switches import (
+        KillSwitchActivationRecord,
+        KillSwitchScope,
+        KillSwitchSemantics,
+    )
+    from app.contracts.model_catalogue import (
+        ModelLifecycleState,
+        ModelLifecycleTransitionRecord,
+        ModelRevisionDriftObservation,
+    )
+    from app.contracts.prompts import PromptControlActionType
+    from app.contracts.workflow_packs import (
+        WorkflowPackActivationState,
+        WorkflowPackControlActionType,
+        WorkflowPackControlEventDescriptor,
+        WorkflowPackRegistrationStatus,
+    )
+    from app.repositories.async_runtime_repository import AsyncRuntimeControlEventRecord
+    from app.repositories.provider_operations_repository import ProviderOperationsEventRecord
+    from app.services.kill_switch_store import get_kill_switch_repository
+    from app.services.model_catalogue_store import get_model_catalogue_repository
+    from app.services.prompt_store import get_prompt_repository
+    from app.services.prompt_rollout_models import PromptRolloutEventRecord
+    from app.services.provider_operations_store import get_provider_operations_store
+    from app.services.workflow_pack_registry_store import get_workflow_pack_registry_store
+
+    audit = get_audit_store()
+    for event_id, age in (("aae_old", 2600), ("aae_young", 10)):
+        audit.save_access_event(
+            AuditAccessEvent(
+                event_id=event_id,
+                caller_app="lotus-platform",
+                caller_trust_source="verified_service_jwt",
+                scope_mode=AuditReadScopeMode.ALL_TENANTS,
+                operation=AuditAccessOperation.LIST_RECORDS,
+                outcome=AuditAccessOutcome.SUCCEEDED,
+                returned_record_count=1,
+                recorded_at=_iso(age),
+            )
+        )
+
+    ops = get_provider_operations_store()
+    from app.contracts.provider_operations import ProviderOperationsControlActionType
+
+    for event_id, age in (("poe_old", 2600), ("poe_young", 10)):
+        ops.save_operations_event(
+            ProviderOperationsEventRecord(
+                event_id=event_id,
+                action_type=ProviderOperationsControlActionType.RESET_DEGRADATION,
+                scope=None,
+                scope_key=None,
+                reason="r",
+                requested_by="ops",
+                approved_by="ops2",
+                affected_record_count=1,
+                authorization=_authz(),
+                recorded_at=_iso(age),
+            )
+        )
+
+    def _gact(action_id: str, status: "GovernedActionStatus", age: int) -> None:
+        ops.upsert_governed_action(
+            GovernedActionRecord(
+                action_id=action_id,
+                action_type=GovernedActionType.KILL_SWITCH_CLEAR,
+                actor_class=GovernedActorClass.HUMAN_APPROVED,
+                status=status,
+                target="ksw_x",
+                action_hash="a" * 64,
+                action_payload={"k": "v"},
+                requester_caller_app="lotus-platform",
+                requester_trust_source="verified_service_jwt",
+                requester_key_id="k1",
+                requested_at=_iso(age),
+            )
+        )
+
+    _gact("gact_old_executed", GovernedActionStatus.EXECUTED, 2600)
+    _gact("gact_old_pending", GovernedActionStatus.PENDING, 2600)
+    _gact("gact_young", GovernedActionStatus.EXECUTED, 10)
+
+    prompts = get_prompt_repository()
+    from app.contracts.prompts import PromptRolloutSelectionMode
+    from app.services.prompt_rollout_models import PromptRolloutStateRecord
+
+    for event_id, age in (("pre_old", 2600), ("pre_young", 10)):
+        prompts.save_prompt_rollout_transition(
+            rollout_state=PromptRolloutStateRecord(
+                task_id="explain.v1",
+                active_prompt_version="foundation.explain.v1",
+                candidate_prompt_version=None,
+                previous_active_prompt_version=None,
+                rollout_mode=PromptRolloutSelectionMode.GOVERNED_STATE_READ_ONLY,
+                runtime_mutation_enabled=False,
+            ),
+            updated_prompts=[],
+            event=PromptRolloutEventRecord(
+                event_id=event_id,
+                task_id="explain.v1",
+                action_type=PromptControlActionType.ROLLBACK_TO_PREVIOUS_ACTIVE,
+                requested_by="lotus-platform (credential k1)",
+                approved_by=None,
+                reason="r",
+                prior_active_prompt_version=None,
+                resulting_active_prompt_version=None,
+                prior_candidate_prompt_version=None,
+                resulting_candidate_prompt_version=None,
+                authorization=_authz(),
+                recorded_at=_iso(age),
+            ),
+        )
+
+    async_runtime = get_async_runtime_store()
+    for event_id, age in (("ace_old", 2600), ("ace_young", 10)):
+        async_runtime.save_control_event(
+            AsyncRuntimeControlEventRecord(
+                event_id=event_id,
+                job_id="job_x",
+                action_type="QUARANTINE_QUEUED_JOB",
+                requested_by="worker-1",
+                approved_by=None,
+                reason="r",
+                prior_status="QUEUED",
+                resulting_status="ABANDONED",
+                affected_attempt_id=None,
+                authorization=_authz(),
+                recorded_at=_iso(age),
+            )
+        )
+
+    switches = get_kill_switch_repository()
+
+    def _switch(switch_id: str, age: int, cleared: bool) -> None:
+        switches.upsert_activation(
+            KillSwitchActivationRecord(
+                switch_id=switch_id,
+                scope=KillSwitchScope.PROVIDER,
+                semantics=KillSwitchSemantics.HARD_KILL,
+                target="text.openai",
+                reason="r",
+                requested_by="lotus-platform (credential k1)",
+                approved_by=None,
+                activated_at=_iso(age),
+                cleared_at=_iso(age - 1) if cleared else None,
+                cleared_by="lotus-platform (credential k2)" if cleared else None,
+                clear_reason="resolved" if cleared else None,
+            )
+        )
+
+    _switch("ksw_old_cleared", 2600, cleared=True)
+    _switch("ksw_old_enforcing", 2600, cleared=False)
+    _switch("ksw_young_cleared", 10, cleared=True)
+
+    registry = get_workflow_pack_registry_store()
+    for event_id, age in (("wpe_old", 2600), ("wpe_young", 10)):
+        registry.save_control_event(
+            WorkflowPackControlEventDescriptor(
+                event_id=event_id,
+                pack_id="advisor_brief.pack",
+                version="v1",
+                action_type=WorkflowPackControlActionType.PAUSE,
+                requested_by="ops.user@lotus",
+                approved_by="ops.approver@lotus",
+                reason="r",
+                prior_registration_status=WorkflowPackRegistrationStatus.REGISTERED,
+                resulting_registration_status=WorkflowPackRegistrationStatus.REGISTERED,
+                prior_activation_state=WorkflowPackActivationState.ACTIVE,
+                resulting_activation_state=WorkflowPackActivationState.PAUSED,
+                caller_app="lotus-platform",
+                authorization=_authz(),
+                recorded_at=_iso(age),
+            )
+        )
+
+    catalogue = get_model_catalogue_repository()
+    for event_id, age in (("mlc_old", 2600), ("mlc_young", 10)):
+        catalogue.append_lifecycle_event(
+            ModelLifecycleTransitionRecord(
+                event_id=event_id,
+                entry_id="text.openai:gpt-5.4",
+                from_state=ModelLifecycleState.CATALOGUED,
+                to_state=ModelLifecycleState.EVALUATING,
+                reason="r",
+                requested_by="lotus-platform (credential k1)",
+                approved_by=None,
+                recorded_at=_iso(age),
+            )
+        )
+
+    def _drift(observation_id: str, last_age: int) -> None:
+        catalogue.upsert_drift_observation(
+            ModelRevisionDriftObservation(
+                observation_id=observation_id,
+                entry_id="text.openai:gpt-5.4",
+                expected_identity="gpt-5.4",
+                observed_model_id="gpt-5.4-other",
+                revision_pinned_at_observation=False,
+                first_observed_at=_iso(2600),
+                last_observed_at=_iso(last_age),
+                observation_count=3,
+            )
+        )
+
+    _drift("drift_old", 2600)
+    _drift("drift_recent", 5)
+
+    from app.provider_retention_confirmations.repository import (
+        ProviderRetentionConfirmationRecord,
+    )
+    from app.provider_retention_confirmations.store import (
+        get_provider_retention_confirmation_store,
+    )
+    from tests.unit.test_provider_retention_confirmation import BASE_RUN, _issue, _request
+
+    confirmations = get_provider_retention_confirmation_store()
+    for suffix, age in (("old", 2600), ("young", 10)):
+        envelope = _issue(BASE_RUN, _request())
+        aged = envelope.model_copy(
+            update={
+                "claims": envelope.claims.model_copy(
+                    update={
+                        "confirmation_id": f"conf_{suffix}",
+                        "provider_confirmation_ref": f"provider-confirmation-{suffix}",
+                        "issued_at_utc": _iso(age),
+                    }
+                )
+            }
+        )
+        confirmations.save(
+            ProviderRetentionConfirmationRecord(
+                idempotency_key=f"idem-{suffix}",
+                request_fingerprint="f" * 64,
+                envelope=aged,
+            )
+        )
+
+
+def test_control_plane_evidence_expiry_honours_the_protective_predicates() -> None:
+    """Old evidence expires across every table in the family; an ENFORCING
+    kill switch, a PENDING governed action, and a recently-observed drift
+    are never expired - and the single family event's digest covers the
+    table-prefixed ids."""
+
+    from app.services.kill_switch_store import get_kill_switch_repository
+    from app.services.model_catalogue_store import get_model_catalogue_repository
+    from app.services.provider_operations_store import get_provider_operations_store
+
+    _seed_control_plane_matrix()
+
+    report = run_data_lifecycle(actor="test.operator")
+
+    results = {r.family_id: r for r in report.results}
+    control = results["control_plane_evidence"]
+    # aae_old, poe_old, gact_old_executed, pre_old, ace_old, ksw_old_cleared,
+    # wpe_old, mlc_old, drift_old, conf_old = 10 expired rows.
+    assert control.deleted_count == 10
+    assert "never expired" in control.detail
+
+    ops = get_provider_operations_store()
+    remaining_actions = {
+        a.action_id for a in ops.list_governed_actions(status=None, target=None, limit=50)
+    }
+    assert remaining_actions == {"gact_old_pending", "gact_young"}
+
+    switches = {s.switch_id for s in get_kill_switch_repository().list_activations()}
+    assert switches == {"ksw_old_enforcing", "ksw_young_cleared"}
+
+    catalogue = get_model_catalogue_repository()
+    assert {o.observation_id for o in catalogue.list_all_drift_observations(limit=10)} == {
+        "drift_recent"
+    }
+    assert {e.event_id for e in catalogue.list_all_lifecycle_events(limit=10)} == {"mlc_young"}
+
+    audit = get_audit_store()
+    events = {e.family_id: e for e in audit.list_lifecycle_events(limit=20)}
+    control_event = events["control_plane_evidence"]
+    assert control_event.row_count == 10
+    expected_ids = sorted(
+        [
+            "audit_access_events:aae_old",
+            "provider_operations_events:poe_old",
+            "provider_governed_actions:gact_old_executed",
+            "prompt_rollout_events:pre_old",
+            "async_control_events:ace_old",
+            "kill_switch_activations:ksw_old_cleared",
+            "workflow_pack_control_events:wpe_old",
+            "model_catalogue_lifecycle_events:mlc_old",
+            "model_revision_drift_observations:drift_old",
+            "provider_retention_confirmations:conf_old",
+        ]
+    )
+    assert (
+        control_event.deleted_ids_digest
+        == hashlib.sha256("\n".join(expected_ids).encode("utf-8")).hexdigest()
+    )
+
+    second = run_data_lifecycle(actor="test.operator")
+    assert all(result.deleted_count == 0 for result in second.results)


### PR DESCRIPTION
Issue #158, S2b (design note on the issue): **the control-plane-evidence family becomes true** — the largest retention family (11 tables across seven stores) flips from `DECLARED_ONLY` to `ENFORCED`, with three protective predicates that keep lifecycle expiry from ever deleting live control state.

## The three predicates, each pinned by test

- **An ENFORCING kill switch is never expired** — deleting an active switch row would silently re-enable stopped traffic; only cleared or expired activations age out.
- **A PENDING governed action is never expired** — it is a live approval intent; only executed/superseded evidence ages out.
- **A drift observation ages on its LAST observation** — a still-recurring drift whose first sighting is ancient stays.

## Mechanics

One family handler expires eleven tables (access events, deletion-evidence ledger, operations events, governed actions, prompt rollout events, async control events, kill-switch activations, workflow-pack control events, catalogue lifecycle events, drift observations, provider retention confirmations), each via its own store's repository — every store owns its deletions; the engine orchestrates and evidences. Deleted ids are **table-prefixed** in the single family event so the digest cannot collide across tables. The deletion-evidence ledger itself is in the family: expiring seven-year-old evidence rows writes a fresh evidence row, by design.

Repository surface: `delete_*`-by-ids on seven stores (memory + SQL adapters, empty-input safe no-ops), plus list-all reads where only per-entry reads existed (catalogue lifecycle events, drift observations, retention confirmations). No route exposes any of them.

## Evidence

The memory matrix seeds old + young rows in every one of the eleven tables plus the three predicate-protected rows, and asserts per-table survivors, the 10-row family event, and a byte-exact digest over the table-prefixed ids; the same matrix then runs through **all nine SQL adapters** over the real migrations, with empty-deletion no-ops proven per adapter; idempotent second run proven in both modes. Combined coverage verified locally before push (98.60%, up from the failing draft — the S2a lesson applied).

No schema changes, no new subsystems: the same engine, the same evidence ledger, one more family telling the truth.
