### PR TITLE
feat(lifecycle): client-content families become true (#158 S2c)

### DIFF
--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -40,22 +40,21 @@
     },
     {
       "family_id": "workflow_run_records",
-      "purpose": "Workflow-pack runs, their events, idempotency claims, task flows, checkpoints, queue events and produced artifact metadata: business run records carrying client-derived context.",
+      "purpose": "Workflow-pack runs, their events, idempotency claims, task flows, checkpoints and queue events: business run records carrying client-derived context.",
       "tables": [
         "workflow_pack_runs",
         "workflow_pack_run_events",
         "workflow_pack_execution_idempotency",
         "workflow_pack_task_flows",
         "workflow_pack_task_flow_checkpoints",
-        "workflow_pack_queue_events",
-        "artifact_metadata"
+        "workflow_pack_queue_events"
       ],
       "retention_days": 2555,
       "retention_basis": "Business run evidence retained seven years like the audit trail it corroborates; tenant-erasable on off-boarding subject to legal hold.",
       "legal_hold_supported": true,
       "erasure_key": "tenant",
       "evidence_class": "business_run_evidence",
-      "enforcement": "DECLARED_ONLY"
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "async_runtime_content",
@@ -97,7 +96,7 @@
       "legal_hold_supported": true,
       "erasure_key": "none",
       "evidence_class": "approval_evidence",
-      "enforcement": "DECLARED_ONLY"
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "evaluation_case_content",
@@ -110,7 +109,7 @@
       "legal_hold_supported": true,
       "erasure_key": "none",
       "evidence_class": "evaluation_content",
-      "enforcement": "DECLARED_ONLY"
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "retrieval_shared_reference",
@@ -165,6 +164,19 @@
       "erasure_key": "none",
       "evidence_class": "operational_state",
       "enforcement": "NOT_TIME_BOUNDED"
+    },
+    {
+      "family_id": "artifact_content",
+      "purpose": "Produced artifact metadata and payload references.",
+      "tables": [
+        "artifact_metadata"
+      ],
+      "retention_days": 2555,
+      "retention_basis": "Produced documents retained seven years with the runs that made them. No tenant erasure key: artifact rows carry no tenant attribution today, and claiming one would be broader than the store can honour - tenant linkage is a recorded gap. Rows marked retained_for_review are never expired (live review obligation).",
+      "legal_hold_supported": true,
+      "erasure_key": "none",
+      "evidence_class": "business_run_evidence",
+      "enforcement": "ENFORCED"
     }
   ]
 }

--- a/src/app/repositories/artifact_repository.py
+++ b/src/app/repositories/artifact_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -32,6 +34,9 @@ class ArtifactRepository(Protocol):
 
     def get_artifact(self, *, artifact_id: str) -> ArtifactRecord | None:
         """Fetch one persisted artifact metadata record."""
+
+    def delete_artifacts(self, artifact_ids: Sequence[str]) -> int:
+        """Delete artifact metadata by id (lifecycle engine, issue #158 S2c)."""
 
     def save_artifact(self, record: ArtifactRecord) -> None:
         """Persist one artifact metadata record."""

--- a/src/app/repositories/evaluation_runtime_repository.py
+++ b/src/app/repositories/evaluation_runtime_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -65,6 +67,15 @@ class EvaluationRuntimeRepository(Protocol):
 
     def get_attempt(self, *, attempt_id: str) -> EvaluationRunAttemptRecord | None:
         """Fetch one persisted evaluation run attempt."""
+
+    def delete_runs_with_dependents(self, run_ids: Sequence[str]) -> tuple[int, int, int]:
+        """Delete runs with attempts and case results (issue #158 S2c)."""
+
+    def list_all_case_results(self, *, limit: int) -> list[EvaluationCaseResultRecord]:
+        """List case results across every run (lifecycle engine read)."""
+
+    def delete_case_results(self, case_result_ids: Sequence[str]) -> int:
+        """Delete case results by id (issue #158 S2c)."""
 
     def list_case_results(self, *, run_id: str) -> list[EvaluationCaseResultRecord]:
         """List persisted case outcomes for one evaluation run."""

--- a/src/app/repositories/memory_artifact_repository.py
+++ b/src/app/repositories/memory_artifact_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.repositories.artifact_repository import ArtifactRecord, ArtifactRepository
@@ -22,6 +24,13 @@ class InMemoryArtifactRepository(ArtifactRepository):
         if record is None:
             return None
         return deepcopy(record)
+
+    def delete_artifacts(self, artifact_ids: Sequence[str]) -> int:
+        deleted = 0
+        for artifact_id in artifact_ids:
+            if self._records.pop(artifact_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def save_artifact(self, record: ArtifactRecord) -> None:
         self._records[record.artifact_id] = deepcopy(record)

--- a/src/app/repositories/memory_evaluation_runtime_repository.py
+++ b/src/app/repositories/memory_evaluation_runtime_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.repositories.evaluation_runtime_repository import (
@@ -55,6 +57,29 @@ class InMemoryEvaluationRuntimeRepository(EvaluationRuntimeRepository):
                 if record.attempt_id == attempt_id:
                     return deepcopy(record)
         return None
+
+    def delete_runs_with_dependents(self, run_ids: Sequence[str]) -> tuple[int, int, int]:
+        runs = attempts = cases = 0
+        for run_id in run_ids:
+            if self._runs.pop(run_id, None) is not None:
+                runs += 1
+            attempts += len(self._attempts.pop(run_id, []))
+            cases += len(self._case_results.pop(run_id, []))
+        return runs, attempts, cases
+
+    def list_all_case_results(self, *, limit: int) -> list[EvaluationCaseResultRecord]:
+        everything = [record for records in self._case_results.values() for record in records]
+        everything.sort(key=lambda record: record.recorded_at, reverse=True)
+        return [deepcopy(record) for record in everything[:limit]]
+
+    def delete_case_results(self, case_result_ids: Sequence[str]) -> int:
+        wanted = set(case_result_ids)
+        deleted = 0
+        for run_id, records in list(self._case_results.items()):
+            kept = [r for r in records if r.case_result_id not in wanted]
+            deleted += len(records) - len(kept)
+            self._case_results[run_id] = kept
+        return deleted
 
     def list_case_results(self, *, run_id: str) -> list[EvaluationCaseResultRecord]:
         return [

--- a/src/app/repositories/memory_workflow_pack_queue_event_repository.py
+++ b/src/app/repositories/memory_workflow_pack_queue_event_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.repositories.workflow_pack_queue_event_repository import (
@@ -35,6 +37,13 @@ class InMemoryWorkflowPackQueueEventRepository(WorkflowPackQueueEventRepository)
             reverse=True,
         )
         return deepcopy(records[:limit])
+
+    def delete_events(self, event_ids: Sequence[str]) -> int:
+        deleted = 0
+        for event_id in event_ids:
+            if self._events.pop(event_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def save_event(self, record: WorkflowPackQueueEventRecord) -> None:
         self._events[record.descriptor.event_id] = deepcopy(record)

--- a/src/app/repositories/memory_workflow_pack_run_repository.py
+++ b/src/app/repositories/memory_workflow_pack_run_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.repositories.workflow_pack_run_repository import (
@@ -65,6 +67,14 @@ class InMemoryWorkflowPackRunRepository(WorkflowPackRunRepository):
 
     def save_run(self, record: WorkflowPackRunRecord) -> None:
         self._runs[record.run_id] = deepcopy(record)
+
+    def delete_runs_with_events(self, run_ids: Sequence[str]) -> tuple[int, int]:
+        runs = events = 0
+        for run_id in run_ids:
+            if self._runs.pop(run_id, None) is not None:
+                runs += 1
+            events += len(self._events.pop(run_id, []))
+        return runs, events
 
     def list_events(self, *, run_id: str) -> list[WorkflowPackRunEventRecord]:
         events = self._events.get(run_id, [])

--- a/src/app/repositories/memory_workflow_pack_task_flow_repository.py
+++ b/src/app/repositories/memory_workflow_pack_task_flow_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.repositories.workflow_pack_task_flow_repository import (
@@ -79,6 +81,18 @@ class InMemoryWorkflowPackTaskFlowRepository(WorkflowPackTaskFlowRepository):
 
     def save_task_flow(self, record: WorkflowPackTaskFlowRecord) -> None:
         self._task_flows[record.descriptor.task_flow_id] = deepcopy(record)
+
+    def delete_task_flows_with_checkpoints(self, task_flow_ids: Sequence[str]) -> tuple[int, int]:
+        flows = checkpoints = 0
+        wanted = set(task_flow_ids)
+        for task_flow_id in task_flow_ids:
+            if self._task_flows.pop(task_flow_id, None) is not None:
+                flows += 1
+        for checkpoint_id, record in list(self._checkpoints.items()):
+            if record.descriptor.task_flow_id in wanted:
+                self._checkpoints.pop(checkpoint_id, None)
+                checkpoints += 1
+        return flows, checkpoints
 
     def list_checkpoints(self, *, task_flow_id: str) -> list[WorkflowPackTaskFlowCheckpointRecord]:
         records = [

--- a/src/app/repositories/sqlalchemy_artifact_repository.py
+++ b/src/app/repositories/sqlalchemy_artifact_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.artifacts import ArtifactLifecycleStatus, ArtifactStorageBackend
 from app.db.models import ArtifactMetadataModel
@@ -29,6 +31,18 @@ class SqlAlchemyArtifactRepository(SqlAlchemyRepositoryBase, ArtifactRepository)
             if model is None:
                 return None
             return self._to_record(model)
+
+    def delete_artifacts(self, artifact_ids: Sequence[str]) -> int:
+        if not artifact_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(ArtifactMetadataModel).where(
+                    ArtifactMetadataModel.artifact_id.in_(list(artifact_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def save_artifact(self, record: ArtifactRecord) -> None:
         model = ArtifactMetadataModel(

--- a/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.db.models import EvaluationCaseResultModel, EvaluationRunAttemptModel, EvaluationRunModel
 from app.repositories.evaluation_runtime_repository import (
@@ -83,6 +85,48 @@ class SqlAlchemyEvaluationRuntimeRepository(SqlAlchemyRepositoryBase, Evaluation
             if model is None:
                 return None
             return self._to_attempt_record(model)
+
+    def delete_runs_with_dependents(self, run_ids: Sequence[str]) -> tuple[int, int, int]:
+        if not run_ids:
+            return 0, 0, 0
+        ids = list(run_ids)
+        with self._session_factory() as session:
+            cases = session.execute(
+                delete(EvaluationCaseResultModel).where(EvaluationCaseResultModel.run_id.in_(ids))
+            )
+            attempts = session.execute(
+                delete(EvaluationRunAttemptModel).where(EvaluationRunAttemptModel.run_id.in_(ids))
+            )
+            runs = session.execute(
+                delete(EvaluationRunModel).where(EvaluationRunModel.run_id.in_(ids))
+            )
+            session.commit()
+            return (
+                int(getattr(runs, "rowcount", 0) or 0),
+                int(getattr(attempts, "rowcount", 0) or 0),
+                int(getattr(cases, "rowcount", 0) or 0),
+            )
+
+    def list_all_case_results(self, *, limit: int) -> list[EvaluationCaseResultRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(EvaluationCaseResultModel)
+                .order_by(EvaluationCaseResultModel.recorded_at.desc())
+                .limit(limit)
+            ).all()
+            return [self._to_case_result_record(model) for model in models]
+
+    def delete_case_results(self, case_result_ids: Sequence[str]) -> int:
+        if not case_result_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(EvaluationCaseResultModel).where(
+                    EvaluationCaseResultModel.case_result_id.in_(list(case_result_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def list_case_results(self, *, run_id: str) -> list[EvaluationCaseResultRecord]:
         with self._session_factory() as session:

--- a/src/app/repositories/sqlalchemy_workflow_pack_queue_event_repository.py
+++ b/src/app/repositories/sqlalchemy_workflow_pack_queue_event_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.workflow_pack_queue_policies import WorkflowPackQueueEventDescriptor
 from app.db.models import WorkflowPackQueueEventModel
@@ -42,6 +44,18 @@ class SqlAlchemyWorkflowPackQueueEventRepository(
         with self._session_factory() as session:
             models = session.scalars(statement).all()
             return [self._to_record(model) for model in models]
+
+    def delete_events(self, event_ids: Sequence[str]) -> int:
+        if not event_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(WorkflowPackQueueEventModel).where(
+                    WorkflowPackQueueEventModel.event_id.in_(list(event_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def save_event(self, record: WorkflowPackQueueEventRecord) -> None:
         descriptor = record.descriptor

--- a/src/app/repositories/sqlalchemy_workflow_pack_run_repository.py
+++ b/src/app/repositories/sqlalchemy_workflow_pack_run_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.artifacts import ArtifactDescriptor
 from app.contracts.evidence import ExecutionEvidenceDescriptor
@@ -133,6 +135,23 @@ class SqlAlchemyWorkflowPackRunRepository(SqlAlchemyRepositoryBase, WorkflowPack
         with self._session_factory() as session:
             session.merge(model)
             session.commit()
+
+    def delete_runs_with_events(self, run_ids: Sequence[str]) -> tuple[int, int]:
+        if not run_ids:
+            return 0, 0
+        ids = list(run_ids)
+        with self._session_factory() as session:
+            events = session.execute(
+                delete(WorkflowPackRunEventModel).where(WorkflowPackRunEventModel.run_id.in_(ids))
+            )
+            runs = session.execute(
+                delete(WorkflowPackRunModel).where(WorkflowPackRunModel.run_id.in_(ids))
+            )
+            session.commit()
+            return (
+                int(getattr(runs, "rowcount", 0) or 0),
+                int(getattr(events, "rowcount", 0) or 0),
+            )
 
     def list_events(self, *, run_id: str) -> list[WorkflowPackRunEventRecord]:
         with self._session_factory() as session:

--- a/src/app/repositories/sqlalchemy_workflow_pack_task_flow_repository.py
+++ b/src/app/repositories/sqlalchemy_workflow_pack_task_flow_repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from app.contracts.workflow_pack_task_flows import (
     WorkflowPackTaskFlowCheckpointDescriptor,
@@ -119,6 +121,27 @@ class SqlAlchemyWorkflowPackTaskFlowRepository(
         with self._session_factory() as session:
             session.merge(model)
             session.commit()
+
+    def delete_task_flows_with_checkpoints(self, task_flow_ids: Sequence[str]) -> tuple[int, int]:
+        if not task_flow_ids:
+            return 0, 0
+        ids = list(task_flow_ids)
+        with self._session_factory() as session:
+            checkpoints = session.execute(
+                delete(WorkflowPackTaskFlowCheckpointModel).where(
+                    WorkflowPackTaskFlowCheckpointModel.task_flow_id.in_(ids)
+                )
+            )
+            flows = session.execute(
+                delete(WorkflowPackTaskFlowModel).where(
+                    WorkflowPackTaskFlowModel.task_flow_id.in_(ids)
+                )
+            )
+            session.commit()
+            return (
+                int(getattr(flows, "rowcount", 0) or 0),
+                int(getattr(checkpoints, "rowcount", 0) or 0),
+            )
 
     def list_checkpoints(self, *, task_flow_id: str) -> list[WorkflowPackTaskFlowCheckpointRecord]:
         with self._session_factory() as session:

--- a/src/app/repositories/workflow_pack_queue_event_repository.py
+++ b/src/app/repositories/workflow_pack_queue_event_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -21,3 +23,7 @@ class WorkflowPackQueueEventRepository(Protocol):
     ) -> list[WorkflowPackQueueEventRecord]: ...
 
     def save_event(self, record: WorkflowPackQueueEventRecord) -> None: ...
+
+    def delete_events(self, event_ids: Sequence[str]) -> int:
+        """Delete queue events by id (lifecycle engine, issue #158 S2c)."""
+        ...

--- a/src/app/repositories/workflow_pack_run_repository.py
+++ b/src/app/repositories/workflow_pack_run_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -93,6 +95,9 @@ class WorkflowPackRunRepository(Protocol):
 
     def save_run(self, record: WorkflowPackRunRecord) -> None:
         """Persist one workflow-pack run record."""
+
+    def delete_runs_with_events(self, run_ids: Sequence[str]) -> tuple[int, int]:
+        """Delete runs and their events (lifecycle engine, issue #158 S2c)."""
 
     def list_events(self, *, run_id: str) -> list[WorkflowPackRunEventRecord]:
         """List persisted events for one workflow-pack run."""

--- a/src/app/repositories/workflow_pack_task_flow_repository.py
+++ b/src/app/repositories/workflow_pack_task_flow_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -41,6 +43,10 @@ class WorkflowPackTaskFlowRepository(Protocol):
     def get_task_flow(self, *, task_flow_id: str) -> WorkflowPackTaskFlowRecord | None: ...
 
     def save_task_flow(self, record: WorkflowPackTaskFlowRecord) -> None: ...
+
+    def delete_task_flows_with_checkpoints(self, task_flow_ids: Sequence[str]) -> tuple[int, int]:
+        """Delete task flows and their checkpoints (lifecycle engine, issue #158 S2c)."""
+        ...
 
     def list_checkpoints(
         self, *, task_flow_id: str

--- a/src/app/services/data_lifecycle_engine.py
+++ b/src/app/services/data_lifecycle_engine.py
@@ -36,6 +36,14 @@ from app.services.workflow_pack_registry_store import get_workflow_pack_registry
 from app.provider_retention_confirmations.store import (
     get_provider_retention_confirmation_store,
 )
+from app.services.artifact_store import get_artifact_repository
+from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+from app.services.workflow_pack_task_flow_store import get_workflow_pack_task_flow_store
+from app.services.workflow_pack_queue_event_store import get_workflow_pack_queue_event_store
+from app.workflow_pack_execution_idempotency.store import (
+    get_workflow_pack_execution_idempotency_store,
+)
 from app.services.workflow_pack_admission_lease_store import (
     get_workflow_pack_admission_lease_repository,
 )
@@ -313,9 +321,147 @@ def _expire_control_plane_evidence(
     )
 
 
+def _held_tenants(family: RetentionFamily) -> set[str]:
+    return {
+        hold.key_value
+        for hold in get_audit_store().list_active_legal_holds(family_id=family.family_id)
+        if hold.key_type == "tenant"
+    }
+
+
+def _expire_workflow_run_records(
+    family: RetentionFamily, cutoff: datetime
+) -> tuple[list[str], str]:
+    """Business run records past retention, honouring tenant-scoped holds.
+
+    Run events and flow checkpoints cascade with their parent - an event of a
+    held run stays regardless of its own age. Idempotency claims and queue
+    events age independently under the same tenant holds.
+    """
+
+    held = _held_tenants(family)
+    deleted: list[str] = []
+    details: list[str] = []
+
+    runs = get_workflow_pack_run_store()
+    expired_runs = [
+        record.run_id
+        for record in runs.list_runs(limit=_CANDIDATE_BATCH_LIMIT)
+        if _is_before(record.created_at, cutoff)
+        and (record.tenant_id is None or record.tenant_id not in held)
+    ]
+    if expired_runs:
+        run_count, event_count = runs.delete_runs_with_events(expired_runs)
+        deleted.extend(f"workflow_pack_runs:{run_id}" for run_id in expired_runs)
+        details.append(f"runs={run_count} run_events={event_count}")
+
+    flows = get_workflow_pack_task_flow_store()
+    expired_flows = [
+        record.descriptor.task_flow_id
+        for record in flows.list_task_flows()
+        if _is_before(record.descriptor.created_at, cutoff)
+        and (record.descriptor.tenant_id is None or record.descriptor.tenant_id not in held)
+    ]
+    if expired_flows:
+        flow_count, checkpoint_count = flows.delete_task_flows_with_checkpoints(expired_flows)
+        deleted.extend(f"workflow_pack_task_flows:{flow_id}" for flow_id in expired_flows)
+        details.append(f"task_flows={flow_count} checkpoints={checkpoint_count}")
+
+    queue_events = get_workflow_pack_queue_event_store()
+    expired_queue_events = [
+        record.descriptor.event_id
+        for record in queue_events.list_events(limit=_CANDIDATE_BATCH_LIMIT)
+        if _is_before(record.descriptor.recorded_at, cutoff)
+        and (record.descriptor.tenant_id is None or record.descriptor.tenant_id not in held)
+    ]
+    if expired_queue_events:
+        count = queue_events.delete_events(expired_queue_events)
+        deleted.extend(
+            f"workflow_pack_queue_events:{event_id}" for event_id in expired_queue_events
+        )
+        details.append(f"queue_events={count}")
+
+    idempotency = get_workflow_pack_execution_idempotency_store()
+    expired_idempotency = [
+        record.record_id
+        for record in idempotency.list_records(limit=_CANDIDATE_BATCH_LIMIT)
+        if _is_before(record.created_at, cutoff)
+        and (record.tenant_scope is None or record.tenant_scope not in held)
+    ]
+    if expired_idempotency:
+        count = idempotency.delete_records(expired_idempotency)
+        deleted.extend(
+            f"workflow_pack_execution_idempotency:{record_id}" for record_id in expired_idempotency
+        )
+        details.append(f"idempotency={count}")
+
+    detail = "; ".join(details) if details else "nothing past retention"
+    return deleted, (
+        f"expired workflow run records ({detail}); held tenants and cascading "
+        "children of held runs are untouched"
+    )
+
+
+def _expire_artifact_content(family: RetentionFamily, cutoff: datetime) -> tuple[list[str], str]:
+    """Aged artifacts, except rows retained for review (live obligation)."""
+
+    repository = get_artifact_repository()
+    expired = [
+        record.artifact_id
+        for record in repository.list_artifacts()
+        if _is_before(record.created_at, cutoff)
+        and record.retention_posture != "retained_for_review"
+    ]
+    count = repository.delete_artifacts(expired) if expired else 0
+    return [f"artifact_metadata:{artifact_id}" for artifact_id in expired], (
+        f"expired {count} artifact metadata rows; retained_for_review rows are never expired"
+    )
+
+
+def _expire_evaluation_approval_evidence(
+    family: RetentionFamily, cutoff: datetime
+) -> tuple[list[str], str]:
+    """Evaluation runs past retention, cascading attempts and any case rows."""
+
+    repository = get_evaluation_runtime_store()
+    expired_runs = [
+        record.run_id
+        for record in repository.list_runs()
+        if _is_before(record.submitted_at, cutoff)
+    ]
+    runs, attempts, cases = (
+        repository.delete_runs_with_dependents(expired_runs) if expired_runs else (0, 0, 0)
+    )
+    return [f"evaluation_runs:{run_id}" for run_id in expired_runs], (
+        f"expired {runs} evaluation runs with {attempts} attempts and {cases} case rows"
+    )
+
+
+def _expire_evaluation_case_content(
+    family: RetentionFamily, cutoff: datetime
+) -> tuple[list[str], str]:
+    """Bulky per-case content ages on its own instant; the run verdict stays."""
+
+    repository = get_evaluation_runtime_store()
+    expired = [
+        record.case_result_id
+        for record in repository.list_all_case_results(limit=_CANDIDATE_BATCH_LIMIT)
+        if _is_before(record.recorded_at, cutoff)
+    ]
+    count = repository.delete_case_results(expired) if expired else 0
+    return [f"evaluation_case_results:{case_id}" for case_id in expired], (
+        f"expired {count} evaluation case rows; run verdicts remain with the "
+        "approval evidence family"
+    )
+
+
 _ENFORCED_FAMILY_HANDLERS = {
     "audit_evidence": _expire_audit_evidence,
     "control_plane_evidence": _expire_control_plane_evidence,
+    "workflow_run_records": _expire_workflow_run_records,
+    "artifact_content": _expire_artifact_content,
+    "evaluation_approval_evidence": _expire_evaluation_approval_evidence,
+    "evaluation_case_content": _expire_evaluation_case_content,
     "async_runtime_content": _expire_async_runtime_content,
     "transient_operational_leases": _expire_transient_leases,
 }

--- a/src/app/workflow_pack_execution_idempotency/memory_repository.py
+++ b/src/app/workflow_pack_execution_idempotency/memory_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import replace
 from threading import Lock
 
@@ -74,6 +76,21 @@ class InMemoryWorkflowPackExecutionIdempotencyRepository:
             )
             self._records[record_id] = indeterminate
             return indeterminate
+
+    def list_records(self, *, limit: int) -> list[WorkflowPackExecutionIdempotencyRecord]:
+        with self._lock:
+            records = sorted(
+                self._records.values(), key=lambda record: record.created_at, reverse=True
+            )
+            return list(records[:limit])
+
+    def delete_records(self, record_ids: Sequence[str]) -> int:
+        with self._lock:
+            deleted = 0
+            for record_id in record_ids:
+                if self._records.pop(record_id, None) is not None:
+                    deleted += 1
+            return deleted
 
     def release(self, *, record_id: str, owner_token: str) -> None:
         with self._lock:

--- a/src/app/workflow_pack_execution_idempotency/repository.py
+++ b/src/app/workflow_pack_execution_idempotency/repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Protocol
@@ -68,3 +70,11 @@ class WorkflowPackExecutionIdempotencyRepository(Protocol):
     ) -> WorkflowPackExecutionIdempotencyRecord: ...
 
     def release(self, *, record_id: str, owner_token: str) -> None: ...
+
+    def list_records(self, *, limit: int) -> list[WorkflowPackExecutionIdempotencyRecord]:
+        """List records, newest first (lifecycle engine read)."""
+        ...
+
+    def delete_records(self, record_ids: Sequence[str]) -> int:
+        """Delete idempotency records by id (lifecycle engine, issue #158 S2c)."""
+        ...

--- a/src/app/workflow_pack_execution_idempotency/sqlalchemy_repository.py
+++ b/src/app/workflow_pack_execution_idempotency/sqlalchemy_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from pathlib import Path
 from typing import Any, cast
 
@@ -91,6 +93,27 @@ class SqlAlchemyWorkflowPackExecutionIdempotencyRepository(SqlAlchemyRepositoryB
             failure_code=failure_code,
             updated_at=updated_at,
         )
+
+    def list_records(self, *, limit: int) -> list[WorkflowPackExecutionIdempotencyRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(WorkflowPackExecutionIdempotencyModel)
+                .order_by(WorkflowPackExecutionIdempotencyModel.created_at.desc())
+                .limit(limit)
+            ).all()
+            return [_to_record(model) for model in models]
+
+    def delete_records(self, record_ids: Sequence[str]) -> int:
+        if not record_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(WorkflowPackExecutionIdempotencyModel).where(
+                    WorkflowPackExecutionIdempotencyModel.record_id.in_(list(record_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def release(self, *, record_id: str, owner_token: str) -> None:
         with self._session_factory() as session:

--- a/tests/unit/test_data_lifecycle_engine.py
+++ b/tests/unit/test_data_lifecycle_engine.py
@@ -256,9 +256,9 @@ def test_expiry_honours_age_terminal_state_and_legal_hold() -> None:
     assert events["audit_evidence"].actor == "test.operator"
 
     # DECLARED_ONLY families are reported, never touched.
-    assert results["workflow_run_records"].enforcement == "DECLARED_ONLY"
-    assert results["workflow_run_records"].deleted_count == 0
-    assert results["workflow_run_records"].event_id is None
+    assert results["retrieval_shared_reference"].enforcement == "DECLARED_ONLY"
+    assert results["retrieval_shared_reference"].deleted_count == 0
+    assert results["retrieval_shared_reference"].event_id is None
 
 
 def test_second_run_is_idempotent() -> None:
@@ -333,11 +333,17 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
         "model_catalogue_store_mode",
         "provider_operations_store_mode",
         "provider_retention_confirmation_store_mode",
+        "workflow_pack_run_store_mode",
+        "workflow_pack_task_flow_store_mode",
+        "workflow_pack_queue_event_store_mode",
+        "artifact_store_mode",
+        "evaluation_runtime_store_mode",
     ):
         monkeypatch.setattr(settings, mode_field, "sqlalchemy")
 
     _seed_expiry_matrix()
     _seed_control_plane_matrix()
+    _seed_run_and_eval_matrix()
     report = run_data_lifecycle(actor="test.operator")
 
     results = {r.family_id: r.deleted_count for r in report.results}
@@ -345,6 +351,10 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
     assert results["async_runtime_content"] == 1
     assert results["transient_operational_leases"] == 2
     assert results["control_plane_evidence"] == 10
+    assert results["workflow_run_records"] == 4
+    assert results["artifact_content"] == 1
+    assert results["evaluation_approval_evidence"] == 1
+    assert results["evaluation_case_content"] == 1
 
     # The SQL adapters' empty deletions are safe no-ops.
     from app.provider_retention_confirmations.store import (
@@ -367,13 +377,30 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
     assert get_audit_store().delete_access_events([]) == 0
     assert get_audit_store().delete_lifecycle_events([]) == 0
 
+    from app.services.artifact_store import get_artifact_repository
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+    from app.services.workflow_pack_queue_event_store import get_workflow_pack_queue_event_store
+    from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+    from app.services.workflow_pack_task_flow_store import get_workflow_pack_task_flow_store
+    from app.workflow_pack_execution_idempotency.store import (
+        get_workflow_pack_execution_idempotency_store,
+    )
+
+    assert get_workflow_pack_run_store().delete_runs_with_events([]) == (0, 0)
+    assert get_workflow_pack_task_flow_store().delete_task_flows_with_checkpoints([]) == (0, 0)
+    assert get_workflow_pack_queue_event_store().delete_events([]) == 0
+    assert get_artifact_repository().delete_artifacts([]) == 0
+    assert get_workflow_pack_execution_idempotency_store().delete_records([]) == 0
+    assert get_evaluation_runtime_store().delete_runs_with_dependents([]) == (0, 0, 0)
+    assert get_evaluation_runtime_store().delete_case_results([]) == 0
+
     audit = get_audit_store()
     assert {r.request_id for r in audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=50)} == {
         "air_old_b_held",
         "air_young_a",
     }
-    events = audit.list_lifecycle_events(limit=10)
-    assert len(events) == 4
+    events = audit.list_lifecycle_events(limit=20)
+    assert len(events) == 8
     assert all(len(event.deleted_ids_digest) == 64 for event in events)
     assert {j.job_id for j in get_async_runtime_store().list_jobs()} == {
         "job_old_queued",
@@ -382,7 +409,7 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
 
     second = run_data_lifecycle(actor="test.operator")
     assert all(result.deleted_count == 0 for result in second.results)
-    assert len(get_audit_store().list_lifecycle_events(limit=10)) == 4
+    assert len(get_audit_store().list_lifecycle_events(limit=20)) == 8
 
 
 def test_naive_timestamps_are_treated_as_utc() -> None:
@@ -776,6 +803,235 @@ def test_control_plane_evidence_expiry_honours_the_protective_predicates() -> No
         control_event.deleted_ids_digest
         == hashlib.sha256("\n".join(expected_ids).encode("utf-8")).hexdigest()
     )
+
+    second = run_data_lifecycle(actor="test.operator")
+    assert all(result.deleted_count == 0 for result in second.results)
+
+
+def _seed_run_and_eval_matrix() -> None:
+    from app.contracts.artifacts import ArtifactLifecycleStatus, ArtifactStorageBackend
+    from app.repositories.artifact_repository import ArtifactRecord
+    from app.repositories.evaluation_runtime_repository import (
+        EvaluationCaseResultRecord,
+        EvaluationRunAttemptRecord,
+        EvaluationRunRecord,
+    )
+    from app.services.artifact_store import get_artifact_repository
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+    from app.services.workflow_pack_queue_event_store import get_workflow_pack_queue_event_store
+    from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+    from app.services.workflow_pack_task_flow_store import get_workflow_pack_task_flow_store
+    from app.repositories.workflow_pack_task_flow_repository import (
+        WorkflowPackTaskFlowCheckpointRecord,
+        WorkflowPackTaskFlowRecord,
+    )
+    from app.repositories.workflow_pack_queue_event_repository import (
+        WorkflowPackQueueEventRecord,
+    )
+    from app.workflow_pack_execution_idempotency.repository import (
+        WorkflowPackExecutionIdempotencyRecord,
+        WorkflowPackExecutionIdempotencyState,
+    )
+    from app.workflow_pack_execution_idempotency.store import (
+        get_workflow_pack_execution_idempotency_store,
+    )
+    from tests.support.workflow_pack_task_flow_fixtures import (
+        workflow_pack_task_flow_checkpoint,
+        workflow_pack_task_flow_descriptor,
+    )
+    from tests.unit.test_workflow_pack_queue_event_store import _queue_event
+    from tests.unit.test_workflow_pack_run_store import _workflow_pack_run_record
+
+    audit = get_audit_store()
+    audit.place_legal_hold(
+        DataLegalHoldRecord(
+            hold_id="hold_run_b",
+            family_id="workflow_run_records",
+            key_type="tenant",
+            key_value="tenant-b",
+            reason="Litigation hold for tenant-b run records.",
+            placed_by="legal.ops@lotus",
+            placed_at=_iso(1),
+        )
+    )
+
+    runs = get_workflow_pack_run_store()
+    runs.save_run(
+        _workflow_pack_run_record(run_id="run_old_a", tenant_id="tenant-a", created_at=_iso(2600))
+    )
+    runs.save_run(
+        _workflow_pack_run_record(
+            run_id="run_old_b_held", tenant_id="tenant-b", created_at=_iso(2600)
+        )
+    )
+    runs.save_run(
+        _workflow_pack_run_record(run_id="run_young_a", tenant_id="tenant-a", created_at=_iso(5))
+    )
+
+    flows = get_workflow_pack_task_flow_store()
+    old_flow = workflow_pack_task_flow_descriptor(task_flow_id="flow_old")
+    old_flow = old_flow.model_copy(update={"created_at": _iso(2600), "tenant_id": "tenant-a"})
+    young_flow = workflow_pack_task_flow_descriptor(task_flow_id="flow_young")
+    young_flow = young_flow.model_copy(update={"created_at": _iso(3), "tenant_id": "tenant-a"})
+    flows.save_task_flow(WorkflowPackTaskFlowRecord(descriptor=old_flow))
+    flows.save_task_flow(WorkflowPackTaskFlowRecord(descriptor=young_flow))
+    checkpoint = workflow_pack_task_flow_checkpoint(task_flow_id="flow_old")
+    flows.save_checkpoint(WorkflowPackTaskFlowCheckpointRecord(descriptor=checkpoint))
+
+    queue_events = get_workflow_pack_queue_event_store()
+    old_event = _queue_event("qev_old", "queue-item-1")
+    old_event = WorkflowPackQueueEventRecord(
+        descriptor=old_event.descriptor.model_copy(update={"recorded_at": _iso(2600)})
+    )
+    queue_events.save_event(old_event)
+    queue_events.save_event(_queue_event("qev_young", "queue-item-2"))
+
+    idempotency = get_workflow_pack_execution_idempotency_store()
+    for record_id, age in (("idem_old", 2600), ("idem_young", 4)):
+        idempotency.reserve(
+            WorkflowPackExecutionIdempotencyRecord(
+                record_id=record_id,
+                caller_app="lotus-gateway",
+                tenant_scope="tenant-a",
+                idempotency_key=f"key-{record_id}",
+                request_fingerprint="f" * 64,
+                state=WorkflowPackExecutionIdempotencyState.COMPLETED,
+                owner_token="tok",
+                response_payload=None,
+                response_checksum_sha256=None,
+                failure_code=None,
+                created_at=_iso(age),
+                updated_at=_iso(age),
+            )
+        )
+
+    artifacts = get_artifact_repository()
+
+    def _artifact(artifact_id: str, age: int, posture: str) -> None:
+        artifacts.save_artifact(
+            ArtifactRecord(
+                artifact_id=artifact_id,
+                domain="workflow_pack_runs",
+                artifact_type="advisor_brief_document",
+                source_object_kind="workflow_pack_run",
+                source_object_id="run_old_a",
+                lifecycle_status=ArtifactLifecycleStatus.RUNTIME_GENERATED,
+                retention_posture=posture,
+                media_type="application/json",
+                byte_size=10,
+                checksum_sha256="c" * 64,
+                storage_backend=ArtifactStorageBackend.MEMORY,
+                storage_reference=f"mem://{artifact_id}",
+                lineage_parent_artifact_id=None,
+                superseded_by_artifact_id=None,
+                created_at=_iso(age),
+                created_by="lotus-ai",
+            )
+        )
+
+    _artifact("art_old", 2600, "active")
+    _artifact("art_old_review", 2600, "retained_for_review")
+    _artifact("art_young", 3, "active")
+
+    evaluation = get_evaluation_runtime_store()
+    for run_id, age in (("eval_old", 2600), ("eval_young", 6)):
+        evaluation.save_run(
+            EvaluationRunRecord(
+                run_id=run_id,
+                fixture_id="fixture",
+                manifest_version="foundation.v1",
+                lifecycle_status="COMPLETED",
+                triggered_by="operator-a",
+                submitted_at=_iso(age),
+                async_job_id=None,
+                latest_message="m",
+                verdict="PASS",
+                case_count=1,
+            )
+        )
+        evaluation.save_attempt(
+            EvaluationRunAttemptRecord(
+                attempt_id=f"att_{run_id}",
+                run_id=run_id,
+                attempt_number=1,
+                lifecycle_status="COMPLETED",
+                started_at=_iso(age),
+                completed_at=_iso(age),
+                worker_id=None,
+                latest_message="m",
+                verdict="PASS",
+                failure_reason=None,
+            )
+        )
+    for case_id, run_id, age in (
+        ("case_old", "eval_young", 400),
+        ("case_young", "eval_young", 6),
+    ):
+        evaluation.save_case_result(
+            EvaluationCaseResultRecord(
+                case_result_id=case_id,
+                run_id=run_id,
+                attempt_id=f"att_{run_id}",
+                case_id=f"c-{case_id}",
+                fixture_id="fixture",
+                outcome="PASS",
+                summary="s",
+                evidence_refs=[],
+                artifact_ids=[],
+                provider_config_sha256=None,
+                recorded_at=_iso(age),
+            )
+        )
+
+
+def test_run_records_eval_and_artifact_expiry_honour_their_semantics() -> None:
+    """S2c: business run records expire under tenant holds with cascading
+    children; artifacts retained for review never expire; eval runs cascade
+    dependents while young case content ages independently."""
+
+    from app.services.artifact_store import get_artifact_repository
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+    from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+    from app.services.workflow_pack_task_flow_store import get_workflow_pack_task_flow_store
+    from app.workflow_pack_execution_idempotency.store import (
+        get_workflow_pack_execution_idempotency_store,
+    )
+
+    _seed_run_and_eval_matrix()
+
+    report = run_data_lifecycle(actor="test.operator")
+    results = {r.family_id: r for r in report.results}
+
+    assert results["workflow_run_records"].deleted_count == 4  # run, flow, qev, idem
+    assert "held tenants" in results["workflow_run_records"].detail
+    assert {r.run_id for r in get_workflow_pack_run_store().list_runs()} == {
+        "run_old_b_held",
+        "run_young_a",
+    }
+    flows = get_workflow_pack_task_flow_store()
+    assert {f.descriptor.task_flow_id for f in flows.list_task_flows()} == {"flow_young"}
+    assert flows.list_checkpoints(task_flow_id="flow_old") == []
+    assert {
+        r.record_id for r in get_workflow_pack_execution_idempotency_store().list_records(limit=10)
+    } == {"idem_young"}
+
+    assert results["artifact_content"].deleted_count == 1
+    assert "retained_for_review" in results["artifact_content"].detail
+    assert {a.artifact_id for a in get_artifact_repository().list_artifacts()} == {
+        "art_old_review",
+        "art_young",
+    }
+
+    evaluation = get_evaluation_runtime_store()
+    assert results["evaluation_approval_evidence"].deleted_count == 1
+    assert {r.run_id for r in evaluation.list_runs()} == {"eval_young"}
+    assert evaluation.list_attempts(run_id="eval_old") == []
+    assert results["evaluation_case_content"].deleted_count == 1
+    assert {c.case_result_id for c in evaluation.list_all_case_results(limit=10)} == {"case_young"}
+
+    events = {e.family_id: e for e in get_audit_store().list_lifecycle_events(limit=20)}
+    assert events["workflow_run_records"].row_count == 4
+    assert events["evaluation_approval_evidence"].row_count == 1
 
     second = run_data_lifecycle(actor="test.operator")
     assert all(result.deleted_count == 0 for result in second.results)


### PR DESCRIPTION
Issue #158, S2c: **the client-content families become true.** Business run records, artifacts, and both evaluation families flip from `DECLARED_ONLY` to `ENFORCED` — with tenant-scoped legal holds doing real work on the family that holds the most client-derived content, and two more protective predicates joining the set.

## Semantics per family, each pinned by test

- **`workflow_run_records`** — runs, task flows, queue events and idempotency claims age past seven years under **tenant-scoped legal holds**; run events and flow checkpoints cascade with their parent, so a child of a held run stays regardless of its own age.
- **`artifact_content`** (new family — see below) — aged artifacts expire **except rows marked `retained_for_review`**: a live review obligation is never deleted by lifecycle.
- **`evaluation_approval_evidence`** — seven-year runs cascade attempts and any straggler case rows in one repository operation, so no orphaned FK rows survive.
- **`evaluation_case_content`** — bulky per-case content ages on its own instant at one year; the run verdict (the approval evidence promotions reference) stays with its own family.

## A fourth policy truth correction

`artifact_metadata` sat in the tenant-erasable run-records family — but artifact rows carry **no tenant attribution**, so the family's erasure claim was broader than the store can honour (the same defect class as the access-events and guard-row corrections in S2a). It moves to its own `artifact_content` family: seven-year retention, hold-supported, `erasure_key: none` with the tenant-linkage gap stated in the basis as a recorded prerequisite for S3 erasure.

## Mechanics

Four engine handlers; delete-by-ids (with parent-child cascades where children have no tenant of their own) on six more stores — run store, task-flow store, queue-event store, artifact store, execution-idempotency store, evaluation runtime store — memory + SQL adapters, empty-input safe, list-all reads added where only scoped reads existed. Deleted ids stay table-prefixed in the family evidence events.

Seven of eight time-bounded families are now `ENFORCED`; only `retrieval_shared_reference` (version-supersession semantics) remains `DECLARED_ONLY`, for S2d.

## Evidence

Memory matrix: held-tenant runs survive with their children while same-age unheld rows expire across all four families; review-retained artifacts survive; eval cascade counts and independent case ageing asserted; idempotent second run. The same matrix runs through the SQL adapters — **all thirteen sqlalchemy store modes at once** over the real migrations — with per-adapter empty-deletion no-ops. Combined coverage verified locally before push. No schema changes.
