### PR TITLE
feat(lifecycle): every declared retention period is now applied (#158 S2d)

### DIFF
--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -113,21 +113,17 @@
     },
     {
       "family_id": "retrieval_shared_reference",
-      "purpose": "Ingested platform reference sources, documents, chunks, versions and ingestion/index jobs shared across tenants.",
+      "purpose": "Superseded retrieval document versions and completed ingestion-job records: the ageable history behind the live reference index.",
       "tables": [
-        "retrieval_sources",
-        "retrieval_documents",
-        "retrieval_chunks",
-        "retrieval_index_jobs",
         "retrieval_document_versions",
         "retrieval_ingestion_jobs"
       ],
       "retention_days": 1095,
-      "retention_basis": "Shared reference content is versioned: superseded versions expire after three years; current versions are re-ingested, not retained past supersession. No tenant erasure - the content is not tenant-derived.",
+      "retention_basis": "Superseded versions expire after three years; ingestion-job records age with them. Current versions and the live index are current state, declared separately. No tenant erasure - the content is not tenant-derived.",
       "legal_hold_supported": true,
       "erasure_key": "shared_reference",
       "evidence_class": "reference_content",
-      "enforcement": "DECLARED_ONLY"
+      "enforcement": "ENFORCED"
     },
     {
       "family_id": "governed_registry_configuration",
@@ -177,6 +173,22 @@
       "erasure_key": "none",
       "evidence_class": "business_run_evidence",
       "enforcement": "ENFORCED"
+    },
+    {
+      "family_id": "retrieval_current_reference",
+      "purpose": "The live reference index: sources, current documents, chunks and index jobs.",
+      "tables": [
+        "retrieval_sources",
+        "retrieval_documents",
+        "retrieval_chunks",
+        "retrieval_index_jobs"
+      ],
+      "retention_days": null,
+      "retention_basis": "Current-state index content, superseded in place through re-ingestion; these rows carry no timestamps to age on, and their superseded history lives (and expires) in retrieval_document_versions. Time-bounding them would claim a mechanism the store cannot honour.",
+      "legal_hold_supported": true,
+      "erasure_key": "shared_reference",
+      "evidence_class": "reference_content",
+      "enforcement": "NOT_TIME_BOUNDED"
     }
   ]
 }

--- a/src/app/repositories/memory_retrieval_repository.py
+++ b/src/app/repositories/memory_retrieval_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from copy import deepcopy
 
 from app.contracts.retrieval import (
@@ -304,6 +306,18 @@ class InMemoryRetrievalRepository(RetrievalRepository):
             key=lambda version: (version.created_at, version.version_id),
             reverse=True,
         )
+
+    def delete_document_versions(self, version_ids: Sequence[str]) -> int:
+        wanted = set(version_ids)
+        before = len(self._document_versions)
+        self._document_versions = [v for v in self._document_versions if v.version_id not in wanted]
+        return before - len(self._document_versions)
+
+    def delete_ingestion_jobs(self, job_ids: Sequence[str]) -> int:
+        wanted = set(job_ids)
+        before = len(self._ingestion_jobs)
+        self._ingestion_jobs = [j for j in self._ingestion_jobs if j.job_id not in wanted]
+        return before - len(self._ingestion_jobs)
 
     def save_document_version(self, descriptor: RetrievalDocumentVersionDescriptor) -> None:
         self._document_versions = [

--- a/src/app/repositories/retrieval_repository.py
+++ b/src/app/repositories/retrieval_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from typing import Protocol
 
 from app.contracts.retrieval import (
@@ -31,6 +33,14 @@ class RetrievalRepository(Protocol):
     def save_document_version(self, descriptor: RetrievalDocumentVersionDescriptor) -> None: ...
 
     def list_ingestion_jobs(self) -> list[RetrievalIngestionJobDescriptor]: ...
+
+    def delete_document_versions(self, version_ids: Sequence[str]) -> int:
+        """Delete superseded version history by id (issue #158, S2d)."""
+        ...
+
+    def delete_ingestion_jobs(self, job_ids: Sequence[str]) -> int:
+        """Delete ingestion-job records by id (issue #158, S2d)."""
+        ...
 
     def get_ingestion_job(self, job_id: str) -> RetrievalIngestionJobDescriptor | None: ...
 

--- a/src/app/repositories/sqlalchemy_retrieval_repository.py
+++ b/src/app/repositories/sqlalchemy_retrieval_repository.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from collections import defaultdict
 from pathlib import Path
 from typing import Callable
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import delete, and_, func, or_, select
 from sqlalchemy.orm import Session
 
 from app.contracts.retrieval import (
@@ -98,6 +100,30 @@ class SqlAlchemyRetrievalRepository(SqlAlchemyRepositoryBase):
                 )
             ).all()
             return [self._to_document_version_descriptor(version) for version in versions]
+
+    def delete_document_versions(self, version_ids: Sequence[str]) -> int:
+        if not version_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(RetrievalDocumentVersionModel).where(
+                    RetrievalDocumentVersionModel.version_id.in_(list(version_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
+
+    def delete_ingestion_jobs(self, job_ids: Sequence[str]) -> int:
+        if not job_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(RetrievalIngestionJobModel).where(
+                    RetrievalIngestionJobModel.job_id.in_(list(job_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def save_document_version(self, descriptor: RetrievalDocumentVersionDescriptor) -> None:
         model = RetrievalDocumentVersionModel(

--- a/src/app/services/data_lifecycle_engine.py
+++ b/src/app/services/data_lifecycle_engine.py
@@ -44,6 +44,7 @@ from app.services.workflow_pack_queue_event_store import get_workflow_pack_queue
 from app.workflow_pack_execution_idempotency.store import (
     get_workflow_pack_execution_idempotency_store,
 )
+from app.services.retrieval_store import get_retrieval_repository
 from app.services.workflow_pack_admission_lease_store import (
     get_workflow_pack_admission_lease_repository,
 )
@@ -455,6 +456,37 @@ def _expire_evaluation_case_content(
     )
 
 
+def _expire_retrieval_reference_history(
+    family: RetentionFamily, cutoff: datetime
+) -> tuple[list[str], str]:
+    """Superseded version history and ingestion-job records past retention.
+
+    Only SUPERSEDED versions age out - the current version of a document is
+    live reference state and never expired by lifecycle, whatever its age.
+    """
+
+    repository = get_retrieval_repository()
+    deleted: list[str] = []
+    expired_versions = [
+        version.version_id
+        for version in repository.list_document_versions()
+        if version.lifecycle_status.value == "SUPERSEDED" and _is_before(version.created_at, cutoff)
+    ]
+    version_count = repository.delete_document_versions(expired_versions) if expired_versions else 0
+    deleted.extend(f"retrieval_document_versions:{vid}" for vid in expired_versions)
+    expired_jobs = [
+        job.job_id
+        for job in repository.list_ingestion_jobs()
+        if _is_before(job.requested_at, cutoff)
+    ]
+    job_count = repository.delete_ingestion_jobs(expired_jobs) if expired_jobs else 0
+    deleted.extend(f"retrieval_ingestion_jobs:{jid}" for jid in expired_jobs)
+    return deleted, (
+        f"expired {version_count} superseded document versions and {job_count} ingestion "
+        "jobs; current versions are live reference state and never expired"
+    )
+
+
 _ENFORCED_FAMILY_HANDLERS = {
     "audit_evidence": _expire_audit_evidence,
     "control_plane_evidence": _expire_control_plane_evidence,
@@ -462,6 +494,7 @@ _ENFORCED_FAMILY_HANDLERS = {
     "artifact_content": _expire_artifact_content,
     "evaluation_approval_evidence": _expire_evaluation_approval_evidence,
     "evaluation_case_content": _expire_evaluation_case_content,
+    "retrieval_shared_reference": _expire_retrieval_reference_history,
     "async_runtime_content": _expire_async_runtime_content,
     "transient_operational_leases": _expire_transient_leases,
 }

--- a/tests/unit/test_data_lifecycle_engine.py
+++ b/tests/unit/test_data_lifecycle_engine.py
@@ -255,10 +255,11 @@ def test_expiry_honours_age_terminal_state_and_legal_hold() -> None:
     assert events["audit_evidence"].policy_version == report.policy_version
     assert events["audit_evidence"].actor == "test.operator"
 
-    # DECLARED_ONLY families are reported, never touched.
-    assert results["retrieval_shared_reference"].enforcement == "DECLARED_ONLY"
-    assert results["retrieval_shared_reference"].deleted_count == 0
-    assert results["retrieval_shared_reference"].event_id is None
+    # Non-engine families are reported, never touched: every time-bounded
+    # family is now ENFORCED, and the not-time-bounded ones say so.
+    assert results["governed_registry_configuration"].enforcement == "NOT_TIME_BOUNDED"
+    assert results["governed_registry_configuration"].deleted_count == 0
+    assert results["governed_registry_configuration"].event_id is None
 
 
 def test_second_run_is_idempotent() -> None:
@@ -338,6 +339,7 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
         "workflow_pack_queue_event_store_mode",
         "artifact_store_mode",
         "evaluation_runtime_store_mode",
+        "retrieval_store_mode",
     ):
         monkeypatch.setattr(settings, mode_field, "sqlalchemy")
 
@@ -393,6 +395,13 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
     assert get_workflow_pack_execution_idempotency_store().delete_records([]) == 0
     assert get_evaluation_runtime_store().delete_runs_with_dependents([]) == (0, 0, 0)
     assert get_evaluation_runtime_store().delete_case_results([]) == 0
+
+    from app.services.retrieval_store import get_retrieval_repository
+
+    assert get_retrieval_repository().delete_document_versions([]) == 0
+    assert get_retrieval_repository().delete_ingestion_jobs([]) == 0
+    assert get_retrieval_repository().delete_document_versions(["ver_never"]) == 0
+    assert get_retrieval_repository().delete_ingestion_jobs(["ing_never"]) == 0
 
     audit = get_audit_store()
     assert {r.request_id for r in audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=50)} == {
@@ -1035,3 +1044,69 @@ def test_run_records_eval_and_artifact_expiry_honour_their_semantics() -> None:
 
     second = run_data_lifecycle(actor="test.operator")
     assert all(result.deleted_count == 0 for result in second.results)
+
+
+def test_retrieval_history_expiry_never_touches_current_versions() -> None:
+    """S2d: only SUPERSEDED versions age out - the current version of a
+    document is live reference state whatever its age - and ingestion-job
+    records age with the history."""
+
+    from app.contracts.retrieval import (
+        RetrievalDocumentVersionDescriptor,
+        RetrievalDocumentVersionLifecycleStatus,
+        RetrievalIngestionAction,
+        RetrievalIngestionJobDescriptor,
+        RetrievalIngestionJobStatus,
+    )
+    from app.services.retrieval_store import get_retrieval_repository
+
+    repository = get_retrieval_repository()
+
+    def _version(version_id: str, status: str, age: int) -> None:
+        repository.save_document_version(
+            RetrievalDocumentVersionDescriptor(
+                version_id=version_id,
+                document_id="doc-1",
+                source_id="lotus-platform-rfcs",
+                title="t",
+                location="loc",
+                lifecycle_status=RetrievalDocumentVersionLifecycleStatus(status),
+                refresh_action=RetrievalIngestionAction.REFRESH,
+                created_at=_iso(age),
+                created_by="ops",
+                notes="n",
+            )
+        )
+
+    _version("ver_old_superseded", "SUPERSEDED", 1200)
+    _version("ver_old_active", "ACTIVE", 1200)
+    _version("ver_young_superseded", "SUPERSEDED", 30)
+
+    for job_id, age in (("ing_old", 1200), ("ing_young", 30)):
+        repository.save_ingestion_job(
+            RetrievalIngestionJobDescriptor(
+                job_id=job_id,
+                source_id="lotus-platform-rfcs",
+                requested_action=RetrievalIngestionAction.REFRESH,
+                status=RetrievalIngestionJobStatus.COMPLETED,
+                requested_by="ops",
+                requested_at=_iso(age),
+                message="m",
+            )
+        )
+
+    report = run_data_lifecycle(actor="test.operator")
+    result = {r.family_id: r for r in report.results}["retrieval_shared_reference"]
+
+    assert result.deleted_count == 2
+    assert "never expired" in result.detail
+    remaining_versions = {v.version_id for v in repository.list_document_versions()}
+    # The memory adapter pre-seeds reference versions; assert on the delta.
+    assert "ver_old_superseded" not in remaining_versions
+    assert {"ver_old_active", "ver_young_superseded"} <= remaining_versions
+    remaining_jobs = {j.job_id for j in repository.list_ingestion_jobs()}
+    assert "ing_old" not in remaining_jobs
+    assert "ing_young" in remaining_jobs
+
+    second = run_data_lifecycle(actor="test.operator")
+    assert all(r.deleted_count == 0 for r in second.results)


### PR DESCRIPTION
Issue #158, S2d: **the last time-bounded family becomes true — every declared retention period in the policy is now applied by the engine.** Zero `DECLARED_ONLY` families remain.

## The versioned-content semantics

`retrieval_shared_reference` flips to `ENFORCED` with the predicate the family's own basis demanded: **only `SUPERSEDED` document versions age out** — the current version of a document is live reference state and is never expired by lifecycle, whatever its age (pinned by test with an old ACTIVE version surviving beside an expired same-age SUPERSEDED one). Ingestion-job records age with the history.

## A fifth policy truth correction

`retrieval_sources`, `retrieval_documents`, `retrieval_chunks` and `retrieval_index_jobs` carried a three-year retention claim — but these tables have **no timestamp columns at all**: time-bounding them claimed a mechanism the store cannot honour (the same defect class as the four earlier corrections). They move to a new `retrieval_current_reference` family, honestly `NOT_TIME_BOUNDED`: current index content superseded in place through re-ingestion, whose history lives — and now expires — in `retrieval_document_versions`.

## Where the programme stands

All **eight time-bounded families ENFORCED**; the engine's handler set and the policy agree bidirectionally by test; every deletion evidenced with table-prefixed digests; legal holds honoured where tenant keys exist; **six protective predicates** across the engine (enforcing switches, pending governed actions, recurring drift, in-flight jobs, review-retained artifacts, current document versions). Remaining #158 slices: S3 (erasure command with signed receipt) and S4 (minimisation).

## Evidence

Superseded-only expiry matrix (old-active survives, old-superseded goes, young-superseded stays) with idempotent second run; the SQL round-trip now spans **fourteen sqlalchemy store modes at once**, with retrieval empty/unknown-id deletions proven no-ops. Combined coverage verified locally before push. No schema changes.
