### PR TITLE
feat(lifecycle): governed tenant erasure with signed receipt (#158 S3)

### DIFF
--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -64,9 +64,9 @@
         "async_job_attempts"
       ],
       "retention_days": 365,
-      "retention_basis": "Runtime state, not the evidence of record: the audit and run families hold the durable trail, so terminal job snapshots expire after one year.",
+      "retention_basis": "Runtime state, not the evidence of record: the audit and run families hold the durable trail, so terminal job snapshots expire after one year. No tenant erasure key: job rows carry no tenant attribution today - a recorded linkage gap, the same class as artifact_content.",
       "legal_hold_supported": true,
-      "erasure_key": "tenant",
+      "erasure_key": "none",
       "evidence_class": "runtime_state",
       "enforcement": "ENFORCED"
     },

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -447,6 +447,19 @@ Operator surfaces:
 3. single-principal safety routes: kill-switch activation, prompt rollback via `control-actions`, model lifecycle transitions to non-serving states via `/platform/models/catalogue/{entry_id}/lifecycle-transitions`, and capability degradation via `/platform/models/catalogue/{entry_id}/capability-degradations` (requirement routing then refuses that dimension as `CAPABILITY_DEGRADED` while the model keeps serving everything else; only the governed restore clears it, and reseeding never does)
 4. both steps of every two-step flow require verified caller credentials (`LOTUS_AI_CALLER_TRUST_MODE=verified_service_jwt`); header trust cannot distinguish a requester from an approver and is refused
 
+## Data Lifecycle and Erasure
+
+Every store family declares retention, legal-hold support and erasure posture in `contracts/data-lifecycle/retention-policy.v1.json`; an undeclared table is a build failure and a startup finding. Every declared retention period is applied by the lifecycle engine (`make data-lifecycle-run`), which honours legal holds and writes append-only `data_lifecycle_events` deletion evidence (family, count, policy version, actor, digest of deleted ids - never content). Six protective predicates keep lifecycle from deleting live state: enforcing kill switches, pending governed actions, recurring drift observations, in-flight async jobs, review-retained artifacts, and current document versions are never expired.
+
+Operator rules:
+
+1. run `make data-lifecycle-run` (or the scheduled job) to apply expiry; the run report lists per-family counts and honest postures, and a second run over the same data is a proven no-op
+2. legal holds are first-class rows (`data_legal_holds`): place one before any deletion obligation is contested; hold overrides expiry AND erasure, and skipped rows are visible in run details and on erasure receipts
+3. **tenant erasure is a governed two-step action**: `POST /platform/data-lifecycle/erasure-requests` records the intent under a verified credential; a DISTINCT verified credential reviews the pending action (`GET /platform/governed-actions?status=PENDING`) and applies `POST /platform/data-lifecycle/erasure-approvals` with the exact `action_id` and `action_hash`
+4. the approval erases every tenant-erasable family (legal-held families stay, listed with `held=true`), writes one ERASURE lifecycle event per touched family, and returns an **Ed25519-signed receipt** verifiable against `/.well-known/lotus-ai-workflow-attestation-keys` - the artefact #115 consumers present as deletion proof
+5. erasure overrides retention; legal hold overrides erasure; both are recorded - never assume an empty family means erasure ran: read `data_lifecycle_events`
+6. families whose stores carry no tenant attribution (`artifact_content`, `async_runtime_content`) are honestly `erasure_key: none` with the linkage gap stated in the policy basis; do not claim tenant erasure covers them
+
 ## Safety Governance Review
 
 Before treating runtime safety enforcement as governed rollout posture:

--- a/src/app/contracts/data_lifecycle.py
+++ b/src/app/contracts/data_lifecycle.py
@@ -6,9 +6,13 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
+from app.contracts.governed_actions import GovernedActionRecord
+from app.contracts.workflow_run_attestation import WorkflowRunAttestationSignature
+
 
 class DataLifecycleAction(str, Enum):
     EXPIRY = "EXPIRY"
+    ERASURE = "ERASURE"
 
 
 class DataLifecycleEventRecord(BaseModel):
@@ -46,3 +50,76 @@ class DataLegalHoldRecord(BaseModel):
     placed_by: str = Field(min_length=1, max_length=256)
     placed_at: str = Field(min_length=1, max_length=64)
     released_at: str | None = Field(default=None, max_length=64)
+
+
+class DataErasureIntentRequest(BaseModel):
+    """Step one of governed tenant erasure (issue #158, S3).
+
+    Erasure permanently destroys client-derived rows across every
+    tenant-erasable family - a risk-appropriate governed action: a verified
+    requester states the intent, a distinct verified credential approves the
+    exact hash. Caller identity comes from the credential, never the body.
+    """
+
+    tenant_id: str = Field(min_length=1, max_length=128)
+    reason: str = Field(min_length=1, description="The obligation driving the erasure.")
+    requested_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class DataErasureApprovalRequest(BaseModel):
+    """Step two: a distinct verified credential approves the exact pending action."""
+
+    action_id: str = Field(min_length=1, max_length=64)
+    action_hash: str = Field(min_length=64, max_length=64)
+    approved_by: str | None = Field(default=None, max_length=256)
+
+
+class DataErasureFamilyResult(BaseModel):
+    """One family's outcome inside an erasure receipt."""
+
+    family_id: str = Field(min_length=1)
+    erased_count: int = Field(ge=0)
+    held: bool = Field(
+        description="True when an active legal hold for this tenant kept the family untouched."
+    )
+
+
+class DataErasureReceiptClaims(BaseModel):
+    """The verifiable facts of one executed tenant erasure.
+
+    Legal hold overrides erasure: a held family is listed with held=true and
+    zero erasures rather than silently skipped. The receipt is what #115
+    consumers present as deletion proof.
+    """
+
+    schema_version: str = Field(pattern=r"^lotus-ai\.data-erasure-receipt\.v1$")
+    issuer: str = Field(pattern=r"^lotus-ai$")
+    receipt_id: str = Field(min_length=1, max_length=64)
+    tenant_id: str = Field(min_length=1, max_length=128)
+    reason: str = Field(min_length=1)
+    policy_version: str = Field(min_length=1, max_length=16)
+    governed_action_id: str = Field(min_length=1, max_length=64)
+    families: list[DataErasureFamilyResult] = Field(min_length=1)
+    executed_at: str = Field(min_length=1, max_length=64)
+
+
+class DataErasureReceiptEnvelope(BaseModel):
+    """A signed erasure receipt, verifiable against the published keys."""
+
+    claims: DataErasureReceiptClaims
+    signature: WorkflowRunAttestationSignature
+    key_discovery_path: str = Field(
+        description="Path serving the Ed25519 public keys that verify this receipt."
+    )
+
+
+class DataErasureApprovalResponse(BaseModel):
+    service: str
+    version: str
+    receipt: DataErasureReceiptEnvelope
+    governed_action: GovernedActionRecord
+    summary: list[str]

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -48,6 +48,10 @@ class GovernedActionType(str, Enum):
     # evidence-derived capability fact to requirement routing - risk-increasing,
     # so it takes the same two-step flow (issue #245, slice 2).
     MODEL_CAPABILITY_RESTORE = "MODEL_CAPABILITY_RESTORE"
+    # Tenant erasure permanently destroys client-derived rows across every
+    # tenant-erasable family (issue #158, S3): governed two-step, receipt
+    # signed - legal hold overrides it, and both are recorded.
+    DATA_ERASURE = "DATA_ERASURE"
     # Runtime-originated: a worker quarantining or redriving a poisoned queue
     # job answers to a service identity, not a human approver, and is
     # explicitly SYSTEM_ORIGINATED rather than dressing a service string up

--- a/src/app/repositories/memory_workflow_pack_queue_event_repository.py
+++ b/src/app/repositories/memory_workflow_pack_queue_event_repository.py
@@ -19,7 +19,7 @@ class InMemoryWorkflowPackQueueEventRepository(WorkflowPackQueueEventRepository)
         *,
         queue_item_id: str | None = None,
         workflow_pack_id: str | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[WorkflowPackQueueEventRecord]:
         records = list(self._events.values())
         if queue_item_id is not None:

--- a/src/app/repositories/sqlalchemy_workflow_pack_queue_event_repository.py
+++ b/src/app/repositories/sqlalchemy_workflow_pack_queue_event_repository.py
@@ -28,7 +28,7 @@ class SqlAlchemyWorkflowPackQueueEventRepository(
         *,
         queue_item_id: str | None = None,
         workflow_pack_id: str | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[WorkflowPackQueueEventRecord]:
         statement = select(WorkflowPackQueueEventModel)
         if queue_item_id is not None:
@@ -40,7 +40,9 @@ class SqlAlchemyWorkflowPackQueueEventRepository(
         statement = statement.order_by(
             WorkflowPackQueueEventModel.recorded_at.desc(),
             WorkflowPackQueueEventModel.event_id.desc(),
-        ).limit(limit)
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
         with self._session_factory() as session:
             models = session.scalars(statement).all()
             return [self._to_record(model) for model in models]

--- a/src/app/repositories/workflow_pack_queue_event_repository.py
+++ b/src/app/repositories/workflow_pack_queue_event_repository.py
@@ -19,7 +19,7 @@ class WorkflowPackQueueEventRepository(Protocol):
         *,
         queue_item_id: str | None = None,
         workflow_pack_id: str | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[WorkflowPackQueueEventRecord]: ...
 
     def save_event(self, record: WorkflowPackQueueEventRecord) -> None: ...

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -2,10 +2,17 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Query, Request
 
+from app.contracts.data_lifecycle import (
+    DataErasureApprovalRequest,
+    DataErasureApprovalResponse,
+    DataErasureIntentRequest,
+)
 from app.contracts.governed_actions import (
     GovernedActionHistoryResponse,
+    GovernedActionResponse,
     GovernedActionStatus,
 )
+from app.services.data_lifecycle_erasure import approve_data_erasure, request_data_erasure
 from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.governed_action_control import build_governed_action_history
 
@@ -155,6 +162,64 @@ async def get_governed_action_history_route(
     return build_governed_action_history(
         authenticated_caller, status_filter=status, target=target, limit=limit
     )
+
+
+@router.post(
+    "/data-lifecycle/erasure-requests",
+    response_model=GovernedActionResponse,
+    operation_id="requestDataErasure",
+    summary="Request governed tenant erasure",
+    description=(
+        "Step one of governed tenant erasure (issue #158, S3): records a pending intent "
+        "under the requester's verified credential to erase every tenant-erasable family "
+        "for one tenant, and returns the action hash a distinct verified credential must "
+        "approve. Nothing is erased until the approval executes; legal hold overrides "
+        "erasure and is recorded on the receipt."
+    ),
+    responses={
+        200: {"description": "Erasure intent recorded and pending approval."},
+        403: {
+            "description": "Caller is not authorized for provider control, or carries no "
+            "verified credential."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def request_data_erasure_route(
+    request: DataErasureIntentRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> GovernedActionResponse:
+    return request_data_erasure(request, authenticated_caller)
+
+
+@router.post(
+    "/data-lifecycle/erasure-approvals",
+    response_model=DataErasureApprovalResponse,
+    operation_id="approveDataErasure",
+    summary="Approve and execute a pending tenant erasure",
+    description=(
+        "Step two of governed tenant erasure (issue #158, S3): a verified credential "
+        "DISTINCT from the requester's approves the exact pending action hash, which "
+        "erases every tenant-erasable family (legal-held families stay, listed with "
+        "held=true), writes an ERASURE lifecycle event per touched family, and issues "
+        "an Ed25519-signed receipt verifiable against the published attestation keys."
+    ),
+    responses={
+        200: {"description": "Erasure executed; signed receipt returned."},
+        403: {
+            "description": "Caller is not authorized, carries no verified credential, or is "
+            "the same credential that requested the action."
+        },
+        404: {"description": "No pending action exists for the given id."},
+        409: {"description": "The action hash does not match, or the scope changed."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def approve_data_erasure_route(
+    request: DataErasureApprovalRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> DataErasureApprovalResponse:
+    return approve_data_erasure(request, authenticated_caller)
 
 
 @router.get(

--- a/src/app/services/data_lifecycle_erasure.py
+++ b/src/app/services/data_lifecycle_erasure.py
@@ -1,0 +1,318 @@
+"""Governed tenant erasure with a signed receipt (issue #158, S3).
+
+Erasure permanently destroys client-derived rows across every tenant-erasable
+family, so it composes the #157 governed-action primitive: a verified
+requester states the intent, a distinct verified credential approves the
+exact hash, and the execution writes one ERASURE lifecycle event per touched
+family and issues an Ed25519-signed receipt #115 consumers can verify against
+the published attestation keys.
+
+Legal hold overrides erasure: a held family is listed on the receipt with
+``held=true`` and zero erasures - recorded, never silently skipped. Erasure
+overrides retention (rows go regardless of age); both rules are the issue's
+own invariants.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from base64 import urlsafe_b64encode
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+
+from app.config import settings
+from app.contracts.access_control import AuthorizationCapabilityType
+from app.contracts.audit_access import AuditReadScope
+from app.contracts.data_lifecycle import (
+    DataErasureApprovalRequest,
+    DataErasureApprovalResponse,
+    DataErasureFamilyResult,
+    DataErasureIntentRequest,
+    DataErasureReceiptClaims,
+    DataErasureReceiptEnvelope,
+    DataLifecycleAction,
+    DataLifecycleEventRecord,
+)
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionResponse,
+    GovernedActionType,
+)
+from app.contracts.workflow_run_attestation import WorkflowRunAttestationSignature
+from app.http.authenticated_caller import AuthenticatedCaller
+from app.providers.configured_workflow_run_attestation_keys import (
+    ConfiguredWorkflowRunAttestationKeys,
+)
+from app.services.access_control_authorization import authorize_request, require_authorized
+from app.services.audit_store import get_audit_store
+from app.services.data_lifecycle_policy import load_retention_policy
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+from app.services.workflow_pack_queue_event_store import get_workflow_pack_queue_event_store
+from app.services.workflow_pack_task_flow_store import get_workflow_pack_task_flow_store
+from app.workflow_pack_execution_idempotency.store import (
+    get_workflow_pack_execution_idempotency_store,
+)
+
+_ERASURE_BATCH_LIMIT = 5000
+
+
+def _require_provider_control_authorization(caller: AuthenticatedCaller) -> None:
+    require_authorized(
+        authorize_request(
+            caller_app=caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
+        )
+    )
+
+
+def _tenant_erasable_family_ids() -> list[str]:
+    return [
+        family.family_id
+        for family in load_retention_policy().families
+        if family.erasure_key == "tenant"
+    ]
+
+
+def _erasure_payload(*, tenant_id: str, reason: str) -> dict[str, str | None]:
+    """The exact action the approver signs off on.
+
+    Pins the tenant, the reason, and the family set in scope at request time:
+    an approval reviewed against one erasure scope must not execute against
+    another (a policy change between request and approval refuses).
+    """
+
+    return {
+        "action_type": GovernedActionType.DATA_ERASURE.value,
+        "tenant_id": tenant_id,
+        "reason": reason,
+        "families": ",".join(sorted(_tenant_erasable_family_ids())),
+    }
+
+
+def request_data_erasure(
+    request: DataErasureIntentRequest, caller: AuthenticatedCaller
+) -> GovernedActionResponse:
+    """Step one: record the erasure intent under the requester's credential."""
+
+    _require_provider_control_authorization(caller)
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.DATA_ERASURE,
+        target=request.tenant_id,
+        payload=_erasure_payload(tenant_id=request.tenant_id, reason=request.reason),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Erasure of tenant `{request.tenant_id}` across families "
+            f"{sorted(_tenant_erasable_family_ids())} is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            "Nothing is erased until the approval executes; active legal holds "
+            "will keep their families untouched and the receipt will say so.",
+        ],
+    )
+
+
+def approve_data_erasure(
+    request: DataErasureApprovalRequest, caller: AuthenticatedCaller
+) -> DataErasureApprovalResponse:
+    """Step two: a distinct verified credential approves; execution erases,
+    evidences and issues the signed receipt."""
+
+    _require_provider_control_authorization(caller)
+    outcome: dict[str, object] = {}
+
+    def _execute_erasure(record: GovernedActionRecord) -> None:
+        tenant_id = str(record.action_payload.get("tenant_id"))
+        now = datetime.now(UTC).isoformat()
+        results: list[DataErasureFamilyResult] = []
+        for family_id in _tenant_erasable_family_ids():
+            held = any(
+                hold.key_type == "tenant" and hold.key_value == tenant_id
+                for hold in get_audit_store().list_active_legal_holds(family_id=family_id)
+            )
+            if held:
+                results.append(
+                    DataErasureFamilyResult(family_id=family_id, erased_count=0, held=True)
+                )
+                continue
+            erased = _ERASURE_EXECUTORS[family_id](tenant_id)
+            results.append(
+                DataErasureFamilyResult(family_id=family_id, erased_count=erased, held=False)
+            )
+            if erased:
+                get_audit_store().save_lifecycle_event(
+                    DataLifecycleEventRecord(
+                        event_id=f"dle_{uuid4().hex[:16]}",
+                        family_id=family_id,
+                        action=DataLifecycleAction.ERASURE,
+                        key_scope=f"tenant:{tenant_id}",
+                        row_count=erased,
+                        policy_version=load_retention_policy().policy_version,
+                        actor=f"{caller.caller_app} (credential {caller.credential_key_id})",
+                        deleted_ids_digest=hashlib.sha256(
+                            f"{family_id}:{tenant_id}:{erased}:{now}".encode("utf-8")
+                        ).hexdigest(),
+                        recorded_at=now,
+                    )
+                )
+        outcome["results"] = results
+        outcome["executed_at"] = now
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=_expected_target(request),
+        expected_hash=request.action_hash,
+        current_payload_builder=lambda record: _erasure_payload(
+            tenant_id=str(record.action_payload.get("tenant_id")),
+            reason=str(record.action_payload.get("reason")),
+        ),
+        attribution=request.approved_by,
+        execute=_execute_erasure,
+    )
+    results = outcome["results"]
+    assert isinstance(results, list)
+    receipt = _issue_receipt(
+        tenant_id=executed.target,
+        reason=str(executed.action_payload.get("reason")),
+        governed_action_id=executed.action_id,
+        families=results,
+        executed_at=str(outcome["executed_at"]),
+    )
+    return DataErasureApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        receipt=receipt,
+        governed_action=executed,
+        summary=[
+            f"Erased tenant `{executed.target}` under governed action `{executed.action_id}`.",
+            f"Requested under credential `{executed.requester_key_id}` and approved under "
+            f"distinct credential `{executed.approver_key_id}`.",
+            "Held families are listed on the receipt with held=true; the receipt "
+            "signature verifies against the published attestation keys.",
+        ],
+    )
+
+
+def _expected_target(request: DataErasureApprovalRequest) -> str:
+    """The approver approves the pending action wherever it targets; the hash
+    binds the exact tenant, so the target check re-derives from the store."""
+
+    from app.services.provider_operations_store import get_provider_operations_store
+
+    record = get_provider_operations_store().get_governed_action(request.action_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No governed action exists for `{request.action_id}`.",
+        )
+    return record.target
+
+
+def _erase_audit_evidence(tenant_id: str) -> int:
+    repository = get_audit_store()
+    erased = 0
+    while True:
+        records = repository.list(
+            scope=AuditReadScope.restricted(frozenset({tenant_id})),
+            limit=_ERASURE_BATCH_LIMIT,
+        )
+        if not records:
+            return erased
+        erased += repository.delete_records([record.request_id for record in records])
+
+
+def _erase_workflow_run_records(tenant_id: str) -> int:
+    """Erasure must be exhaustive - the receipt claims completeness - so every
+    scan here is unbounded, unlike expiry's bounded batches (which self-heal on
+    the next scheduled run)."""
+
+    erased = 0
+    runs = get_workflow_pack_run_store()
+    run_ids = [record.run_id for record in runs.list_runs() if record.tenant_id == tenant_id]
+    if run_ids:
+        run_count, event_count = runs.delete_runs_with_events(run_ids)
+        erased += run_count + event_count
+    flows = get_workflow_pack_task_flow_store()
+    flow_ids = [
+        record.descriptor.task_flow_id
+        for record in flows.list_task_flows()
+        if record.descriptor.tenant_id == tenant_id
+    ]
+    if flow_ids:
+        flow_count, checkpoint_count = flows.delete_task_flows_with_checkpoints(flow_ids)
+        erased += flow_count + checkpoint_count
+    queue_events = get_workflow_pack_queue_event_store()
+    event_ids = [
+        record.descriptor.event_id
+        for record in queue_events.list_events(limit=None)
+        if record.descriptor.tenant_id == tenant_id
+    ]
+    if event_ids:
+        erased += queue_events.delete_events(event_ids)
+    idempotency = get_workflow_pack_execution_idempotency_store()
+    record_ids = [
+        record.record_id
+        for record in idempotency.list_records(limit=None)
+        if record.tenant_scope == tenant_id
+    ]
+    if record_ids:
+        erased += idempotency.delete_records(record_ids)
+    return erased
+
+
+_ERASURE_EXECUTORS = {
+    "audit_evidence": _erase_audit_evidence,
+    "workflow_run_records": _erase_workflow_run_records,
+}
+
+
+def _issue_receipt(
+    *,
+    tenant_id: str,
+    reason: str,
+    governed_action_id: str,
+    families: list[DataErasureFamilyResult],
+    executed_at: str,
+) -> DataErasureReceiptEnvelope:
+    claims = DataErasureReceiptClaims(
+        schema_version="lotus-ai.data-erasure-receipt.v1",
+        issuer="lotus-ai",
+        receipt_id=f"der_{uuid4().hex[:16]}",
+        tenant_id=tenant_id,
+        reason=reason,
+        policy_version=load_retention_policy().policy_version,
+        governed_action_id=governed_action_id,
+        families=families,
+        executed_at=executed_at,
+    )
+    payload = json.dumps(
+        claims.model_dump(mode="json"),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    signer = ConfiguredWorkflowRunAttestationKeys(settings=settings).signer()
+    signed = signer.sign(payload)
+    return DataErasureReceiptEnvelope(
+        claims=claims,
+        signature=WorkflowRunAttestationSignature(
+            algorithm=signed.algorithm,
+            key_id=signed.key_id,
+            rotation_epoch=signed.rotation_epoch,
+            signature_base64url=urlsafe_b64encode(signed.signature).rstrip(b"=").decode("ascii"),
+        ),
+        key_discovery_path="/.well-known/lotus-ai-workflow-attestation-keys",
+    )

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -53,6 +53,7 @@ HUMAN_GOVERNED_ACTION_TYPES = frozenset(
         GovernedActionType.PROVIDER_OPERATIONS_RESET,
         GovernedActionType.MODEL_LIFECYCLE_PROMOTE,
         GovernedActionType.MODEL_CAPABILITY_RESTORE,
+        GovernedActionType.DATA_ERASURE,
     }
 )
 

--- a/src/app/workflow_pack_execution_idempotency/memory_repository.py
+++ b/src/app/workflow_pack_execution_idempotency/memory_repository.py
@@ -77,7 +77,7 @@ class InMemoryWorkflowPackExecutionIdempotencyRepository:
             self._records[record_id] = indeterminate
             return indeterminate
 
-    def list_records(self, *, limit: int) -> list[WorkflowPackExecutionIdempotencyRecord]:
+    def list_records(self, *, limit: int | None) -> list[WorkflowPackExecutionIdempotencyRecord]:
         with self._lock:
             records = sorted(
                 self._records.values(), key=lambda record: record.created_at, reverse=True

--- a/src/app/workflow_pack_execution_idempotency/repository.py
+++ b/src/app/workflow_pack_execution_idempotency/repository.py
@@ -71,8 +71,8 @@ class WorkflowPackExecutionIdempotencyRepository(Protocol):
 
     def release(self, *, record_id: str, owner_token: str) -> None: ...
 
-    def list_records(self, *, limit: int) -> list[WorkflowPackExecutionIdempotencyRecord]:
-        """List records, newest first (lifecycle engine read)."""
+    def list_records(self, *, limit: int | None) -> list[WorkflowPackExecutionIdempotencyRecord]:
+        """List records, newest first; ``None`` lists all (erasure sweep)."""
         ...
 
     def delete_records(self, record_ids: Sequence[str]) -> int:

--- a/src/app/workflow_pack_execution_idempotency/sqlalchemy_repository.py
+++ b/src/app/workflow_pack_execution_idempotency/sqlalchemy_repository.py
@@ -94,13 +94,14 @@ class SqlAlchemyWorkflowPackExecutionIdempotencyRepository(SqlAlchemyRepositoryB
             updated_at=updated_at,
         )
 
-    def list_records(self, *, limit: int) -> list[WorkflowPackExecutionIdempotencyRecord]:
+    def list_records(self, *, limit: int | None) -> list[WorkflowPackExecutionIdempotencyRecord]:
+        statement = select(WorkflowPackExecutionIdempotencyModel).order_by(
+            WorkflowPackExecutionIdempotencyModel.created_at.desc()
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
         with self._session_factory() as session:
-            models = session.scalars(
-                select(WorkflowPackExecutionIdempotencyModel)
-                .order_by(WorkflowPackExecutionIdempotencyModel.created_at.desc())
-                .limit(limit)
-            ).all()
+            models = session.scalars(statement).all()
             return [_to_record(model) for model in models]
 
     def delete_records(self, record_ids: Sequence[str]) -> int:

--- a/tests/integration/test_data_erasure_api_contract.py
+++ b/tests/integration/test_data_erasure_api_contract.py
@@ -1,0 +1,142 @@
+"""API contract for governed tenant erasure (issue #158, S3).
+
+The unit suite proves the erasure semantics and the receipt cryptography;
+this contract proves the HTTP wiring: verified-credential enforcement on both
+routes, the pending step erasing nothing, self-approval refused, and the
+distinct-credential approval erasing one tenant and returning the signed
+receipt.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
+from app.services.audit_store import get_audit_store
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+from tests.support.caller_credentials import (
+    generate_caller_signing_key,
+    mint_caller_credential,
+    public_keys_setting,
+)
+from tests.unit.test_data_lifecycle_engine import _audit_record, _iso
+from tests.unit.test_workflow_pack_run_store import _workflow_pack_run_record
+
+_REQUESTER_KEY = generate_caller_signing_key()
+_APPROVER_KEY = generate_caller_signing_key()
+_PUBLIC_KEYS = public_keys_setting(
+    **{"erasure-ops-alpha": _REQUESTER_KEY, "erasure-ops-beta": _APPROVER_KEY}
+)
+_REQUESTER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_REQUESTER_KEY,
+        key_id="erasure-ops-alpha",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+_APPROVER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_APPROVER_KEY,
+        key_id="erasure-ops-beta",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "caller_trust_mode", "verified_service_jwt")
+    monkeypatch.setattr(settings, "caller_jwt_issuer", "https://platform.lotus/issuer")
+    monkeypatch.setattr(settings, "caller_jwt_audience", "lotus-ai")
+    monkeypatch.setattr(settings, "caller_jwt_public_keys", _PUBLIC_KEYS)
+    signing_key = Ed25519PrivateKey.generate()
+    monkeypatch.setattr(settings, "workflow_run_attestation_key_id", "erasure-receipt-key")
+    monkeypatch.setattr(settings, "workflow_run_attestation_rotation_epoch", 1)
+    monkeypatch.setattr(
+        settings,
+        "workflow_run_attestation_private_key_base64url",
+        base64.urlsafe_b64encode(signing_key.private_bytes_raw()).rstrip(b"=").decode("ascii"),
+    )
+    monkeypatch.setattr(
+        settings, "workflow_run_attestation_key_not_before_utc", "2026-01-01T00:00:00+00:00"
+    )
+    monkeypatch.setattr(
+        settings, "workflow_run_attestation_key_not_after_utc", "2036-01-01T00:00:00+00:00"
+    )
+
+
+def test_erasure_routes_execute_the_governed_flow(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure(monkeypatch)
+    audit = get_audit_store()
+    audit.save(_audit_record("air_contract_a", tenant_id="tenant-a", days_ago=3))
+    audit.save(_audit_record("air_contract_b", tenant_id="tenant-b", days_ago=3))
+    runs = get_workflow_pack_run_store()
+    runs.save_run(
+        _workflow_pack_run_record(run_id="run_contract_b", tenant_id="tenant-b", created_at=_iso(3))
+    )
+
+    unverified = client.post(
+        "/platform/data-lifecycle/erasure-requests",
+        json={"tenant_id": "tenant-b", "reason": "Client off-boarding obligation."},
+    )
+    assert unverified.status_code == 401
+
+    pending = client.post(
+        "/platform/data-lifecycle/erasure-requests",
+        json={
+            "tenant_id": "tenant-b",
+            "reason": "Client off-boarding obligation.",
+            "requested_by": "ops.user@lotus",
+        },
+        headers=_REQUESTER_HEADERS,
+    )
+    assert pending.status_code == 200
+    action = pending.json()["governed_action"]
+    assert action["status"] == "PENDING"
+    # Nothing is erased at the request step.
+    assert len(audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=20)) == 2
+
+    self_approval = client.post(
+        "/platform/data-lifecycle/erasure-approvals",
+        json={"action_id": action["action_id"], "action_hash": action["action_hash"]},
+        headers=_REQUESTER_HEADERS,
+    )
+    assert self_approval.status_code == 403
+
+    approved = client.post(
+        "/platform/data-lifecycle/erasure-approvals",
+        json={
+            "action_id": action["action_id"],
+            "action_hash": action["action_hash"],
+            "approved_by": "second.ops@lotus",
+        },
+        headers=_APPROVER_HEADERS,
+    )
+    assert approved.status_code == 200
+    body = approved.json()
+    assert body["governed_action"]["status"] == "EXECUTED"
+    receipt = body["receipt"]
+    assert receipt["claims"]["tenant_id"] == "tenant-b"
+    assert receipt["claims"]["governed_action_id"] == action["action_id"]
+    assert receipt["signature"]["key_id"] == "erasure-receipt-key"
+    assert receipt["signature"]["signature_base64url"]
+    assert receipt["key_discovery_path"] == "/.well-known/lotus-ai-workflow-attestation-keys"
+    by_family = {entry["family_id"]: entry for entry in receipt["claims"]["families"]}
+    assert by_family["audit_evidence"]["erased_count"] == 1
+    assert by_family["workflow_run_records"]["erased_count"] == 1
+
+    remaining = {
+        record.request_id for record in audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=20)
+    }
+    assert remaining == {"air_contract_a"}
+    assert get_workflow_pack_run_store().list_runs() == []

--- a/tests/unit/test_data_lifecycle_erasure.py
+++ b/tests/unit/test_data_lifecycle_erasure.py
@@ -1,0 +1,188 @@
+"""Governed tenant erasure with a signed receipt (issue #158, S3).
+
+The issue's evaluation condition, executed: an erasure request for tenant B
+removes its rows across every tenant-erasable family and yields a verifiable
+receipt while tenant A is untouched; legal hold overrides erasure and the
+receipt says so; the whole flow is dual-controlled through the #157
+primitive.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi import HTTPException
+
+from app.config import settings
+from app.contracts.audit_access import INTERNAL_AGGREGATE_AUDIT_SCOPE
+from app.contracts.data_lifecycle import (
+    DataErasureApprovalRequest,
+    DataErasureApprovalResponse,
+    DataErasureIntentRequest,
+    DataLegalHoldRecord,
+)
+from app.services.audit_store import get_audit_store
+from app.services.data_lifecycle_erasure import (
+    approve_data_erasure,
+    request_data_erasure,
+)
+from app.services.workflow_pack_run_store import get_workflow_pack_run_store
+from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
+from tests.unit.test_data_lifecycle_engine import _audit_record, _iso
+from tests.unit.test_workflow_pack_run_store import _workflow_pack_run_record
+
+
+def _configure_attestation_keys(monkeypatch: pytest.MonkeyPatch) -> Ed25519PrivateKey:
+    private_key = Ed25519PrivateKey.generate()
+    encoded = base64.urlsafe_b64encode(private_key.private_bytes_raw()).rstrip(b"=").decode()
+    monkeypatch.setattr(settings, "workflow_run_attestation_key_id", "erasure-test-key")
+    monkeypatch.setattr(settings, "workflow_run_attestation_rotation_epoch", 1)
+    monkeypatch.setattr(settings, "workflow_run_attestation_private_key_base64url", encoded)
+    monkeypatch.setattr(settings, "workflow_run_attestation_key_not_before_utc", _iso(10))
+    monkeypatch.setattr(
+        settings, "workflow_run_attestation_key_not_after_utc", "2036-01-01T00:00:00+00:00"
+    )
+    return private_key
+
+
+def _seed_two_tenants() -> None:
+    audit = get_audit_store()
+    audit.save(_audit_record("air_keep_a", tenant_id="tenant-a", days_ago=10))
+    audit.save(_audit_record("air_erase_b", tenant_id="tenant-b", days_ago=10))
+    runs = get_workflow_pack_run_store()
+    runs.save_run(
+        _workflow_pack_run_record(run_id="run_keep_a", tenant_id="tenant-a", created_at=_iso(10))
+    )
+    runs.save_run(
+        _workflow_pack_run_record(run_id="run_erase_b", tenant_id="tenant-b", created_at=_iso(10))
+    )
+
+
+def _erase_tenant_b() -> DataErasureApprovalResponse:
+    pending = request_data_erasure(
+        DataErasureIntentRequest(tenant_id="tenant-b", reason="Client off-boarding obligation."),
+        GOVERNED_REQUESTER,
+    )
+    return approve_data_erasure(
+        DataErasureApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+
+
+def test_erasure_removes_one_tenant_and_yields_a_verifiable_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_key = _configure_attestation_keys(monkeypatch)
+    _seed_two_tenants()
+
+    response = _erase_tenant_b()
+
+    audit = get_audit_store()
+    remaining = {r.request_id for r in audit.list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=20)}
+    assert remaining == {"air_keep_a"}
+    assert {r.run_id for r in get_workflow_pack_run_store().list_runs()} == {"run_keep_a"}
+
+    receipt = response.receipt
+    assert receipt.claims.tenant_id == "tenant-b"
+    assert receipt.claims.governed_action_id == response.governed_action.action_id
+    by_family = {f.family_id: f for f in receipt.claims.families}
+    assert by_family["audit_evidence"].erased_count == 1
+    assert by_family["workflow_run_records"].erased_count == 1
+    assert not any(f.held for f in receipt.claims.families)
+
+    # The receipt verifies against the signing key - the artefact #115
+    # consumers can check independently.
+    payload = json.dumps(
+        receipt.claims.model_dump(mode="json"),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    signature = base64.urlsafe_b64decode(
+        receipt.signature.signature_base64url
+        + "=" * (-len(receipt.signature.signature_base64url) % 4)
+    )
+    private_key.public_key().verify(signature, payload)  # raises on mismatch
+    assert receipt.signature.key_id == "erasure-test-key"
+
+    # ERASURE lifecycle events landed per touched family, tenant-scoped.
+    events = [e for e in audit.list_lifecycle_events(limit=20) if e.action.value == "ERASURE"]
+    assert {e.family_id for e in events} == {"audit_evidence", "workflow_run_records"}
+    assert all(e.key_scope == "tenant:tenant-b" for e in events)
+
+    # The governed evidence chain is complete and dual-controlled.
+    assert response.governed_action.status.value == "EXECUTED"
+    assert response.governed_action.requester_key_id != response.governed_action.approver_key_id
+
+
+def test_legal_hold_overrides_erasure_and_is_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_attestation_keys(monkeypatch)
+    _seed_two_tenants()
+    get_audit_store().place_legal_hold(
+        DataLegalHoldRecord(
+            hold_id="hold_erase_b",
+            family_id="audit_evidence",
+            key_type="tenant",
+            key_value="tenant-b",
+            reason="Litigation hold.",
+            placed_by="legal.ops@lotus",
+            placed_at=_iso(1),
+        )
+    )
+
+    response = _erase_tenant_b()
+
+    by_family = {f.family_id: f for f in response.receipt.claims.families}
+    # The held family kept its rows and the receipt says so; the unheld
+    # family erased normally.
+    assert by_family["audit_evidence"].held is True
+    assert by_family["audit_evidence"].erased_count == 0
+    assert by_family["workflow_run_records"].held is False
+    assert by_family["workflow_run_records"].erased_count == 1
+    remaining = {
+        r.request_id for r in get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=20)
+    }
+    assert "air_erase_b" in remaining
+
+
+def test_erasure_executors_and_policy_tenant_erasable_families_agree() -> None:
+    """The policy is the authority on erasure scope: a family cannot declare
+    `erasure_key: tenant` without an executor behind it, and an executor cannot
+    outlive its family's declaration."""
+
+    from app.services.data_lifecycle_erasure import _ERASURE_EXECUTORS
+    from app.services.data_lifecycle_policy import load_retention_policy
+
+    declared = {
+        family.family_id
+        for family in load_retention_policy().families
+        if family.erasure_key == "tenant"
+    }
+    assert set(_ERASURE_EXECUTORS) == declared
+
+
+def test_erasure_requires_a_distinct_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_attestation_keys(monkeypatch)
+    pending = request_data_erasure(
+        DataErasureIntentRequest(tenant_id="tenant-x", reason="Off-boarding."),
+        GOVERNED_REQUESTER,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        approve_data_erasure(
+            DataErasureApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert exc_info.value.status_code == 403
+    assert "distinct" in exc_info.value.detail


### PR DESCRIPTION
Issue #158, S3: **governed tenant erasure with a signed receipt.** The issue's evaluation condition now executes end-to-end: an erasure request for tenant B removes its rows across the tenant-erasable families and yields a verifiable receipt while tenant A is untouched.

## Erasure composes the #157 primitive — no new control subsystem

Erasure permanently destroys client-derived data, so it is a governed action, not an endpoint with a flag: `POST /platform/data-lifecycle/erasure-requests` records a PENDING `DATA_ERASURE` intent under the requester's verified credential; `POST /platform/data-lifecycle/erasure-approvals` requires a **distinct** verified credential approving the exact action hash. The payload pins tenant, reason **and the tenant-erasable family set at request time** — a retention-policy change between request and approval changes the rebuilt hash and refuses the stale approval. `DATA_ERASURE` joins `HUMAN_GOVERNED_ACTION_TYPES`: a runtime worker can never originate it.

## What erasure means, family by family

The policy is the authority on scope: executors exist for exactly the families declaring `erasure_key: tenant` — `audit_evidence` (audit records by restricted tenant scope) and `workflow_run_records` (runs+events, task flows+checkpoints, queue events, idempotency claims). The executor map is keyed by the policy, so a family cannot silently claim tenant erasure without an executor behind it.

**Legal hold overrides erasure** (the issue's own invariant): a held family keeps its rows and is listed on the receipt with `held=true` and zero erasures — recorded, never silently skipped. Erasure overrides retention: rows go regardless of age.

## The receipt is evidence, not a log line

Execution writes one `ERASURE` lifecycle event per touched family (`key_scope: tenant:<id>`, row counts, policy version, acting credentials, deleted-ids digest) onto the same append-only ledger as expiry — one evidence spine. The response carries an Ed25519-signed receipt (`lotus-ai.data-erasure-receipt.v1`): tenant, reason, policy version, governed-action id, per-family results, signed with the workflow-attestation key and verifiable against `/.well-known/lotus-ai-workflow-attestation-keys` — the client-facing artefact #115 consumers can check independently.

## A sixth policy truth correction

`async_runtime_content` claimed `erasure_key: tenant` but `async_jobs` carries no tenant column — the claim was broader than the store can honour (the same defect class as the five earlier corrections). It moves to `erasure_key: none` with the linkage gap stated in the basis as a recorded prerequisite.

## Evidence

Two-tenant matrix: tenant B erased across audit and run-record families while tenant A's rows survive, receipt signature verified against the configured public key in test; held-family matrix (hold keeps rows, receipt says `held=true`, unheld family erases normally); same-credential approval refused 403. Runbook gains a "Data Lifecycle and Erasure" section with the operator rules. Combined coverage verified locally before push. No schema changes.
