### PR TITLE
feat(lifecycle): minimisation - preview cap and passing-case horizon (#158 S4)

### DIFF
--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -105,11 +105,13 @@
         "evaluation_case_results"
       ],
       "retention_days": 365,
-      "retention_basis": "Case-level content is diagnostic, not the verdict of record; one year covers regression investigation. Minimisation (retain longer only for failures) is the S4 slice.",
+      "retention_basis": "Case-level content is diagnostic, not the verdict of record; one year covers regression investigation for failures.",
       "legal_hold_supported": true,
       "erasure_key": "none",
       "evidence_class": "evaluation_content",
-      "enforcement": "ENFORCED"
+      "enforcement": "ENFORCED",
+      "minimised_retention_days": 90,
+      "minimisation_basis": "A passing case's inputs and outputs have no diagnostic purpose beyond the review horizon: the run verdict survives with the approval-evidence family, so only failures need the full year for defect forensics."
     },
     {
       "family_id": "retrieval_shared_reference",

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -459,6 +459,7 @@ Operator rules:
 4. the approval erases every tenant-erasable family (legal-held families stay, listed with `held=true`), writes one ERASURE lifecycle event per touched family, and returns an **Ed25519-signed receipt** verifiable against `/.well-known/lotus-ai-workflow-attestation-keys` - the artefact #115 consumers present as deletion proof
 5. erasure overrides retention; legal hold overrides erasure; both are recorded - never assume an empty family means erasure ran: read `data_lifecycle_events`
 6. families whose stores carry no tenant attribution (`artifact_content`, `async_runtime_content`) are honestly `erasure_key: none` with the linkage gap stated in the policy basis; do not claim tenant erasure covers them
+7. **minimisation** (issue #158, S4): audit rows keep a capped `result_preview` with an explicit truncation marker, never a second full copy of the generated output, and a *passing* evaluation case's content expires at the policy's minimised horizon (90 days) while failures keep the full year - do not expect passing-case content beyond that horizon
 
 ## Safety Governance Review
 

--- a/src/app/contracts/audit.py
+++ b/src/app/contracts/audit.py
@@ -120,7 +120,13 @@ class AuditRecordResponse(BaseModel):
     context_summary: str = Field(description="Short summary of the caller-provided context.")
     context_keys: list[str] = Field(description="Sorted list of structured context keys.")
     source_refs: list[str] = Field(description="Source references carried by the caller.")
-    result_preview: str = Field(description="Short preview of the generated result.")
+    result_preview: str = Field(
+        description=(
+            "Short preview of the generated result, capped at persistence time "
+            "(issue #158, S4): the caller received the full message in the task "
+            "response; the audit trail does not keep a second full copy."
+        )
+    )
     structured_output: dict[str, Any] = Field(
         default_factory=dict,
         description="Structured task result stored in the audit record.",

--- a/src/app/services/data_lifecycle_engine.py
+++ b/src/app/services/data_lifecycle_engine.py
@@ -441,18 +441,31 @@ def _expire_evaluation_approval_evidence(
 def _expire_evaluation_case_content(
     family: RetentionFamily, cutoff: datetime
 ) -> tuple[list[str], str]:
-    """Bulky per-case content ages on its own instant; the run verdict stays."""
+    """Bulky per-case content ages on its own instant; the run verdict stays.
 
+    Minimisation (issue #158, S4): a PASSING case's content ages out at the
+    family's declared minimised horizon - it has no diagnostic purpose beyond
+    review - while failures keep the full period for defect forensics.
+    """
+
+    minimised_cutoff = cutoff
+    if family.minimised_retention_days is not None:
+        assert family.retention_days is not None  # pinned by policy validation
+        now = cutoff + timedelta(days=family.retention_days)
+        minimised_cutoff = now - timedelta(days=family.minimised_retention_days)
     repository = get_evaluation_runtime_store()
-    expired = [
-        record.case_result_id
-        for record in repository.list_all_case_results(limit=_CANDIDATE_BATCH_LIMIT)
-        if _is_before(record.recorded_at, cutoff)
-    ]
+    expired: list[str] = []
+    minimised = 0
+    for record in repository.list_all_case_results(limit=_CANDIDATE_BATCH_LIMIT):
+        if _is_before(record.recorded_at, cutoff):
+            expired.append(record.case_result_id)
+        elif record.outcome == "PASS" and _is_before(record.recorded_at, minimised_cutoff):
+            expired.append(record.case_result_id)
+            minimised += 1
     count = repository.delete_case_results(expired) if expired else 0
     return [f"evaluation_case_results:{case_id}" for case_id in expired], (
-        f"expired {count} evaluation case rows; run verdicts remain with the "
-        "approval evidence family"
+        f"expired {count} evaluation case rows ({minimised} passing cases at the "
+        "minimised horizon); run verdicts remain with the approval evidence family"
     )
 
 
@@ -504,6 +517,13 @@ def enforced_family_handler_ids() -> frozenset[str]:
     """The families the engine actually applies - pinned against the policy."""
 
     return frozenset(_ENFORCED_FAMILY_HANDLERS)
+
+
+# Families whose handler honours a declared minimised horizon (issue #158,
+# S4). Pinned bidirectionally against the policy by test: a declared
+# minimisation without a handler behind it would be a claim the engine does
+# not keep.
+MINIMISING_FAMILY_HANDLER_IDS = frozenset({"evaluation_case_content"})
 
 
 def _record_deletion_evidence(

--- a/src/app/services/data_lifecycle_policy.py
+++ b/src/app/services/data_lifecycle_policy.py
@@ -57,6 +57,20 @@ class RetentionFamily(BaseModel):
             "applied; NOT_TIME_BOUNDED matches a null retention period."
         ),
     )
+    minimised_retention_days: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Shorter horizon for rows the family's engine handler classifies as "
+            "minimisable (issue #158, S4) - e.g. passing evaluation cases whose "
+            "content has no diagnostic purpose beyond review. Requires a "
+            "minimisation_basis and an ENFORCED handler that honours it."
+        ),
+    )
+    minimisation_basis: str | None = Field(
+        default=None,
+        description="Why the minimisable subset needs less retention - required with the days.",
+    )
 
 
 class RetentionPolicy(BaseModel):
@@ -98,6 +112,21 @@ def load_retention_policy() -> RetentionPolicy:
             raise ValueError(
                 f"retention policy family '{family.family_id}' is inconsistent: a null "
                 "retention period and the NOT_TIME_BOUNDED posture must imply each other"
+            )
+        if (family.minimised_retention_days is None) != (family.minimisation_basis is None):
+            raise ValueError(
+                f"retention policy family '{family.family_id}' is inconsistent: a "
+                "minimised retention period and its basis must be declared together"
+            )
+        if family.minimised_retention_days is not None and (
+            family.enforcement != "ENFORCED"
+            or family.retention_days is None
+            or family.minimised_retention_days >= family.retention_days
+        ):
+            raise ValueError(
+                f"retention policy family '{family.family_id}' is inconsistent: minimised "
+                "retention requires an ENFORCED family and must be shorter than the "
+                "family's own retention period"
             )
         for table in family.tables:
             if table in seen_tables:

--- a/src/app/services/task_execution_mapping.py
+++ b/src/app/services/task_execution_mapping.py
@@ -174,6 +174,20 @@ def _provider_config_sha256(resolved: ResolvedTaskExecution) -> str | None:
     )
 
 
+# The audit row keeps a preview, not the output of record (issue #158, S4):
+# the caller received the full message in the task response, and the audit
+# trail's purpose is traceability - digests, verdicts, selection evidence -
+# not a second copy of every generated document.
+_RESULT_PREVIEW_MAX_CHARS = 512
+
+
+def _minimised_result_preview(message: str) -> str:
+    if len(message) <= _RESULT_PREVIEW_MAX_CHARS:
+        return message
+    omitted = len(message) - _RESULT_PREVIEW_MAX_CHARS
+    return f"{message[:_RESULT_PREVIEW_MAX_CHARS]} [truncated {omitted} of {len(message)} chars]"
+
+
 def _audited_context_summary(context: TaskExecutionContext) -> str:
     """Redact the caller-supplied summary at the persistence boundary.
 
@@ -232,7 +246,7 @@ def map_audit_record(
         context_summary=_audited_context_summary(context),
         context_keys=sorted(context.request.context.payload.keys()),
         source_refs=context.request.context.source_refs,
-        result_preview=response.result.message,
+        result_preview=_minimised_result_preview(response.result.message),
         structured_output=response.result.structured_output,
         evidence=response.evidence,
     )

--- a/tests/unit/test_data_lifecycle_engine.py
+++ b/tests/unit/test_data_lifecycle_engine.py
@@ -1046,6 +1046,98 @@ def test_run_records_eval_and_artifact_expiry_honour_their_semantics() -> None:
     assert all(result.deleted_count == 0 for result in second.results)
 
 
+def test_passing_case_content_expires_at_the_minimised_horizon() -> None:
+    """S4 minimisation: a passing case's content ages out at the declared
+    minimised horizon while a same-age failure keeps the full period for
+    defect forensics; failures still expire at the family horizon."""
+
+    from app.repositories.evaluation_runtime_repository import (
+        EvaluationCaseResultRecord,
+        EvaluationRunAttemptRecord,
+        EvaluationRunRecord,
+    )
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+    evaluation = get_evaluation_runtime_store()
+    evaluation.save_run(
+        EvaluationRunRecord(
+            run_id="eval_min",
+            fixture_id="fixture",
+            manifest_version="foundation.v1",
+            lifecycle_status="COMPLETED",
+            triggered_by="operator-a",
+            submitted_at=_iso(5),
+            async_job_id=None,
+            latest_message="m",
+            verdict="PASS",
+            case_count=4,
+        )
+    )
+    evaluation.save_attempt(
+        EvaluationRunAttemptRecord(
+            attempt_id="att_eval_min",
+            run_id="eval_min",
+            attempt_number=1,
+            lifecycle_status="COMPLETED",
+            started_at=_iso(5),
+            completed_at=_iso(5),
+            worker_id=None,
+            latest_message="m",
+            verdict="PASS",
+            failure_reason=None,
+        )
+    )
+    for case_id, outcome, age in (
+        ("case_pass_aged", "PASS", 100),
+        ("case_fail_aged", "FAIL", 100),
+        ("case_pass_fresh", "PASS", 50),
+        ("case_fail_expired", "FAIL", 400),
+    ):
+        evaluation.save_case_result(
+            EvaluationCaseResultRecord(
+                case_result_id=case_id,
+                run_id="eval_min",
+                attempt_id="att_eval_min",
+                case_id=f"c-{case_id}",
+                fixture_id="fixture",
+                outcome=outcome,
+                summary="s",
+                evidence_refs=[],
+                artifact_ids=[],
+                provider_config_sha256=None,
+                recorded_at=_iso(age),
+            )
+        )
+
+    report = run_data_lifecycle(actor="test.operator")
+    results = {r.family_id: r for r in report.results}
+
+    assert results["evaluation_case_content"].deleted_count == 2
+    assert "(1 passing cases at the minimised horizon)" in results["evaluation_case_content"].detail
+    assert {c.case_result_id for c in evaluation.list_all_case_results(limit=10)} == {
+        "case_fail_aged",
+        "case_pass_fresh",
+    }
+
+    second = run_data_lifecycle(actor="test.operator")
+    assert all(result.deleted_count == 0 for result in second.results)
+
+
+def test_minimising_handlers_and_policy_declarations_agree() -> None:
+    """A declared minimised horizon without a handler honouring it would be a
+    policy claim the engine does not keep - and a minimising handler for an
+    undeclared family would delete ahead of the policy."""
+
+    from app.services.data_lifecycle_engine import MINIMISING_FAMILY_HANDLER_IDS
+
+    declared = {
+        family.family_id
+        for family in load_retention_policy().families
+        if family.minimised_retention_days is not None
+    }
+    assert declared == MINIMISING_FAMILY_HANDLER_IDS
+
+
 def test_retrieval_history_expiry_never_touches_current_versions() -> None:
     """S2d: only SUPERSEDED versions age out - the current version of a
     document is live reference state whatever its age - and ingestion-job

--- a/tests/unit/test_data_lifecycle_policy.py
+++ b/tests/unit/test_data_lifecycle_policy.py
@@ -197,3 +197,15 @@ def test_loader_refuses_each_malformation_with_a_bounded_message(
     assert "in more than one family" in _load_from(_policy(_family(), _family("f2")))
     assert "must imply each other" in _load_from(_policy(_family(retention_days=None)))
     assert "must imply each other" in _load_from(_policy(_family(enforcement="NOT_TIME_BOUNDED")))
+    # Minimisation consistency (issue #158, S4): days and basis travel
+    # together, only on an ENFORCED family, and strictly inside its period.
+    assert "declared together" in _load_from(_policy(_family(minimised_retention_days=7)))
+    assert "declared together" in _load_from(_policy(_family(minimisation_basis="why")))
+    assert "requires an ENFORCED family" in _load_from(
+        _policy(_family(minimised_retention_days=7, minimisation_basis="why"))
+    )
+    assert "shorter than the family's own retention" in _load_from(
+        _policy(
+            _family(enforcement="ENFORCED", minimised_retention_days=30, minimisation_basis="why")
+        )
+    )

--- a/tests/unit/test_task_execution_mapping.py
+++ b/tests/unit/test_task_execution_mapping.py
@@ -43,9 +43,32 @@ def test_map_audit_record_preserves_sorted_context_keys() -> None:
     assert audit_record.requested_by is None
     assert audit_record.tenant_id == "tenant-sg-001"
     assert audit_record.context_keys == ["rule_count", "status"]
+    # A short message persists whole; the cap only bites past the preview bound.
     assert audit_record.result_preview == response.result.message
     assert audit_record.prompt_selection.prompt_version == "foundation.explain.v1"
     assert audit_record.evidence == response.evidence
+
+
+def test_map_audit_record_caps_result_preview_at_persistence() -> None:
+    """Minimisation (issue #158, S4): the caller received the full message in
+    the task response; the audit row keeps a bounded preview with an explicit
+    truncation marker, never a second full copy."""
+
+    context = validate_task_request(
+        _request("explain.v1", expected_output_label=OutputLabel.EXPLANATION_ONLY)
+    )
+    resolved = resolve_task_execution(context=context)
+    response = map_task_execution_response(resolved=resolved)
+    long_message = "x" * 2000
+    response = response.model_copy(
+        update={"result": response.result.model_copy(update={"message": long_message})}
+    )
+
+    audit_record = map_audit_record(context=context, response=response)
+
+    assert len(audit_record.result_preview) < len(long_message)
+    assert audit_record.result_preview.startswith("x" * 512)
+    assert audit_record.result_preview.endswith("[truncated 1488 of 2000 chars]")
 
 
 def test_map_audit_record_preserves_full_caller_identity() -> None:


### PR DESCRIPTION
Issue #158, S4 (final slice): **minimisation — stop persisting what has no purpose.** The two targets are the issue's own: the audit `result_preview` and passing evaluation case content.

## The audit row keeps a preview, not the output of record

`result_preview` claimed preview semantics ("Short preview of the generated result") while persisting the **entire generated message** — a second full copy of every output, accumulating indefinitely next to the copy the caller already received. It is now capped at persistence time (512 chars) with an explicit truncation marker (`… [truncated N of M chars]`) — the audit trail's purpose is traceability (digests, verdicts, selection evidence), not content archival. No consumer reads served output back from the preview (verified: the field's only writers are the mapping and retrieval audit paths; no reader treats it as content).

## Passing case content ages at a declared minimised horizon

The policy contract gains two optional, mutually-requiring fields: `minimised_retention_days` + `minimisation_basis` — validated as a pair, only on an `ENFORCED` family, strictly shorter than the family's own period. `evaluation_case_content` declares 90 days with the basis stated: a passing case's inputs and outputs have no diagnostic purpose beyond the review horizon; the run verdict survives with the approval-evidence family, so only failures need the full year for defect forensics.

The engine's case-content handler honours it: PASS-outcome rows past the minimised horizon expire (counted separately in the run detail), FAIL rows keep the full period. A new bidirectional pin — families declaring minimisation == the engine's minimising-handler set — makes a declared horizon without a handler behind it (or the reverse) a build failure, the same guarantee the enforcement map already carries.

## Evidence

Matrix: PASS@100d expires at the minimised horizon while FAIL@100d survives; FAIL@400d expires at the family horizon; PASS@50d survives; idempotent second run. Loader refuses each new malformation with a bounded message (days without basis, basis without days, minimisation on a non-ENFORCED family, horizon not shorter than the period). Preview cap: short messages persist whole; a 2000-char message stores 512 chars + marker. Runbook rule 7 added. Combined coverage verified locally before push. No schema changes.

This completes the #158 slice programme: S1 policy contract + coverage invariant, S2a–S2d every declared period enforced, S3 governed erasure with signed receipt, S4 minimisation.
