### PR TITLE
fix(economics): attempt-level billing truth for retried generations (#232)

### DIFF
--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -524,6 +524,15 @@ Runtime semantics under `ordered_fallback`:
 6. circuit-breaker bookkeeping is keyed per provider identity (`live_text_generation:<provider_id>`), so the primary's failures never open the alternate's breaker; `RESET_DEGRADATION` and `RESET_ALL_PROVIDER_OPERATIONS` control actions clear every candidate's counters
 7. `GET /platform/providers/routing-posture` names both candidates with their catalogue bindings and per-candidate breaker posture, and exposes `candidate_universe` - the same derivation the gateway enumerates from, so the posture cannot disagree with routing. Optional capability query parameters (`?structured_output_required=true`, `?tool_calling_required=true`) add per-candidate eligibility verdicts (`CAPABILITY_NOT_SUPPORTED`, `CAPABILITY_UNKNOWN`, `CAPABILITY_DEGRADED`) and `would_select_entry_id`. The serving identity is always stamped on the response and its audit record - there is no silent fallback
 
+## Provider Billing Truth
+
+Recorded spend covers every billed attempt of a live generation, not just the served one (issue #232): a retried timeout or 5xx may have generated and billed provider-side before failing.
+
+- `estimated_cost_usd` on responses and audit records is the attempt-summed figure, and the budget envelope records it. The composition — `failed_attempt_cost_usd`, `failed_attempt_cost_basis` (`ACTUAL_USAGE` | `CONSERVATIVE_ESTIMATE` | `MIXED` | `NONE`), `billed_attempt_count` — is on the provider execution response; the audit row's attempt context is `retry_count` and its cost posture.
+- `LOTUS_AI_PROVIDER_FAILED_ATTEMPT_COST_POSTURE` defaults to `conservative`: an unknown-usage billable-risk failure is estimated at the identical request body's input tokens plus the `max_output_tokens` ceiling - spend can overstate, never understate. `actual_only` bills failed attempts only on provider-reported usage; choosing it in the promoted profile is a loud protection-override finding.
+- Rate-limited (429) and connection-level failures are never billed - the provider did not generate.
+- Residual (recorded, not hidden): an execution whose every attempt fails records no spend; there is no usage evidence to price and the failure is visible on the operations ledger instead.
+
 ## Durable Provider Operations Recovery
 
 When `LOTUS_AI_PROVIDER_OPERATIONS_STORE_MODE=sqlalchemy`, quota, budget, and degradation posture are durable rather than process-local.

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -10,6 +10,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # the operator supplies the limits.
 PROMOTED_PROFILE_DEFAULTS: dict[str, object] = {
     "provider_retry_limit": 2,
+    "provider_failed_attempt_cost_posture": "conservative",
     "live_text_quota_enforced": True,
     "live_text_budget_enforced": True,
     "live_text_degradation_enforced": True,
@@ -38,6 +39,9 @@ PROMOTED_PROTECTION_FIELDS: frozenset[str] = frozenset(
         "workflow_pack_admission_store_mode",
         "readiness_probe_policy",
         "startup_readiness_policy",
+        # Billing-truth posture (issue #232): actual_only can only understate
+        # spend against the real bill, so weakening it in promoted must be loud.
+        "provider_failed_attempt_cost_posture",
     }
 )
 
@@ -83,6 +87,7 @@ class Settings(BaseSettings):
     live_text_circuit_open_seconds: int | None = None
     provider_timeout_ms: int = 4000
     provider_retry_limit: int = 0
+    provider_failed_attempt_cost_posture: str = "conservative"
     provider_max_output_tokens: int = 512
     live_text_temperature: float = 0.0
     live_text_top_p: float | None = None

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -667,6 +668,16 @@ class ProviderExecutionRequest(BaseModel):
     retry_limit: int = Field(
         description="Maximum bounded retry count allowed for this execution request."
     )
+    failed_attempt_cost_posture: Literal["conservative", "actual_only"] = Field(
+        default="conservative",
+        description=(
+            "How unknown-usage failed attempts are billed (issue #232): 'conservative' "
+            "estimates a billable-risk failed attempt (timeout, 5xx) at the final "
+            "attempt's input tokens - the identical request body - plus the "
+            "max_output_tokens ceiling; 'actual_only' bills failed attempts only when "
+            "the provider returned usage evidence before failing."
+        ),
+    )
     max_output_tokens: int = Field(
         description="Maximum bounded output-token budget allowed for this execution request."
     )
@@ -773,7 +784,29 @@ class ProviderExecutionResponse(BaseModel):
     )
     estimated_cost_usd: float | None = Field(
         default=None,
-        description="Estimated USD cost for the provider execution when rate-card data is configured.",
+        description="Estimated USD cost across every billed attempt of this execution "
+        "(issue #232) when rate-card data is configured - the final attempt plus any "
+        "failed-attempt billing per failed_attempt_cost_basis.",
+    )
+    failed_attempt_cost_usd: float | None = Field(
+        default=None,
+        description="Estimated USD cost attributed to failed attempts before the served "
+        "one (issue #232); null when no failed attempt was billed.",
+    )
+    failed_attempt_cost_basis: (
+        Literal["ACTUAL_USAGE", "CONSERVATIVE_ESTIMATE", "MIXED", "NONE"] | None
+    ) = Field(
+        default=None,
+        description="Evidence basis for failed-attempt billing (issue #232): ACTUAL_USAGE "
+        "from provider-reported usage on the failed attempt, CONSERVATIVE_ESTIMATE from "
+        "the identical request body's input tokens plus the max_output_tokens ceiling, "
+        "MIXED when both applied, NONE when nothing was billable. Null on stub or "
+        "single-attempt executions.",
+    )
+    billed_attempt_count: int | None = Field(
+        default=None,
+        description="Number of attempts included in estimated_cost_usd (issue #232); "
+        "1 means only the served attempt.",
     )
     rate_card_ref: str | None = Field(
         default=None,

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -35,7 +35,10 @@ from app.providers.advisor_brief_quality_guardrails import (
     build_advisor_brief_user_message,
     normalize_advisor_brief_output,
 )
-from app.services.provider_usage_accounting import estimate_live_text_cost
+from app.services.provider_usage_accounting import (
+    estimate_live_text_cost,
+    settle_attempt_billing,
+)
 
 
 def execute_openai_compatible_text_request(
@@ -107,6 +110,14 @@ def execute_openai_compatible_text_request(
         output_tokens=output_tokens,
         model_revision=model_version or model_id,
     )
+    billing = settle_attempt_billing(
+        failed_attempts=extract_failed_attempts(response_payload),
+        posture=request.failed_attempt_cost_posture,
+        final_cost=cost,
+        final_input_tokens=input_tokens,
+        max_output_tokens=request.max_output_tokens,
+        model_revision=model_version or model_id,
+    )
     return ProviderExecutionResponse(
         provider_id=serving_provider_id,
         provider_mode=descriptor.runtime_mode.value,
@@ -121,7 +132,10 @@ def execute_openai_compatible_text_request(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
-        estimated_cost_usd=cost.estimated_cost_usd,
+        estimated_cost_usd=billing.estimated_cost_usd,
+        failed_attempt_cost_usd=billing.failed_attempt_cost_usd,
+        failed_attempt_cost_basis=billing.failed_attempt_cost_basis,
+        billed_attempt_count=billing.billed_attempt_count,
         rate_card_ref=cost.rate_card_ref,
         stubbed=False,
         message=message,
@@ -213,6 +227,10 @@ def post_openai_compatible_response(
     deadline_at = _monotonic() + backoff_plan.total_deadline_seconds
     if execution_deadline_at is not None:
         deadline_at = min(deadline_at, execution_deadline_at)
+    # Usage evidence for each failed attempt that precedes the served one
+    # (issue #232): the provider may have generated and billed before failing,
+    # so the billing settlement needs what each attempt is known to have used.
+    failed_attempts: list[dict[str, object]] = []
     for attempt_index in range(bounded_retry_limit + 1):
         if execution_deadline_at is not None:
             remaining_seconds = execution_deadline_at - _monotonic()
@@ -245,6 +263,7 @@ def post_openai_compatible_response(
                 record_provider_span_outcome(attempt_span, outcome="success")
                 response_payload = cast(dict[str, Any], json.loads(response.read().decode("utf-8")))
                 response_payload["_lotus_retry_count"] = attempt_index
+                response_payload["_lotus_failed_attempts"] = failed_attempts
                 usage = response_payload.get("usage")
                 usage_fields = usage if isinstance(usage, dict) else {}
                 attempt_latency_ms = _attempt_latency_ms(attempt_started)
@@ -268,7 +287,7 @@ def post_openai_compatible_response(
                 )
                 return response_payload
         except error.HTTPError as exc:
-            load_error_payload(exc)
+            error_payload = load_error_payload(exc)
             category = failure_category_for_http_status(exc.code)
             retryable = is_retryable_provider_failure(category=category, http_status_code=exc.code)
             retry_decision = plan_retry(
@@ -297,6 +316,11 @@ def post_openai_compatible_response(
                 latency_ms=attempt_latency_ms,
             )
             if will_retry:
+                # 5xx may follow completed generation; 4xx (incl. 429) refuses
+                # before generation and carries no billable risk.
+                failed_attempts.append(
+                    _failed_attempt_evidence(error_payload, billable_risk=exc.code >= 500)
+                )
                 wait_for_retry(retry_decision)
                 continue
             deadline_stop = _governed_deadline_stop(
@@ -339,6 +363,9 @@ def post_openai_compatible_response(
                 latency_ms=attempt_latency_ms,
             )
             if will_retry:
+                # A timeout after acceptance may still have generated and
+                # billed provider-side.
+                failed_attempts.append(_failed_attempt_evidence({}, billable_risk=True))
                 wait_for_retry(retry_decision)
                 continue
             deadline_stop = _governed_deadline_stop(
@@ -381,6 +408,9 @@ def post_openai_compatible_response(
                 latency_ms=attempt_latency_ms,
             )
             if will_retry:
+                # Connection-level failure: the request did not reach a
+                # generating provider, so no billable risk.
+                failed_attempts.append(_failed_attempt_evidence({}, billable_risk=False))
                 wait_for_retry(retry_decision)
                 continue
             deadline_stop = _governed_deadline_stop(
@@ -534,6 +564,33 @@ def extract_retry_count(payload: dict[str, Any]) -> int:
     return as_int(payload.get("_lotus_retry_count")) or 0
 
 
+def _failed_attempt_evidence(
+    error_payload: dict[str, Any], *, billable_risk: bool
+) -> dict[str, object]:
+    """What one failed attempt is known to have used (issue #232).
+
+    An OpenAI-compatible error body rarely carries usage, but when it does
+    that is actual billing evidence and beats any estimate.
+    """
+
+    usage = error_payload.get("usage")
+    usage_fields = usage if isinstance(usage, dict) else {}
+    return {
+        "billable_risk": billable_risk,
+        "input_tokens": as_int(usage_fields.get("input_tokens")),
+        "output_tokens": as_int(usage_fields.get("output_tokens")),
+    }
+
+
+def extract_failed_attempts(payload: dict[str, Any]) -> list[dict[str, object]]:
+    attempts = payload.get("_lotus_failed_attempts")
+    return (
+        [attempt for attempt in attempts if isinstance(attempt, dict)]
+        if isinstance(attempts, list)
+        else []
+    )
+
+
 def as_str(value: object) -> str | None:
     return value if isinstance(value, str) and value.strip() else None
 
@@ -573,12 +630,25 @@ def build_structured_output(
         output_tokens=output_tokens,
         model_revision=configured_model_id,
     )
+    structured_billing = settle_attempt_billing(
+        failed_attempts=extract_failed_attempts(response_payload),
+        posture=request.failed_attempt_cost_posture,
+        final_cost=structured_cost,
+        final_input_tokens=input_tokens,
+        max_output_tokens=request.max_output_tokens,
+        model_revision=configured_model_id,
+    )
     structured_output.update(
         {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "total_tokens": total_tokens,
-            "estimated_cost_usd": structured_cost.estimated_cost_usd,
+            # The attempt-summed figure (issue #232) - the same number the
+            # budget envelope records. The composition detail (basis, counts)
+            # lives on the response and audit record: the echo's SHAPE is
+            # pinned by the captured pack output contracts, so new keys here
+            # would fail output validation for every family.
+            "estimated_cost_usd": structured_billing.estimated_cost_usd,
             "rate_card_ref": structured_cost.rate_card_ref,
             "cost_posture": structured_cost.cost_posture,
         }

--- a/src/app/services/provider_execution_config.py
+++ b/src/app/services/provider_execution_config.py
@@ -66,6 +66,7 @@ class ProviderExecutionConfig:
     allowed_task_ids: str
     timeout_ms: int
     retry_limit: int
+    failed_attempt_cost_posture: str
     max_output_tokens: int
     temperature: float
     top_p: float | None
@@ -112,6 +113,7 @@ def resolve_provider_execution_config() -> ProviderExecutionConfig:
         allowed_task_ids=settings.live_text_allowed_task_ids,
         timeout_ms=max(settings.provider_timeout_ms, 1),
         retry_limit=max(settings.provider_retry_limit, 0),
+        failed_attempt_cost_posture=settings.provider_failed_attempt_cost_posture,
         max_output_tokens=max(settings.provider_max_output_tokens, 1),
         temperature=settings.live_text_temperature,
         top_p=settings.live_text_top_p,
@@ -220,6 +222,7 @@ def derive_fallback_execution_config(
         allowed_task_ids=config.allowed_task_ids,
         timeout_ms=config.timeout_ms,
         retry_limit=config.retry_limit,
+        failed_attempt_cost_posture=config.failed_attempt_cost_posture,
         max_output_tokens=config.max_output_tokens,
         temperature=config.temperature,
         top_p=config.top_p,

--- a/src/app/services/provider_request_builder.py
+++ b/src/app/services/provider_request_builder.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from app.contracts.providers import ProviderExecutionRequest
 from app.services.provider_execution_config import resolve_provider_execution_config
 from app.services.task_execution_models import TaskExecutionContext
+
+
+def _as_cost_posture(value: str) -> Literal["conservative", "actual_only"]:
+    """An unrecognised configured posture falls back to conservative - the
+    direction that can only overstate spend, never understate it (issue #232)."""
+
+    return "actual_only" if value == "actual_only" else "conservative"
 
 
 def build_provider_execution_request(
@@ -29,6 +38,7 @@ def build_provider_execution_request(
         source_refs=context.request.context.source_refs,
         timeout_ms=config.timeout_ms,
         retry_limit=config.retry_limit,
+        failed_attempt_cost_posture=_as_cost_posture(config.failed_attempt_cost_posture),
         max_output_tokens=config.max_output_tokens,
         temperature=config.temperature,
         top_p=config.top_p,

--- a/src/app/services/provider_usage_accounting.py
+++ b/src/app/services/provider_usage_accounting.py
@@ -23,6 +23,7 @@ ranges for the same scope key - the write-side invariant every producer
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 from datetime import UTC, datetime
 
 from fastapi import HTTPException, status
@@ -48,6 +49,102 @@ class UsageCostEstimate:
 
 
 UNKNOWN_COST = UsageCostEstimate(estimated_cost_usd=None, rate_card_ref=None)
+
+FailedAttemptCostBasis = Literal["ACTUAL_USAGE", "CONSERVATIVE_ESTIMATE", "MIXED", "NONE"]
+
+
+@dataclass(frozen=True)
+class AttemptBillingSettlement:
+    """Execution-level billing across every attempt (issue #232).
+
+    ``estimated_cost_usd`` is the figure spend recording and the budget
+    envelope use: the served attempt plus every billed failed attempt, so
+    recorded spend cannot understate the real bill by the retry factor.
+    """
+
+    estimated_cost_usd: float | None
+    failed_attempt_cost_usd: float | None
+    failed_attempt_cost_basis: FailedAttemptCostBasis | None
+    billed_attempt_count: int
+
+
+def settle_attempt_billing(
+    *,
+    failed_attempts: list[dict[str, object]],
+    posture: str,
+    final_cost: UsageCostEstimate,
+    final_input_tokens: int | None,
+    max_output_tokens: int,
+    model_revision: str | None = None,
+) -> AttemptBillingSettlement:
+    """Price the failed attempts behind a served response (issue #232).
+
+    Evidence order per failed attempt: provider-reported usage on the failed
+    attempt prices as ACTUAL_USAGE; otherwise, under the conservative posture,
+    a billable-risk failure (timeout, 5xx - the provider may have generated
+    and billed) prices at the final attempt's input tokens - the identical
+    request body - plus the max_output_tokens ceiling (CONSERVATIVE_ESTIMATE).
+    Non-billable failures (429 refused before generation, connection-level
+    errors) and unknown-usage failures under actual_only are never priced.
+    """
+
+    failed_total = 0.0
+    actual_count = 0
+    conservative_count = 0
+    for attempt in failed_attempts:
+        input_tokens = attempt.get("input_tokens")
+        output_tokens = attempt.get("output_tokens")
+        if isinstance(input_tokens, int) and isinstance(output_tokens, int):
+            attempt_cost = estimate_live_text_cost(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                model_revision=model_revision,
+            )
+            if attempt_cost.estimated_cost_usd is not None:
+                failed_total += attempt_cost.estimated_cost_usd
+                actual_count += 1
+            continue
+        if (
+            posture == "conservative"
+            and attempt.get("billable_risk") is True
+            and final_input_tokens is not None
+        ):
+            attempt_cost = estimate_live_text_cost(
+                input_tokens=final_input_tokens,
+                output_tokens=max_output_tokens,
+                model_revision=model_revision,
+            )
+            if attempt_cost.estimated_cost_usd is not None:
+                failed_total += attempt_cost.estimated_cost_usd
+                conservative_count += 1
+
+    billed_failed = actual_count + conservative_count
+    if billed_failed == 0:
+        return AttemptBillingSettlement(
+            estimated_cost_usd=final_cost.estimated_cost_usd,
+            failed_attempt_cost_usd=None,
+            failed_attempt_cost_basis="NONE" if failed_attempts else None,
+            billed_attempt_count=1,
+        )
+    basis: FailedAttemptCostBasis
+    if actual_count and conservative_count:
+        basis = "MIXED"
+    elif actual_count:
+        basis = "ACTUAL_USAGE"
+    else:
+        basis = "CONSERVATIVE_ESTIMATE"
+    failed_cost = round(failed_total, 8)
+    total = (
+        round(final_cost.estimated_cost_usd + failed_cost, 8)
+        if final_cost.estimated_cost_usd is not None
+        else failed_cost
+    )
+    return AttemptBillingSettlement(
+        estimated_cost_usd=total,
+        failed_attempt_cost_usd=failed_cost,
+        failed_attempt_cost_basis=basis,
+        billed_attempt_count=1 + billed_failed,
+    )
 
 
 def save_rate_card(card: RateCard) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,7 @@ def reset_runtime_settings() -> Generator[None, None, None]:
         ),
         "runtime_profile": settings.runtime_profile,
         "provider_retry_limit": settings.provider_retry_limit,
+        "provider_failed_attempt_cost_posture": settings.provider_failed_attempt_cost_posture,
         "provider_retention_confirmation_store_mode": (
             settings.provider_retention_confirmation_store_mode
         ),

--- a/tests/unit/test_attempt_billing.py
+++ b/tests/unit/test_attempt_billing.py
@@ -1,0 +1,237 @@
+"""Attempt-level billing truth (issue #232).
+
+Recorded spend must cover every billed attempt of a non-idempotent
+generation, not just the served one: a retried 5xx or timeout may have
+generated and billed provider-side. The settlement prices actual usage
+evidence first, conservative estimates second (identical request body's
+input tokens plus the max_output_tokens ceiling), and never bills failures
+that cannot have generated (429, connection-level).
+"""
+
+from email.message import Message
+from io import BytesIO
+from urllib import error
+
+from pytest import MonkeyPatch
+
+from app.config import settings
+from app.services.provider_budget_policy import record_provider_spend
+from app.services.provider_operations_store import get_provider_operations_store
+from app.services.provider_usage_accounting import (
+    AttemptBillingSettlement,
+    UsageCostEstimate,
+    settle_attempt_billing,
+)
+
+
+def _seed_cost_scalars() -> None:
+    settings.live_text_model_id = "gpt-5.4"
+    settings.live_text_input_cost_per_1k_tokens = 0.01
+    settings.live_text_output_cost_per_1k_tokens = 0.03
+
+
+_FINAL_COST = UsageCostEstimate(estimated_cost_usd=0.0035, rate_card_ref="default-live-text")
+
+
+def _settle(
+    attempts: list[dict[str, object]], *, posture: str = "conservative"
+) -> AttemptBillingSettlement:
+    return settle_attempt_billing(
+        failed_attempts=attempts,
+        posture=posture,
+        final_cost=_FINAL_COST,
+        final_input_tokens=200,
+        max_output_tokens=512,
+        model_revision="gpt-5.4",
+    )
+
+
+def test_settlement_prices_each_evidence_class_honestly() -> None:
+    _seed_cost_scalars()
+
+    # No failed attempts: the served attempt is the whole bill.
+    single = _settle([])
+    assert single.estimated_cost_usd == 0.0035
+    assert single.failed_attempt_cost_usd is None
+    assert single.failed_attempt_cost_basis is None
+    assert single.billed_attempt_count == 1
+
+    # Unknown-usage billable-risk failure under the conservative posture:
+    # input tokens are the identical request body's 200; output is the
+    # 512-token ceiling -> 0.002 + 0.01536.
+    conservative = _settle([{"billable_risk": True, "input_tokens": None, "output_tokens": None}])
+    assert conservative.failed_attempt_cost_usd == 0.01736
+    assert conservative.estimated_cost_usd == 0.02086
+    assert conservative.failed_attempt_cost_basis == "CONSERVATIVE_ESTIMATE"
+    assert conservative.billed_attempt_count == 2
+
+    # Provider-reported usage on the failed attempt is actual evidence and
+    # beats any estimate.
+    actual = _settle([{"billable_risk": True, "input_tokens": 200, "output_tokens": 100}])
+    assert actual.failed_attempt_cost_usd == 0.005
+    assert actual.failed_attempt_cost_basis == "ACTUAL_USAGE"
+
+    mixed = _settle(
+        [
+            {"billable_risk": True, "input_tokens": 200, "output_tokens": 100},
+            {"billable_risk": True, "input_tokens": None, "output_tokens": None},
+        ]
+    )
+    assert mixed.failed_attempt_cost_basis == "MIXED"
+    assert mixed.billed_attempt_count == 3
+    assert mixed.failed_attempt_cost_usd == 0.02236
+
+    # A failure that cannot have generated (429 refused pre-generation,
+    # connection-level) is never billed, whatever the posture.
+    unbillable = _settle([{"billable_risk": False, "input_tokens": None, "output_tokens": None}])
+    assert unbillable.estimated_cost_usd == 0.0035
+    assert unbillable.failed_attempt_cost_basis == "NONE"
+    assert unbillable.billed_attempt_count == 1
+
+    # actual_only never estimates - it bills only usage evidence.
+    actual_only = _settle(
+        [{"billable_risk": True, "input_tokens": None, "output_tokens": None}],
+        posture="actual_only",
+    )
+    assert actual_only.estimated_cost_usd == 0.0035
+    assert actual_only.failed_attempt_cost_basis == "NONE"
+
+
+def test_transport_bills_the_failed_attempt_behind_a_served_retry(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The issue's acceptance: fails once with a 5xx, succeeds on retry -
+    recorded spend covers both attempts under the conservative posture."""
+
+    from app.providers.local_openai_compatible_text_provider import (
+        LocalOpenAICompatibleTextProvider,
+    )
+    from app.providers.openai_compatible_text_transport import (
+        execute_openai_compatible_text_request,
+    )
+    from tests.unit.test_provider_gateway import _request
+
+    _seed_cost_scalars()
+    monkeypatch.setattr("app.services.provider_retry_backoff._sleep", lambda delay: None)
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+
+    attempts = {"count": 0}
+
+    class _Response:
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return (
+                b'{"id": "resp_billing", "model": "gpt-5.4", "output_text": "OK",'
+                b' "usage": {"input_tokens": 200, "output_tokens": 50, "total_tokens": 250}}'
+            )
+
+    def _urlopen(request: object, timeout: float) -> _Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise error.HTTPError(
+                url="http://localhost/v1/responses",
+                code=503,
+                msg="unavailable",
+                hdrs=Message(),
+                fp=BytesIO(b"{}"),
+            )
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    response = execute_openai_compatible_text_request(
+        descriptor=LocalOpenAICompatibleTextProvider().descriptor,
+        request=_request(retry_limit=1),
+        api_base="http://localhost:1234/v1",
+        api_key=None,
+        require_api_key=False,
+        model_id="gpt-5.4",
+        model_version=None,
+    )
+
+    assert attempts["count"] == 2
+    assert response.retry_count == 1
+    # Final attempt 0.0035 plus the conservative estimate for the failed one
+    # (200 input tokens of the identical body + the 512-token ceiling).
+    assert response.failed_attempt_cost_usd == 0.01736
+    assert response.estimated_cost_usd == 0.02086
+    assert response.failed_attempt_cost_basis == "CONSERVATIVE_ESTIMATE"
+    assert response.billed_attempt_count == 2
+    # The structured echo carries the same summed figure - one cost truth.
+    # (The composition detail lives only on the response/audit level: the
+    # echo's shape is pinned by the captured pack output contracts.)
+    assert response.structured_output["estimated_cost_usd"] == 0.02086
+    assert "billed_attempt_count" not in response.structured_output
+
+    # The budget envelope records the summed figure.
+    record_provider_spend(response)
+    budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
+    assert budget is not None
+    assert budget.current_spend_usd == 0.02086
+
+
+def test_a_rate_limited_retry_is_not_billed(monkeypatch: MonkeyPatch) -> None:
+    """429 refuses before generation: retried rate-limits carry no billable
+    risk and the settlement says NONE."""
+
+    from app.providers.local_openai_compatible_text_provider import (
+        LocalOpenAICompatibleTextProvider,
+    )
+    from app.providers.openai_compatible_text_transport import (
+        execute_openai_compatible_text_request,
+    )
+    from tests.unit.test_provider_gateway import _request
+
+    _seed_cost_scalars()
+    monkeypatch.setattr("app.services.provider_retry_backoff._sleep", lambda delay: None)
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+
+    attempts = {"count": 0}
+
+    class _Response:
+        def __enter__(self) -> "_Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return (
+                b'{"id": "resp_429", "model": "gpt-5.4", "output_text": "OK",'
+                b' "usage": {"input_tokens": 200, "output_tokens": 50, "total_tokens": 250}}'
+            )
+
+    def _urlopen(request: object, timeout: float) -> _Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise error.HTTPError(
+                url="http://localhost/v1/responses",
+                code=429,
+                msg="rate limited",
+                hdrs=Message(),
+                fp=BytesIO(b"{}"),
+            )
+        return _Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    response = execute_openai_compatible_text_request(
+        descriptor=LocalOpenAICompatibleTextProvider().descriptor,
+        request=_request(retry_limit=1),
+        api_base="http://localhost:1234/v1",
+        api_key=None,
+        require_api_key=False,
+        model_id="gpt-5.4",
+        model_version=None,
+    )
+
+    assert response.retry_count == 1
+    assert response.estimated_cost_usd == 0.0035
+    assert response.failed_attempt_cost_usd is None
+    assert response.failed_attempt_cost_basis == "NONE"
+    assert response.billed_attempt_count == 1

--- a/tests/unit/test_runtime_profile.py
+++ b/tests/unit/test_runtime_profile.py
@@ -110,6 +110,14 @@ def test_explicitly_weakened_protections_are_captured_loudly() -> None:
     )
     assert Settings(runtime_profile="local").promoted_protection_overrides == []
 
+    # Billing-truth posture is a protection (issue #232): actual_only can only
+    # understate spend, so choosing it in promoted is loud.
+    billing_weakened = Settings(
+        runtime_profile="promoted", provider_failed_attempt_cost_posture="actual_only"
+    ).promoted_protection_overrides
+    assert len(billing_weakened) == 1
+    assert "provider_failed_attempt_cost_posture" in billing_weakened[0]
+
 
 def test_startup_readiness_surfaces_promoted_overrides(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #232: **recorded spend now covers every billed attempt of a non-idempotent generation.** Under promoted `provider_retry_limit=2`, tracked spend could understate the real bill by up to 3x — a retried timeout or 5xx may have generated and billed provider-side before failing, and only the final attempt was priced.

## Evidence order, not invention

The transport already sees every attempt; now it keeps what each failed attempt is known to have used. Settlement (in the usage-accounting module, where billing math lives) prices in strict evidence order:

1. **Provider-reported usage on the failed attempt** (`ACTUAL_USAGE`) — an error body that carries usage is actual billing evidence and beats any estimate.
2. **Conservative estimate** (`CONSERVATIVE_ESTIMATE`, default posture) for unknown-usage *billable-risk* failures only: input tokens are the final attempt's — the retry re-POSTs the identical body, so that count is hard evidence, not a guess — plus the `max_output_tokens` ceiling. Spend can overstate, never understate.
3. **Never billed**: 429 (refused before generation) and connection-level failures — a failure that cannot have generated is not billed under any posture.

`estimated_cost_usd` on the response, the structured echo, and the audit record is now the attempt-summed figure — one cost truth. The composition (`failed_attempt_cost_usd`, `failed_attempt_cost_basis`, `billed_attempt_count`) lives on the response contract: the echo's *shape* is pinned by the captured pack output contracts, so new echo keys would fail output validation for every family (caught by the local gate — the echo keeps its contract shape and carries just the summed number), and the audit row carries the summed figure with its existing attempt context (`retry_count`, per the issue's own acceptance) and cost posture — persisting the per-attempt basis on the audit row is a recorded residual, not claimed. `record_provider_spend` and the budget envelope consume that same field, so **budget enforcement uses the summed figure** with no change to the enforcement path.

## The posture is a governed protection

`LOTUS_AI_PROVIDER_FAILED_ATTEMPT_COST_POSTURE` (default `conservative`) joins `PROMOTED_PROFILE_DEFAULTS` **and** `PROMOTED_PROTECTION_FIELDS`: `actual_only` can only understate spend against the real bill, so choosing it in promoted is a loud protection-override finding — the same #233 machinery, no new mechanism. The posture rides the frozen `ProviderExecutionConfig` into the request; the transport stays settings-free.

## Evidence

The issue's acceptance, executed: a fails-once-with-503-then-succeeds transport run (fake at the urlopen boundary — the real retry loop, evidence stamping and settlement all execute) records spend covering both attempts (`0.0035` final + `0.01736` conservative = `0.02086` reaches the budget envelope), basis `CONSERVATIVE_ESTIMATE`, `billed_attempt_count=2`; a retried 429 bills nothing (`NONE`, count 1). Settlement matrix: actual-usage, conservative, mixed, unbillable, `actual_only`, and no-rate-card cases. Promoted weakening of the posture is captured loudly (test extended). Runbook gains "Provider Billing Truth" with the residual stated honestly: an execution whose every attempt fails records no spend — there is no usage evidence to price — and stays visible on the operations ledger.

Ordered fallback inherits the summed figure unchanged (both candidates run the same transport path). No schema changes — audit's typed `estimated_cost_usd` carries the summed figure through the existing column.
