### PR TITLE
fix(validation): unit-typed numeric basis, reference-semantic citations, bounded profile (#230, #239)

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import PrivateAttr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -47,7 +49,11 @@ PROMOTED_PROTECTION_FIELDS: frozenset[str] = frozenset(
 
 
 class Settings(BaseSettings):
-    runtime_profile: str = "local"
+    # Bounded on purpose (issue #230): every profile gate in the runtime
+    # compares against these two values, so a typo ("promted") would silently
+    # get the lenient local tier everywhere. Unknown values refuse at
+    # construction instead.
+    runtime_profile: Literal["local", "promoted"] = "local"
     service_name: str = "lotus-ai"
     service_version: str = "0.1.0"
     delivery_phase: str = "foundation"

--- a/src/app/services/output_validation.py
+++ b/src/app/services/output_validation.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from typing import Any
 
 from app.contracts.output_validation import (
@@ -142,7 +143,7 @@ def _validate(
         for token in ungrounded_tokens[:_MAX_RECORDED_FINDINGS]:
             findings.append(
                 f"{RULE_NUMERIC_GROUNDING}: narrative token '{token}' does not trace to "
-                "any numeric value supplied in the execution context"
+                "any same-unit numeric value supplied in the execution context"
             )
 
     if salvaged_json:
@@ -253,40 +254,88 @@ def _ungrounded_references(value: Any, *, supplied: set[str]) -> list[str]:
     return unsupported
 
 
-def _numeric_basis(context_payload: dict[str, Any]) -> list[float]:
-    """Every numeric value supplied anywhere in the execution context."""
+# Unit-class markers for the numeric basis (issue #230): a context value
+# grounds a percent or currency token only when its key or its own text says
+# it carries that unit - a bare count must not ground a fabricated "5%".
+# Matching is on exact underscore-separated key parts, so "workflow_count"
+# never reads as cash flow.
+_PERCENT_BASIS_KEY_PARTS = frozenset({"pct", "percent", "percentage", "ratio", "rate"})
+_CURRENCY_BASIS_KEY_PARTS = frozenset(
+    {
+        "usd",
+        "amount",
+        "cost",
+        "price",
+        "spend",
+        "budget",
+        "fee",
+        "cash",
+        "aum",
+        "balance",
+        "notional",
+    }
+)
 
-    basis: list[float] = []
 
-    def walk(node: Any, depth: int) -> None:
+@dataclass(frozen=True)
+class _NumericBasis:
+    percent: list[float]
+    currency: list[float]
+
+
+def _key_parts(key: str) -> set[str]:
+    return {part for part in key.lower().replace("-", "_").split("_") if part}
+
+
+def _numeric_basis(context_payload: dict[str, Any]) -> _NumericBasis:
+    """Context numerics, pooled by the unit class their source declares.
+
+    A value joins the percent pool when its key names a percent-class unit or
+    its own text carries a ``%``; the currency pool when its key names a
+    monetary unit or its text carries a ``$``. An untyped numeric (a count, an
+    id) grounds neither - that typelessness let a payload count ``5`` ground a
+    fabricated "5%" before this sharpening.
+    """
+
+    percent: list[float] = []
+    currency: list[float] = []
+
+    def classify(key: str | None, value: float, *, text: str | None) -> None:
+        parts = _key_parts(key) if key is not None else set()
+        if parts & _PERCENT_BASIS_KEY_PARTS or (text is not None and "%" in text):
+            percent.append(value)  # monetary-float-ok: leak-detection comparison basis
+        if parts & _CURRENCY_BASIS_KEY_PARTS or (text is not None and "$" in text):
+            currency.append(value)  # monetary-float-ok: leak-detection comparison basis
+
+    def walk(node: Any, key: str | None, depth: int) -> None:
         if depth > _MAX_TRAVERSAL_DEPTH:
             raise ValueError("context payload exceeds the validation traversal depth")
         if isinstance(node, bool):
             return
         if isinstance(node, (int, float)):
-            basis.append(float(node))  # monetary-float-ok: leak-detection comparison basis
+            classify(key, float(node), text=None)
             return
         if isinstance(node, str):
             try:
-                basis.append(  # monetary-float-ok: leak-detection comparison basis
-                    float(node.replace(",", ""))
-                )
+                parsed = float(node.replace(",", "").replace("%", "").replace("$", ""))
             except ValueError:
-                pass
+                return
+            classify(key, parsed, text=node)
             return
         if isinstance(node, dict):
-            for child in node.values():
-                walk(child, depth + 1)
+            for child_key, child in node.items():
+                walk(child, child_key if isinstance(child_key, str) else key, depth + 1)
         elif isinstance(node, list):
             for item in node:
-                walk(item, depth + 1)
+                walk(item, key, depth + 1)
 
-    walk(context_payload, 0)
-    return basis
+    walk(context_payload, None, 0)
+    return _NumericBasis(percent=percent, currency=currency)
 
 
-def _ungrounded_numeric_tokens(value: Any, *, basis: list[float]) -> list[str]:
-    """Percent/currency tokens in output narrative that trace to no supplied value."""
+def _ungrounded_numeric_tokens(value: Any, *, basis: _NumericBasis) -> list[str]:
+    """Percent/currency tokens in output narrative that trace to no supplied
+    value of the same unit class (issue #230)."""
 
     ungrounded: list[str] = []
     seen: set[str] = set()
@@ -297,7 +346,9 @@ def _ungrounded_numeric_tokens(value: Any, *, basis: list[float]) -> list[str]:
                 token.replace("%", "").replace(",", "")
             )
             if (
-                not any(abs(candidate - expected) <= _PERCENT_TOLERANCE for expected in basis)
+                not any(
+                    abs(candidate - expected) <= _PERCENT_TOLERANCE for expected in basis.percent
+                )
                 and token not in seen
             ):
                 seen.add(token)
@@ -310,7 +361,9 @@ def _ungrounded_numeric_tokens(value: Any, *, basis: list[float]) -> list[str]:
                 normalized
             )
             if (
-                not any(abs(candidate - expected) <= _CURRENCY_TOLERANCE for expected in basis)
+                not any(
+                    abs(candidate - expected) <= _CURRENCY_TOLERANCE for expected in basis.currency
+                )
                 and token not in seen
             ):
                 seen.add(token)
@@ -357,25 +410,45 @@ def _ungrounded_narrative_citations(
     return ungrounded
 
 
+# The keys whose subtrees carry reference semantics (issue #239), enumerated
+# from what shipped families actually emit: the validator's own reference
+# keys, retrieval's citation entries and source_ids, and the composite parts.
+_REFERENCE_BASIS_KEYS = _REFERENCE_KEYS | {"citations", "source_ids", "source_id", "document_id"}
+
+
 def _structured_reference_basis(structured_output: Any) -> set[str]:
+    """Strings from reference-semantic fields only (issue #239).
+
+    A string joins the citation basis only from under a reference-semantic
+    key: a model emitting a fabricated reference as the WHOLE value of a
+    free-text field (a headline that is exactly `lotus-manage:doc:999`) no
+    longer self-grounds its own narrative citation. The composite
+    ``source_id:document_id`` form stays - those keys are themselves
+    reference-semantic.
+    """
+
     basis: set[str] = set()
 
-    def walk(node: Any, depth: int) -> None:
+    def walk(node: Any, depth: int, *, referential: bool) -> None:
         if depth > _MAX_TRAVERSAL_DEPTH:
             raise ValueError("structured output exceeds the validation traversal depth")
         if isinstance(node, str):
-            basis.add(node)
+            if referential:
+                basis.add(node)
         elif isinstance(node, dict):
             source_id = node.get("source_id")
             document_id = node.get("document_id")
             if isinstance(source_id, str) and isinstance(document_id, str):
                 # The declared citation shape, rendered joined in narrative.
                 basis.add(f"{source_id}:{document_id}")
-            for child in node.values():
-                walk(child, depth + 1)
+            for key, child in node.items():
+                child_referential = referential or (
+                    isinstance(key, str) and key in _REFERENCE_BASIS_KEYS
+                )
+                walk(child, depth + 1, referential=child_referential)
         elif isinstance(node, list):
             for item in node:
-                walk(item, depth + 1)
+                walk(item, depth + 1, referential=referential)
 
-    walk(structured_output, 0)
+    walk(structured_output, 0, referential=False)
     return basis

--- a/tests/unit/test_output_validation.py
+++ b/tests/unit/test_output_validation.py
@@ -166,7 +166,9 @@ def test_numeric_grounding_traces_tokens_to_the_supplied_context() -> None:
 
 
 def test_numeric_grounding_scans_nested_narrative_and_respects_tolerance() -> None:
-    payload = {"metrics": [{"value": "7.93"}], "count": 3}
+    # The metric declares its unit class through its key (issue #230): an
+    # untyped {"value": "7.93"} would no longer ground a percent token.
+    payload = {"metrics": [{"benchmark_rate": "7.93"}], "count": 3}
 
     within_tolerance = _validate(
         {"sections": [{"detail": "Benchmark delivered 7.94% this period."}]},
@@ -186,6 +188,79 @@ def test_numeric_grounding_scans_nested_narrative_and_respects_tolerance() -> No
         {"summary": "Reviewed 42 positions across 7 sleeves."}, context_payload=payload
     )
     assert bare_numbers.validation_state is OutputValidationState.VALIDATED
+
+
+def test_numeric_grounding_is_unit_typed_across_fields() -> None:
+    """Issue #230: the basis pools by unit class - an untyped payload count
+    must not ground a fabricated percent or dollar token of the same digits,
+    and a value grounds only tokens of its own unit."""
+
+    counts_only = {"rule_count": 5, "position_total": 25000}
+    cross_field_percent = _validate(
+        {"summary": "Compliance improved 5% this quarter."}, context_payload=counts_only
+    )
+    assert cross_field_percent.validation_state is OutputValidationState.REJECTED
+    assert cross_field_percent.failed_rule_ids == ["numeric_grounding"]
+
+    cross_field_currency = _validate(
+        {"summary": "Net flows reached $25,000."}, context_payload=counts_only
+    )
+    assert cross_field_currency.validation_state is OutputValidationState.REJECTED
+
+    # The same digits ground once the source declares the unit - by key part
+    # or by the value's own text.
+    typed_by_key = _validate(
+        {"summary": "Compliance improved 5% this quarter."},
+        context_payload={"improvement_pct": 5},
+    )
+    assert typed_by_key.validation_state is OutputValidationState.VALIDATED
+    typed_by_text = _validate(
+        {"summary": "Net flows reached $25,000."},
+        context_payload={"flows": "$25,000"},
+    )
+    assert typed_by_text.validation_state is OutputValidationState.VALIDATED
+
+    # A percent-typed value does not ground a currency token of the same
+    # digits, and vice versa.
+    wrong_unit = _validate(
+        {"summary": "Fees were $1.25."}, context_payload={"portfolio_return_pct": 1.25}
+    )
+    assert wrong_unit.validation_state is OutputValidationState.REJECTED
+
+
+def test_free_text_fields_cannot_self_ground_narrative_citations() -> None:
+    """Issue #239: a fabricated reference emitted as the whole value of a
+    free-text structured field must not ground the narrative citing it -
+    only reference-semantic fields carry citation basis."""
+
+    self_grounded = _validate(
+        {"headline": "lotus-manage:doc:999"},
+        message="Grounded in lotus-manage:doc:999 as agreed.",
+    )
+    assert self_grounded.validation_state is OutputValidationState.REJECTED
+    assert self_grounded.failed_rule_ids == ["evidence_grounding"]
+
+    # The same token grounds from a reference-semantic field - supplied
+    # refs, evidence entries, or citation composites.
+    referential = _validate(
+        {"evidence_refs": [{"source_ref": "lotus-manage:doc:999"}]},
+        message="Grounded in lotus-manage:doc:999 as agreed.",
+        supplied_source_refs=["lotus-manage:doc:999"],
+    )
+    assert referential.validation_state is OutputValidationState.VALIDATED
+
+
+def test_unknown_runtime_profile_is_refused_at_construction() -> None:
+    """Issue #230: a typo'd profile ("promted") must not silently get the
+    lenient local tier everywhere the profile gates."""
+
+    import pytest
+    from pydantic import ValidationError
+
+    from app.config import Settings
+
+    with pytest.raises(ValidationError, match="runtime_profile"):
+        Settings.model_validate({"runtime_profile": "promted"})
 
 
 def test_validator_fault_fails_closed_as_validation_unavailable() -> None:


### PR DESCRIPTION
Closes #230, closes #239: **the validator's grounding bases now model the concepts they claim to** — numeric grounding is unit-typed, citation grounding is reference-semantic, and the runtime profile can no longer typo its way into the lenient tier.

## Unit-typed numeric basis (#230.1)

`_numeric_basis` pooled every context numeric into one typeless pool, so a payload count `5` grounded a fabricated "5%" and a position total grounded a dollar figure. The basis now pools by unit class: a value grounds percent tokens only when its source declares percent semantics (exact underscore-separated key parts — `pct`, `percent`, `percentage`, `ratio`, `rate` — so `workflow_count` never reads as cash flow; or the value's own text carries `%`), and currency likewise (`usd`, `amount`, `cost`, `cash`, `aum`, … or a `$` in the value's text). An untyped numeric grounds neither. Cross-field percent AND currency fabrication are rejected in tests; a percent-typed value no longer grounds a same-digits dollar token. The key-part vocabularies are enumerated from what shipped families actually emit (`*_pct` floats, `net_cash_flow`); every family's real output still validates — the conformance and e2e suites are the guard.

## Reference-semantic citation basis (#239)

`_structured_reference_basis` collected **every** string node as citation grounding, so a model emitting a fabricated reference as the whole value of a free-text field (a headline that is exactly `lotus-manage:doc:999`) self-grounded its own narrative citation. The basis is now collected only from reference-semantic subtrees — the validator's own reference keys (`source_ref[s]`, `evidence_ref[s]`) plus retrieval's `citations`/`source_ids` and the composite `source_id:document_id` form (those keys are themselves reference-semantic) — enumerated from shipped family shapes per the issue's evidence-first instruction. The self-grounding case is rejected in a test; the same token grounds from a reference-semantic field; the knowledge-answer citation rendering and both narrative e2e paths still validate.

## Bounded runtime profile (#230.3)

`runtime_profile` was a free string compared against `"promoted"` at every gate — `promted` silently got the lenient local tier everywhere. It is now `Literal["local", "promoted"]`: an unknown value refuses at settings construction with an error naming the field.

## Live-branch pack contracts (#230.2 — documented plan, per the acceptance)

15/17 pack contracts schema only the stub envelope; the plan is recorded on the issue: live branches land per-family when that family's live execution nears, via advisor-brief's established `anyOf` pattern and capture-don't-invent authoring (execute the live path in fixture, capture the shape) — never speculatively, because an invented live schema would be a rejection wall of its own making.

## Evidence

Unit-typed matrix (cross-field percent/currency rejected, typed-by-key and typed-by-text grounded, wrong-unit rejected); self-grounding citation rejected while referential grounding holds; unknown profile refused at construction; the tolerance test's payload updated to a unit-typed shape (its subject — nested scan, tolerance, bare-numbers-out-of-scope — unchanged). Full validation, narrative, contract-conformance, advisor-brief and e2e evaluation-condition suites green. Combined coverage verified locally before push.
