### PR TITLE
docs(context): state the current truth in the engineering context (#154 docs slice)

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -111,14 +111,31 @@ builder; execution states are `ENFORCED` / `PARTIAL` / `DOCUMENTED_ONLY` /
 `OUT_OF_SCOPE` and readiness is derived, never asserted. A lint-lane guard
 refuses new copy-paste readiness modules and ratchets module size.
 
-**Current limitations.** Consumers name a task and cannot state requirements —
-latency, cost, residency, or a quality floor — and the task-to-model binding is
-configuration-driven rather than derived from capability facts or eval evidence;
-model capability dimensions and eval-backed fungibility do not exist yet (#244,
-#245). Refused privileged audit reads leave no record, and the access-events
-ledger has no read path (#167). High-impact governance actions still accept
-caller-supplied approver strings (#157). Forward priorities live on the North
-Star execution board (#246).
+**Data lifecycle.** Retention is policy-as-data
+(`contracts/data-lifecycle/retention-policy.v1.json`) over every ORM table, with
+a bidirectional coverage invariant; one idempotent engine applies every declared
+period (legal holds override expiry; six protective predicates keep live state —
+enforcing switches, pending governed actions, in-flight jobs, review-retained
+artifacts, current document versions, recurring drift — out of reach), and every
+deletion writes an append-only `data_lifecycle_events` row referencing content
+only by digest. Tenant erasure is a governed two-step `DATA_ERASURE` action
+yielding an Ed25519-signed receipt verifiable against the published attestation
+keys; erasure overrides retention, legal hold overrides erasure, and both are
+recorded. Minimisation caps the audit `result_preview` at persistence and ages
+passing evaluation-case content at a declared shorter horizon.
+
+**Current limitations.** Capability requirements exist for latency (one governed
+end-to-end budget), structured output, and tool calling (catalogue-evidence
+eligibility inside the routing decision), with cost recorded as a preference;
+cost has not yet graduated to a hard requirement (its billing-truth prerequisite
+closed with #232), and residency, classification, and quality-floor dimensions
+await concrete enforcement stories. Dual control binds two distinct verified
+service credentials, not verified human principals — the platform identity
+dependency recorded on #157's closure. Twenty-one activation/evidence readiness
+modules still predate the readiness catalog (the runbook family converted in
+#154; consolidation is #284). Provider-side retention execution and external
+certification evidence remain externally blocked (#115, #122, #126). Forward
+priorities live on the North Star execution board (#246).
 
 ## Architecture And Module Map
 


### PR DESCRIPTION
Closes #154: the steering-scoped docs slice — the context document now states the current truth, and the one remaining code item has a filed, implementation-ready home.

## Declared state, corrected

The "Current limitations" paragraph claimed four limitations that no longer exist: capability requirements "do not exist yet" (#244/#245 closed — latency budget, structured-output/tool-calling eligibility live in the routing decision), refused privileged reads "leave no record" (they are recorded before the 403 since the operator-evidence corrections), the access-events ledger "has no read path" (`GET /ai/audit/access-events` exists), and governance actions "accept caller-supplied approver strings" (#157 closed — distinct verified credentials). The paragraph now states the real limitations: cost not yet a hard requirement (its #232 prerequisite just closed), residency/classification/quality-floor undimensioned, dual control bound to service credentials pending platform identity, 21 readiness modules pre-catalog (#284), external P0 blocks (#115/#122/#126).

The Current Architecture section gains the data-lifecycle posture (#158: policy-as-data over every table, evidenced expiry/erasure, signed receipts, minimisation) — the doc's own maintenance rule requires recording a major capability posture change.

## Where the acceptance stands, item by item (verified in-tree, not recalled)

- **Provider path unified** ✅ — `openai_live_text_provider.py` is 27 lines (< 60), delegating to the shared transport; payload-parity held since S2 of the campaign.
- **Monetary guard wired** ✅ — in `make lint` (revived in #212; it caught three new violations the day it revived).
- **Module-size budget** ✅ — `check_module_budget.py` in the lint lane with a both-ways ratchet (#154 S3).
- **Readiness modules** — the runbook family is one catalog + builder and the guard refuses new copies (S1/S3); **21 activation/evidence modules remain**, 12 carrying declared `READY`-class literals. That is real remaining work and it is not silently ticked: it is #284, filed implementation-ready (per-family slices, catalog `computed: true` for genuinely derived domains, contract-stable adapters). Closing #154 records this as an explicit deviation, not completion by assertion.
- **Context document corrected** ✅ — this PR; the onboarding-path "defect" failed verification earlier (the links point at lotus-platform, where the files exist) and is recorded as such on the issue.

Doc-only change; lint and the readiness-catalog tests green.
