### PR TITLE
chore(readiness): computed-adapter registry closes the consolidation (#284 S2)

### DIFF
--- a/contracts/readiness/computed_readiness_adapters.json
+++ b/contracts/readiness/computed_readiness_adapters.json
@@ -1,0 +1,121 @@
+{
+  "description": "Every services/*_readiness*.py module that remains OUTSIDE the runbook readiness catalog, with the runtime surfaces its posture derives from (issue #284). A module may exist here or as a converted catalog domain, never neither: the bidirectional pin test refuses an unlisted module and a stale entry alike. These are computed adapters - their statuses derive from live state, and converting them to catalog data would destroy the derivation.",
+  "adapters": {
+    "access_control_activation_readiness.py": {
+      "derives_from": [
+        "access-control store mode and caller-policy runtime status"
+      ]
+    },
+    "artifact_activation_readiness.py": {
+      "derives_from": [
+        "artifact metadata/object store runtime status"
+      ]
+    },
+    "async_activation_readiness_service.py": {
+      "derives_from": [
+        "async runtime status (cutover state, queue backend, worker execution)",
+        "async operational state degraded findings"
+      ]
+    },
+    "capability_pack_activation_readiness.py": {
+      "derives_from": [
+        "per-pack approval gate (eval evidence)",
+        "downstream anchor presence on the pack descriptor",
+        "per-pack observability summary"
+      ]
+    },
+    "capability_pack_runbook_readiness.py": {
+      "derives_from": [
+        "first-use-case runbook readiness (catalog-derived)",
+        "use-case onboarding template presence",
+        "per-pack branching on the governed pack catalog"
+      ]
+    },
+    "deployment_split_activation_readiness.py": {
+      "derives_from": [
+        "deployment-split runtime status (configured vs effective stage, degradation)"
+      ]
+    },
+    "first_use_case_readiness.py": {
+      "derives_from": [
+        "caller-policy row for lotus-performance",
+        "staged eval fixture families and the first-use-case approval gate",
+        "safety execution outcome",
+        "audit-store runtime status",
+        "access-control/observability/resilience governance and artifact runtime surfaces"
+      ]
+    },
+    "governance_readiness.py": {
+      "derives_from": [
+        "shared summarize helpers only - no posture of its own"
+      ]
+    },
+    "observability_activation_readiness.py": {
+      "derives_from": [
+        "tracing/metrics settings and observability runtime status"
+      ]
+    },
+    "production_baseline_activation_readiness.py": {
+      "derives_from": [
+        "production-baseline runtime status (durable store seams, queue, secrets posture)"
+      ]
+    },
+    "production_go_live_activation_readiness.py": {
+      "derives_from": [
+        "production go-live runtime status (platform approval, freeze state)",
+        "provider governance status"
+      ]
+    },
+    "prompt_activation_readiness.py": {
+      "derives_from": [
+        "prompt and evaluation-runtime store modes"
+      ]
+    },
+    "prompt_evidence_readiness.py": {
+      "derives_from": [
+        "staged eval fixture inventory and the prompt approval gate"
+      ]
+    },
+    "provider_activation_readiness.py": {
+      "derives_from": [
+        "text/embedding configuration status",
+        "quota, budget and degradation policy validity",
+        "rollout posture and live execution state"
+      ]
+    },
+    "provider_evidence_readiness.py": {
+      "derives_from": [
+        "staged and recorded eval fixture inventories",
+        "provider approval gate summary",
+        "evidence category ids"
+      ]
+    },
+    "resilience_activation_readiness.py": {
+      "derives_from": [
+        "resilience runtime status (posture, recovery state)",
+        "restore plan step count",
+        "drill evidence readiness"
+      ]
+    },
+    "retrieval_activation_readiness.py": {
+      "derives_from": [
+        "retrieval mode/store settings and retrieval runtime status"
+      ]
+    },
+    "retrieval_evidence_readiness.py": {
+      "derives_from": [
+        "staged eval fixture inventory and retrieval runtime surfaces"
+      ]
+    },
+    "runtime_readiness.py": {
+      "derives_from": [
+        "every durable store seam's live status - the cross-cutting runtime probe"
+      ]
+    },
+    "safety_evidence_readiness.py": {
+      "derives_from": [
+        "staged eval fixture inventory and safety runtime outcome"
+      ]
+    }
+  }
+}

--- a/tests/unit/test_readiness_catalog.py
+++ b/tests/unit/test_readiness_catalog.py
@@ -204,6 +204,26 @@ def test_catalog_hook_references_and_registries_agree() -> None:
     assert referenced_note_hooks == set(readiness_catalog.COMPUTED_NOTE_SUFFIX_HOOKS)
 
 
+def test_every_readiness_module_is_converted_or_a_named_computed_adapter() -> None:
+    """#284's closing invariant: a readiness module exists on disk only if the
+    computed-adapter registry names it with its deriving surfaces - and a
+    registry entry without a module is a stale claim. Converted domains have
+    no module at all; everything else is a computed adapter whose statuses
+    derive from live state (converting them to catalog data would destroy
+    the derivation - verified per body, not per grep)."""
+
+    services_dir = Path(readiness_catalog.__file__).resolve().parent
+    on_disk = {path.name for path in services_dir.glob("*readiness*.py")} - {"readiness_catalog.py"}
+    registry_path = (
+        Path(readiness_catalog._CATALOG_PATH).parent / "computed_readiness_adapters.json"
+    )
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    named = set(registry["adapters"])
+    assert on_disk == named
+    for module_name, entry in registry["adapters"].items():
+        assert entry["derives_from"], f"{module_name} names no deriving surface"
+
+
 def test_unknown_computed_hook_reference_is_refused_at_load(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #284 (slice 2, the closing slice): **every remaining readiness module is now a catalog-named computed adapter — and that set is pinned bidirectionally.**

## The finding that closes the issue

The issue's premise was "21 modules to consolidate". Body-by-body verification (each module read line-by-line, not grep-classified) found **3 convertible** modules — landed in slice 1 — and **20 genuine computed adapters**: every activation-readiness module derives its posture from live runtime/governance surfaces (store modes, cutover states, approval gates, drill evidence, policy validity), every evidence-readiness module derives from the staged/recorded eval-fixture inventories, and `first_use_case_readiness` composes seven live surfaces. Their `"READY"` literals are computed branches, not declared posture — the #154-S2 conversions had already made most of this family honest by derivation. Consolidating them into catalog data would *destroy* real derivations, the opposite of this issue's goal.

## What this slice adds

`contracts/readiness/computed_readiness_adapters.json` names all 20 modules with the surfaces each derives from — the issue's "catalog marks it computed: true", made a contract file. A bidirectional pin test closes the loop: a readiness module may exist on disk only if the registry names it (or its domain converted — in which case no module exists at all); a registry entry without a module is a stale claim. `ls src/app/services/*_readiness*.py` outside the engine now equals the named computed-adapter set exactly — the acceptance's "= 0 outside catalog-marked computed adapters", checkable in one test. Derivation proofs live in each adapter's existing test suite (store-mode flips, cutover-state branches, fixture-inventory subsets); the slice-1 hook tests prove the catalog-side derivations.

## Acceptance mapping (honest, per item)

- Module count outside computed adapters: **0** ✅ (pinned, not counted by hand).
- READY-literal posture: the three declared-literal modules are gone (slice 1); remaining literals are computed branches inside named adapters ✅.
- API contracts unchanged ✅ (route/e2e suites green throughout).
- Module-budget allowlist shrank by two in slice 1; the no-new-modules guard still stands ✅.
- Per-slice gates green ✅.

Net across #284: −219 module lines, 13 catalog domains, per-item computed hooks with load-time validation and bidirectional pins, `MISSING` in the state vocabulary, and a registry that makes "computed adapter" a checkable claim instead of a description.
