### PR TITLE
feat(economics): durable attempt-level billing - spend debits exactly once per attempt (#289)

### DIFF
--- a/alembic/versions/0066_provider_attempt_debits.py
+++ b/alembic/versions/0066_provider_attempt_debits.py
@@ -1,0 +1,41 @@
+"""provider attempt debits
+
+Revision ID: 0066_provider_attempt_debits
+Revises: 0065_data_lifecycle_evidence
+Create Date: 2026-09-04
+
+Issue #289: every potentially billable provider attempt becomes durable
+economic evidence at the attempt boundary. The debit id is the idempotent
+attempt identity, so a row exists exactly once per attempt regardless of
+whether the execution later succeeds, fails completely, falls back, or the
+process dies.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0066_provider_attempt_debits"
+down_revision = "0065_data_lifecycle_evidence"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "provider_attempt_debits",
+        sa.Column("debit_id", sa.String(length=200), primary_key=True),
+        sa.Column("provider_id", sa.String(length=128), nullable=False),
+        sa.Column("basis", sa.String(length=32), nullable=False),
+        sa.Column("amount_usd", sa.Float(), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column("rate_card_ref", sa.String(length=128), nullable=False),
+        sa.Column("recorded_at", sa.String(length=64), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("provider_attempt_debits")

--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -29,7 +29,8 @@
         "workflow_pack_control_events",
         "provider_retention_confirmations",
         "audit_access_events",
-        "data_lifecycle_events"
+        "data_lifecycle_events",
+        "provider_attempt_debits"
       ],
       "retention_days": 2555,
       "retention_basis": "Control-plane decision evidence retained seven years; it carries no client-derived content, so no tenant erasure key applies.",

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -526,12 +526,15 @@ Runtime semantics under `ordered_fallback`:
 
 ## Provider Billing Truth
 
-Recorded spend covers every billed attempt of a live generation, not just the served one (issue #232): a retried timeout or 5xx may have generated and billed provider-side before failing.
+**Every potentially billable provider attempt debits Lotus spend exactly once, at its own boundary** (issue #289) — regardless of whether the execution succeeds, fails completely, falls back, or the process dies later.
 
-- `estimated_cost_usd` on responses and audit records is the attempt-summed figure, and the budget envelope records it. The composition — `failed_attempt_cost_usd`, `failed_attempt_cost_basis` (`ACTUAL_USAGE` | `CONSERVATIVE_ESTIMATE` | `MIXED` | `NONE`), `billed_attempt_count` — is on the provider execution response; the audit row's attempt context is `retry_count` and its cost posture.
-- `LOTUS_AI_PROVIDER_FAILED_ATTEMPT_COST_POSTURE` defaults to `conservative`: an unknown-usage billable-risk failure is estimated at the identical request body's input tokens plus the `max_output_tokens` ceiling - spend can overstate, never understate. `actual_only` bills failed attempts only on provider-reported usage; choosing it in the promoted profile is a loud protection-override finding.
-- Rate-limited (429) and connection-level failures are never billed - the provider did not generate.
-- Residual (recorded, not hidden): an execution whose every attempt fails records no spend; there is no usage evidence to price and the failure is visible on the operations ledger instead.
+- Each attempt records a durable debit row (`provider_attempt_debits`, on the provider-operations store) under an idempotent identity `adbt:<execution_id>:<provider_id>:<attempt_index>`; the budget counter advances in the same transaction. An execution whose every attempt fails has still moved the envelope, and a crash after an attempt loses nothing.
+- Pricing per attempt, in evidence order: provider-reported usage → `ACTUAL_USAGE` debit; unknown-usage timeout/5xx under the conservative posture → `CONSERVATIVE_ESTIMATE` debit at the input estimate (provider-reported input from any attempt of the same execution when available, else the documented request-body approximation of ~4 bytes/token) plus the `max_output_tokens` ceiling; 429 and connection-level failures → no debit (the provider did not generate); a missing rate card → no debit (the explicit cost-unknown posture, never a silent zero).
+- `LOTUS_AI_PROVIDER_FAILED_ATTEMPT_COST_POSTURE` defaults to `conservative` (spend can overstate, never understate); `actual_only` debits only on provider-reported usage, and choosing it in the promoted profile is a loud protection-override finding.
+- When a response exists, `estimated_cost_usd` / `failed_attempt_cost_usd` / `failed_attempt_cost_basis` / `billed_attempt_count` are a **projection of the recorded attempt debits** — the durable rows are where spend became real, and response settlement never debits again.
+- Retry and fallback candidates share one execution identity and debit cumulatively under their own attempt identities and rate cards; spend is never reset mid-execution.
+- Debit rows are lifecycle-governed evidence (control-plane evidence family, 7y): their expiry never reverses the budget counter.
+- `max_estimated_cost_usd` remains an unenforced preference until the hard execution-cost ceiling lands (one budget across retries and fallback — the latency-budget precedent).
 
 ## Durable Provider Operations Recovery
 

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -668,6 +668,15 @@ class ProviderExecutionRequest(BaseModel):
     retry_limit: int = Field(
         description="Maximum bounded retry count allowed for this execution request."
     )
+    execution_id: str | None = Field(
+        default=None,
+        description=(
+            "Execution identity minted once per gateway execution (issue #289): "
+            "shared across retry and fallback candidates, it keys the idempotent "
+            "per-attempt spend debits. Null only outside the gateway path; the "
+            "transport then mints one so every live attempt still debits."
+        ),
+    )
     failed_attempt_cost_posture: Literal["conservative", "actual_only"] = Field(
         default="conservative",
         description=(

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -243,6 +243,23 @@ class ProviderBudgetStateModel(Base):
     updated_at: Mapped[str] = mapped_column(String(64), nullable=False)
 
 
+class ProviderAttemptDebitModel(Base):
+    """Durable per-attempt economic evidence (issue #289): the debit id is
+    the idempotent attempt identity, so a row exists exactly once per
+    potentially billable attempt regardless of execution outcome."""
+
+    __tablename__ = "provider_attempt_debits"
+
+    debit_id: Mapped[str] = mapped_column(String(200), primary_key=True)
+    provider_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    basis: Mapped[str] = mapped_column(String(32), nullable=False)
+    amount_usd: Mapped[float] = mapped_column(Float, nullable=False)
+    input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rate_card_ref: Mapped[str] = mapped_column(String(128), nullable=False)
+    recorded_at: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
 class ProviderDegradationStateModel(Base):
     __tablename__ = "provider_degradation_state"
 

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -5,6 +5,7 @@ import logging
 import time
 from typing import Any, cast
 from urllib import error, request as urllib_request
+from uuid import uuid4
 
 from app.contracts.providers import (
     ProviderAdapterKind,
@@ -35,9 +36,12 @@ from app.providers.advisor_brief_quality_guardrails import (
     build_advisor_brief_user_message,
     normalize_advisor_brief_output,
 )
+from app.services.provider_budget_policy import record_attempt_spend
 from app.services.provider_usage_accounting import (
+    AttemptDebit,
     estimate_live_text_cost,
-    settle_attempt_billing,
+    price_attempt,
+    project_attempt_billing,
 )
 
 
@@ -94,6 +98,9 @@ def execute_openai_compatible_text_request(
         require_api_key=require_api_key,
         retry_limit=request.retry_limit,
         execution_deadline_at=request.execution_deadline_at,
+        execution_id=request.execution_id,
+        cost_posture=request.failed_attempt_cost_posture,
+        model_revision=model_version or model_id,
     )
     output_message = extract_output_text(response_payload)
     message, structured_output = build_structured_output(
@@ -110,13 +117,14 @@ def execute_openai_compatible_text_request(
         output_tokens=output_tokens,
         model_revision=model_version or model_id,
     )
-    billing = settle_attempt_billing(
-        failed_attempts=extract_failed_attempts(response_payload),
-        posture=request.failed_attempt_cost_posture,
+    # The response projects the durable attempt debits (issue #289): the
+    # failed-attempt figures are exactly what the boundary recorded, and the
+    # served attempt's cost equals its own boundary debit by construction
+    # (same usage, same rate card).
+    billing = project_attempt_billing(
         final_cost=cost,
-        final_input_tokens=input_tokens,
-        max_output_tokens=request.max_output_tokens,
-        model_revision=model_version or model_id,
+        failed_debits=extract_failed_attempt_debits(response_payload),
+        had_failed_attempts=bool(extract_failed_attempts(response_payload)),
     )
     return ProviderExecutionResponse(
         provider_id=serving_provider_id,
@@ -175,6 +183,9 @@ def post_openai_compatible_response(
     require_api_key: bool,
     retry_limit: int = 0,
     execution_deadline_at: float | None = None,
+    execution_id: str | None = None,
+    cost_posture: str = "conservative",
+    model_revision: str | None = None,
 ) -> dict[str, Any]:
     """POST one OpenAI-compatible request, labelling every surface it emits
     with ``serving_provider_id``.
@@ -231,6 +242,45 @@ def post_openai_compatible_response(
     # (issue #232): the provider may have generated and billed before failing,
     # so the billing settlement needs what each attempt is known to have used.
     failed_attempts: list[dict[str, object]] = []
+    # Every potentially billable attempt debits durable spend AT ITS OWN
+    # BOUNDARY (issue #289) - the identity below keys the idempotent debit,
+    # so an execution that never succeeds, falls back, or dies later has
+    # already moved the budget envelope. Without a gateway-minted identity
+    # (direct callers) the transport mints one: production attempts always
+    # debit.
+    debit_execution_id = execution_id or uuid4().hex
+    # Conservative input estimate for attempts that never revealed usage:
+    # the request body is hard evidence of what was sent; ~4 bytes/token is
+    # the documented approximation, replaced by provider-reported input
+    # tokens the moment any attempt in this execution reveals them.
+    input_estimate = max(1, len(body) // 4)
+    payload_max_output = as_int(payload.get("max_output_tokens")) or 0
+
+    def _debit_boundary(
+        *,
+        attempt_index: int,
+        input_tokens: int | None,
+        output_tokens: int | None,
+        billable_risk: bool,
+    ) -> AttemptDebit | None:
+        debit = price_attempt(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            billable_risk=billable_risk,
+            posture=cost_posture,
+            fallback_input_estimate=input_estimate,
+            max_output_tokens=payload_max_output,
+            model_revision=model_revision,
+        )
+        if debit is not None:
+            record_attempt_spend(
+                execution_id=debit_execution_id,
+                provider_id=serving_provider_id,
+                attempt_index=attempt_index,
+                debit=debit,
+            )
+        return debit
+
     for attempt_index in range(bounded_retry_limit + 1):
         if execution_deadline_at is not None:
             remaining_seconds = execution_deadline_at - _monotonic()
@@ -266,6 +316,14 @@ def post_openai_compatible_response(
                 response_payload["_lotus_failed_attempts"] = failed_attempts
                 usage = response_payload.get("usage")
                 usage_fields = usage if isinstance(usage, dict) else {}
+                # The served attempt debits at its own boundary too: spend is
+                # real before any response-layer settlement can run.
+                _debit_boundary(
+                    attempt_index=attempt_index,
+                    input_tokens=as_int(usage_fields.get("input_tokens")),
+                    output_tokens=as_int(usage_fields.get("output_tokens")),
+                    billable_risk=True,
+                )
                 attempt_latency_ms = _attempt_latency_ms(attempt_started)
                 record_provider_attempt(
                     provider_id=serving_provider_id,
@@ -315,12 +373,24 @@ def post_openai_compatible_response(
                 http_status=exc.code,
                 latency_ms=attempt_latency_ms,
             )
+            # 5xx may follow completed generation; 4xx (incl. 429) refuses
+            # before generation and carries no billable risk. The debit
+            # happens HERE, terminal or not: an execution whose every
+            # attempt fails has still moved the envelope (issue #289).
+            evidence = _failed_attempt_evidence(error_payload, billable_risk=exc.code >= 500)
+            error_input_tokens = as_int(evidence.get("input_tokens"))
+            if error_input_tokens is not None:
+                # Provider-reported input on a failed attempt is hard
+                # evidence for later conservative estimates of the same body.
+                input_estimate = error_input_tokens
+            debit = _debit_boundary(
+                attempt_index=attempt_index,
+                input_tokens=error_input_tokens,
+                output_tokens=as_int(evidence.get("output_tokens")),
+                billable_risk=exc.code >= 500,
+            )
             if will_retry:
-                # 5xx may follow completed generation; 4xx (incl. 429) refuses
-                # before generation and carries no billable risk.
-                failed_attempts.append(
-                    _failed_attempt_evidence(error_payload, billable_risk=exc.code >= 500)
-                )
+                failed_attempts.append(_with_debit(evidence, debit))
                 wait_for_retry(retry_decision)
                 continue
             deadline_stop = _governed_deadline_stop(
@@ -362,10 +432,18 @@ def post_openai_compatible_response(
                 failure_class=ProviderFailureCategory.PROVIDER_TIMEOUT.value,
                 latency_ms=attempt_latency_ms,
             )
+            # A timeout after acceptance may still have generated and billed
+            # provider-side - debited at the boundary, terminal or not.
+            debit = _debit_boundary(
+                attempt_index=attempt_index,
+                input_tokens=None,
+                output_tokens=None,
+                billable_risk=True,
+            )
             if will_retry:
-                # A timeout after acceptance may still have generated and
-                # billed provider-side.
-                failed_attempts.append(_failed_attempt_evidence({}, billable_risk=True))
+                failed_attempts.append(
+                    _with_debit(_failed_attempt_evidence({}, billable_risk=True), debit)
+                )
                 wait_for_retry(retry_decision)
                 continue
             deadline_stop = _governed_deadline_stop(
@@ -582,6 +660,46 @@ def _failed_attempt_evidence(
     }
 
 
+def _with_debit(evidence: dict[str, object], debit: AttemptDebit | None) -> dict[str, object]:
+    """Stamp what the boundary durably recorded onto the attempt evidence, so
+    the response projection restates the recorded numbers rather than
+    re-estimating them (issue #289)."""
+
+    if debit is not None:
+        evidence["debit_usd"] = debit.amount_usd
+        evidence["debit_basis"] = debit.basis
+        evidence["debit_input_tokens"] = debit.input_tokens
+        evidence["debit_output_tokens"] = debit.output_tokens
+        evidence["debit_rate_card_ref"] = debit.rate_card_ref
+    return evidence
+
+
+def extract_failed_attempt_debits(payload: dict[str, Any]) -> list[AttemptDebit]:
+    debits: list[AttemptDebit] = []
+    for attempt in extract_failed_attempts(payload):
+        amount = attempt.get("debit_usd")
+        basis = attempt.get("debit_basis")
+        rate_card_ref = attempt.get("debit_rate_card_ref")
+        if (
+            isinstance(amount, (int, float))
+            and not isinstance(amount, bool)
+            and basis in ("ACTUAL_USAGE", "CONSERVATIVE_ESTIMATE")
+            and isinstance(rate_card_ref, str)
+        ):
+            input_tokens = attempt.get("debit_input_tokens")
+            output_tokens = attempt.get("debit_output_tokens")
+            debits.append(
+                AttemptDebit(
+                    amount_usd=float(amount),  # monetary-float-ok: restating the recorded debit
+                    basis=basis,
+                    input_tokens=input_tokens if isinstance(input_tokens, int) else None,
+                    output_tokens=output_tokens if isinstance(output_tokens, int) else None,
+                    rate_card_ref=rate_card_ref,
+                )
+            )
+    return debits
+
+
 def extract_failed_attempts(payload: dict[str, Any]) -> list[dict[str, object]]:
     attempts = payload.get("_lotus_failed_attempts")
     return (
@@ -630,13 +748,10 @@ def build_structured_output(
         output_tokens=output_tokens,
         model_revision=configured_model_id,
     )
-    structured_billing = settle_attempt_billing(
-        failed_attempts=extract_failed_attempts(response_payload),
-        posture=request.failed_attempt_cost_posture,
+    structured_billing = project_attempt_billing(
         final_cost=structured_cost,
-        final_input_tokens=input_tokens,
-        max_output_tokens=request.max_output_tokens,
-        model_revision=configured_model_id,
+        failed_debits=extract_failed_attempt_debits(response_payload),
+        had_failed_attempts=bool(extract_failed_attempts(response_payload)),
     )
     structured_output.update(
         {

--- a/src/app/repositories/memory_provider_operations_repository.py
+++ b/src/app/repositories/memory_provider_operations_repository.py
@@ -10,6 +10,7 @@ from app.contracts.providers import (
 )
 from app.contracts.governed_actions import GovernedActionRecord, GovernedActionStatus
 from app.repositories.provider_operations_repository import (
+    ProviderAttemptDebitRecord,
     ProviderBudgetStateRecord,
     ProviderDegradationStateRecord,
     ProviderOperationsEventRecord,
@@ -25,6 +26,7 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
         self._degradation_states: dict[str, ProviderDegradationStateRecord] = {}
         self._event_records: list[ProviderOperationsEventRecord] = []
         self._governed_actions: dict[str, GovernedActionRecord] = {}
+        self._attempt_debits: dict[str, ProviderAttemptDebitRecord] = {}
 
     def list_quota_states(self) -> list[ProviderQuotaStateRecord]:
         return [
@@ -90,6 +92,32 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
         )
         self._budget_states[budget_key] = deepcopy(updated)
         return deepcopy(updated)
+
+    def record_attempt_debit(self, record: ProviderAttemptDebitRecord, *, budget_key: str) -> bool:
+        if record.debit_id in self._attempt_debits:
+            return False
+        self._attempt_debits[record.debit_id] = deepcopy(record)
+        self.add_budget_spend(
+            budget_key=budget_key,
+            amount_usd=record.amount_usd,
+            updated_at=record.recorded_at,
+        )
+        return True
+
+    def list_attempt_debits(self, *, limit: int = 100) -> Sequence[ProviderAttemptDebitRecord]:
+        records = sorted(
+            self._attempt_debits.values(),
+            key=lambda item: (item.recorded_at, item.debit_id),
+            reverse=True,
+        )
+        return [deepcopy(record) for record in records[: max(limit, 0)]]
+
+    def delete_attempt_debits(self, debit_ids: Sequence[str]) -> int:
+        deleted = 0
+        for debit_id in debit_ids:
+            if self._attempt_debits.pop(debit_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def get_degradation_state(
         self,

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -29,6 +29,27 @@ class ProviderBudgetStateRecord:
 
 
 @dataclass(frozen=True)
+class ProviderAttemptDebitRecord:
+    """One durable economic debit at a provider attempt boundary (issue #289).
+
+    The debit_id is the idempotent attempt identity
+    (``adbt:<execution_id>:<provider_id>:<attempt_index>``): recording the
+    same identity twice is a no-op, so a crash-and-retry of the recording
+    call can never double-debit, and a process death after the attempt
+    loses nothing - the debit is already durable.
+    """
+
+    debit_id: str
+    provider_id: str
+    basis: str
+    amount_usd: float
+    input_tokens: int | None
+    output_tokens: int | None
+    rate_card_ref: str
+    recorded_at: str
+
+
+@dataclass(frozen=True)
 class ProviderDegradationStateRecord:
     degradation_key: str
     consecutive_failure_count: int
@@ -93,6 +114,19 @@ class ProviderOperationsRepository(Protocol):
         updated_at: str,
     ) -> ProviderBudgetStateRecord:
         """Atomically add spend to one provider budget state record and return the updated value."""
+
+    def record_attempt_debit(self, record: ProviderAttemptDebitRecord, *, budget_key: str) -> bool:
+        """Durably record one attempt debit and advance the budget counter
+        together (issue #289). Returns False - a complete no-op, counter
+        untouched - when the debit identity is already recorded."""
+
+    def list_attempt_debits(self, *, limit: int = 100) -> Sequence[ProviderAttemptDebitRecord]:
+        """Attempt-debit evidence, newest first."""
+
+    def delete_attempt_debits(self, debit_ids: Sequence[str]) -> int:
+        """Delete attempt-debit evidence rows for the lifecycle engine
+        (control-plane evidence family). Deleting evidence never reverses
+        the budget counter - the spend already happened."""
 
     def get_degradation_state(
         self,

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -21,12 +21,14 @@ from app.contracts.provider_operations import ProviderOperationsControlActionTyp
 from app.contracts.governed_actions import GovernedActionRecord
 from app.db.models import (
     GovernedActionModel,
+    ProviderAttemptDebitModel,
     ProviderBudgetStateModel,
     ProviderDegradationStateModel,
     ProviderOperationsEventModel,
     ProviderQuotaStateModel,
 )
 from app.repositories.provider_operations_repository import (
+    ProviderAttemptDebitRecord,
     ProviderBudgetStateRecord,
     ProviderDegradationStateRecord,
     ProviderOperationsEventRecord,
@@ -162,6 +164,88 @@ class SqlAlchemyProviderOperationsRepository(
                     session.rollback()
                     continue
         raise RuntimeError("Failed to add provider budget spend atomically.")
+
+    def record_attempt_debit(self, record: ProviderAttemptDebitRecord, *, budget_key: str) -> bool:
+        """Debit row and budget counter advance in ONE transaction: a crash
+        between them cannot happen, and a duplicate identity is a complete
+        no-op (the counter is untouched)."""
+
+        with self._session_factory() as session:
+            existing = session.get(ProviderAttemptDebitModel, record.debit_id)
+            if existing is not None:
+                return False
+            session.add(
+                ProviderAttemptDebitModel(
+                    debit_id=record.debit_id,
+                    provider_id=record.provider_id,
+                    basis=record.basis,
+                    amount_usd=record.amount_usd,
+                    input_tokens=record.input_tokens,
+                    output_tokens=record.output_tokens,
+                    rate_card_ref=record.rate_card_ref,
+                    recorded_at=record.recorded_at,
+                )
+            )
+            budget = session.execute(
+                select(ProviderBudgetStateModel)
+                .where(ProviderBudgetStateModel.budget_key == budget_key)
+                .with_for_update()
+            ).scalar_one_or_none()
+            if budget is None:
+                session.add(
+                    ProviderBudgetStateModel(
+                        budget_key=budget_key,
+                        current_spend_usd=round(record.amount_usd, 8),
+                        updated_at=record.recorded_at,
+                    )
+                )
+            else:
+                budget.current_spend_usd = round(budget.current_spend_usd + record.amount_usd, 8)
+                budget.updated_at = record.recorded_at
+            try:
+                session.commit()
+            except IntegrityError:
+                # A concurrent recorder won the same identity: their debit
+                # stands, ours is the duplicate.
+                session.rollback()
+                return False
+            return True
+
+    def list_attempt_debits(self, *, limit: int = 100) -> Sequence[ProviderAttemptDebitRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(ProviderAttemptDebitModel)
+                .order_by(
+                    ProviderAttemptDebitModel.recorded_at.desc(),
+                    ProviderAttemptDebitModel.debit_id.desc(),
+                )
+                .limit(max(limit, 0))
+            ).all()
+            return [
+                ProviderAttemptDebitRecord(
+                    debit_id=model.debit_id,
+                    provider_id=model.provider_id,
+                    basis=model.basis,
+                    amount_usd=model.amount_usd,
+                    input_tokens=model.input_tokens,
+                    output_tokens=model.output_tokens,
+                    rate_card_ref=model.rate_card_ref,
+                    recorded_at=model.recorded_at,
+                )
+                for model in models
+            ]
+
+    def delete_attempt_debits(self, debit_ids: Sequence[str]) -> int:
+        if not debit_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(ProviderAttemptDebitModel).where(
+                    ProviderAttemptDebitModel.debit_id.in_(list(debit_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
 
     def get_degradation_state(
         self,

--- a/src/app/services/data_lifecycle_engine.py
+++ b/src/app/services/data_lifecycle_engine.py
@@ -247,6 +247,16 @@ def _expire_control_plane_evidence(
         ],
         ops.delete_operations_events,
     )
+    # Attempt-debit evidence (issue #289) expires like the rest of the
+    # family; deleting evidence never reverses the budget counter.
+    _expire(
+        "provider_attempt_debits",
+        [
+            (d.debit_id, d.recorded_at)
+            for d in ops.list_attempt_debits(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        ops.delete_attempt_debits,
+    )
     _expire(
         "provider_governed_actions",
         [

--- a/src/app/services/provider_budget_policy.py
+++ b/src/app/services/provider_budget_policy.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from app.config import settings
-from app.services.provider_usage_accounting import resolve_effective_live_text_card
+from app.services.provider_usage_accounting import AttemptDebit, resolve_effective_live_text_card
 from app.contracts.providers import (
     ProviderBudgetPolicyResponse,
     ProviderBudgetState,
-    ProviderExecutionResponse,
     ProviderFailureCategory,
 )
 from app.providers.base import ProviderExecutionError
+from app.repositories.provider_operations_repository import ProviderAttemptDebitRecord
 from app.services.provider_operations_store import get_provider_operations_store
 from app.services.provider_execution_config import resolve_provider_execution_config
 
@@ -106,7 +106,7 @@ def parse_provider_budget_policy() -> ParsedProviderBudgetPolicy:
         remaining_budget_usd=remaining_budget_usd,
         findings=findings,
         usage_to_budget_notes=[
-            "Tracked spend is derived only from structured live-provider cost evidence emitted by successful provider responses.",
+            "Tracked spend is recorded durably per provider attempt at the attempt boundary (issue #289): actual usage debits as actual, billable-risk failures debit conservatively, and an execution whose every attempt fails still moves the envelope.",
             "Soft budget posture is advisory and inspectable; hard budget posture is blocking when enforcement is enabled.",
             "Tracked spend now flows through the configured provider-operations store so budget posture can remain durable when the SQL-backed provider-operations path is enabled.",
         ],
@@ -129,16 +129,36 @@ def enforce_provider_budget() -> None:
         )
 
 
-def record_provider_spend(response: ProviderExecutionResponse) -> None:
-    if response.stubbed:
-        return
-    if response.estimated_cost_usd is None:
-        return
+def record_attempt_spend(
+    *,
+    execution_id: str,
+    provider_id: str,
+    attempt_index: int,
+    debit: AttemptDebit,
+) -> bool:
+    """Durably debit one provider attempt at its boundary (issue #289).
+
+    The identity is derived from the execution/candidate/attempt context, so
+    recording is idempotent: a crash after the attempt loses nothing, and a
+    duplicate recording is a complete no-op. The budget counter advances in
+    the same transaction, which is why an execution whose every attempt
+    fails still moves the envelope - spend becomes real per attempt, not at
+    response settlement.
+    """
+
     repository = get_provider_operations_store()
-    repository.add_budget_spend(
+    return repository.record_attempt_debit(
+        ProviderAttemptDebitRecord(
+            debit_id=f"adbt:{execution_id}:{provider_id}:{attempt_index}",
+            provider_id=provider_id,
+            basis=debit.basis,
+            amount_usd=debit.amount_usd,
+            input_tokens=debit.input_tokens,
+            output_tokens=debit.output_tokens,
+            rate_card_ref=debit.rate_card_ref,
+            recorded_at=_utcnow(),
+        ),
         budget_key=_BUDGET_KEY,
-        amount_usd=response.estimated_cost_usd,
-        updated_at=_utcnow(),
     )
 
 

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 from fastapi import HTTPException, status
 
 from app.contracts.access_control import AuthorizationCapabilityType
@@ -43,7 +45,7 @@ from app.services.model_catalogue import (
     record_model_revision_drift,
 )
 from app.services.provider_policy import require_supported_text_generation_mode
-from app.services.provider_budget_policy import enforce_provider_budget, record_provider_spend
+from app.services.provider_budget_policy import enforce_provider_budget
 from app.services.provider_degradation_state import (
     enforce_provider_degradation_preflight,
     record_provider_failure,
@@ -80,6 +82,10 @@ class ProviderGatewayUnavailableError(HTTPException):
 
 def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecutionResponse:
     request = _apply_latency_ceiling(request)
+    if request.execution_id is None:
+        # One identity per execution, shared by every retry and fallback
+        # candidate: attempt debits key on it (issue #289).
+        request = request.model_copy(update={"execution_id": uuid4().hex})
     config = resolve_provider_execution_config()
     mode = require_supported_text_generation_mode()
     live_execution_state = build_provider_live_execution_state(task_id=request.task_id)
@@ -155,7 +161,8 @@ def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecut
             decided_at=decided_at,
         )
         if mode in LIVE_TEXT_MODES:
-            record_provider_spend(response)
+            # Spend was debited durably at each attempt boundary (issue
+            # #289); the response merely projects those debits.
             record_successful_provider_execution()
         return response
     except ProviderExecutionError as exc:
@@ -340,7 +347,6 @@ def _execute_ordered_fallback(
                 decided_at=_utc_now_iso(),
                 universe=universe,
             )
-            record_provider_spend(response)
             record_successful_provider_execution()
             return response
 

--- a/src/app/services/provider_usage_accounting.py
+++ b/src/app/services/provider_usage_accounting.py
@@ -68,72 +68,97 @@ class AttemptBillingSettlement:
     billed_attempt_count: int
 
 
-def settle_attempt_billing(
+@dataclass(frozen=True)
+class AttemptDebit:
+    """One priced provider attempt (issue #289): what the boundary records
+    durably and the response later projects."""
+
+    amount_usd: float
+    basis: FailedAttemptCostBasis
+    input_tokens: int | None
+    output_tokens: int | None
+    rate_card_ref: str
+
+
+def price_attempt(
     *,
-    failed_attempts: list[dict[str, object]],
+    input_tokens: int | None,
+    output_tokens: int | None,
+    billable_risk: bool,
     posture: str,
-    final_cost: UsageCostEstimate,
-    final_input_tokens: int | None,
+    fallback_input_estimate: int,
     max_output_tokens: int,
     model_revision: str | None = None,
-) -> AttemptBillingSettlement:
-    """Price the failed attempts behind a served response (issue #232).
+) -> AttemptDebit | None:
+    """Price one attempt at its boundary (issue #289), in evidence order.
 
-    Evidence order per failed attempt: provider-reported usage on the failed
-    attempt prices as ACTUAL_USAGE; otherwise, under the conservative posture,
-    a billable-risk failure (timeout, 5xx - the provider may have generated
-    and billed) prices at the final attempt's input tokens - the identical
-    request body - plus the max_output_tokens ceiling (CONSERVATIVE_ESTIMATE).
-    Non-billable failures (429 refused before generation, connection-level
-    errors) and unknown-usage failures under actual_only are never priced.
+    Provider-reported usage prices as ACTUAL_USAGE. Otherwise, under the
+    conservative posture, a billable-risk attempt (timeout, 5xx, or a served
+    response whose usage was withheld - the provider may have generated and
+    billed) prices at the input estimate plus the max_output_tokens ceiling
+    as CONSERVATIVE_ESTIMATE. Non-billable failures (429 refused before
+    generation, connection-level errors) and unknown-usage attempts under
+    actual_only price as None - no debit. A missing rate card also prices
+    None: an unpriceable attempt cannot debit, which is the explicit
+    cost-unknown posture, not a silent zero.
     """
 
-    failed_total = 0.0
-    actual_count = 0
-    conservative_count = 0
-    for attempt in failed_attempts:
-        input_tokens = attempt.get("input_tokens")
-        output_tokens = attempt.get("output_tokens")
-        if isinstance(input_tokens, int) and isinstance(output_tokens, int):
-            attempt_cost = estimate_live_text_cost(
+    if isinstance(input_tokens, int) and isinstance(output_tokens, int):
+        cost = estimate_live_text_cost(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            model_revision=model_revision,
+        )
+        if cost.estimated_cost_usd is not None and cost.rate_card_ref is not None:
+            return AttemptDebit(
+                amount_usd=cost.estimated_cost_usd,
+                basis="ACTUAL_USAGE",
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
-                model_revision=model_revision,
+                rate_card_ref=cost.rate_card_ref,
             )
-            if attempt_cost.estimated_cost_usd is not None:
-                failed_total += attempt_cost.estimated_cost_usd
-                actual_count += 1
-            continue
-        if (
-            posture == "conservative"
-            and attempt.get("billable_risk") is True
-            and final_input_tokens is not None
-        ):
-            attempt_cost = estimate_live_text_cost(
-                input_tokens=final_input_tokens,
+        return None
+    if posture == "conservative" and billable_risk:
+        cost = estimate_live_text_cost(
+            input_tokens=fallback_input_estimate,
+            output_tokens=max_output_tokens,
+            model_revision=model_revision,
+        )
+        if cost.estimated_cost_usd is not None and cost.rate_card_ref is not None:
+            return AttemptDebit(
+                amount_usd=cost.estimated_cost_usd,
+                basis="CONSERVATIVE_ESTIMATE",
+                input_tokens=fallback_input_estimate,
                 output_tokens=max_output_tokens,
-                model_revision=model_revision,
+                rate_card_ref=cost.rate_card_ref,
             )
-            if attempt_cost.estimated_cost_usd is not None:
-                failed_total += attempt_cost.estimated_cost_usd
-                conservative_count += 1
+    return None
 
-    billed_failed = actual_count + conservative_count
-    if billed_failed == 0:
+
+def project_attempt_billing(
+    *,
+    final_cost: UsageCostEstimate,
+    failed_debits: list[AttemptDebit],
+    had_failed_attempts: bool,
+) -> AttemptBillingSettlement:
+    """Project the response-level figures from the attempt evidence
+    (issue #289): the durable debits are where spend became real; the
+    response merely restates them alongside the served attempt's cost."""
+
+    if not failed_debits:
         return AttemptBillingSettlement(
             estimated_cost_usd=final_cost.estimated_cost_usd,
             failed_attempt_cost_usd=None,
-            failed_attempt_cost_basis="NONE" if failed_attempts else None,
+            failed_attempt_cost_basis="NONE" if had_failed_attempts else None,
             billed_attempt_count=1,
         )
-    basis: FailedAttemptCostBasis
-    if actual_count and conservative_count:
-        basis = "MIXED"
-    elif actual_count:
-        basis = "ACTUAL_USAGE"
-    else:
-        basis = "CONSERVATIVE_ESTIMATE"
-    failed_cost = round(failed_total, 8)
+    bases = {debit.basis for debit in failed_debits}
+    basis: FailedAttemptCostBasis = (
+        "MIXED"
+        if len(bases) > 1
+        else ("ACTUAL_USAGE" if "ACTUAL_USAGE" in bases else "CONSERVATIVE_ESTIMATE")
+    )
+    failed_cost = round(sum(debit.amount_usd for debit in failed_debits), 8)
     total = (
         round(final_cost.estimated_cost_usd + failed_cost, 8)
         if final_cost.estimated_cost_usd is not None
@@ -143,7 +168,7 @@ def settle_attempt_billing(
         estimated_cost_usd=total,
         failed_attempt_cost_usd=failed_cost,
         failed_attempt_cost_basis=basis,
-        billed_attempt_count=1 + billed_failed,
+        billed_attempt_count=1 + len(failed_debits),
     )
 
 

--- a/tests/integration/test_provider_api_contract.py
+++ b/tests/integration/test_provider_api_contract.py
@@ -11,7 +11,8 @@ from app.contracts.providers import (
     ProviderExecutionResponse,
     ProviderFailureCategory,
 )
-from app.services.provider_budget_policy import record_provider_spend
+from app.services.provider_budget_policy import record_attempt_spend
+from app.services.provider_usage_accounting import AttemptDebit
 from app.services.provider_degradation_state import record_provider_failure
 from app.services.provider_operations_store import reset_provider_operations_store_cache
 from app.services.provider_quota_policy import enforce_provider_quota
@@ -28,6 +29,21 @@ from tests.support.caller_credentials import (
     mint_caller_credential,
     public_keys_setting,
 )
+
+
+def _seed_attempt_spend(amount: float, *, execution_id: str) -> None:
+    record_attempt_spend(
+        execution_id=execution_id,
+        provider_id="text.openai",
+        attempt_index=0,
+        debit=AttemptDebit(
+            amount_usd=amount,
+            basis="ACTUAL_USAGE",
+            input_tokens=100,
+            output_tokens=200,
+            rate_card_ref="default-live-text",
+        ),
+    )
 
 
 def _budget_response(cost: float | None, *, stubbed: bool = False) -> ProviderExecutionResponse:
@@ -208,7 +224,7 @@ def test_provider_budget_policy_route_reports_durable_sql_backed_spend(
     settings.live_text_hard_budget_usd = 1.0
     upgrade_database_to_head(settings.database_url)
 
-    record_provider_spend(_budget_response(0.75))
+    _seed_attempt_spend(0.75, execution_id="exec-contract-soft")
 
     response = client.get("/platform/providers/budget-policy")
 
@@ -338,7 +354,7 @@ def test_provider_operations_control_action_route_resets_durable_sql_backed_stat
     request = _request("explain.v1", expected_output_label=None)
     provider_request = build_provider_execution_request(context=validate_task_request(request))
     enforce_provider_quota(provider_request)
-    record_provider_spend(_budget_response(0.75))
+    _seed_attempt_spend(0.75, execution_id="exec-contract-reset")
     record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
 
     _verified_control_settings()

--- a/tests/unit/test_attempt_billing.py
+++ b/tests/unit/test_attempt_billing.py
@@ -1,26 +1,26 @@
-"""Attempt-level billing truth (issue #232).
+"""Attempt-level durable billing (issue #289, superseding #232's settlement).
 
-Recorded spend must cover every billed attempt of a non-idempotent
-generation, not just the served one: a retried 5xx or timeout may have
-generated and billed provider-side. The settlement prices actual usage
-evidence first, conservative estimates second (identical request body's
-input tokens plus the max_output_tokens ceiling), and never bills failures
-that cannot have generated (429, connection-level).
+Every potentially billable provider attempt debits Lotus spend exactly once
+at its own boundary - durably, idempotently, and regardless of whether the
+execution later succeeds, fails completely, falls back, or the process dies.
+The response, when one exists, merely projects the recorded evidence.
 """
 
 from email.message import Message
 from io import BytesIO
 from urllib import error
 
-from pytest import MonkeyPatch
+from pytest import MonkeyPatch, raises
 
 from app.config import settings
-from app.services.provider_budget_policy import record_provider_spend
+from app.contracts.providers import ProviderExecutionResponse
+from app.providers.base import ProviderExecutionError
 from app.services.provider_operations_store import get_provider_operations_store
 from app.services.provider_usage_accounting import (
-    AttemptBillingSettlement,
+    AttemptDebit,
     UsageCostEstimate,
-    settle_attempt_billing,
+    price_attempt,
+    project_attempt_billing,
 )
 
 
@@ -30,208 +30,346 @@ def _seed_cost_scalars() -> None:
     settings.live_text_output_cost_per_1k_tokens = 0.03
 
 
-_FINAL_COST = UsageCostEstimate(estimated_cost_usd=0.0035, rate_card_ref="default-live-text")
+def test_price_attempt_follows_the_evidence_order() -> None:
+    _seed_cost_scalars()
 
-
-def _settle(
-    attempts: list[dict[str, object]], *, posture: str = "conservative"
-) -> AttemptBillingSettlement:
-    return settle_attempt_billing(
-        failed_attempts=attempts,
-        posture=posture,
-        final_cost=_FINAL_COST,
-        final_input_tokens=200,
+    actual = price_attempt(
+        input_tokens=200,
+        output_tokens=100,
+        billable_risk=True,
+        posture="conservative",
+        fallback_input_estimate=999,
         max_output_tokens=512,
         model_revision="gpt-5.4",
     )
+    assert actual is not None
+    assert actual.basis == "ACTUAL_USAGE"
+    assert actual.amount_usd == 0.005
+    assert actual.rate_card_ref
+
+    conservative = price_attempt(
+        input_tokens=None,
+        output_tokens=None,
+        billable_risk=True,
+        posture="conservative",
+        fallback_input_estimate=200,
+        max_output_tokens=512,
+        model_revision="gpt-5.4",
+    )
+    assert conservative is not None
+    assert conservative.basis == "CONSERVATIVE_ESTIMATE"
+    assert conservative.amount_usd == 0.01736
+    assert conservative.input_tokens == 200
+    assert conservative.output_tokens == 512
+
+    # Non-billable risk, actual_only posture, or a missing rate card never
+    # price - no debit is the explicit outcome, not a silent zero.
+    assert (
+        price_attempt(
+            input_tokens=None,
+            output_tokens=None,
+            billable_risk=False,
+            posture="conservative",
+            fallback_input_estimate=200,
+            max_output_tokens=512,
+            model_revision="gpt-5.4",
+        )
+        is None
+    )
+    assert (
+        price_attempt(
+            input_tokens=None,
+            output_tokens=None,
+            billable_risk=True,
+            posture="actual_only",
+            fallback_input_estimate=200,
+            max_output_tokens=512,
+            model_revision="gpt-5.4",
+        )
+        is None
+    )
 
 
-def test_settlement_prices_each_evidence_class_honestly() -> None:
-    _seed_cost_scalars()
+def test_projection_restates_recorded_debits() -> None:
+    final = UsageCostEstimate(estimated_cost_usd=0.0035, rate_card_ref="default-live-text")
+    conservative = AttemptDebit(
+        amount_usd=0.01736,
+        basis="CONSERVATIVE_ESTIMATE",
+        input_tokens=200,
+        output_tokens=512,
+        rate_card_ref="default-live-text",
+    )
+    actual = AttemptDebit(
+        amount_usd=0.005,
+        basis="ACTUAL_USAGE",
+        input_tokens=200,
+        output_tokens=100,
+        rate_card_ref="default-live-text",
+    )
 
-    # No failed attempts: the served attempt is the whole bill.
-    single = _settle([])
+    single = project_attempt_billing(final_cost=final, failed_debits=[], had_failed_attempts=False)
     assert single.estimated_cost_usd == 0.0035
     assert single.failed_attempt_cost_usd is None
     assert single.failed_attempt_cost_basis is None
     assert single.billed_attempt_count == 1
 
-    # Unknown-usage billable-risk failure under the conservative posture:
-    # input tokens are the identical request body's 200; output is the
-    # 512-token ceiling -> 0.002 + 0.01536.
-    conservative = _settle([{"billable_risk": True, "input_tokens": None, "output_tokens": None}])
-    assert conservative.failed_attempt_cost_usd == 0.01736
-    assert conservative.estimated_cost_usd == 0.02086
-    assert conservative.failed_attempt_cost_basis == "CONSERVATIVE_ESTIMATE"
-    assert conservative.billed_attempt_count == 2
+    unbilled = project_attempt_billing(final_cost=final, failed_debits=[], had_failed_attempts=True)
+    assert unbilled.failed_attempt_cost_basis == "NONE"
+    assert unbilled.billed_attempt_count == 1
 
-    # Provider-reported usage on the failed attempt is actual evidence and
-    # beats any estimate.
-    actual = _settle([{"billable_risk": True, "input_tokens": 200, "output_tokens": 100}])
-    assert actual.failed_attempt_cost_usd == 0.005
-    assert actual.failed_attempt_cost_basis == "ACTUAL_USAGE"
-
-    mixed = _settle(
-        [
-            {"billable_risk": True, "input_tokens": 200, "output_tokens": 100},
-            {"billable_risk": True, "input_tokens": None, "output_tokens": None},
-        ]
+    mixed = project_attempt_billing(
+        final_cost=final, failed_debits=[conservative, actual], had_failed_attempts=True
     )
     assert mixed.failed_attempt_cost_basis == "MIXED"
-    assert mixed.billed_attempt_count == 3
     assert mixed.failed_attempt_cost_usd == 0.02236
+    assert mixed.estimated_cost_usd == 0.02586
+    assert mixed.billed_attempt_count == 3
 
-    # A failure that cannot have generated (429 refused pre-generation,
-    # connection-level) is never billed, whatever the posture.
-    unbillable = _settle([{"billable_risk": False, "input_tokens": None, "output_tokens": None}])
-    assert unbillable.estimated_cost_usd == 0.0035
-    assert unbillable.failed_attempt_cost_basis == "NONE"
-    assert unbillable.billed_attempt_count == 1
 
-    # actual_only never estimates - it bills only usage evidence.
-    actual_only = _settle(
-        [{"billable_risk": True, "input_tokens": None, "output_tokens": None}],
-        posture="actual_only",
+class _Response:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+_SUCCESS_BODY = (
+    b'{"id": "resp_billing", "model": "gpt-5.4", "output_text": "OK",'
+    b' "usage": {"input_tokens": 200, "output_tokens": 50, "total_tokens": 250}}'
+)
+
+
+def _quiet_backoff(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("app.services.provider_retry_backoff._sleep", lambda delay: None)
+    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+
+
+def _http_error(code: int) -> error.HTTPError:
+    return error.HTTPError(
+        url="http://localhost/v1/responses",
+        code=code,
+        msg="failure",
+        hdrs=Message(),
+        fp=BytesIO(b"{}"),
     )
-    assert actual_only.estimated_cost_usd == 0.0035
-    assert actual_only.failed_attempt_cost_basis == "NONE"
 
 
-def test_transport_bills_the_failed_attempt_behind_a_served_retry(
+def _run_transport(*, retry_limit: int, execution_id: str) -> "ProviderExecutionResponse":
+    from app.providers.local_openai_compatible_text_provider import (
+        LocalOpenAICompatibleTextProvider,
+    )
+    from app.providers.openai_compatible_text_transport import (
+        execute_openai_compatible_text_request,
+    )
+    from tests.unit.test_provider_gateway import _request
+
+    return execute_openai_compatible_text_request(
+        descriptor=LocalOpenAICompatibleTextProvider().descriptor,
+        request=_request(retry_limit=retry_limit, execution_id=execution_id),
+        api_base="http://localhost:1234/v1",
+        api_key=None,
+        require_api_key=False,
+        model_id="gpt-5.4",
+        model_version=None,
+    )
+
+
+def test_served_execution_debits_each_attempt_and_projects_them(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """The issue's acceptance: fails once with a 5xx, succeeds on retry -
-    recorded spend covers both attempts under the conservative posture."""
-
-    from app.providers.local_openai_compatible_text_provider import (
-        LocalOpenAICompatibleTextProvider,
-    )
-    from app.providers.openai_compatible_text_transport import (
-        execute_openai_compatible_text_request,
-    )
-    from tests.unit.test_provider_gateway import _request
+    """Fails once with a 5xx, succeeds on retry: BOTH attempts are durable
+    debit rows, the budget envelope moved at each boundary, and the response
+    figures equal the recorded evidence - spend was real before settlement."""
 
     _seed_cost_scalars()
-    monkeypatch.setattr("app.services.provider_retry_backoff._sleep", lambda delay: None)
-    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
-
+    _quiet_backoff(monkeypatch)
     attempts = {"count": 0}
-
-    class _Response:
-        def __enter__(self) -> "_Response":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-        def read(self) -> bytes:
-            return (
-                b'{"id": "resp_billing", "model": "gpt-5.4", "output_text": "OK",'
-                b' "usage": {"input_tokens": 200, "output_tokens": 50, "total_tokens": 250}}'
-            )
 
     def _urlopen(request: object, timeout: float) -> _Response:
         attempts["count"] += 1
         if attempts["count"] == 1:
-            raise error.HTTPError(
-                url="http://localhost/v1/responses",
-                code=503,
-                msg="unavailable",
-                hdrs=Message(),
-                fp=BytesIO(b"{}"),
-            )
-        return _Response()
+            raise _http_error(503)
+        return _Response(_SUCCESS_BODY)
 
     monkeypatch.setattr("urllib.request.urlopen", _urlopen)
 
-    response = execute_openai_compatible_text_request(
-        descriptor=LocalOpenAICompatibleTextProvider().descriptor,
-        request=_request(retry_limit=1),
-        api_base="http://localhost:1234/v1",
-        api_key=None,
-        require_api_key=False,
-        model_id="gpt-5.4",
-        model_version=None,
-    )
+    response = _run_transport(retry_limit=1, execution_id="exec-served")
 
-    assert attempts["count"] == 2
-    assert response.retry_count == 1
-    # Final attempt 0.0035 plus the conservative estimate for the failed one
-    # (200 input tokens of the identical body + the 512-token ceiling).
-    assert response.failed_attempt_cost_usd == 0.01736
-    assert response.estimated_cost_usd == 0.02086
+    rows = {row.debit_id: row for row in get_provider_operations_store().list_attempt_debits()}
+    failed_row = rows["adbt:exec-served:text.local:0"]
+    served_row = rows["adbt:exec-served:text.local:1"]
+    assert failed_row.basis == "CONSERVATIVE_ESTIMATE"
+    assert failed_row.output_tokens == 512
+    assert served_row.basis == "ACTUAL_USAGE"
+    assert served_row.amount_usd == 0.0035
+
+    assert response.failed_attempt_cost_usd == failed_row.amount_usd
+    assert response.estimated_cost_usd == round(failed_row.amount_usd + served_row.amount_usd, 8)
     assert response.failed_attempt_cost_basis == "CONSERVATIVE_ESTIMATE"
     assert response.billed_attempt_count == 2
-    # The structured echo carries the same summed figure - one cost truth.
-    # (The composition detail lives only on the response/audit level: the
-    # echo's shape is pinned by the captured pack output contracts.)
-    assert response.structured_output["estimated_cost_usd"] == 0.02086
-    assert "billed_attempt_count" not in response.structured_output
+    assert response.structured_output["estimated_cost_usd"] == response.estimated_cost_usd
 
-    # The budget envelope records the summed figure.
-    record_provider_spend(response)
     budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
     assert budget is not None
-    assert budget.current_spend_usd == 0.02086
+    assert budget.current_spend_usd == response.estimated_cost_usd
 
 
-def test_a_rate_limited_retry_is_not_billed(monkeypatch: MonkeyPatch) -> None:
-    """429 refuses before generation: retried rate-limits carry no billable
-    risk and the settlement says NONE."""
-
-    from app.providers.local_openai_compatible_text_provider import (
-        LocalOpenAICompatibleTextProvider,
-    )
-    from app.providers.openai_compatible_text_transport import (
-        execute_openai_compatible_text_request,
-    )
-    from tests.unit.test_provider_gateway import _request
+def test_terminal_all_fail_execution_still_debits_every_billable_attempt(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The steering's P1 case: no success ever exists, yet both billable-risk
+    attempts moved the envelope at their boundaries."""
 
     _seed_cost_scalars()
-    monkeypatch.setattr("app.services.provider_retry_backoff._sleep", lambda delay: None)
-    monkeypatch.setattr("app.services.provider_retry_backoff._jitter_source", lambda: 0.0)
+    _quiet_backoff(monkeypatch)
 
+    def _urlopen(request: object, timeout: float) -> _Response:
+        raise _http_error(503)
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    with raises(ProviderExecutionError):
+        _run_transport(retry_limit=1, execution_id="exec-allfail")
+
+    rows = [
+        row
+        for row in get_provider_operations_store().list_attempt_debits()
+        if row.debit_id.startswith("adbt:exec-allfail:")
+    ]
+    assert {row.debit_id for row in rows} == {
+        "adbt:exec-allfail:text.local:0",
+        "adbt:exec-allfail:text.local:1",
+    }
+    assert all(row.basis == "CONSERVATIVE_ESTIMATE" for row in rows)
+    budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
+    assert budget is not None
+    assert budget.current_spend_usd == round(sum(row.amount_usd for row in rows), 8)
+
+
+def test_rate_limited_and_pre_connect_failures_never_debit(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _seed_cost_scalars()
+    _quiet_backoff(monkeypatch)
     attempts = {"count": 0}
-
-    class _Response:
-        def __enter__(self) -> "_Response":
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-        def read(self) -> bytes:
-            return (
-                b'{"id": "resp_429", "model": "gpt-5.4", "output_text": "OK",'
-                b' "usage": {"input_tokens": 200, "output_tokens": 50, "total_tokens": 250}}'
-            )
 
     def _urlopen(request: object, timeout: float) -> _Response:
         attempts["count"] += 1
         if attempts["count"] == 1:
-            raise error.HTTPError(
-                url="http://localhost/v1/responses",
-                code=429,
-                msg="rate limited",
-                hdrs=Message(),
-                fp=BytesIO(b"{}"),
-            )
-        return _Response()
+            raise _http_error(429)
+        if attempts["count"] == 2:
+            raise error.URLError("connection refused")
+        return _Response(_SUCCESS_BODY)
 
     monkeypatch.setattr("urllib.request.urlopen", _urlopen)
 
-    response = execute_openai_compatible_text_request(
-        descriptor=LocalOpenAICompatibleTextProvider().descriptor,
-        request=_request(retry_limit=1),
-        api_base="http://localhost:1234/v1",
-        api_key=None,
-        require_api_key=False,
-        model_id="gpt-5.4",
-        model_version=None,
-    )
+    response = _run_transport(retry_limit=2, execution_id="exec-unbillable")
 
-    assert response.retry_count == 1
+    rows = [
+        row
+        for row in get_provider_operations_store().list_attempt_debits()
+        if row.debit_id.startswith("adbt:exec-unbillable:")
+    ]
+    # Only the served attempt debited: 429 refused before generation and the
+    # connection-level failure never reached a generating provider.
+    assert {row.debit_id for row in rows} == {"adbt:exec-unbillable:text.local:2"}
     assert response.estimated_cost_usd == 0.0035
-    assert response.failed_attempt_cost_usd is None
     assert response.failed_attempt_cost_basis == "NONE"
     assert response.billed_attempt_count == 1
+
+
+def test_candidates_sharing_an_execution_debit_cumulatively(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Fallback semantics (issue #289): candidates share one execution
+    identity, each attempt keys its own debit, and spend accumulates - it is
+    never reset between candidates."""
+
+    _seed_cost_scalars()
+    _quiet_backoff(monkeypatch)
+    from app.providers.openai_compatible_text_transport import (
+        post_openai_compatible_response,
+    )
+
+    def _urlopen(request: object, timeout: float) -> _Response:
+        raise _http_error(503)
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    for provider_id in ("text.primary", "text.alternate"):
+        with raises(ProviderExecutionError):
+            post_openai_compatible_response(
+                api_base="http://localhost:1234/v1",
+                api_key=None,
+                payload={"model": "gpt-5.4", "max_output_tokens": 512},
+                timeout_seconds=1.0,
+                serving_provider_id=provider_id,
+                require_api_key=False,
+                retry_limit=0,
+                execution_id="exec-fallback",
+                model_revision="gpt-5.4",
+            )
+
+    rows = [
+        row
+        for row in get_provider_operations_store().list_attempt_debits()
+        if row.debit_id.startswith("adbt:exec-fallback:")
+    ]
+    assert {row.debit_id for row in rows} == {
+        "adbt:exec-fallback:text.primary:0",
+        "adbt:exec-fallback:text.alternate:0",
+    }
+    budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
+    assert budget is not None
+    assert budget.current_spend_usd == round(sum(row.amount_usd for row in rows), 8)
+
+
+def test_gateway_mints_one_execution_identity_per_execution(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The gateway stamps execution_id once, at the top of the execution,
+    before candidate dispatch - retries and fallback candidates then share
+    it, and a fresh execution gets a fresh identity."""
+
+    from fastapi import HTTPException
+
+    from app.contracts.providers import ProviderExecutionRequest, ProviderFailureCategory
+    from app.services import provider_gateway
+    from app.services.provider_execution_config import ProviderExecutionConfig
+    from tests.unit.test_provider_gateway import _request
+
+    settings.provider_mode = "stub"
+    captured: list[str | None] = []
+
+    class _Adapter:
+        def execute(
+            self, request: ProviderExecutionRequest, *, config: ProviderExecutionConfig
+        ) -> object:
+            captured.append(request.execution_id)
+            raise ProviderExecutionError(
+                category=ProviderFailureCategory.UNSUPPORTED_MODE,
+                message="capture only",
+            )
+
+    monkeypatch.setattr(
+        provider_gateway, "resolve_text_generation_adapter", lambda mode: _Adapter()
+    )
+
+    for _ in range(2):
+        with raises(HTTPException):
+            provider_gateway.execute_text_generation(_request())
+    with raises(HTTPException):
+        provider_gateway.execute_text_generation(_request(execution_id="exec-preset"))
+
+    assert len(captured) == 3
+    assert captured[0] and captured[1]
+    assert captured[0] != captured[1]
+    # A caller-supplied identity is preserved, never re-minted.
+    assert captured[2] == "exec-preset"

--- a/tests/unit/test_data_lifecycle_engine.py
+++ b/tests/unit/test_data_lifecycle_engine.py
@@ -352,7 +352,7 @@ def test_sqlalchemy_adapters_round_trip(tmp_path: object, monkeypatch: object) -
     assert results["audit_evidence"] == 1
     assert results["async_runtime_content"] == 1
     assert results["transient_operational_leases"] == 2
-    assert results["control_plane_evidence"] == 10
+    assert results["control_plane_evidence"] == 11
     assert results["workflow_run_records"] == 4
     assert results["artifact_content"] == 1
     assert results["evaluation_approval_evidence"] == 1
@@ -577,6 +577,23 @@ def _seed_control_plane_matrix() -> None:
             )
         )
 
+    from app.repositories.provider_operations_repository import ProviderAttemptDebitRecord
+
+    for debit_id, age in (("adbt_old", 2600), ("adbt_young", 10)):
+        ops.record_attempt_debit(
+            ProviderAttemptDebitRecord(
+                debit_id=debit_id,
+                provider_id="text.openai",
+                basis="ACTUAL_USAGE",
+                amount_usd=0.001,
+                input_tokens=10,
+                output_tokens=10,
+                rate_card_ref="default-live-text",
+                recorded_at=_iso(age),
+            ),
+            budget_key="live_text_generation",
+        )
+
     def _gact(action_id: str, status: "GovernedActionStatus", age: int) -> None:
         ops.upsert_governed_action(
             GovernedActionRecord(
@@ -770,9 +787,9 @@ def test_control_plane_evidence_expiry_honours_the_protective_predicates() -> No
 
     results = {r.family_id: r for r in report.results}
     control = results["control_plane_evidence"]
-    # aae_old, poe_old, gact_old_executed, pre_old, ace_old, ksw_old_cleared,
-    # wpe_old, mlc_old, drift_old, conf_old = 10 expired rows.
-    assert control.deleted_count == 10
+    # aae_old, poe_old, adbt_old, gact_old_executed, pre_old, ace_old,
+    # ksw_old_cleared, wpe_old, mlc_old, drift_old, conf_old = 11 expired rows.
+    assert control.deleted_count == 11
     assert "never expired" in control.detail
 
     ops = get_provider_operations_store()
@@ -793,11 +810,12 @@ def test_control_plane_evidence_expiry_honours_the_protective_predicates() -> No
     audit = get_audit_store()
     events = {e.family_id: e for e in audit.list_lifecycle_events(limit=20)}
     control_event = events["control_plane_evidence"]
-    assert control_event.row_count == 10
+    assert control_event.row_count == 11
     expected_ids = sorted(
         [
             "audit_access_events:aae_old",
             "provider_operations_events:poe_old",
+            "provider_attempt_debits:adbt_old",
             "provider_governed_actions:gact_old_executed",
             "prompt_rollout_events:pre_old",
             "async_control_events:ace_old",

--- a/tests/unit/test_provider_activation_readiness.py
+++ b/tests/unit/test_provider_activation_readiness.py
@@ -97,28 +97,20 @@ def test_provider_activation_readiness_reports_hard_budget_blocking() -> None:
     settings.live_text_output_cost_per_1k_tokens = 0.03
     settings.live_text_hard_budget_usd = 1.0
 
-    from app.contracts.providers import ProviderAdapterKind, ProviderExecutionResponse
-    from app.services.provider_budget_policy import record_provider_spend
+    from app.services.provider_budget_policy import record_attempt_spend
+    from app.services.provider_usage_accounting import AttemptDebit
 
-    record_provider_spend(
-        ProviderExecutionResponse(
-            provider_id="text.openai",
-            provider_mode="openai",
-            adapter_kind=ProviderAdapterKind.OPENAI_LIVE,
-            failure_category=None,
-            timeout_ms=4000,
-            retry_count=0,
-            max_output_tokens=512,
-            model_id="gpt-5.4",
-            provider_request_id="req-budget-hard-1",
+    record_attempt_spend(
+        execution_id="exec-activation-hard",
+        provider_id="text.openai",
+        attempt_index=0,
+        debit=AttemptDebit(
+            amount_usd=1.0,
+            basis="ACTUAL_USAGE",
             input_tokens=100,
             output_tokens=200,
-            total_tokens=300,
-            estimated_cost_usd=1.0,
-            stubbed=False,
-            message="live response",
-            structured_output={},
-        )
+            rate_card_ref="default-live-text",
+        ),
     )
 
     readiness = build_provider_activation_readiness()

--- a/tests/unit/test_provider_budget_policy.py
+++ b/tests/unit/test_provider_budget_policy.py
@@ -1,40 +1,33 @@
 from pathlib import Path
 
 from app.config import settings
-from app.contracts.providers import (
-    ProviderAdapterKind,
-    ProviderBudgetState,
-    ProviderExecutionResponse,
-)
+from app.contracts.providers import ProviderBudgetState
 from app.services.provider_budget_policy import (
     build_provider_budget_policy,
     enforce_provider_budget,
-    record_provider_spend,
+    record_attempt_spend,
 )
+from app.services.provider_usage_accounting import AttemptDebit
 from app.providers.base import ProviderExecutionError
 from app.services.provider_operations_store import reset_provider_operations_store_cache
 from app.services.rate_card_store import reset_rate_card_store_cache
 from tests.support.migration_runner import upgrade_database_to_head
 
 
-def _response(cost: float | None, *, stubbed: bool = False) -> ProviderExecutionResponse:
-    return ProviderExecutionResponse(
+def _seed_spend(
+    amount: float, *, execution_id: str = "exec-budget-test", attempt_index: int = 0
+) -> bool:
+    return record_attempt_spend(
+        execution_id=execution_id,
         provider_id="text.openai",
-        provider_mode="openai",
-        adapter_kind=ProviderAdapterKind.OPENAI_LIVE,
-        failure_category=None,
-        timeout_ms=4000,
-        retry_count=0,
-        max_output_tokens=512,
-        model_id="gpt-5.4",
-        provider_request_id="req-budget-1",
-        input_tokens=100,
-        output_tokens=200,
-        total_tokens=300,
-        estimated_cost_usd=cost,
-        stubbed=stubbed,
-        message="live response",
-        structured_output={},
+        attempt_index=attempt_index,
+        debit=AttemptDebit(
+            amount_usd=amount,
+            basis="ACTUAL_USAGE",
+            input_tokens=100,
+            output_tokens=200,
+            rate_card_ref="default-live-text",
+        ),
     )
 
 
@@ -57,7 +50,7 @@ def test_provider_budget_policy_reports_soft_limit_after_tracked_spend() -> None
     settings.live_text_soft_budget_usd = 0.5
     settings.live_text_hard_budget_usd = 1.0
 
-    record_provider_spend(_response(0.75))
+    _seed_spend(0.75)
 
     response = build_provider_budget_policy()
 
@@ -104,7 +97,7 @@ def test_provider_budget_policy_blocks_when_hard_limit_is_reached() -> None:
     settings.live_text_soft_budget_usd = 0.5
     settings.live_text_hard_budget_usd = 1.0
 
-    record_provider_spend(_response(1.0))
+    _seed_spend(1.0)
 
     response = build_provider_budget_policy()
     assert response.budget_state == ProviderBudgetState.HARD_LIMIT_BLOCKED
@@ -129,19 +122,22 @@ def test_provider_budget_policy_enforcement_rejects_invalid_configuration() -> N
         raise AssertionError("Expected invalid budget configuration to block execution")
 
 
-def test_record_provider_spend_ignores_stubbed_or_unpriced_responses() -> None:
+def test_recording_the_same_attempt_identity_twice_debits_once() -> None:
+    """Issue #289: the attempt identity makes recording idempotent - a
+    crash-and-retry of the recording call can never double-debit."""
+
     settings.live_text_budget_enforced = True
     settings.live_text_input_cost_per_1k_tokens = 0.01
     settings.live_text_output_cost_per_1k_tokens = 0.03
     settings.live_text_soft_budget_usd = 1.0
     settings.live_text_hard_budget_usd = 2.0
 
-    record_provider_spend(_response(0.5, stubbed=True))
-    record_provider_spend(_response(None))
+    assert _seed_spend(0.5) is True
+    assert _seed_spend(0.5) is False
 
     response = build_provider_budget_policy()
 
-    assert response.current_spend_usd == 0.0
+    assert response.current_spend_usd == 0.5
     assert response.budget_state == ProviderBudgetState.BELOW_SOFT_LIMIT
 
 
@@ -157,7 +153,7 @@ def test_provider_budget_policy_persists_spend_in_sql_store_across_store_reset(
     settings.live_text_hard_budget_usd = 2.0
     upgrade_database_to_head(settings.database_url)
 
-    record_provider_spend(_response(0.75))
+    _seed_spend(0.75)
     reset_provider_operations_store_cache()
     reset_rate_card_store_cache()
 
@@ -179,7 +175,7 @@ def test_provider_budget_policy_durable_enforcement_blocks_on_persisted_hard_lim
     settings.live_text_hard_budget_usd = 1.0
     upgrade_database_to_head(settings.database_url)
 
-    record_provider_spend(_response(1.0))
+    _seed_spend(1.0)
     reset_provider_operations_store_cache()
     reset_rate_card_store_cache()
 

--- a/tests/unit/test_provider_gateway.py
+++ b/tests/unit/test_provider_gateway.py
@@ -383,6 +383,25 @@ def test_execute_text_generation_rejects_live_provider_when_budget_is_exceeded()
     first_response = execute_text_generation(_request())
     assert first_response.provider_id == "text.openai"
 
+    # Spend becomes real at the attempt boundary (issue #289), a layer this
+    # test's fake adapter deliberately bypasses - seed the debit exactly as
+    # the real transport records it, then prove the preflight blocks.
+    from app.services.provider_budget_policy import record_attempt_spend
+    from app.services.provider_usage_accounting import AttemptDebit
+
+    record_attempt_spend(
+        execution_id="exec-gateway-budget",
+        provider_id="text.openai",
+        attempt_index=0,
+        debit=AttemptDebit(
+            amount_usd=1.0,
+            basis="ACTUAL_USAGE",
+            input_tokens=10,
+            output_tokens=20,
+            rate_card_ref="default-live-text",
+        ),
+    )
+
     with pytest.raises(HTTPException) as exc_info:
         execute_text_generation(_request())
 

--- a/tests/unit/test_provider_operations_control.py
+++ b/tests/unit/test_provider_operations_control.py
@@ -16,7 +16,8 @@ from app.contracts.provider_operations import (
     ProviderOperationsResetIntentRequest,
 )
 from app.http.authenticated_caller import AuthenticatedCaller
-from app.services.provider_budget_policy import record_provider_spend
+from app.services.provider_budget_policy import record_attempt_spend
+from app.services.provider_usage_accounting import AttemptDebit
 from app.services.provider_degradation_state import record_provider_failure
 from app.services.provider_operations_control import (
     approve_provider_operations_reset,
@@ -29,6 +30,21 @@ from app.services.provider_request_builder import build_provider_execution_reque
 from app.services.task_execution_pipeline import validate_task_request
 from tests.support.migration_runner import upgrade_database_to_head
 from tests.unit.test_task_executor import _request
+
+
+def _seed_attempt_spend(amount: float, *, execution_id: str) -> None:
+    record_attempt_spend(
+        execution_id=execution_id,
+        provider_id="text.openai",
+        attempt_index=0,
+        debit=AttemptDebit(
+            amount_usd=amount,
+            basis="ACTUAL_USAGE",
+            input_tokens=100,
+            output_tokens=200,
+            rate_card_ref="default-live-text",
+        ),
+    )
 
 
 def _budget_response(cost: float) -> ProviderExecutionResponse:
@@ -111,7 +127,7 @@ def test_provider_operations_control_action_resets_durable_state_and_records_eve
         context=validate_task_request(_request("explain.v1"))
     )
     enforce_provider_quota(provider_request)
-    record_provider_spend(_budget_response(0.75))
+    _seed_attempt_spend(0.75, execution_id="exec-ops-control-1")
     record_provider_failure(ProviderFailureCategory.PROVIDER_TIMEOUT)
 
     response = _governed_reset(ProviderOperationsControlActionType.RESET_ALL_PROVIDER_OPERATIONS)

--- a/tests/unit/test_provider_operations_status.py
+++ b/tests/unit/test_provider_operations_status.py
@@ -45,28 +45,20 @@ def test_provider_operations_status_reports_soft_budget_state_when_live_path_is_
     settings.live_text_soft_budget_usd = 0.5
     settings.live_text_hard_budget_usd = 1.0
 
-    from app.contracts.providers import ProviderAdapterKind, ProviderExecutionResponse
-    from app.services.provider_budget_policy import record_provider_spend
+    from app.services.provider_budget_policy import record_attempt_spend
+    from app.services.provider_usage_accounting import AttemptDebit
 
-    record_provider_spend(
-        ProviderExecutionResponse(
-            provider_id="text.openai",
-            provider_mode="openai",
-            adapter_kind=ProviderAdapterKind.OPENAI_LIVE,
-            failure_category=None,
-            timeout_ms=4000,
-            retry_count=0,
-            max_output_tokens=512,
-            model_id="gpt-5.4",
-            provider_request_id="req-ops-1",
+    record_attempt_spend(
+        execution_id="exec-ops-status-soft",
+        provider_id="text.openai",
+        attempt_index=0,
+        debit=AttemptDebit(
+            amount_usd=0.75,
+            basis="ACTUAL_USAGE",
             input_tokens=100,
             output_tokens=200,
-            total_tokens=300,
-            estimated_cost_usd=0.75,
-            stubbed=False,
-            message="live response",
-            structured_output={},
-        )
+            rate_card_ref="default-live-text",
+        ),
     )
 
     status = build_provider_operations_status()
@@ -258,28 +250,20 @@ def test_provider_operations_status_reports_hard_budget_blocked_state() -> None:
     settings.live_text_output_cost_per_1k_tokens = 0.03
     settings.live_text_hard_budget_usd = 1.0
 
-    from app.contracts.providers import ProviderAdapterKind, ProviderExecutionResponse
-    from app.services.provider_budget_policy import record_provider_spend
+    from app.services.provider_budget_policy import record_attempt_spend
+    from app.services.provider_usage_accounting import AttemptDebit
 
-    record_provider_spend(
-        ProviderExecutionResponse(
-            provider_id="text.openai",
-            provider_mode="openai",
-            adapter_kind=ProviderAdapterKind.OPENAI_LIVE,
-            failure_category=None,
-            timeout_ms=4000,
-            retry_count=0,
-            max_output_tokens=512,
-            model_id="gpt-5.4",
-            provider_request_id="req-ops-budget-1",
+    record_attempt_spend(
+        execution_id="exec-ops-status-hard",
+        provider_id="text.openai",
+        attempt_index=0,
+        debit=AttemptDebit(
+            amount_usd=1.0,
+            basis="ACTUAL_USAGE",
             input_tokens=100,
             output_tokens=200,
-            total_tokens=300,
-            estimated_cost_usd=1.0,
-            stubbed=False,
-            message="live response",
-            structured_output={},
-        )
+            rate_card_ref="default-live-text",
+        ),
     )
 
     status = build_provider_operations_status()

--- a/tests/unit/test_sqlalchemy_provider_operations_repository.py
+++ b/tests/unit/test_sqlalchemy_provider_operations_repository.py
@@ -156,6 +156,51 @@ def test_sqlalchemy_provider_operations_repository_applies_atomic_mutations(
     assert degradation.upstream_error_failure_count == 1
 
 
+def test_sqlalchemy_attempt_debits_are_idempotent_and_transactional(
+    tmp_path: Path,
+) -> None:
+    """Issue #289: the debit row and the budget counter advance together in
+    one transaction, a duplicate identity is a complete no-op, and deleting
+    evidence never reverses the counter."""
+
+    from app.repositories.provider_operations_repository import ProviderAttemptDebitRecord
+
+    database_url = f"sqlite:///{tmp_path / 'lotus-ai-provider-debits.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyProviderOperationsRepository(database_url)
+
+    debit = ProviderAttemptDebitRecord(
+        debit_id="adbt:exec-sql:text.openai:0",
+        provider_id="text.openai",
+        basis="CONSERVATIVE_ESTIMATE",
+        amount_usd=0.01736,
+        input_tokens=200,
+        output_tokens=512,
+        rate_card_ref="default-live-text",
+        recorded_at="2026-03-23T00:00:00Z",
+    )
+
+    assert repository.record_attempt_debit(debit, budget_key="live_text_generation") is True
+    assert repository.record_attempt_debit(debit, budget_key="live_text_generation") is False
+
+    budget = repository.get_budget_state(budget_key="live_text_generation")
+    assert budget is not None
+    assert budget.current_spend_usd == 0.01736
+
+    rows = repository.list_attempt_debits(limit=10)
+    assert [row.debit_id for row in rows] == ["adbt:exec-sql:text.openai:0"]
+    assert rows[0].basis == "CONSERVATIVE_ESTIMATE"
+    assert rows[0].input_tokens == 200
+
+    assert repository.delete_attempt_debits([]) == 0
+    assert repository.delete_attempt_debits(["adbt:exec-sql:text.openai:0", "missing"]) == 1
+    assert repository.list_attempt_debits(limit=10) == []
+    # Evidence expiry never refunds the envelope.
+    budget = repository.get_budget_state(budget_key="live_text_generation")
+    assert budget is not None
+    assert budget.current_spend_usd == 0.01736
+
+
 def test_sqlalchemy_provider_operations_repository_records_events_and_resets_state(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #289: **every potentially billable provider attempt debits Lotus spend exactly once, at its own boundary** — regardless of whether the execution succeeds, fails completely, falls back, or the process dies later. This is the 2026-09-04 steering's P1: #232 had fixed the success path; an all-fail execution recorded nothing, and accumulation-to-settlement was a crash window.

## Spend becomes real per attempt, not at settlement

The transport's retry loop now records a durable debit at each attempt boundary on the provider-operations store (`provider_attempt_debits`, migration 0066) under an idempotent identity `adbt:<execution_id>:<provider_id>:<attempt_index>` — the debit row and the budget counter advance in **one transaction** (SQL) so no crash can separate them, and a duplicate identity is a complete no-op with the counter untouched. The gateway mints one `execution_id` per execution, shared across retry and fallback candidates; without one (non-gateway callers) the transport mints its own, so every live attempt debits.

Pricing per attempt, in evidence order (`price_attempt` in the accounting module): provider-reported usage → `ACTUAL_USAGE`; unknown-usage billable-risk failures (timeout, 5xx) under the conservative posture → `CONSERVATIVE_ESTIMATE` at the input estimate plus the `max_output_tokens` ceiling — the input estimate is provider-reported input from any attempt of the same execution when available (identical body), else the documented ~4-bytes/token request-body approximation; 429 and connection-level failures → no debit; a missing rate card → no debit (the explicit cost-unknown posture, never a silent zero).

## The response is a projection

When a response exists, `estimated_cost_usd` / `failed_attempt_cost_usd` / `failed_attempt_cost_basis` / `billed_attempt_count` restate the recorded debits (stamped attempt evidence → `project_attempt_billing`); the gateway's response-time `record_provider_spend` is **deleted** — settlement never debits again, so the exactly-once invariant holds by construction. The structured echo keeps its contract shape and carries the same number.

## Evidence lifecycle

Debit rows join the `control_plane_evidence` retention family (7y): the engine's family handler sweeps them like the rest of the family, and **expiry never reverses the counter** — the spend happened. Coverage invariant, handler↔policy pin, and the control-plane matrix all extend.

## The steering's acceptance, executed

- **Terminal all-fail** (two 503 attempts, no success): both attempts are durable rows, the envelope moved by their sum — proven at the urlopen boundary with the real retry loop.
- **Fails-once-then-succeeds**: both attempts are rows; the response figures equal the recorded evidence; the budget equals the response total — recorded exactly once.
- **Idempotency**: duplicate identity is a no-op on both adapters (memory + SQL, transactional test).
- **429/pre-connect**: zero debits; the served attempt alone bills.
- **Fallback/cumulative**: candidates sharing an execution debit under their own identities and rate-card resolution; spend accumulates, never resets. The gateway's single-identity stamp is pinned (fresh id per execution, caller-supplied id preserved).
- **Crash window**: closed by construction — the debit is durable before any later step runs.

## Boundaries kept

`max_estimated_cost_usd` stays an **unenforced preference** — the hard execution-cost ceiling is #290, gated on this PR, and will consume from these same debits. No new billing subsystem: one store, one budget key, one accounting module. One test's fake adapter had silently depended on response-time spend recording (the fake-fidelity class): it now seeds the debit exactly as the real transport records it. Runbook "Provider Billing Truth" rewritten; the old "all-fail records no spend" residual paragraph is gone because the residual is gone.
