### PR TITLE
feat(economics): hard cost ceiling as one execution budget (#290)

### DIFF
--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -534,7 +534,7 @@ Runtime semantics under `ordered_fallback`:
 - When a response exists, `estimated_cost_usd` / `failed_attempt_cost_usd` / `failed_attempt_cost_basis` / `billed_attempt_count` are a **projection of the recorded attempt debits** — the durable rows are where spend became real, and response settlement never debits again.
 - Retry and fallback candidates share one execution identity and debit cumulatively under their own attempt identities and rate cards; spend is never reset mid-execution.
 - Debit rows are lifecycle-governed evidence (control-plane evidence family, 7y): their expiry never reverses the budget counter.
-- `max_estimated_cost_usd` remains an unenforced preference until the hard execution-cost ceiling lands (one budget across retries and fallback — the latency-budget precedent).
+- `max_estimated_cost_usd` is a **hard execution cost ceiling** (issue #290): one budget across every retry and fallback candidate, never reset. Before each attempt starts, the remaining ceiling must support that attempt at its conservative bound (input estimate + `max_output_tokens`) under the candidate's own rate card — a cheaper fallback can fit where the primary would not, and consumption is exactly the durable attempt debits. A refused attempt is `REQUEST_COST_EXHAUSTED` (the caller's ceiling, not the platform envelope) and bills nothing; a declared ceiling on a candidate no rate card prices fails closed — an unverifiable guarantee never silently passes.
 
 ## Durable Provider Operations Recovery
 

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -67,6 +67,12 @@ class ProviderFailureCategory(str, Enum):
     # request deadline was exhausted by earlier attempts, backoff, or
     # fallback, and no further attempt may start.
     REQUEST_DEADLINE_EXHAUSTED = "REQUEST_DEADLINE_EXHAUSTED"
+    # The caller's declared cost ceiling cannot support the next attempt
+    # (issue #290). Distinct from BUDGET_EXCEEDED: the platform envelope is
+    # fine - the request's own max_estimated_cost_usd budget was consumed by
+    # earlier attempts, or the candidate cannot be priced so a hard ceiling
+    # fails closed. A cheaper fallback candidate may still fit.
+    REQUEST_COST_EXHAUSTED = "REQUEST_COST_EXHAUSTED"
     PROVIDER_TIMEOUT = "PROVIDER_TIMEOUT"
     PROVIDER_RATE_LIMITED = "PROVIDER_RATE_LIMITED"
     PROVIDER_UPSTREAM_ERROR = "PROVIDER_UPSTREAM_ERROR"
@@ -675,6 +681,15 @@ class ProviderExecutionRequest(BaseModel):
             "shared across retry and fallback candidates, it keys the idempotent "
             "per-attempt spend debits. Null only outside the gateway path; the "
             "transport then mints one so every live attempt still debits."
+        ),
+    )
+    cost_ceiling_usd: float | None = Field(
+        default=None,
+        description=(
+            "The caller's hard execution cost ceiling (issue #290), stamped once "
+            "from requirements.max_estimated_cost_usd: one budget across every "
+            "retry and fallback candidate, consumed by the durable attempt "
+            "debits and never reset mid-execution."
         ),
     )
     failed_attempt_cost_posture: Literal["conservative", "actual_only"] = Field(

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -36,7 +36,7 @@ from app.providers.advisor_brief_quality_guardrails import (
     build_advisor_brief_user_message,
     normalize_advisor_brief_output,
 )
-from app.services.provider_budget_policy import record_attempt_spend
+from app.services.provider_budget_policy import record_attempt_spend, spent_for_execution
 from app.services.provider_usage_accounting import (
     AttemptDebit,
     estimate_live_text_cost,
@@ -101,6 +101,7 @@ def execute_openai_compatible_text_request(
         execution_id=request.execution_id,
         cost_posture=request.failed_attempt_cost_posture,
         model_revision=model_version or model_id,
+        cost_ceiling_usd=request.cost_ceiling_usd,
     )
     output_message = extract_output_text(response_payload)
     message, structured_output = build_structured_output(
@@ -186,6 +187,7 @@ def post_openai_compatible_response(
     execution_id: str | None = None,
     cost_posture: str = "conservative",
     model_revision: str | None = None,
+    cost_ceiling_usd: float | None = None,
 ) -> dict[str, Any]:
     """POST one OpenAI-compatible request, labelling every surface it emits
     with ``serving_provider_id``.
@@ -294,6 +296,41 @@ def post_openai_compatible_response(
                 )
             # An attempt may wait only for what remains of the budget.
             timeout_seconds = min(timeout_seconds, remaining_seconds)
+        if cost_ceiling_usd is not None:
+            # Pre-attempt cost admission (issue #290): the remaining ceiling
+            # must support this attempt at its conservative bound under THIS
+            # candidate's rate card. Consumption is the durable attempt
+            # debits, so retries and fallback candidates share one budget.
+            projected = price_attempt(
+                input_tokens=None,
+                output_tokens=None,
+                billable_risk=True,
+                posture="conservative",
+                fallback_input_estimate=input_estimate,
+                max_output_tokens=payload_max_output,
+                model_revision=model_revision,
+            )
+            if projected is None:
+                # A hard ceiling the platform cannot price fails closed: an
+                # unverifiable guarantee must not silently pass.
+                raise ProviderExecutionError(
+                    category=ProviderFailureCategory.REQUEST_COST_EXHAUSTED,
+                    message=(
+                        "The caller declared max_estimated_cost_usd, but no effective "
+                        "rate card prices this candidate; the hard cost ceiling "
+                        "cannot be verified and fails closed."
+                    ),
+                )
+            spent = spent_for_execution(debit_execution_id)
+            if round(spent + projected.amount_usd, 8) > cost_ceiling_usd:
+                raise ProviderExecutionError(
+                    category=ProviderFailureCategory.REQUEST_COST_EXHAUSTED,
+                    message=(
+                        "The caller's max_estimated_cost_usd budget cannot support "
+                        "the next attempt at its conservative bound; no further "
+                        "attempt may start on this candidate."
+                    ),
+                )
         provider_request = urllib_request.Request(
             endpoint,
             data=body,

--- a/src/app/repositories/memory_provider_operations_repository.py
+++ b/src/app/repositories/memory_provider_operations_repository.py
@@ -119,6 +119,16 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
                 deleted += 1
         return deleted
 
+    def sum_attempt_debits(self, *, debit_id_prefix: str) -> float:
+        return round(
+            sum(
+                record.amount_usd
+                for debit_id, record in self._attempt_debits.items()
+                if debit_id.startswith(debit_id_prefix)
+            ),
+            8,
+        )
+
     def get_degradation_state(
         self,
         *,

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -123,6 +123,11 @@ class ProviderOperationsRepository(Protocol):
     def list_attempt_debits(self, *, limit: int = 100) -> Sequence[ProviderAttemptDebitRecord]:
         """Attempt-debit evidence, newest first."""
 
+    def sum_attempt_debits(self, *, debit_id_prefix: str) -> float:
+        """Total recorded spend across one execution's debit identities
+        (issue #290): the same durable rows that moved the envelope also
+        answer 'how much of the caller's ceiling is already consumed'."""
+
     def delete_attempt_debits(self, debit_ids: Sequence[str]) -> int:
         """Delete attempt-debit evidence rows for the lifecycle engine
         (control-plane evidence family). Deleting evidence never reverses

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from pathlib import Path
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 
 from app.contracts.access_control import (
@@ -246,6 +246,17 @@ class SqlAlchemyProviderOperationsRepository(
             )
             session.commit()
             return int(getattr(result, "rowcount", 0) or 0)
+
+    def sum_attempt_debits(self, *, debit_id_prefix: str) -> float:
+        with self._session_factory() as session:
+            total = session.execute(
+                select(func.coalesce(func.sum(ProviderAttemptDebitModel.amount_usd), 0.0)).where(
+                    # Identities are adbt:<uuid-hex>:<provider-id>:<index>;
+                    # none of those parts contain SQL LIKE wildcards.
+                    ProviderAttemptDebitModel.debit_id.like(f"{debit_id_prefix}%")
+                )
+            ).scalar_one()
+            return round(float(total), 8)
 
     def get_degradation_state(
         self,

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -276,7 +276,15 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
 # estimated-cost ceiling is declared-only until a pre-execution bound exists,
 # and the routing decision says so.
 ENFORCED_REQUIREMENT_DIMENSIONS = frozenset(
-    {"structured_output_required", "tool_calling_required", "max_latency_ms"}
+    {
+        "structured_output_required",
+        "tool_calling_required",
+        "max_latency_ms",
+        # One execution cost budget across retries and fallback (issue #290):
+        # pre-attempt admission consumes from the durable attempt debits, and
+        # a declared ceiling on an unpriceable candidate fails closed.
+        "max_estimated_cost_usd",
+    }
 )
 
 _CAPABILITY_FACT_BY_REQUIREMENT = {

--- a/src/app/services/provider_budget_policy.py
+++ b/src/app/services/provider_budget_policy.py
@@ -162,6 +162,15 @@ def record_attempt_spend(
     )
 
 
+def spent_for_execution(execution_id: str) -> float:
+    """This execution's consumed spend, from its durable attempt debits
+    (issue #290): the caller's cost ceiling admits or refuses the next
+    attempt against exactly the number the envelope recorded."""
+
+    repository = get_provider_operations_store()
+    return repository.sum_attempt_debits(debit_id_prefix=f"adbt:{execution_id}:")
+
+
 def reset_provider_budget_state() -> None:
     repository = get_provider_operations_store()
     repository.reset_budget_state(budget_key=_BUDGET_KEY)

--- a/src/app/services/provider_gateway.py
+++ b/src/app/services/provider_gateway.py
@@ -68,6 +68,11 @@ _FALLBACK_TRIGGER_CATEGORIES = frozenset(
         ProviderFailureCategory.PROVIDER_TIMEOUT,
         ProviderFailureCategory.PROVIDER_RATE_LIMITED,
         ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR,
+        # The caller's cost ceiling refusing THIS candidate does not refuse
+        # the execution: a cheaper alternate's own admission check may still
+        # fit within the shared remaining ceiling (issue #290). The latency
+        # budget differs deliberately - exhausted time is global.
+        ProviderFailureCategory.REQUEST_COST_EXHAUSTED,
     }
 )
 
@@ -82,6 +87,7 @@ class ProviderGatewayUnavailableError(HTTPException):
 
 def execute_text_generation(request: ProviderExecutionRequest) -> ProviderExecutionResponse:
     request = _apply_latency_ceiling(request)
+    request = _apply_cost_ceiling(request)
     if request.execution_id is None:
         # One identity per execution, shared by every retry and fallback
         # candidate: attempt debits key on it (issue #289).
@@ -543,6 +549,21 @@ def _apply_latency_ceiling(request: ProviderExecutionRequest) -> ProviderExecuti
             "execution_deadline_at": _monotonic() + requirements.max_latency_ms / 1000.0,
         }
     )
+
+
+def _apply_cost_ceiling(request: ProviderExecutionRequest) -> ProviderExecutionRequest:
+    """Start the governed execution cost budget (issue #290).
+
+    `max_estimated_cost_usd` is one execution ceiling, not an attempt price:
+    it is stamped once here, every retry and fallback candidate consumes
+    from it through the durable attempt debits, and nothing resets it - the
+    latency budget's own design, applied to money.
+    """
+
+    requirements = request.requirements
+    if requirements is None or requirements.max_estimated_cost_usd is None:
+        return request
+    return request.model_copy(update={"cost_ceiling_usd": requirements.max_estimated_cost_usd})
 
 
 def _remaining_budget_ms(request: ProviderExecutionRequest) -> int | None:

--- a/tests/unit/test_attempt_billing.py
+++ b/tests/unit/test_attempt_billing.py
@@ -373,3 +373,151 @@ def test_gateway_mints_one_execution_identity_per_execution(
     assert captured[0] != captured[1]
     # A caller-supplied identity is preserved, never re-minted.
     assert captured[2] == "exec-preset"
+
+
+def _post_with_ceiling(
+    *,
+    provider_id: str,
+    model_revision: str,
+    execution_id: str,
+    ceiling: float,
+    retry_limit: int = 0,
+) -> dict[str, object]:
+    from app.providers.openai_compatible_text_transport import (
+        post_openai_compatible_response,
+    )
+
+    return post_openai_compatible_response(
+        api_base="http://localhost:1234/v1",
+        api_key=None,
+        payload={"model": "gpt-5.4", "max_output_tokens": 512},
+        timeout_seconds=1.0,
+        serving_provider_id=provider_id,
+        require_api_key=False,
+        retry_limit=retry_limit,
+        execution_id=execution_id,
+        model_revision=model_revision,
+        cost_ceiling_usd=ceiling,
+    )
+
+
+def test_cost_ceiling_refuses_the_next_attempt_before_it_starts(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Issue #290: one execution budget - the first attempt's conservative
+    debit consumes it, and the second attempt is refused pre-connect with
+    the bounded category; nothing is billed for the refused attempt."""
+
+    _seed_cost_scalars()
+    _quiet_backoff(monkeypatch)
+    calls = {"count": 0}
+
+    def _urlopen(request: object, timeout: float) -> _Response:
+        calls["count"] += 1
+        raise _http_error(503)
+
+    monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    # Conservative bound per attempt with these scalars is well over 0.02:
+    # the first attempt fits, the retry cannot.
+    with raises(ProviderExecutionError) as exc_info:
+        _post_with_ceiling(
+            provider_id="text.local",
+            model_revision="gpt-5.4",
+            execution_id="exec-ceiling",
+            ceiling=0.02,
+            retry_limit=1,
+        )
+
+    assert exc_info.value.category.value == "REQUEST_COST_EXHAUSTED"
+    assert calls["count"] == 1
+    rows = [
+        row
+        for row in get_provider_operations_store().list_attempt_debits()
+        if row.debit_id.startswith("adbt:exec-ceiling:")
+    ]
+    assert {row.debit_id for row in rows} == {"adbt:exec-ceiling:text.local:0"}
+
+
+def test_a_cheaper_fallback_candidate_fits_the_shared_remaining_ceiling(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Issue #290: the ceiling is shared, never reset - and the alternate's
+    admission prices under the ALTERNATE's rate card, so a cheaper candidate
+    fits where the primary would not."""
+
+    from app.contracts.rate_cards import RateCard, RateCardScopeKind
+    from app.services.provider_usage_accounting import save_rate_card
+
+    _seed_cost_scalars()
+    _quiet_backoff(monkeypatch)
+    save_rate_card(
+        RateCard(
+            card_id="cheap-alternate",
+            scope_kind=RateCardScopeKind.MODEL_REVISION,
+            scope_target="cheap-rev",
+            currency="USD",
+            input_cost_per_1k_tokens=0.0001,
+            output_cost_per_1k_tokens=0.0001,
+            effective_from_utc=None,
+            effective_to_utc=None,
+            created_at="2026-08-31T00:00:00Z",
+            last_updated_at="2026-08-31T00:00:00Z",
+        )
+    )
+    monkeypatch.setattr("urllib.request.urlopen", lambda request, timeout: _Response(_SUCCESS_BODY))
+
+    # The primary's conservative bound under the default card exceeds the
+    # ceiling outright: refused before any connection.
+    with raises(ProviderExecutionError) as exc_info:
+        _post_with_ceiling(
+            provider_id="text.primary",
+            model_revision="gpt-5.4",
+            execution_id="exec-cheap-fallback",
+            ceiling=0.01,
+        )
+    assert exc_info.value.category.value == "REQUEST_COST_EXHAUSTED"
+
+    payload = _post_with_ceiling(
+        provider_id="text.alternate",
+        model_revision="cheap-rev",
+        execution_id="exec-cheap-fallback",
+        ceiling=0.01,
+    )
+    assert payload["id"] == "resp_billing"
+    rows = [
+        row
+        for row in get_provider_operations_store().list_attempt_debits()
+        if row.debit_id.startswith("adbt:exec-cheap-fallback:")
+    ]
+    # Only the alternate billed, under its own card.
+    assert {row.debit_id for row in rows} == {"adbt:exec-cheap-fallback:text.alternate:0"}
+    assert rows[0].rate_card_ref == "cheap-alternate"
+
+
+def test_a_declared_ceiling_on_an_unpriceable_candidate_fails_closed() -> None:
+    """Issue #290: no rate card means the ceiling cannot be verified - the
+    guarantee refuses rather than silently passing."""
+
+    with raises(ProviderExecutionError) as exc_info:
+        _post_with_ceiling(
+            provider_id="text.local",
+            model_revision="unpriced-rev",
+            execution_id="exec-unpriceable",
+            ceiling=5.0,
+        )
+    assert exc_info.value.category.value == "REQUEST_COST_EXHAUSTED"
+    assert "cannot be verified" in exc_info.value.message
+
+
+def test_gateway_stamps_the_cost_ceiling_from_requirements() -> None:
+    from app.contracts.capability_requirements import CapabilityRequirements
+    from app.services.provider_gateway import _apply_cost_ceiling
+    from tests.unit.test_provider_gateway import _request
+
+    stamped = _apply_cost_ceiling(
+        _request(requirements=CapabilityRequirements(max_estimated_cost_usd=0.25))
+    )
+    assert stamped.cost_ceiling_usd == 0.25
+    untouched = _apply_cost_ceiling(_request())
+    assert untouched.cost_ceiling_usd is None

--- a/tests/unit/test_ordered_fallback_routing.py
+++ b/tests/unit/test_ordered_fallback_routing.py
@@ -782,10 +782,13 @@ def test_an_assessed_candidate_serves_while_the_unassessed_one_is_rejected(
     assert decision.candidates[0].rejection_reason is ProviderFailureCategory.CAPABILITY_UNKNOWN
     assert decision.selected_provider_id == ALTERNATE
     assert decision.fallback_path == []
-    # The decision names what it held and what it did not: the cost ceiling
-    # has no pre-execution bound yet, and saying so is the contract.
-    assert decision.requirements_enforced_dimensions == ["structured_output_required"]
-    assert decision.requirements_unenforced_dimensions == ["max_estimated_cost_usd"]
+    # The decision names what it holds: the cost ceiling is enforced by
+    # pre-attempt admission over the durable attempt debits (issue #290).
+    assert decision.requirements_enforced_dimensions == [
+        "max_estimated_cost_usd",
+        "structured_output_required",
+    ]
+    assert decision.requirements_unenforced_dimensions == []
 
 
 def test_a_declared_latency_ceiling_tightens_the_execution_timeout(

--- a/tests/unit/test_sqlalchemy_provider_operations_repository.py
+++ b/tests/unit/test_sqlalchemy_provider_operations_repository.py
@@ -192,6 +192,11 @@ def test_sqlalchemy_attempt_debits_are_idempotent_and_transactional(
     assert rows[0].basis == "CONSERVATIVE_ESTIMATE"
     assert rows[0].input_tokens == 200
 
+    # Execution-scoped consumption (issue #290): the sum answers the cost
+    # ceiling's admission question from the same durable rows.
+    assert repository.sum_attempt_debits(debit_id_prefix="adbt:exec-sql:") == 0.01736
+    assert repository.sum_attempt_debits(debit_id_prefix="adbt:exec-other:") == 0.0
+
     assert repository.delete_attempt_debits([]) == 0
     assert repository.delete_attempt_debits(["adbt:exec-sql:text.openai:0", "missing"]) == 1
     assert repository.list_attempt_debits(limit=10) == []


### PR DESCRIPTION
Closes #290: **`max_estimated_cost_usd` graduates from recorded preference to hard requirement** — one execution cost budget across every retry and fallback candidate, on the latency budget's exact design: one declared ceiling, one remaining budget, every later attempt consumes from it.

## The design, mirrored from latency

`_apply_cost_ceiling` stamps the ceiling once at gateway entry (beside `_apply_latency_ceiling`); the transport's loop-top admission — the same place the deadline check lives — verifies before each attempt starts that the remaining ceiling supports that attempt **at its conservative bound** (input estimate + `max_output_tokens` ceiling) **under the candidate's own rate card**. Consumption is the durable #289 attempt debits (`sum_attempt_debits` over the execution's identity prefix — admission and accounting share one number), so the budget survives retries, crosses fallback candidates, and is never reset.

## Bounded refusal semantics

- `REQUEST_COST_EXHAUSTED` is a new category, deliberately distinct from `BUDGET_EXCEEDED`: the caller's declared ceiling ran out, not the platform envelope. A refused attempt bills nothing and never connects.
- It joins `_FALLBACK_TRIGGER_CATEGORIES` — unlike deadline exhaustion (time is global), a cost refusal of THIS candidate does not refuse the execution: the alternate's own admission prices under the alternate's rate card, so **a cheaper fallback fits where the primary would not** (proven with a per-revision rate card in test).
- **Fail-closed on unpriceable candidates**: a declared hard ceiling with no effective rate card refuses with an explicit "cannot be verified" message — the CAPABILITY_UNKNOWN precedent; an unverifiable guarantee never silently passes.
- `max_estimated_cost_usd` moves into `ENFORCED_REQUIREMENT_DIMENSIONS`: routing decisions now claim it enforced (the #244 honesty split flips, assertions strengthened).

## The acceptance, executed

- First attempt's conservative debit consumes most of a small ceiling → the retry is refused **pre-connect** (urlopen called exactly once), nothing billed for the refused attempt.
- Shared-ceiling fallback: primary refused outright under the default card; the alternate under a cheap `MODEL_REVISION` card fits, serves, and its debit carries the alternate's `rate_card_ref`.
- Never reset: consumption is read from the execution's durable debit rows on every admission (SQL prefix-sum + memory adapter both proven).
- Unpriceable + declared ceiling → fails closed with the bounded category.
- Gateway stamp pinned (requirements → `cost_ceiling_usd`; absent requirements → untouched).

## Boundaries kept

No weighted ranking, no optimizer, no cost-based candidate ordering — the candidate order stays the governed policy order; cost only admits or refuses. Runbook's Provider Billing Truth bullet flips from "remains unenforced" to the ceiling semantics. Gated on #289 (merged): the ceiling consumes from the same durable rows that close the all-fail and crash gaps.
