### PR TITLE
feat(evals): fixture families declare the capability dimensions they prove (#312 S1)

### DIFF
--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -78,6 +78,15 @@ class EvaluationFixtureDescriptor(BaseModel):
         default=0,
         description="Number of concrete fixture cases currently staged for the family.",
     )
+    proves_capability_dimensions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "The governed capability dimensions a PASS over this family is evidence "
+            "for (issue #312) - drawn from the same vocabulary routing enforces. A "
+            "family that declares nothing proves nothing: one successful general "
+            "eval never becomes evidence for every capability."
+        ),
+    )
 
 
 class EvaluationFixtureCaseDescriptor(BaseModel):

--- a/src/app/evals/fixture_manifest.py
+++ b/src/app/evals/fixture_manifest.py
@@ -11,6 +11,7 @@ from app.contracts.evals import (
     EvaluationFixtureCaseDescriptor,
     EvaluationFixtureDescriptor,
 )
+from app.contracts.model_catalogue import DEGRADABLE_CAPABILITY_DIMENSIONS
 
 
 class EvaluationFixtureManifest:
@@ -80,6 +81,7 @@ def load_evaluation_fixture_manifest() -> EvaluationFixtureManifest:
                     repo_root=repo_root,
                     manifest_path=item.get("manifest_path"),
                 ),
+                proves_capability_dimensions=list(item.get("proves_capability_dimensions", [])),
             )
             for item in payload["fixture_families"]
         ],
@@ -239,6 +241,37 @@ def _validate_fixture_families(*, repo_root: Path, fixture_families: Any) -> Non
                 f"Duplicate fixture family id '{fixture_id}' in evaluation fixture manifest."
             )
         fixture_ids.add(fixture_id)
+
+        proven = item.get("proves_capability_dimensions")
+        if proven is not None:
+            # Capability-scoped eval evidence (issue #312): a family may
+            # declare which governed capability dimensions a PASS over it
+            # proves. The vocabulary is exactly the set routing enforces -
+            # one authority, so an eval can never claim a dimension no
+            # routing decision consults. Unknown names fail the gate closed.
+            if not isinstance(proven, list):
+                raise EvaluationFixtureManifestValidationError(
+                    f"Fixture family '{fixture_id}' proves_capability_dimensions must be a list."
+                )
+            seen_dimensions: set[str] = set()
+            for dimension in proven:
+                if not isinstance(dimension, str) or not dimension.strip():
+                    raise EvaluationFixtureManifestValidationError(
+                        f"Fixture family '{fixture_id}' proves_capability_dimensions entries "
+                        "must be non-empty strings."
+                    )
+                if dimension not in DEGRADABLE_CAPABILITY_DIMENSIONS:
+                    raise EvaluationFixtureManifestValidationError(
+                        f"Fixture family '{fixture_id}' declares unknown capability "
+                        f"dimension '{dimension}'; governed dimensions are "
+                        f"{sorted(DEGRADABLE_CAPABILITY_DIMENSIONS)}."
+                    )
+                if dimension in seen_dimensions:
+                    raise EvaluationFixtureManifestValidationError(
+                        f"Fixture family '{fixture_id}' declares capability dimension "
+                        f"'{dimension}' more than once."
+                    )
+                seen_dimensions.add(dimension)
 
         status = EvaluationAssetStatus(item["status"])
         manifest_path = item.get("manifest_path")

--- a/tests/unit/test_eval_fixture_manifest.py
+++ b/tests/unit/test_eval_fixture_manifest.py
@@ -603,3 +603,73 @@ def test_load_evaluation_fixture_family_rejects_non_list_case_payload(tmp_path: 
             match="non-list cases payload",
         ):
             load_evaluation_fixture_family(fixture_id="bad_fixture")
+
+
+def _capability_manifest(proves: object) -> dict[str, object]:
+    return {
+        "manifest_version": "foundation.v1",
+        "evidence_categories": [
+            {"category_id": "task_contract", "description": "Bounded task contract evidence."}
+        ],
+        "fixture_families": [
+            {
+                "fixture_id": "explanation_task_examples",
+                "status": "STAGED",
+                "description": "Golden examples for explanation-oriented tasks.",
+                "manifest_path": "docs/evals/fixtures/explain.v1/basic_cases.json",
+                "proves_capability_dimensions": proves,
+            }
+        ],
+    }
+
+
+def test_a_family_may_declare_governed_capability_dimensions() -> None:
+    """Issue #312 S1: the declaration vocabulary is exactly the capability
+    dimensions routing enforces - one authority, no parallel list."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    validate_evaluation_fixture_manifest(
+        repo_root=repo_root,
+        manifest_payload=_capability_manifest(["supports_structured_output"]),
+    )
+
+
+def test_an_unknown_capability_dimension_fails_the_manifest_gate_closed() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    with pytest.raises(
+        EvaluationFixtureManifestValidationError, match="unknown capability dimension"
+    ):
+        validate_evaluation_fixture_manifest(
+            repo_root=repo_root,
+            manifest_payload=_capability_manifest(["supports_time_travel"]),
+        )
+
+
+def test_malformed_capability_declarations_fail_the_manifest_gate_closed() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    with pytest.raises(EvaluationFixtureManifestValidationError, match="must be a list"):
+        validate_evaluation_fixture_manifest(
+            repo_root=repo_root,
+            manifest_payload=_capability_manifest("supports_structured_output"),
+        )
+    with pytest.raises(EvaluationFixtureManifestValidationError, match="non-empty strings"):
+        validate_evaluation_fixture_manifest(
+            repo_root=repo_root,
+            manifest_payload=_capability_manifest(["  "]),
+        )
+    with pytest.raises(EvaluationFixtureManifestValidationError, match="more than once"):
+        validate_evaluation_fixture_manifest(
+            repo_root=repo_root,
+            manifest_payload=_capability_manifest(
+                ["supports_structured_output", "supports_structured_output"]
+            ),
+        )
+
+
+def test_undeclared_families_prove_no_capability_dimensions() -> None:
+    """A family that declares nothing proves nothing - the shipped manifest
+    stays honest: none of its families were designed as capability proofs,
+    so every loaded family carries an empty proof scope."""
+
+    manifest = load_evaluation_fixture_manifest()
+    assert all(fixture.proves_capability_dimensions == [] for fixture in manifest.fixture_families)


### PR DESCRIPTION
First slice of #312 (the 2026-09-04 steering's selected next programme): **eval fixture families can declare which governed capability dimensions they prove — with fail-closed defaults, so nothing changes until a fixture is deliberately built as a capability proof.**

## What lands

- `EvaluationFixtureDescriptor.proves_capability_dimensions`: the capability dimensions a PASS over the family is evidence for. The vocabulary is **exactly** the set routing enforces (`DEGRADABLE_CAPABILITY_DIMENSIONS` — `supports_structured_output`, `supports_tool_calling`): one authority, no parallel list, so an eval can never claim a dimension no routing decision consults.
- The eval-manifest gate validates declarations fail-closed: unknown dimension names, non-list shapes, blank entries and duplicates all fail the gate.
- **A family that declares nothing proves nothing.** The shipped manifest deliberately declares nothing on any family — none of the 19 were designed as capability proofs, and a pinned test keeps that honesty explicit until a fixture is reviewed and declared.

## What deliberately does NOT land yet

- S2: a PASS run's proven dimensions (union of its executed families' declarations) on the run evidence surface.
- S3: promotion evidence recording the proven scope on the governed action and catalogue evidence.
- No auto-promotion, no ranking — unchanged and excluded.

## Evidence

Declaration accepted for a governed dimension; unknown dimension fails the manifest gate closed; malformed shapes (non-list, blank, duplicate) each fail closed; every shipped family loads with an empty proof scope; the gate passes on the current manifest (19 families, 46 staged cases); OpenAPI gate, lint, mypy green.
