### PR TITLE
feat(evals): scope-aware capability proofs and served-candidate capture (#312 S2)

### DIFF
--- a/alembic/versions/0072_case_result_candidate_reference.py
+++ b/alembic/versions/0072_case_result_candidate_reference.py
@@ -1,0 +1,33 @@
+"""case result candidate reference
+
+Revision ID: 0072_case_result_candidate_reference
+Revises: 0071_debit_canonical_reference
+Create Date: 2026-09-05
+
+Issue #312: evaluation case results capture the served candidate's
+canonical identity so capability evidence can bind the exact candidate and
+revision it proves. Historical rows stay honestly null - unknown serving
+identity yields no evidence.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0072_case_result_candidate_reference"
+down_revision = "0071_debit_canonical_reference"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "evaluation_case_results",
+        sa.Column("candidate_id_v2", sa.String(length=80), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("evaluation_case_results", "candidate_id_v2")

--- a/scripts/check_module_budget.py
+++ b/scripts/check_module_budget.py
@@ -28,7 +28,7 @@ DEFAULT_MAX_LINES = 1000
 # Dated ceilings for modules that were already oversized when the budget
 # landed (2026-09-01). These may only shrink - see the module docstring.
 OVERSIZED_ALLOWLIST: dict[str, int] = {
-    "services/eval_runtime_execution.py": 1471,
+    "services/eval_runtime_execution.py": 1470,
     "services/workflow_pack_registry_seed.py": 1365,
     "routers/workflow_packs.py": 1250,
 }

--- a/src/app/contracts/evals.py
+++ b/src/app/contracts/evals.py
@@ -64,6 +64,33 @@ class EvaluationEvidenceCategoryDescriptor(BaseModel):
     description: str = Field(description="Human-readable description of the evidence category.")
 
 
+class CapabilityEvidenceScopeType(str, Enum):
+    GLOBAL = "GLOBAL"
+    OUTPUT_CONTRACT = "OUTPUT_CONTRACT"
+
+
+class CapabilityProofDeclaration(BaseModel):
+    """One capability claim a PASS over a fixture family is evidence for
+    (issue #312), at exactly the scope the fixtures exercise.
+
+    A genuinely global claim declares GLOBAL scope with no key; a
+    workload-specific claim (e.g. structured output for ONE approved output
+    contract) declares its scope type and key, and never widens into a
+    universal statement. The dimension vocabulary is exactly the set
+    routing enforces.
+    """
+
+    dimension: str = Field(min_length=1, description="Governed capability dimension proven.")
+    scope_type: CapabilityEvidenceScopeType = Field(description="How broad the proof honestly is.")
+    scope_key: str | None = Field(
+        default=None,
+        description=(
+            "The exact scope exercised (e.g. the output-contract key); required for "
+            "every non-GLOBAL scope type and forbidden for GLOBAL."
+        ),
+    )
+
+
 class EvaluationFixtureDescriptor(BaseModel):
     fixture_id: str = Field(description="Stable evaluation fixture family identifier.")
     status: EvaluationAssetStatus = Field(
@@ -78,13 +105,13 @@ class EvaluationFixtureDescriptor(BaseModel):
         default=0,
         description="Number of concrete fixture cases currently staged for the family.",
     )
-    proves_capability_dimensions: list[str] = Field(
+    proves: list[CapabilityProofDeclaration] = Field(
         default_factory=list,
         description=(
-            "The governed capability dimensions a PASS over this family is evidence "
-            "for (issue #312) - drawn from the same vocabulary routing enforces. A "
-            "family that declares nothing proves nothing: one successful general "
-            "eval never becomes evidence for every capability."
+            "The scope-aware capability claims a PASS over this family is evidence "
+            "for (issue #312). A family that declares nothing proves nothing: one "
+            "successful general eval never becomes evidence for every capability, "
+            "and a scoped proof never becomes a global statement."
         ),
     )
 
@@ -258,6 +285,14 @@ class EvaluationCaseResultDescriptor(BaseModel):
     artifact_refs: list[ArtifactDescriptor] = Field(
         default_factory=list,
         description="Governed artifact descriptors attached to the persisted case outcome.",
+    )
+    candidate_id_v2: str | None = Field(
+        default=None,
+        description=(
+            "Canonical identity of the candidate that served this case (issue "
+            "#312); null when the serving candidate could not be pinned - and "
+            "an unknown candidate yields no capability evidence."
+        ),
     )
     provider_config_sha256: str | None = Field(
         default=None,

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -522,6 +522,8 @@ class EvaluationCaseResultModel(Base):
     artifact_ids: Mapped[list[str]] = mapped_column(JSON, nullable=False)
     provider_config_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
     recorded_at: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # Served candidate's canonical identity (issue #312); null = unknown.
+    candidate_id_v2: Mapped[str | None] = mapped_column(String(80), nullable=True)
 
     run: Mapped["EvaluationRunModel"] = relationship(back_populates="case_results")
 

--- a/src/app/evals/fixture_manifest.py
+++ b/src/app/evals/fixture_manifest.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any, cast
 
 from app.contracts.evals import (
+    CapabilityEvidenceScopeType,
+    CapabilityProofDeclaration,
     EvaluationAssetStatus,
     EvaluationEvidenceCategoryDescriptor,
     EvaluationFixtureCaseDescriptor,
@@ -81,7 +83,7 @@ def load_evaluation_fixture_manifest() -> EvaluationFixtureManifest:
                     repo_root=repo_root,
                     manifest_path=item.get("manifest_path"),
                 ),
-                proves_capability_dimensions=list(item.get("proves_capability_dimensions", [])),
+                proves=_parse_capability_proofs(item.get("proves")),
             )
             for item in payload["fixture_families"]
         ],
@@ -242,36 +244,7 @@ def _validate_fixture_families(*, repo_root: Path, fixture_families: Any) -> Non
             )
         fixture_ids.add(fixture_id)
 
-        proven = item.get("proves_capability_dimensions")
-        if proven is not None:
-            # Capability-scoped eval evidence (issue #312): a family may
-            # declare which governed capability dimensions a PASS over it
-            # proves. The vocabulary is exactly the set routing enforces -
-            # one authority, so an eval can never claim a dimension no
-            # routing decision consults. Unknown names fail the gate closed.
-            if not isinstance(proven, list):
-                raise EvaluationFixtureManifestValidationError(
-                    f"Fixture family '{fixture_id}' proves_capability_dimensions must be a list."
-                )
-            seen_dimensions: set[str] = set()
-            for dimension in proven:
-                if not isinstance(dimension, str) or not dimension.strip():
-                    raise EvaluationFixtureManifestValidationError(
-                        f"Fixture family '{fixture_id}' proves_capability_dimensions entries "
-                        "must be non-empty strings."
-                    )
-                if dimension not in DEGRADABLE_CAPABILITY_DIMENSIONS:
-                    raise EvaluationFixtureManifestValidationError(
-                        f"Fixture family '{fixture_id}' declares unknown capability "
-                        f"dimension '{dimension}'; governed dimensions are "
-                        f"{sorted(DEGRADABLE_CAPABILITY_DIMENSIONS)}."
-                    )
-                if dimension in seen_dimensions:
-                    raise EvaluationFixtureManifestValidationError(
-                        f"Fixture family '{fixture_id}' declares capability dimension "
-                        f"'{dimension}' more than once."
-                    )
-                seen_dimensions.add(dimension)
+        _validate_capability_proofs(fixture_id=fixture_id, proves=item.get("proves"))
 
         status = EvaluationAssetStatus(item["status"])
         manifest_path = item.get("manifest_path")
@@ -346,3 +319,70 @@ def _require_non_empty_string(value: Any, *, field_name: str) -> None:
         raise EvaluationFixtureManifestValidationError(
             f"Evaluation fixture manifest field '{field_name}' must be a non-empty string."
         )
+
+
+def _parse_capability_proofs(raw: object) -> list[CapabilityProofDeclaration]:
+    if raw is None:
+        return []
+    assert isinstance(raw, list)
+    return [CapabilityProofDeclaration.model_validate(entry) for entry in raw]
+
+
+def _validate_capability_proofs(*, fixture_id: str, proves: object) -> None:
+    """Scope-aware proof declarations, validated fail-closed (issue #312).
+
+    The dimension vocabulary is exactly the set routing enforces - one
+    authority, so an eval can never claim a dimension no routing decision
+    consults. The scope shape is part of the claim: a non-GLOBAL scope
+    requires its key (which scope was actually exercised), and a GLOBAL
+    claim must not smuggle one.
+    """
+
+    if proves is None:
+        return
+    if not isinstance(proves, list):
+        raise EvaluationFixtureManifestValidationError(
+            f"Fixture family '{fixture_id}' proves must be a list."
+        )
+    seen: set[tuple[str, str, str | None]] = set()
+    for entry in proves:
+        if not isinstance(entry, dict):
+            raise EvaluationFixtureManifestValidationError(
+                f"Fixture family '{fixture_id}' proves entries must be objects."
+            )
+        dimension = entry.get("dimension")
+        if not isinstance(dimension, str) or not dimension.strip():
+            raise EvaluationFixtureManifestValidationError(
+                f"Fixture family '{fixture_id}' proves entries require a non-empty 'dimension'."
+            )
+        if dimension not in DEGRADABLE_CAPABILITY_DIMENSIONS:
+            raise EvaluationFixtureManifestValidationError(
+                f"Fixture family '{fixture_id}' declares unknown capability "
+                f"dimension '{dimension}'; governed dimensions are "
+                f"{sorted(DEGRADABLE_CAPABILITY_DIMENSIONS)}."
+            )
+        scope_type = entry.get("scope_type")
+        valid_scopes = {scope.value for scope in CapabilityEvidenceScopeType}
+        if scope_type not in valid_scopes:
+            raise EvaluationFixtureManifestValidationError(
+                f"Fixture family '{fixture_id}' proves entries require scope_type in "
+                f"{sorted(valid_scopes)}."
+            )
+        scope_key = entry.get("scope_key")
+        if scope_type == CapabilityEvidenceScopeType.GLOBAL.value:
+            if scope_key is not None:
+                raise EvaluationFixtureManifestValidationError(
+                    f"Fixture family '{fixture_id}' declares a GLOBAL proof with a "
+                    "scope_key; a global claim must not smuggle a scope."
+                )
+        elif not isinstance(scope_key, str) or not scope_key.strip():
+            raise EvaluationFixtureManifestValidationError(
+                f"Fixture family '{fixture_id}' declares a {scope_type} proof without "
+                "its scope_key; a scoped claim must name the exact scope exercised."
+            )
+        marker = (dimension, str(scope_type), scope_key)
+        if marker in seen:
+            raise EvaluationFixtureManifestValidationError(
+                f"Fixture family '{fixture_id}' declares the same proof more than once."
+            )
+        seen.add(marker)

--- a/src/app/repositories/evaluation_runtime_repository.py
+++ b/src/app/repositories/evaluation_runtime_repository.py
@@ -47,6 +47,11 @@ class EvaluationCaseResultRecord:
     artifact_ids: list[str]
     provider_config_sha256: str | None
     recorded_at: str
+    # The served candidate's canonical identity (issue #312): captured only
+    # when the case's fixed-strategy configuration names one complete
+    # candidate (configured == served); None means unknown, and unknown
+    # yields no capability evidence.
+    candidate_id_v2: str | None = None
 
 
 class EvaluationRuntimeRepository(Protocol):

--- a/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
+++ b/src/app/repositories/sqlalchemy_evaluation_runtime_repository.py
@@ -149,6 +149,7 @@ class SqlAlchemyEvaluationRuntimeRepository(SqlAlchemyRepositoryBase, Evaluation
             evidence_refs=record.evidence_refs,
             artifact_ids=record.artifact_ids,
             provider_config_sha256=record.provider_config_sha256,
+            candidate_id_v2=record.candidate_id_v2,
             recorded_at=record.recorded_at,
         )
         with self._session_factory() as session:
@@ -197,6 +198,7 @@ class SqlAlchemyEvaluationRuntimeRepository(SqlAlchemyRepositoryBase, Evaluation
             evidence_refs=list(model.evidence_refs),
             artifact_ids=list(model.artifact_ids),
             provider_config_sha256=model.provider_config_sha256,
+            candidate_id_v2=model.candidate_id_v2,
             recorded_at=model.recorded_at,
         )
 

--- a/src/app/services/eval_run_service.py
+++ b/src/app/services/eval_run_service.py
@@ -151,5 +151,6 @@ def _map_runtime_case_result(record: EvaluationCaseResultRecord) -> EvaluationCa
         evidence_refs=record.evidence_refs,
         artifact_refs=load_artifact_descriptors(artifact_ids=record.artifact_ids),
         provider_config_sha256=record.provider_config_sha256,
+        candidate_id_v2=record.candidate_id_v2,
         recorded_at=record.recorded_at,
     )

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -45,17 +45,12 @@ from app.services.artifact_payloads import persist_json_artifact
 from app.services.embedding_live_execution_state import build_embedding_live_execution_state
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 from app.services.prompt_rollout_models import PromptRolloutEventRecord, PromptRolloutStateRecord
-from app.services.local_openai_compatible_endpoint_probe import (
-    LocalOpenAICompatibleEndpointStatus,
-)
-from app.services.prompt_store import get_prompt_repository
-from app.services.prompt_store import reset_prompt_store_cache
+from app.services.local_openai_compatible_endpoint_probe import LocalOpenAICompatibleEndpointStatus
+from app.services.prompt_store import get_prompt_repository, reset_prompt_store_cache
 from app.services.provider_budget_policy import build_provider_budget_policy
 from app.contracts.rate_cards import RateCard, RateCardScopeKind
 from app.services.provider_usage_accounting import save_rate_card
-from app.services.rate_card_store import (
-    reset_rate_card_store_cache,
-)
+from app.services.rate_card_store import reset_rate_card_store_cache
 from app.services.runtime_mode_config import (
     override_runtime_mode_config,
     resolve_runtime_mode_config,
@@ -64,6 +59,7 @@ from app.services.provider_execution_config import (
     compute_provider_config_sha256,
     override_provider_execution_config,
     resolve_provider_execution_config,
+    served_candidate_identity,
 )
 from app.services.provider_execution_overrides import (
     hermetic_provider_execution,
@@ -238,6 +234,7 @@ def _evaluate_case(
             seed=case_provider_config.seed,
             max_output_tokens=case_provider_config.max_output_tokens,
         )
+        candidate_id_v2 = served_candidate_identity(case_provider_config)
         summary, outcome, evidence_refs = _execute_fixture_case(
             fixture_id=run.fixture_id,
             fixture_task_id=fixture_task_id,
@@ -261,6 +258,7 @@ def _evaluate_case(
                 "summary": summary,
                 "evidence_refs": evidence_refs,
                 "provider_config_sha256": provider_config_sha256,
+                "candidate_id_v2": candidate_id_v2,
             },
             sort_keys=True,
         ).encode("utf-8"),
@@ -277,6 +275,7 @@ def _evaluate_case(
         artifact_ids=[artifact.artifact_id],
         provider_config_sha256=provider_config_sha256,
         recorded_at=_utcnow_iso(),
+        candidate_id_v2=candidate_id_v2,
     )
 
 

--- a/src/app/services/provider_execution_config.py
+++ b/src/app/services/provider_execution_config.py
@@ -29,6 +29,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 
 from app.config import settings
+from app.contracts.model_catalogue import derive_candidate_identity_v2
 
 
 @dataclass(frozen=True)
@@ -290,3 +291,26 @@ def compute_provider_config_sha256(
         separators=(",", ":"),
     )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def served_candidate_identity(config: ProviderExecutionConfig) -> str | None:
+    """The canonical identity of the candidate an eval case is served by,
+    or None when it cannot be pinned (issue #312).
+
+    Under the fixed strategy the configured candidate IS the serving
+    candidate, so the identity is exact. Under ordered fallback the server
+    may differ from the configured primary, and a config without a complete
+    model identity names no candidate at all - both are honestly unknown,
+    and an unknown serving candidate yields no capability evidence.
+    """
+
+    if config.routing_strategy != "fixed":
+        return None
+    if not (config.provider_id and config.model_id):
+        return None
+    return derive_candidate_identity_v2(
+        provider_id=config.provider_id,
+        model_family=config.model_id,
+        model_revision=config.model_version or config.model_id,
+        deployment=config.deployment,
+    )

--- a/tests/unit/test_eval_async_execution.py
+++ b/tests/unit/test_eval_async_execution.py
@@ -312,3 +312,33 @@ def test_run_next_evaluation_execution_job_fails_unsupported_claim() -> None:
     assert result is None
     fail_async_job.assert_called_once()
     assert fail_async_job.call_args.kwargs["failure_reason"] == "UNSUPPORTED_ASYNC_JOB_TYPE"
+
+
+def test_served_candidate_identity_is_exact_or_honestly_unknown() -> None:
+    """Issue #312 S2: capability evidence may only bind a candidate the case
+    provably served - the fixed strategy pins it exactly; ordered fallback
+    and incomplete identities are unknown and yield no evidence."""
+
+    from dataclasses import replace
+
+    from app.contracts.model_catalogue import derive_candidate_identity_v2
+    from app.services.provider_execution_config import (
+        resolve_provider_execution_config,
+        served_candidate_identity,
+    )
+
+    settings.provider_mode = "openai"
+    settings.live_text_provider_id = "text.openai"
+    settings.live_text_model_id = "gpt-5.4"
+    settings.live_text_model_version = "gpt-5.4-2026-06-01"
+    settings.routing_strategy = "fixed"
+    fixed = resolve_provider_execution_config()
+    assert served_candidate_identity(fixed) == derive_candidate_identity_v2(
+        provider_id="text.openai",
+        model_family="gpt-5.4",
+        model_revision="gpt-5.4-2026-06-01",
+        deployment=None,
+    )
+
+    assert served_candidate_identity(replace(fixed, routing_strategy="ordered_fallback")) is None
+    assert served_candidate_identity(replace(fixed, model_id=None)) is None

--- a/tests/unit/test_eval_fixture_manifest.py
+++ b/tests/unit/test_eval_fixture_manifest.py
@@ -617,59 +617,74 @@ def _capability_manifest(proves: object) -> dict[str, object]:
                 "status": "STAGED",
                 "description": "Golden examples for explanation-oriented tasks.",
                 "manifest_path": "docs/evals/fixtures/explain.v1/basic_cases.json",
-                "proves_capability_dimensions": proves,
+                "proves": proves,
             }
         ],
     }
 
 
-def test_a_family_may_declare_governed_capability_dimensions() -> None:
-    """Issue #312 S1: the declaration vocabulary is exactly the capability
-    dimensions routing enforces - one authority, no parallel list."""
+def test_a_family_may_declare_scope_aware_capability_proofs() -> None:
+    """Issue #312 S2: a proof is a claim at an exact scope - global where
+    genuinely global, keyed where the fixtures exercise one scope - drawn
+    from the same dimension vocabulary routing enforces."""
 
     repo_root = Path(__file__).resolve().parents[2]
     validate_evaluation_fixture_manifest(
         repo_root=repo_root,
-        manifest_payload=_capability_manifest(["supports_structured_output"]),
+        manifest_payload=_capability_manifest(
+            [
+                {"dimension": "supports_tool_calling", "scope_type": "GLOBAL"},
+                {
+                    "dimension": "supports_structured_output",
+                    "scope_type": "OUTPUT_CONTRACT",
+                    "scope_key": "advisor_brief.pack",
+                },
+            ]
+        ),
     )
 
 
-def test_an_unknown_capability_dimension_fails_the_manifest_gate_closed() -> None:
+def test_malformed_capability_proofs_fail_the_manifest_gate_closed() -> None:
     repo_root = Path(__file__).resolve().parents[2]
-    with pytest.raises(
-        EvaluationFixtureManifestValidationError, match="unknown capability dimension"
-    ):
-        validate_evaluation_fixture_manifest(
-            repo_root=repo_root,
-            manifest_payload=_capability_manifest(["supports_time_travel"]),
-        )
+    cases = [
+        ([{"dimension": "supports_time_travel", "scope_type": "GLOBAL"}], "unknown capability"),
+        ([{"dimension": "supports_tool_calling", "scope_type": "REGIONAL"}], "scope_type in"),
+        (
+            [{"dimension": "supports_structured_output", "scope_type": "OUTPUT_CONTRACT"}],
+            "without its scope_key",
+        ),
+        (
+            [
+                {
+                    "dimension": "supports_tool_calling",
+                    "scope_type": "GLOBAL",
+                    "scope_key": "sneaky",
+                }
+            ],
+            "must not smuggle",
+        ),
+        ("supports_structured_output", "must be a list"),
+        ([{"dimension": "  ", "scope_type": "GLOBAL"}], "non-empty 'dimension'"),
+        (
+            [
+                {"dimension": "supports_tool_calling", "scope_type": "GLOBAL"},
+                {"dimension": "supports_tool_calling", "scope_type": "GLOBAL"},
+            ],
+            "more than once",
+        ),
+    ]
+    for proves, match in cases:
+        with pytest.raises(EvaluationFixtureManifestValidationError, match=match):
+            validate_evaluation_fixture_manifest(
+                repo_root=repo_root,
+                manifest_payload=_capability_manifest(proves),
+            )
 
 
-def test_malformed_capability_declarations_fail_the_manifest_gate_closed() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    with pytest.raises(EvaluationFixtureManifestValidationError, match="must be a list"):
-        validate_evaluation_fixture_manifest(
-            repo_root=repo_root,
-            manifest_payload=_capability_manifest("supports_structured_output"),
-        )
-    with pytest.raises(EvaluationFixtureManifestValidationError, match="non-empty strings"):
-        validate_evaluation_fixture_manifest(
-            repo_root=repo_root,
-            manifest_payload=_capability_manifest(["  "]),
-        )
-    with pytest.raises(EvaluationFixtureManifestValidationError, match="more than once"):
-        validate_evaluation_fixture_manifest(
-            repo_root=repo_root,
-            manifest_payload=_capability_manifest(
-                ["supports_structured_output", "supports_structured_output"]
-            ),
-        )
-
-
-def test_undeclared_families_prove_no_capability_dimensions() -> None:
+def test_undeclared_families_prove_nothing() -> None:
     """A family that declares nothing proves nothing - the shipped manifest
     stays honest: none of its families were designed as capability proofs,
-    so every loaded family carries an empty proof scope."""
+    so every loaded family carries an empty proof list."""
 
     manifest = load_evaluation_fixture_manifest()
-    assert all(fixture.proves_capability_dimensions == [] for fixture in manifest.fixture_families)
+    assert all(fixture.proves == [] for fixture in manifest.fixture_families)

--- a/tests/unit/test_memory_evaluation_runtime_repository.py
+++ b/tests/unit/test_memory_evaluation_runtime_repository.py
@@ -50,6 +50,7 @@ def test_memory_evaluation_runtime_repository_round_trip() -> None:
             evidence_refs=["evidence://retrieval.answer.case_001"],
             artifact_ids=[],
             provider_config_sha256="d" * 64,
+            candidate_id_v2="cand2_" + "a" * 64,
             recorded_at="2026-03-23T00:05:00Z",
         )
     )

--- a/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
+++ b/tests/unit/test_sqlalchemy_evaluation_runtime_repository.py
@@ -58,6 +58,7 @@ def test_sqlalchemy_evaluation_runtime_repository_round_trip(tmp_path: Path) -> 
             evidence_refs=["evidence://retrieval.answer.case_001"],
             artifact_ids=[],
             provider_config_sha256="d" * 64,
+            candidate_id_v2="cand2_" + "a" * 64,
             recorded_at="2026-03-23T00:05:00Z",
         )
     )
@@ -72,6 +73,8 @@ def test_sqlalchemy_evaluation_runtime_repository_round_trip(tmp_path: Path) -> 
     assert attempts[0].attempt_id == "evalrun_001_attempt_001"
     assert len(results) == 1
     assert results[0].case_id == "retrieval.answer.case_001"
+    # The served candidate's canonical reference round-trips (issue #312).
+    assert results[0].candidate_id_v2 == "cand2_" + "a" * 64
 
 
 def test_sqlalchemy_evaluation_runtime_repository_returns_empty_results_for_unknown_records(


### PR DESCRIPTION
Second slice of #312 (scope-aware, per the canonical-identity steering): **fixture families declare capability proofs at exactly the scope they exercise, and eval case results pin the served candidate's canonical identity — or honestly don't.**

## What lands

- **Scope-aware proof declarations**: `proves: [{dimension, scope_type: GLOBAL | OUTPUT_CONTRACT, scope_key?}]` replaces S1's flat dimension list (which had zero declarations and zero consumers — a clean contract change, no migration). The manifest gate validates fail-closed: dimensions against the exact vocabulary routing enforces, `scope_key` required for every non-GLOBAL scope and **forbidden for GLOBAL** (a global claim must not smuggle a scope), duplicates refused. A family that declares nothing proves nothing, and a scoped proof never becomes a global statement — the shipped manifest deliberately declares nothing, pinned by test.
- **Served-candidate capture** (migration 0072): evaluation case results record `candidate_id_v2` — the canonical identity of the candidate that served the case. The rule is exact-or-unknown (`served_candidate_identity`, homed in `provider_execution_config` beside the config it interprets): under the fixed strategy the configured candidate IS the serving candidate; under ordered fallback the server may differ from the configured primary, and an incomplete identity names no candidate — both record null, **and an unknown serving candidate will yield no capability evidence** in S3. Historical rows stay honestly null. The capture rides the case-result artifact payload, both store adapters, and the run-detail read surface.
- The module-budget ratchet held both ways: the eval runtime module shrank under its allowlisted ceiling (helper moved to its proper home, imports tidied) and the ceiling ratcheted DOWN to the new size.

## What deliberately does NOT land yet (S3)

The authoritative `CapabilityEvidenceRecord` (candidate_id_v2 + revision + dimension + scope + fixture + run + verdict + provenance), written on a COMPLETED PASS only when one candidate served every case, and consumed by eligibility through the existing scoped seam. This slice makes that binding *possible and honest*; nothing consumes declarations yet.

## Evidence

Scope-declaration matrix (governed accepted; unknown dimension, bad scope type, missing key, smuggled GLOBAL key, non-list, blank dimension, duplicate — each fails the gate closed); exact-or-unknown capture proven for fixed / ordered / incomplete configs; canonical reference round-trips both adapters; 381 targeted tests, lint, mypy, OpenAPI gate, migration smoke green; full coverage verdict-gated before push.
