### PR TITLE
feat(evals): authoritative scope-aware capability evidence (#312 S3)

### DIFF
--- a/alembic/versions/0073_capability_evidence_records.py
+++ b/alembic/versions/0073_capability_evidence_records.py
@@ -1,0 +1,44 @@
+"""capability evidence records
+
+Revision ID: 0073_capability_evidence_records
+Revises: 0072_case_result_candidate_reference
+Create Date: 2026-09-05
+
+Issue #312: authoritative scope-aware observed-capability claims. One row
+per declared proof per PASS run, bound to the exact canonical candidate,
+revision, scope, fixture family, manifest version, run and provenance.
+Eligibility consumes matching PASS rows; nothing is ever widened.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0073_capability_evidence_records"
+down_revision = "0072_case_result_candidate_reference"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "capability_evidence_records",
+        sa.Column("evidence_id", sa.String(length=160), primary_key=True),
+        sa.Column("candidate_id_v2", sa.String(length=80), nullable=False, index=True),
+        sa.Column("model_revision", sa.String(length=128), nullable=False),
+        sa.Column("dimension", sa.String(length=64), nullable=False, index=True),
+        sa.Column("scope_type", sa.String(length=32), nullable=False),
+        sa.Column("scope_key", sa.String(length=256), nullable=True),
+        sa.Column("fixture_id", sa.String(length=128), nullable=False),
+        sa.Column("manifest_version", sa.String(length=64), nullable=False),
+        sa.Column("evaluation_run_id", sa.String(length=128), nullable=False, index=True),
+        sa.Column("verdict", sa.String(length=16), nullable=False),
+        sa.Column("triggered_by", sa.String(length=256), nullable=True),
+        sa.Column("recorded_at", sa.String(length=64), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("capability_evidence_records")

--- a/contracts/data-lifecycle/retention-policy.v1.json
+++ b/contracts/data-lifecycle/retention-policy.v1.json
@@ -30,7 +30,8 @@
         "provider_retention_confirmations",
         "audit_access_events",
         "data_lifecycle_events",
-        "provider_attempt_debits"
+        "provider_attempt_debits",
+        "capability_evidence_records"
       ],
       "retention_days": 2555,
       "retention_basis": "Control-plane decision evidence retained seven years; it carries no client-derived content, so no tenant erasure key applies.",

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -430,6 +430,17 @@ Before treating retrieval or provider evaluation evidence as approval-ready:
 5. if replay or retry is required, apply the governed async control action first and then verify a new evaluation attempt appears instead of mutating prior case evidence in place
 6. treat `foundation_eval_*` run artifacts as historical baselines only; they do not satisfy current runtime-backed approval posture by themselves
 
+## Capability Evidence
+
+Observed-capability truth is scope-aware (issue #312) and layered — never one boolean:
+
+- **Declared**: the catalogue entry's assessed facts (provider/configuration assertion).
+- **Observed**: `capability_evidence_records` — one authoritative row per proof a fixture family declares, written only when a COMPLETED PASS run was served entirely by ONE candidate (mixed or unknown serving candidates yield nothing; unknown never upgrades into truth). Each row binds the canonical candidate identity, exact revision, dimension, scope (`GLOBAL`, or `OUTPUT_CONTRACT` with its key), fixture family, manifest version, run, verdict and provenance. Control-plane evidence family, 7-year expiry — expired evidence honestly reverts the claim to unknown.
+- **Certified**: the governed serving promotion (PASS-run evidence hash-bound through the two-step flow) — evidence enables the decision, never makes it; no auto-promotion exists.
+- **Eligibility**: `enforce_capability_requirements` consumes exactly the matching scoped PASS claim for the exact candidate AND revision — structured-output evidence for one approved output contract never becomes a universal statement, a GLOBAL claim serves everywhere, and revision-mismatched, scope-mismatched or absent evidence stays `CAPABILITY_UNKNOWN`.
+
+Fixture families declare proofs in the manifest as `proves: [{dimension, scope_type, scope_key?}]`, validated fail-closed (governed dimension vocabulary; `scope_key` required for non-GLOBAL scopes and forbidden for GLOBAL). A family that declares nothing proves nothing.
+
 ## Governed Actions
 
 One reusable governance pattern covers every high-impact control-plane action; there are no domain-specific approval frameworks. The rule is the **direction of risk**:

--- a/scripts/check_module_budget.py
+++ b/scripts/check_module_budget.py
@@ -28,7 +28,7 @@ DEFAULT_MAX_LINES = 1000
 # Dated ceilings for modules that were already oversized when the budget
 # landed (2026-09-01). These may only shrink - see the module docstring.
 OVERSIZED_ALLOWLIST: dict[str, int] = {
-    "services/eval_runtime_execution.py": 1470,
+    "services/eval_runtime_execution.py": 1131,
     "services/workflow_pack_registry_seed.py": 1365,
     "routers/workflow_packs.py": 1250,
 }

--- a/src/app/contracts/model_catalogue.py
+++ b/src/app/contracts/model_catalogue.py
@@ -263,6 +263,36 @@ class ModelCatalogueEntry(BaseModel):
         return self
 
 
+class CapabilityEvidenceRecord(BaseModel):
+    """One authoritative, scope-aware observed-capability claim (issue #312).
+
+    Binds everything the claim depends on: the exact candidate (canonical
+    identity plus its revision, denormalized for audit honesty), the
+    capability dimension, the exact scope the fixtures exercised, the
+    fixture family and manifest that declared the proof, the evaluation run
+    that produced it, its verdict, and provenance. Evidence ENABLES the
+    governed lifecycle decision - it never makes it - and eligibility
+    consumes only PASS rows whose scope matches the execution at hand.
+    """
+
+    evidence_id: str = Field(min_length=1, description="Stable evidence record identifier.")
+    candidate_id_v2: str = Field(
+        min_length=1, description="Canonical identity of the candidate the run served."
+    )
+    model_revision: str = Field(min_length=1, description="Exact revision the run exercised.")
+    dimension: str = Field(min_length=1, description="Governed capability dimension proven.")
+    scope_type: str = Field(min_length=1, description="CapabilityEvidenceScopeType value.")
+    scope_key: str | None = Field(
+        default=None, description="Exact scope key for non-GLOBAL scope types."
+    )
+    fixture_id: str = Field(min_length=1, description="Fixture family that declared the proof.")
+    manifest_version: str = Field(min_length=1, description="Fixture manifest version at run time.")
+    evaluation_run_id: str = Field(min_length=1, description="The run that produced the claim.")
+    verdict: str = Field(min_length=1, description="The run's verdict (PASS rows are evidence).")
+    triggered_by: str | None = Field(default=None, description="Who triggered the producing run.")
+    recorded_at: str = Field(description="Instant the evidence was recorded (UTC).")
+
+
 class ModelCatalogueSeedReport(BaseModel):
     """Outcome of one idempotent seeding pass."""
 

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -889,6 +889,27 @@ class ModelCatalogueEntryModel(Base):
     )
 
 
+class CapabilityEvidenceModel(Base):
+    """Authoritative scope-aware observed-capability claims (issue #312):
+    one row per declared proof per PASS run, bound to the exact candidate,
+    scope, fixture, run and provenance."""
+
+    __tablename__ = "capability_evidence_records"
+
+    evidence_id: Mapped[str] = mapped_column(String(160), primary_key=True)
+    candidate_id_v2: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    model_revision: Mapped[str] = mapped_column(String(128), nullable=False)
+    dimension: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    scope_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    scope_key: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    fixture_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    manifest_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    evaluation_run_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    verdict: Mapped[str] = mapped_column(String(16), nullable=False)
+    triggered_by: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    recorded_at: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
 class DataLifecycleEventModel(Base):
     """Append-only deletion evidence (issue #158, S2a): what the lifecycle
     engine removed, by family and count, referencing content only by digest."""

--- a/src/app/repositories/memory_model_catalogue_repository.py
+++ b/src/app/repositories/memory_model_catalogue_repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from app.contracts.model_catalogue import (
+    CapabilityEvidenceRecord,
     ServingPolicyVersionRecord,
     ModelCatalogueEntry,
     ModelLifecycleTransitionRecord,
@@ -16,6 +17,7 @@ class InMemoryModelCatalogueRepository:
         self._lifecycle_events: list[ModelLifecycleTransitionRecord] = []
         self._drift_observations: dict[str, ModelRevisionDriftObservation] = {}
         self._serving_policy_versions: dict[int, ServingPolicyVersionRecord] = {}
+        self._capability_evidence: dict[str, CapabilityEvidenceRecord] = {}
 
     def list_entries(self) -> list[ModelCatalogueEntry]:
         return [self._entries[entry_id].model_copy(deep=True) for entry_id in sorted(self._entries)]
@@ -29,6 +31,37 @@ class InMemoryModelCatalogueRepository:
             if entry.candidate_id_v2 == candidate_id_v2:
                 return entry.model_copy(deep=True)
         return None
+
+    def save_capability_evidence(self, record: CapabilityEvidenceRecord) -> None:
+        self._capability_evidence[record.evidence_id] = record.model_copy(deep=True)
+
+    def list_capability_evidence(
+        self, *, candidate_id_v2: str, dimension: str
+    ) -> list[CapabilityEvidenceRecord]:
+        return sorted(
+            (
+                record.model_copy(deep=True)
+                for record in self._capability_evidence.values()
+                if record.candidate_id_v2 == candidate_id_v2 and record.dimension == dimension
+            ),
+            key=lambda record: record.recorded_at,
+            reverse=True,
+        )
+
+    def list_all_capability_evidence(self, *, limit: int) -> list[CapabilityEvidenceRecord]:
+        records = sorted(
+            self._capability_evidence.values(),
+            key=lambda record: record.recorded_at,
+            reverse=True,
+        )
+        return [record.model_copy(deep=True) for record in records[: max(limit, 0)]]
+
+    def delete_capability_evidence(self, evidence_ids: Sequence[str]) -> int:
+        deleted = 0
+        for evidence_id in evidence_ids:
+            if self._capability_evidence.pop(evidence_id, None) is not None:
+                deleted += 1
+        return deleted
 
     def upsert_entry(self, entry: ModelCatalogueEntry) -> None:
         self._entries[entry.entry_id] = _with_verified_canonical_identity(entry)

--- a/src/app/repositories/model_catalogue_repository.py
+++ b/src/app/repositories/model_catalogue_repository.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import Protocol
 
 from app.contracts.model_catalogue import (
+    CapabilityEvidenceRecord,
     ModelCatalogueEntry,
     ModelLifecycleTransitionRecord,
     ModelRevisionDriftObservation,
@@ -18,6 +19,16 @@ class ModelCatalogueRepository(Protocol):
     def get_entry(self, entry_id: str) -> ModelCatalogueEntry | None: ...
 
     def get_entry_by_candidate_id(self, candidate_id_v2: str) -> ModelCatalogueEntry | None: ...
+
+    def save_capability_evidence(self, record: CapabilityEvidenceRecord) -> None: ...
+
+    def list_capability_evidence(
+        self, *, candidate_id_v2: str, dimension: str
+    ) -> list[CapabilityEvidenceRecord]: ...
+
+    def list_all_capability_evidence(self, *, limit: int) -> list[CapabilityEvidenceRecord]: ...
+
+    def delete_capability_evidence(self, evidence_ids: "Sequence[str]") -> int: ...
 
     def upsert_entry(self, entry: ModelCatalogueEntry) -> None: ...
 

--- a/src/app/repositories/sqlalchemy_model_catalogue_repository.py
+++ b/src/app/repositories/sqlalchemy_model_catalogue_repository.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from sqlalchemy import delete, select
 
 from app.contracts.model_catalogue import (
+    CapabilityEvidenceRecord,
     ServingPolicyVersionRecord,
     ModelCapabilityDegradation,
     ModelCatalogueEntry,
@@ -19,6 +20,7 @@ from app.contracts.model_catalogue import (
     ModelRevisionDriftObservation,
 )
 from app.db.models import (
+    CapabilityEvidenceModel,
     ServingPolicyVersionModel,
     ModelCatalogueEntryModel,
     ModelCatalogueLifecycleEventModel,
@@ -313,6 +315,76 @@ class SqlAlchemyModelCatalogueRepository(SqlAlchemyRepositoryBase):
                 )
             )
             session.commit()
+
+    def save_capability_evidence(self, record: CapabilityEvidenceRecord) -> None:
+        with self._session_factory() as session:
+            model = session.get(CapabilityEvidenceModel, record.evidence_id)
+            if model is None:
+                model = CapabilityEvidenceModel(evidence_id=record.evidence_id)
+                session.add(model)
+            model.candidate_id_v2 = record.candidate_id_v2
+            model.model_revision = record.model_revision
+            model.dimension = record.dimension
+            model.scope_type = record.scope_type
+            model.scope_key = record.scope_key
+            model.fixture_id = record.fixture_id
+            model.manifest_version = record.manifest_version
+            model.evaluation_run_id = record.evaluation_run_id
+            model.verdict = record.verdict
+            model.triggered_by = record.triggered_by
+            model.recorded_at = record.recorded_at
+            session.commit()
+
+    def list_capability_evidence(
+        self, *, candidate_id_v2: str, dimension: str
+    ) -> list[CapabilityEvidenceRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(CapabilityEvidenceModel)
+                .where(
+                    CapabilityEvidenceModel.candidate_id_v2 == candidate_id_v2,
+                    CapabilityEvidenceModel.dimension == dimension,
+                )
+                .order_by(CapabilityEvidenceModel.recorded_at.desc())
+            ).all()
+            return [self._to_capability_evidence(model) for model in models]
+
+    def list_all_capability_evidence(self, *, limit: int) -> list[CapabilityEvidenceRecord]:
+        with self._session_factory() as session:
+            models = session.scalars(
+                select(CapabilityEvidenceModel)
+                .order_by(CapabilityEvidenceModel.recorded_at.desc())
+                .limit(max(limit, 0))
+            ).all()
+            return [self._to_capability_evidence(model) for model in models]
+
+    def delete_capability_evidence(self, evidence_ids: Sequence[str]) -> int:
+        if not evidence_ids:
+            return 0
+        with self._session_factory() as session:
+            result = session.execute(
+                delete(CapabilityEvidenceModel).where(
+                    CapabilityEvidenceModel.evidence_id.in_(list(evidence_ids))
+                )
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0)
+
+    def _to_capability_evidence(self, model: CapabilityEvidenceModel) -> CapabilityEvidenceRecord:
+        return CapabilityEvidenceRecord(
+            evidence_id=model.evidence_id,
+            candidate_id_v2=model.candidate_id_v2,
+            model_revision=model.model_revision,
+            dimension=model.dimension,
+            scope_type=model.scope_type,
+            scope_key=model.scope_key,
+            fixture_id=model.fixture_id,
+            manifest_version=model.manifest_version,
+            evaluation_run_id=model.evaluation_run_id,
+            verdict=model.verdict,
+            triggered_by=model.triggered_by,
+            recorded_at=model.recorded_at,
+        )
 
     def list_serving_policy_versions(self, *, limit: int) -> list[ServingPolicyVersionRecord]:
         with self._session_factory() as session:

--- a/src/app/services/capability_evidence.py
+++ b/src/app/services/capability_evidence.py
@@ -1,0 +1,98 @@
+"""Scope-aware observed-capability evidence (issue #312).
+
+The write side records the authoritative claims a PASS evaluation run
+proves - one record per proof its fixture family declares, bound to the
+candidate that served every case. The read side answers eligibility's
+question: does applicable PASS evidence exist for this exact candidate,
+dimension and scope? Evidence ENABLES the governed lifecycle decision; it
+never makes it, and unknown never upgrades into truth.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.contracts.evals import CapabilityEvidenceScopeType, EvaluationRunVerdict
+from app.contracts.model_catalogue import CapabilityEvidenceRecord, ModelCatalogueEntry
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunRecord,
+)
+from app.services.model_catalogue_store import get_model_catalogue_repository
+
+
+def record_capability_evidence_for_pass_run(
+    *, run: EvaluationRunRecord, results: list[EvaluationCaseResultRecord]
+) -> None:
+    """Persist the scope-aware claims a PASS run proves.
+
+    A run whose serving candidate is unknown for any case - or that more
+    than one candidate served - yields no evidence rather than mis-binding.
+    A candidate that vanished from the catalogue binds nothing.
+    """
+
+    from app.evals.fixture_manifest import load_evaluation_fixture_manifest
+
+    manifest = load_evaluation_fixture_manifest()
+    fixture = next((f for f in manifest.fixture_families if f.fixture_id == run.fixture_id), None)
+    if fixture is None or not fixture.proves:
+        return
+    served = {result.candidate_id_v2 for result in results}
+    if len(served) != 1 or None in served:
+        return
+    candidate_id_v2 = next(iter(served))
+    assert candidate_id_v2 is not None
+    repository = get_model_catalogue_repository()
+    entry = repository.get_entry_by_candidate_id(candidate_id_v2)
+    if entry is None:
+        return
+    for proof in fixture.proves:
+        repository.save_capability_evidence(
+            CapabilityEvidenceRecord(
+                evidence_id=(f"capev_{run.run_id}_{proof.dimension}_{proof.scope_key or 'global'}"),
+                candidate_id_v2=candidate_id_v2,
+                model_revision=entry.model_revision,
+                dimension=proof.dimension,
+                scope_type=proof.scope_type.value,
+                scope_key=proof.scope_key,
+                fixture_id=run.fixture_id,
+                manifest_version=run.manifest_version,
+                evaluation_run_id=run.run_id,
+                verdict=EvaluationRunVerdict.PASS.value,
+                triggered_by=run.triggered_by,
+                recorded_at=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            )
+        )
+
+
+def applicable_capability_evidence(
+    *,
+    entry: ModelCatalogueEntry,
+    dimension: str,
+    output_contract_key: str | None,
+) -> CapabilityEvidenceRecord | None:
+    """The observed-evidence answer eligibility consumes (issue #312).
+
+    A PASS record applies when it binds this exact candidate AND revision,
+    at GLOBAL scope or at the OUTPUT_CONTRACT scope this execution
+    validates under. Revision-mismatched, scope-mismatched or absent
+    evidence stays unknown - never widened, never inferred.
+    """
+
+    repository = get_model_catalogue_repository()
+    for record in repository.list_capability_evidence(
+        candidate_id_v2=entry.candidate_id_v2, dimension=dimension
+    ):
+        if record.verdict != EvaluationRunVerdict.PASS.value:
+            continue
+        if record.model_revision != entry.model_revision:
+            continue
+        if record.scope_type == CapabilityEvidenceScopeType.GLOBAL.value:
+            return record
+        if (
+            record.scope_type == CapabilityEvidenceScopeType.OUTPUT_CONTRACT.value
+            and output_contract_key is not None
+            and record.scope_key == output_contract_key
+        ):
+            return record
+    return None

--- a/src/app/services/data_lifecycle_engine.py
+++ b/src/app/services/data_lifecycle_engine.py
@@ -257,6 +257,17 @@ def _expire_control_plane_evidence(
         ],
         ops.delete_attempt_debits,
     )
+    # Observed-capability evidence (issue #312) expires like the rest of
+    # the control-plane evidence family; eligibility then honestly reads
+    # the claim as unknown again.
+    _expire(
+        "capability_evidence_records",
+        [
+            (e.evidence_id, e.recorded_at)
+            for e in catalogue.list_all_capability_evidence(limit=_CANDIDATE_BATCH_LIMIT)
+        ],
+        catalogue.delete_capability_evidence,
+    )
     _expire(
         "provider_governed_actions",
         [

--- a/src/app/services/eval_case_configuration.py
+++ b/src/app/services/eval_case_configuration.py
@@ -1,0 +1,365 @@
+"""Hermetic per-case execution configuration for runtime evals.
+
+Split from eval_runtime_execution when the module budget fired (issue
+#312 S3): this family interprets a fixture case's input payload into
+scoped configuration overrides - provider, prompt, probe, rate-card and
+store state - applied for exactly one case and unwound afterwards. It
+carries no run orchestration.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any
+
+from contextlib import ExitStack
+from dataclasses import replace
+from typing import Iterator, cast
+
+
+from app.config import settings
+from app.contracts.providers import ProviderFailureCategory, ProviderQuotaScope
+from app.services.local_openai_compatible_endpoint_probe import LocalOpenAICompatibleEndpointStatus
+from app.services.prompt_store import reset_prompt_store_cache
+from app.contracts.rate_cards import RateCard, RateCardScopeKind
+from app.services.provider_usage_accounting import save_rate_card
+from app.services.rate_card_store import reset_rate_card_store_cache
+from app.services.runtime_mode_config import (
+    override_runtime_mode_config,
+    resolve_runtime_mode_config,
+)
+from app.services.provider_execution_config import (
+    override_provider_execution_config,
+    resolve_provider_execution_config,
+)
+from app.services.provider_execution_overrides import (
+    hermetic_provider_execution,
+    override_local_probe_status,
+    override_text_transport_post,
+)
+from app.services.provider_degradation_state import (
+    record_provider_failure,
+    reset_provider_degradation_state,
+)
+from app.services.provider_operations_store import (
+    override_provider_operations_store_mode,
+    resolved_provider_operations_store_mode,
+    get_provider_operations_store,
+    reset_provider_operations_store_cache,
+)
+from app.services.provider_quota_policy import reset_provider_quota_counters
+from app.services.retrieval_store import get_retrieval_repository, reset_retrieval_repository
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+# A self-describing non-credential reference (issue #148): it satisfies the
+# key-presence validation for hermetic openai-mode cases, and because every
+# case runs under hermetic_provider_execution() it can never reach a real
+# network call. It is not a secret and must never be shaped like one.
+EVAL_HERMETIC_CREDENTIAL_REF = "credential-ref:eval-hermetic"
+
+
+def _raise_provider_execution_error(*, category: ProviderFailureCategory, message: str) -> Any:
+    from app.providers.base import ProviderExecutionError
+
+    raise ProviderExecutionError(category=category, message=message)
+
+
+@contextmanager
+def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None]:
+    try:
+        with ExitStack() as stack:
+            # Every case runs hermetically: the live network seams fail
+            # closed unless the case installs an explicit override below.
+            stack.enter_context(hermetic_provider_execution())
+            reset_prompt_store_cache()
+            reset_retrieval_repository()
+            reset_provider_operations_store_cache()
+            reset_provider_quota_counters()
+            reset_provider_degradation_state()
+            reset_rate_card_store_cache()
+            runtime_modes = resolve_runtime_mode_config()
+            if "retrieval_mode" in input_payload:
+                runtime_modes = replace(
+                    runtime_modes, retrieval_mode=str(input_payload["retrieval_mode"])
+                )
+            if "safety_mode" in input_payload:
+                runtime_modes = replace(
+                    runtime_modes, safety_mode=str(input_payload["safety_mode"])
+                )
+            if "embedding_provider_mode" in input_payload:
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_provider_mode=str(input_payload["embedding_provider_mode"]),
+                )
+            if "live_embedding_provider_id" in input_payload:
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_provider_id=(
+                        str(input_payload["live_embedding_provider_id"])
+                        if input_payload["live_embedding_provider_id"] is not None
+                        else None
+                    ),
+                )
+            if "live_embedding_model_id" in input_payload:
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_model_id=(
+                        str(input_payload["live_embedding_model_id"])
+                        if input_payload["live_embedding_model_id"] is not None
+                        else None
+                    ),
+                )
+            if "live_embedding_provider_api_key" in input_payload:
+                runtime_modes = replace(
+                    runtime_modes,
+                    embedding_api_key=(
+                        str(input_payload["live_embedding_provider_api_key"])
+                        if input_payload["live_embedding_provider_api_key"] is not None
+                        else None
+                    ),
+                )
+            stack.enter_context(override_runtime_mode_config(runtime_modes))
+            indexed_sources = input_payload.get("index_sources", [])
+            if isinstance(indexed_sources, list):
+                repository = get_retrieval_repository()
+                for source_id in indexed_sources:
+                    if isinstance(source_id, str):
+                        repository.set_source_index_status(
+                            source_id=source_id,
+                            index_status="INDEXED",
+                        )
+            case_mode = str(
+                input_payload.get(
+                    "provider_mode",
+                    input_payload.get("configured_mode", settings.provider_mode),
+                )
+            )
+            case_rollout = str(input_payload.get("rollout_state", settings.provider_rollout_state))
+            if (
+                input_payload.get("provider_operations_store_mode") == "sqlalchemy"
+                and settings.database_url
+            ):
+                stack.enter_context(override_provider_operations_store_mode("sqlalchemy"))
+                reset_provider_operations_store_cache()
+            live_execution_signals = any(
+                key in input_payload
+                for key in (
+                    "request_limit",
+                    "hard_budget_usd",
+                    "tracked_spend_usd",
+                    "recorded_spend_usd",
+                    "degraded_failure_count_threshold",
+                    "circuit_open_seconds",
+                )
+            )
+            case_config = replace(
+                resolve_provider_execution_config(),
+                provider_mode=case_mode,
+                rollout_state=case_rollout,
+            )
+            if case_mode == "openai" and (
+                input_payload.get("rollout_state") in {"CANARY_ENABLED", "ROLLED_OUT"}
+                or live_execution_signals
+            ):
+                case_config = replace(
+                    case_config,
+                    rollout_state=(
+                        case_rollout if "rollout_state" in input_payload else "CANARY_ENABLED"
+                    ),
+                    provider_id="text.openai",
+                    model_id="gpt-5.4",
+                    api_key=EVAL_HERMETIC_CREDENTIAL_REF,
+                    allowed_task_ids=str(input_payload.get("task_id", "")),
+                )
+            if case_mode == "local_openai_compatible":
+                case_config = replace(
+                    case_config,
+                    rollout_state=(
+                        case_rollout if "rollout_state" in input_payload else "CANARY_ENABLED"
+                    ),
+                    provider_id="text.local",
+                    model_id=str(input_payload.get("live_text_model_id", "qwen3:8b")),
+                    api_base=str(input_payload.get("live_text_api_base", "http://ollama:11434/v1")),
+                    api_key=(
+                        str(input_payload["live_text_provider_api_key"])
+                        if input_payload.get("live_text_provider_api_key") is not None
+                        else None
+                    ),
+                    allowed_task_ids=str(input_payload.get("task_id", "")),
+                )
+            enforcement = case_config.enforcement
+            if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
+                enforcement = replace(
+                    enforcement,
+                    quota_enforced=True,
+                    task_quota_limits=(
+                        f"{input_payload['task_id']}="
+                        f"{int(cast(int | str, input_payload['request_limit']))}"
+                    ),
+                )
+            if "hard_budget_usd" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    budget_enforced=True,
+                    hard_budget_usd=float(
+                        cast(int | float | str, input_payload["hard_budget_usd"])
+                    ),
+                    soft_budget_usd=float(
+                        cast(
+                            int | float | str,
+                            input_payload.get(
+                                "recorded_spend_usd", input_payload.get("tracked_spend_usd", 0.5)
+                            ),
+                        )
+                    ),
+                )
+            if "degraded_failure_count_threshold" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    degradation_enforced=True,
+                    degraded_failure_count_threshold=int(
+                        cast(int | str, input_payload["degraded_failure_count_threshold"])
+                    ),
+                )
+            if "circuit_open_failure_count_threshold" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    circuit_open_failure_count_threshold=int(
+                        cast(int | str, input_payload["circuit_open_failure_count_threshold"])
+                    ),
+                )
+            if "circuit_open_seconds" in input_payload:
+                enforcement = replace(
+                    enforcement,
+                    circuit_open_seconds=int(
+                        cast(int | str, input_payload["circuit_open_seconds"])
+                    ),
+                )
+                if "degraded_failure_count_threshold" not in input_payload:
+                    # A circuit-posture case without explicit thresholds trips
+                    # the breaker on the single recorded failure below.
+                    enforcement = replace(
+                        enforcement,
+                        degradation_enforced=True,
+                        degraded_failure_count_threshold=1,
+                        circuit_open_failure_count_threshold=1,
+                    )
+            elif any(
+                key in input_payload
+                for key in (
+                    "degraded_failure_count_threshold",
+                    "circuit_open_failure_count_threshold",
+                )
+            ):
+                enforcement = replace(enforcement, circuit_open_seconds=60)
+            case_config = replace(case_config, enforcement=enforcement)
+            stack.enter_context(override_provider_execution_config(case_config))
+            if case_mode == "local_openai_compatible":
+                local_probe_status = input_payload.get("local_probe_status")
+                if isinstance(local_probe_status, dict):
+                    stack.enter_context(
+                        override_local_probe_status(
+                            LocalOpenAICompatibleEndpointStatus(
+                                endpoint_reachable=bool(
+                                    local_probe_status.get("endpoint_reachable", False)
+                                ),
+                                model_available=bool(
+                                    local_probe_status.get("model_available", False)
+                                ),
+                                configured_model_id=case_config.model_id,
+                                blocking_reason=cast(
+                                    str | None, local_probe_status.get("blocking_reason")
+                                ),
+                            )
+                        )
+                    )
+                local_provider_response = input_payload.get("local_provider_response")
+                if isinstance(local_provider_response, dict):
+                    stack.enter_context(
+                        override_text_transport_post(lambda **_: local_provider_response)
+                    )
+                local_provider_error = input_payload.get("local_provider_error")
+                if isinstance(local_provider_error, dict):
+                    failure_category = ProviderFailureCategory(
+                        str(local_provider_error["failure_category"])
+                    )
+                    stack.enter_context(
+                        override_text_transport_post(
+                            lambda **_: _raise_provider_execution_error(
+                                category=failure_category,
+                                message=str(local_provider_error["message"]),
+                            )
+                        )
+                    )
+            if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
+                get_provider_operations_store().increment_quota_state(
+                    scope=ProviderQuotaScope.TASK,
+                    scope_key=str(input_payload["task_id"]),
+                    amount=int(cast(int | str, input_payload["request_limit"])),
+                    updated_at=_utcnow_iso(),
+                )
+            if "hard_budget_usd" in input_payload:
+                # The card is fixture data (issue #178 S3): budget cases
+                # declare their rates in the fixture payload.
+                fixture_rates = cast(dict[str, object], input_payload["rate_card"])
+                seeded_at = _utcnow_iso()
+                save_rate_card(
+                    RateCard(
+                        card_id="eval-hermetic-live-text",
+                        scope_kind=RateCardScopeKind.DEFAULT_LIVE_TEXT,
+                        currency="USD",
+                        # monetary-float-ok markers: rate-card contract rates
+                        # are float-typed by design (#178 S1).
+                        input_cost_per_1k_tokens=float(  # monetary-float-ok: rate-card contract field is float-typed
+                            cast(int | float | str, fixture_rates["input_cost_per_1k_tokens"])
+                        ),
+                        output_cost_per_1k_tokens=float(  # monetary-float-ok: rate-card contract field is float-typed
+                            cast(int | float | str, fixture_rates["output_cost_per_1k_tokens"])
+                        ),
+                        effective_from_utc=None,
+                        effective_to_utc=None,
+                        created_at=seeded_at,
+                        last_updated_at=seeded_at,
+                    )
+                )
+                tracked_spend = float(
+                    cast(
+                        int | float | str,
+                        input_payload.get(
+                            "tracked_spend_usd", input_payload.get("recorded_spend_usd", 0.0)
+                        ),
+                    )
+                )
+                if tracked_spend > 0:
+                    get_provider_operations_store().add_budget_spend(
+                        budget_key="live_text_generation",
+                        amount_usd=tracked_spend,
+                        updated_at=_utcnow_iso(),
+                    )
+                    if resolved_provider_operations_store_mode() == "sqlalchemy":
+                        reset_provider_operations_store_cache()
+            if "degraded_failure_count_threshold" in input_payload:
+                failure_count = int(
+                    cast(int | str, input_payload["degraded_failure_count_threshold"])
+                )
+                for _ in range(failure_count):
+                    record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
+                if resolved_provider_operations_store_mode() == "sqlalchemy":
+                    reset_provider_operations_store_cache()
+            elif "circuit_open_seconds" in input_payload:
+                record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
+                if resolved_provider_operations_store_mode() == "sqlalchemy":
+                    reset_provider_operations_store_cache()
+            yield
+    finally:
+        reset_retrieval_repository()
+        reset_prompt_store_cache()
+        reset_provider_operations_store_cache()
+        reset_provider_quota_counters()
+        reset_provider_degradation_state()
+        reset_rate_card_store_cache()

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from contextlib import ExitStack, contextmanager
-from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from dataclasses import dataclass
 import json
-from typing import Any, Iterator, cast
+from typing import cast
 
 from fastapi import HTTPException
 
-from app.config import settings
 from app.contracts.access_control import (
     AuthorizationCapabilityType,
     AuthorizationDecision,
@@ -21,7 +18,6 @@ from app.contracts.prompts import (
     PromptLifecycleStatus,
     PromptRolloutSelectionMode,
 )
-from app.contracts.providers import ProviderFailureCategory, ProviderQuotaScope
 from app.contracts.safety import SafetyExecutionOutcome
 from app.contracts.tasks import (
     CallerMetadata,
@@ -43,47 +39,23 @@ from app.repositories.evaluation_runtime_repository import (
 from app.services.eval_run_submission_service import RUNTIME_BACKED_EVALUATION_FIXTURE_IDS
 from app.services.artifact_payloads import persist_json_artifact
 from app.services.embedding_live_execution_state import build_embedding_live_execution_state
+from app.services.capability_evidence import record_capability_evidence_for_pass_run
+from app.services.eval_case_configuration import _apply_case_configuration, _utcnow_iso
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store
 from app.services.prompt_rollout_models import PromptRolloutEventRecord, PromptRolloutStateRecord
-from app.services.local_openai_compatible_endpoint_probe import LocalOpenAICompatibleEndpointStatus
-from app.services.prompt_store import get_prompt_repository, reset_prompt_store_cache
+from app.services.prompt_store import get_prompt_repository
 from app.services.provider_budget_policy import build_provider_budget_policy
-from app.contracts.rate_cards import RateCard, RateCardScopeKind
-from app.services.provider_usage_accounting import save_rate_card
-from app.services.rate_card_store import reset_rate_card_store_cache
-from app.services.runtime_mode_config import (
-    override_runtime_mode_config,
-    resolve_runtime_mode_config,
-)
 from app.services.provider_execution_config import (
     compute_provider_config_sha256,
-    override_provider_execution_config,
     resolve_provider_execution_config,
     served_candidate_identity,
 )
-from app.services.provider_execution_overrides import (
-    hermetic_provider_execution,
-    override_local_probe_status,
-    override_text_transport_post,
-)
 from app.services.provider_catalog import build_provider_catalog
 from app.services.provider_configuration_status import build_embedding_configuration_status
-from app.services.provider_degradation_state import (
-    record_provider_failure,
-    reset_provider_degradation_state,
-)
 from app.services.provider_operations_status import build_provider_operations_status
 from app.services.provider_policy import build_provider_policy
-from app.services.provider_operations_store import (
-    override_provider_operations_store_mode,
-    resolved_provider_operations_store_mode,
-    get_provider_operations_store,
-    reset_provider_operations_store_cache,
-)
-from app.services.provider_quota_policy import reset_provider_quota_counters
 from app.services.retrieval_embedding_runtime import build_retrieval_embedding_runtime
 from app.services.retrieval_execution_status import build_retrieval_execution_status
-from app.services.retrieval_store import get_retrieval_repository, reset_retrieval_repository
 from app.services.safety_enforcement import (
     apply_safety_enforcement,
     resolve_safety_policy_for_output,
@@ -170,6 +142,8 @@ def execute_runtime_backed_evaluation_run(
         if all(result.outcome == EvaluationCaseOutcome.PASS.value for result in persisted_results)
         else EvaluationRunVerdict.FAIL
     )
+    if verdict == EvaluationRunVerdict.PASS:
+        record_capability_evidence_for_pass_run(run=run, results=persisted_results)
     completed_at = _utcnow_iso()
     store.save_attempt(
         EvaluationRunAttemptRecord(
@@ -982,315 +956,6 @@ def _default_eval_tenant_id(*, caller_app: str, case_tenant_id: object | None) -
     return None
 
 
-# A self-describing non-credential reference (issue #148): it satisfies the
-# key-presence validation for hermetic openai-mode cases, and because every
-# case runs under hermetic_provider_execution() it can never reach a real
-# network call. It is not a secret and must never be shaped like one.
-EVAL_HERMETIC_CREDENTIAL_REF = "credential-ref:eval-hermetic"
-
-
-@contextmanager
-def _apply_case_configuration(input_payload: dict[str, object]) -> Iterator[None]:
-    try:
-        with ExitStack() as stack:
-            # Every case runs hermetically: the live network seams fail
-            # closed unless the case installs an explicit override below.
-            stack.enter_context(hermetic_provider_execution())
-            reset_prompt_store_cache()
-            reset_retrieval_repository()
-            reset_provider_operations_store_cache()
-            reset_provider_quota_counters()
-            reset_provider_degradation_state()
-            reset_rate_card_store_cache()
-            runtime_modes = resolve_runtime_mode_config()
-            if "retrieval_mode" in input_payload:
-                runtime_modes = replace(
-                    runtime_modes, retrieval_mode=str(input_payload["retrieval_mode"])
-                )
-            if "safety_mode" in input_payload:
-                runtime_modes = replace(
-                    runtime_modes, safety_mode=str(input_payload["safety_mode"])
-                )
-            if "embedding_provider_mode" in input_payload:
-                runtime_modes = replace(
-                    runtime_modes,
-                    embedding_provider_mode=str(input_payload["embedding_provider_mode"]),
-                )
-            if "live_embedding_provider_id" in input_payload:
-                runtime_modes = replace(
-                    runtime_modes,
-                    embedding_provider_id=(
-                        str(input_payload["live_embedding_provider_id"])
-                        if input_payload["live_embedding_provider_id"] is not None
-                        else None
-                    ),
-                )
-            if "live_embedding_model_id" in input_payload:
-                runtime_modes = replace(
-                    runtime_modes,
-                    embedding_model_id=(
-                        str(input_payload["live_embedding_model_id"])
-                        if input_payload["live_embedding_model_id"] is not None
-                        else None
-                    ),
-                )
-            if "live_embedding_provider_api_key" in input_payload:
-                runtime_modes = replace(
-                    runtime_modes,
-                    embedding_api_key=(
-                        str(input_payload["live_embedding_provider_api_key"])
-                        if input_payload["live_embedding_provider_api_key"] is not None
-                        else None
-                    ),
-                )
-            stack.enter_context(override_runtime_mode_config(runtime_modes))
-            indexed_sources = input_payload.get("index_sources", [])
-            if isinstance(indexed_sources, list):
-                repository = get_retrieval_repository()
-                for source_id in indexed_sources:
-                    if isinstance(source_id, str):
-                        repository.set_source_index_status(
-                            source_id=source_id,
-                            index_status="INDEXED",
-                        )
-            case_mode = str(
-                input_payload.get(
-                    "provider_mode",
-                    input_payload.get("configured_mode", settings.provider_mode),
-                )
-            )
-            case_rollout = str(input_payload.get("rollout_state", settings.provider_rollout_state))
-            if (
-                input_payload.get("provider_operations_store_mode") == "sqlalchemy"
-                and settings.database_url
-            ):
-                stack.enter_context(override_provider_operations_store_mode("sqlalchemy"))
-                reset_provider_operations_store_cache()
-            live_execution_signals = any(
-                key in input_payload
-                for key in (
-                    "request_limit",
-                    "hard_budget_usd",
-                    "tracked_spend_usd",
-                    "recorded_spend_usd",
-                    "degraded_failure_count_threshold",
-                    "circuit_open_seconds",
-                )
-            )
-            case_config = replace(
-                resolve_provider_execution_config(),
-                provider_mode=case_mode,
-                rollout_state=case_rollout,
-            )
-            if case_mode == "openai" and (
-                input_payload.get("rollout_state") in {"CANARY_ENABLED", "ROLLED_OUT"}
-                or live_execution_signals
-            ):
-                case_config = replace(
-                    case_config,
-                    rollout_state=(
-                        case_rollout if "rollout_state" in input_payload else "CANARY_ENABLED"
-                    ),
-                    provider_id="text.openai",
-                    model_id="gpt-5.4",
-                    api_key=EVAL_HERMETIC_CREDENTIAL_REF,
-                    allowed_task_ids=str(input_payload.get("task_id", "")),
-                )
-            if case_mode == "local_openai_compatible":
-                case_config = replace(
-                    case_config,
-                    rollout_state=(
-                        case_rollout if "rollout_state" in input_payload else "CANARY_ENABLED"
-                    ),
-                    provider_id="text.local",
-                    model_id=str(input_payload.get("live_text_model_id", "qwen3:8b")),
-                    api_base=str(input_payload.get("live_text_api_base", "http://ollama:11434/v1")),
-                    api_key=(
-                        str(input_payload["live_text_provider_api_key"])
-                        if input_payload.get("live_text_provider_api_key") is not None
-                        else None
-                    ),
-                    allowed_task_ids=str(input_payload.get("task_id", "")),
-                )
-            enforcement = case_config.enforcement
-            if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
-                enforcement = replace(
-                    enforcement,
-                    quota_enforced=True,
-                    task_quota_limits=(
-                        f"{input_payload['task_id']}="
-                        f"{int(cast(int | str, input_payload['request_limit']))}"
-                    ),
-                )
-            if "hard_budget_usd" in input_payload:
-                enforcement = replace(
-                    enforcement,
-                    budget_enforced=True,
-                    hard_budget_usd=float(
-                        cast(int | float | str, input_payload["hard_budget_usd"])
-                    ),
-                    soft_budget_usd=float(
-                        cast(
-                            int | float | str,
-                            input_payload.get(
-                                "recorded_spend_usd", input_payload.get("tracked_spend_usd", 0.5)
-                            ),
-                        )
-                    ),
-                )
-            if "degraded_failure_count_threshold" in input_payload:
-                enforcement = replace(
-                    enforcement,
-                    degradation_enforced=True,
-                    degraded_failure_count_threshold=int(
-                        cast(int | str, input_payload["degraded_failure_count_threshold"])
-                    ),
-                )
-            if "circuit_open_failure_count_threshold" in input_payload:
-                enforcement = replace(
-                    enforcement,
-                    circuit_open_failure_count_threshold=int(
-                        cast(int | str, input_payload["circuit_open_failure_count_threshold"])
-                    ),
-                )
-            if "circuit_open_seconds" in input_payload:
-                enforcement = replace(
-                    enforcement,
-                    circuit_open_seconds=int(
-                        cast(int | str, input_payload["circuit_open_seconds"])
-                    ),
-                )
-                if "degraded_failure_count_threshold" not in input_payload:
-                    # A circuit-posture case without explicit thresholds trips
-                    # the breaker on the single recorded failure below.
-                    enforcement = replace(
-                        enforcement,
-                        degradation_enforced=True,
-                        degraded_failure_count_threshold=1,
-                        circuit_open_failure_count_threshold=1,
-                    )
-            elif any(
-                key in input_payload
-                for key in (
-                    "degraded_failure_count_threshold",
-                    "circuit_open_failure_count_threshold",
-                )
-            ):
-                enforcement = replace(enforcement, circuit_open_seconds=60)
-            case_config = replace(case_config, enforcement=enforcement)
-            stack.enter_context(override_provider_execution_config(case_config))
-            if case_mode == "local_openai_compatible":
-                local_probe_status = input_payload.get("local_probe_status")
-                if isinstance(local_probe_status, dict):
-                    stack.enter_context(
-                        override_local_probe_status(
-                            LocalOpenAICompatibleEndpointStatus(
-                                endpoint_reachable=bool(
-                                    local_probe_status.get("endpoint_reachable", False)
-                                ),
-                                model_available=bool(
-                                    local_probe_status.get("model_available", False)
-                                ),
-                                configured_model_id=case_config.model_id,
-                                blocking_reason=cast(
-                                    str | None, local_probe_status.get("blocking_reason")
-                                ),
-                            )
-                        )
-                    )
-                local_provider_response = input_payload.get("local_provider_response")
-                if isinstance(local_provider_response, dict):
-                    stack.enter_context(
-                        override_text_transport_post(lambda **_: local_provider_response)
-                    )
-                local_provider_error = input_payload.get("local_provider_error")
-                if isinstance(local_provider_error, dict):
-                    failure_category = ProviderFailureCategory(
-                        str(local_provider_error["failure_category"])
-                    )
-                    stack.enter_context(
-                        override_text_transport_post(
-                            lambda **_: _raise_provider_execution_error(
-                                category=failure_category,
-                                message=str(local_provider_error["message"]),
-                            )
-                        )
-                    )
-            if "request_limit" in input_payload and input_payload.get("quota_scope") == "task":
-                get_provider_operations_store().increment_quota_state(
-                    scope=ProviderQuotaScope.TASK,
-                    scope_key=str(input_payload["task_id"]),
-                    amount=int(cast(int | str, input_payload["request_limit"])),
-                    updated_at=_utcnow_iso(),
-                )
-            if "hard_budget_usd" in input_payload:
-                # The card is fixture data (issue #178 S3): budget cases
-                # declare their rates in the fixture payload.
-                fixture_rates = cast(dict[str, object], input_payload["rate_card"])
-                seeded_at = _utcnow_iso()
-                save_rate_card(
-                    RateCard(
-                        card_id="eval-hermetic-live-text",
-                        scope_kind=RateCardScopeKind.DEFAULT_LIVE_TEXT,
-                        currency="USD",
-                        # monetary-float-ok markers: rate-card contract rates
-                        # are float-typed by design (#178 S1).
-                        input_cost_per_1k_tokens=float(  # monetary-float-ok: rate-card contract field is float-typed
-                            cast(int | float | str, fixture_rates["input_cost_per_1k_tokens"])
-                        ),
-                        output_cost_per_1k_tokens=float(  # monetary-float-ok: rate-card contract field is float-typed
-                            cast(int | float | str, fixture_rates["output_cost_per_1k_tokens"])
-                        ),
-                        effective_from_utc=None,
-                        effective_to_utc=None,
-                        created_at=seeded_at,
-                        last_updated_at=seeded_at,
-                    )
-                )
-                tracked_spend = float(
-                    cast(
-                        int | float | str,
-                        input_payload.get(
-                            "tracked_spend_usd", input_payload.get("recorded_spend_usd", 0.0)
-                        ),
-                    )
-                )
-                if tracked_spend > 0:
-                    get_provider_operations_store().add_budget_spend(
-                        budget_key="live_text_generation",
-                        amount_usd=tracked_spend,
-                        updated_at=_utcnow_iso(),
-                    )
-                    if resolved_provider_operations_store_mode() == "sqlalchemy":
-                        reset_provider_operations_store_cache()
-            if "degraded_failure_count_threshold" in input_payload:
-                failure_count = int(
-                    cast(int | str, input_payload["degraded_failure_count_threshold"])
-                )
-                for _ in range(failure_count):
-                    record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
-                if resolved_provider_operations_store_mode() == "sqlalchemy":
-                    reset_provider_operations_store_cache()
-            elif "circuit_open_seconds" in input_payload:
-                record_provider_failure(ProviderFailureCategory.PROVIDER_UPSTREAM_ERROR)
-                if resolved_provider_operations_store_mode() == "sqlalchemy":
-                    reset_provider_operations_store_cache()
-            yield
-    finally:
-        reset_retrieval_repository()
-        reset_prompt_store_cache()
-        reset_provider_operations_store_cache()
-        reset_provider_quota_counters()
-        reset_provider_degradation_state()
-        reset_rate_card_store_cache()
-
-
-def _raise_provider_execution_error(*, category: ProviderFailureCategory, message: str) -> Any:
-    from app.providers.base import ProviderExecutionError
-
-    raise ProviderExecutionError(category=category, message=message)
-
-
 def _apply_prompt_transition_for_evaluation(
     *,
     task_id: str,
@@ -1424,10 +1089,6 @@ def _apply_prompt_rollback_for_evaluation(
         ],
         event=event,
     )
-
-
-def _utcnow_iso() -> str:
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _evaluation_control_authorization(

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -361,6 +361,22 @@ def enforce_capability_requirements(
             entry, output_contract_key
         ):
             continue
+        # Observed evaluation evidence at an honest scope (issue #312): a
+        # PASS record binding this exact candidate AND revision, GLOBAL or
+        # scoped to exactly the output contract this execution validates
+        # under. Anything narrower, staler or revision-mismatched stays
+        # unknown - evidence is never widened by inference.
+        from app.services.capability_evidence import applicable_capability_evidence
+
+        if (
+            applicable_capability_evidence(
+                entry=entry,
+                dimension=fact_field,
+                output_contract_key=output_contract_key,
+            )
+            is not None
+        ):
+            continue
         raise ProviderExecutionError(
             category=ProviderFailureCategory.CAPABILITY_UNKNOWN,
             message=(

--- a/tests/unit/test_capability_evidence.py
+++ b/tests/unit/test_capability_evidence.py
@@ -1,0 +1,388 @@
+"""Scope-aware observed-capability evidence (issue #312 S3).
+
+A PASS run over a declaring fixture family yields one authoritative record
+per declared proof, bound to the candidate that served every case; mixed or
+unknown serving candidates yield nothing; and eligibility consumes exactly
+the matching scoped PASS claim - never a widened one.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+from app.contracts.evals import (
+    CapabilityEvidenceScopeType,
+    CapabilityProofDeclaration,
+    EvaluationAssetStatus,
+    EvaluationFixtureDescriptor,
+)
+from app.contracts.model_catalogue import (
+    ModelCatalogueEntry,
+    ModelCatalogueSeedSource,
+    ModelLifecycleState,
+    derive_model_catalogue_entry_id,
+)
+from app.contracts.providers import ProviderFailureCategory
+from app.providers.base import ProviderExecutionError
+from app.repositories.evaluation_runtime_repository import (
+    EvaluationCaseResultRecord,
+    EvaluationRunRecord,
+)
+from app.services.capability_evidence import (
+    applicable_capability_evidence,
+    record_capability_evidence_for_pass_run,
+)
+from app.services.model_catalogue import (
+    enforce_capability_requirements,
+    upsert_model_catalogue_entry,
+)
+from app.services.model_catalogue_store import get_model_catalogue_repository
+
+PROVIDER = "text.regional"
+MODEL = "claude-sonnet-5"
+REVISION = "claude-sonnet-5-2026-05"
+
+
+def _catalogued_entry() -> ModelCatalogueEntry:
+    entry = ModelCatalogueEntry(
+        entry_id=derive_model_catalogue_entry_id(
+            provider_id=PROVIDER, model_revision=REVISION, deployment=None
+        ),
+        provider_id=PROVIDER,
+        provider_mode="openai",
+        model_family=MODEL,
+        model_revision=REVISION,
+        deployment=None,
+        sku=None,
+        lifecycle_state=ModelLifecycleState.APPROVED,
+        revision_pinned=True,
+        modalities=["text"],
+        seed_source=ModelCatalogueSeedSource.SETTINGS_LIVE_TEXT,
+        created_at="2026-09-01T00:00:00Z",
+        last_updated_at="2026-09-01T00:00:00Z",
+    )
+    upsert_model_catalogue_entry(entry)
+    stored = get_model_catalogue_repository().get_entry(entry.entry_id)
+    assert stored is not None
+    return stored
+
+
+def _run(fixture_id: str = "capability_proof_examples") -> EvaluationRunRecord:
+    return EvaluationRunRecord(
+        run_id="evalrun_cap_001",
+        fixture_id=fixture_id,
+        manifest_version="foundation.v1",
+        lifecycle_status="COMPLETED",
+        triggered_by="operator-a",
+        submitted_at="2026-09-05T00:00:00Z",
+        async_job_id=None,
+        latest_message="done",
+        verdict="PASS",
+        case_count=2,
+    )
+
+
+def _case(case_id: str, candidate_id_v2: str | None) -> EvaluationCaseResultRecord:
+    return EvaluationCaseResultRecord(
+        case_result_id=f"attempt_{case_id}",
+        run_id="evalrun_cap_001",
+        attempt_id="attempt_001",
+        case_id=case_id,
+        fixture_id="capability_proof_examples",
+        outcome="PASS",
+        summary="ok",
+        evidence_refs=[],
+        artifact_ids=[],
+        provider_config_sha256="d" * 64,
+        candidate_id_v2=candidate_id_v2,
+        recorded_at="2026-09-05T00:01:00Z",
+    )
+
+
+def _declaring_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.evals import fixture_manifest as manifest_module
+
+    declaring = EvaluationFixtureDescriptor(
+        fixture_id="capability_proof_examples",
+        status=EvaluationAssetStatus.STAGED,
+        description="Capability proof fixtures.",
+        manifest_path="docs/evals/fixtures/explain.v1/basic_cases.json",
+        proves=[
+            CapabilityProofDeclaration(
+                dimension="supports_tool_calling",
+                scope_type=CapabilityEvidenceScopeType.GLOBAL,
+            ),
+            CapabilityProofDeclaration(
+                dimension="supports_structured_output",
+                scope_type=CapabilityEvidenceScopeType.OUTPUT_CONTRACT,
+                scope_key="advisor_brief.pack",
+            ),
+        ],
+    )
+    manifest = manifest_module.EvaluationFixtureManifest(
+        manifest_version="foundation.v1",
+        evidence_categories=[],
+        fixture_families=[declaring],
+    )
+    monkeypatch.setattr(
+        "app.evals.fixture_manifest.load_evaluation_fixture_manifest", lambda: manifest
+    )
+
+
+def test_a_pass_run_records_one_claim_per_declared_proof(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = _catalogued_entry()
+    _declaring_manifest(monkeypatch)
+
+    record_capability_evidence_for_pass_run(
+        run=_run(),
+        results=[
+            _case("case_001", entry.candidate_id_v2),
+            _case("case_002", entry.candidate_id_v2),
+        ],
+    )
+
+    repository = get_model_catalogue_repository()
+    tool_rows = repository.list_capability_evidence(
+        candidate_id_v2=entry.candidate_id_v2, dimension="supports_tool_calling"
+    )
+    assert len(tool_rows) == 1
+    assert tool_rows[0].scope_type == "GLOBAL"
+    assert tool_rows[0].model_revision == REVISION
+    assert tool_rows[0].evaluation_run_id == "evalrun_cap_001"
+    scoped_rows = repository.list_capability_evidence(
+        candidate_id_v2=entry.candidate_id_v2, dimension="supports_structured_output"
+    )
+    assert len(scoped_rows) == 1
+    assert scoped_rows[0].scope_key == "advisor_brief.pack"
+
+
+def test_unknown_or_mixed_serving_candidates_yield_no_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = _catalogued_entry()
+    _declaring_manifest(monkeypatch)
+
+    record_capability_evidence_for_pass_run(
+        run=_run(),
+        results=[_case("case_001", entry.candidate_id_v2), _case("case_002", None)],
+    )
+    record_capability_evidence_for_pass_run(
+        run=_run(),
+        results=[
+            _case("case_001", entry.candidate_id_v2),
+            _case("case_002", "cand2_" + "b" * 64),
+        ],
+    )
+
+    assert (
+        get_model_catalogue_repository().list_capability_evidence(
+            candidate_id_v2=entry.candidate_id_v2, dimension="supports_tool_calling"
+        )
+        == []
+    )
+
+
+def test_eligibility_consumes_exactly_the_matching_scoped_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The steering's core invariant: structured-output evidence for ONE
+    approved output contract never becomes a universal statement, a global
+    claim serves everywhere, and revision-mismatched evidence stays
+    unknown."""
+
+    from app.contracts.capability_requirements import CapabilityRequirements
+
+    entry = _catalogued_entry()
+    _declaring_manifest(monkeypatch)
+    record_capability_evidence_for_pass_run(
+        run=_run(),
+        results=[_case("case_001", entry.candidate_id_v2)],
+    )
+
+    tool_required = CapabilityRequirements(tool_calling_required=True)
+    # GLOBAL evidence satisfies the unknown declared fact everywhere.
+    enforce_capability_requirements(requirements=tool_required, entry=entry)
+
+    structured_required = CapabilityRequirements(structured_output_required=True)
+    # The scoped claim satisfies exactly its contract...
+    enforce_capability_requirements(
+        requirements=structured_required,
+        entry=entry,
+        output_contract_key="advisor_brief.pack",
+    )
+    # ...and no other contract, and not the global question.
+    with pytest.raises(ProviderExecutionError) as other_scope:
+        enforce_capability_requirements(
+            requirements=structured_required,
+            entry=entry,
+            output_contract_key="some_other.pack",
+        )
+    assert other_scope.value.category is ProviderFailureCategory.CAPABILITY_UNKNOWN
+    with pytest.raises(ProviderExecutionError) as no_scope:
+        enforce_capability_requirements(requirements=structured_required, entry=entry)
+    assert no_scope.value.category is ProviderFailureCategory.CAPABILITY_UNKNOWN
+
+    # Revision drift invalidates the claim: same candidate id cannot occur
+    # with a different revision (identity binds it), so simulate via the
+    # applicable-evidence check on a modified entry copy.
+    drifted = entry.model_copy(
+        update={"model_revision": "claude-sonnet-5-2026-06", "candidate_id_v2": ""}
+    )
+    assert (
+        applicable_capability_evidence(
+            entry=drifted,
+            dimension="supports_tool_calling",
+            output_contract_key=None,
+        )
+        is None
+    )
+
+
+def test_undeclared_families_and_vanished_candidates_record_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = _catalogued_entry()
+    from app.evals import fixture_manifest as manifest_module
+
+    manifest = manifest_module.EvaluationFixtureManifest(
+        manifest_version="foundation.v1",
+        evidence_categories=[],
+        fixture_families=[
+            EvaluationFixtureDescriptor(
+                fixture_id="capability_proof_examples",
+                status=EvaluationAssetStatus.STAGED,
+                description="No declarations.",
+                manifest_path="docs/evals/fixtures/explain.v1/basic_cases.json",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "app.evals.fixture_manifest.load_evaluation_fixture_manifest", lambda: manifest
+    )
+    record_capability_evidence_for_pass_run(
+        run=_run(), results=[_case("case_001", entry.candidate_id_v2)]
+    )
+    assert (
+        get_model_catalogue_repository().list_capability_evidence(
+            candidate_id_v2=entry.candidate_id_v2, dimension="supports_tool_calling"
+        )
+        == []
+    )
+
+    _declaring_manifest(monkeypatch)
+    record_capability_evidence_for_pass_run(
+        run=_run(), results=[_case("case_001", "cand2_" + "c" * 64)]
+    )
+    assert (
+        get_model_catalogue_repository().list_capability_evidence(
+            candidate_id_v2="cand2_" + "c" * 64, dimension="supports_tool_calling"
+        )
+        == []
+    )
+
+
+def test_evidence_rows_round_trip_and_expire_on_both_adapters(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """The evidence store behaves identically on both adapters: save/list
+    round-trips the full binding, list_all feeds the lifecycle engine, and
+    delete removes exactly the named rows (expiry then honestly reverts the
+    claim to unknown)."""
+
+    from app.contracts.model_catalogue import CapabilityEvidenceRecord
+    from app.repositories.sqlalchemy_model_catalogue_repository import (
+        SqlAlchemyModelCatalogueRepository,
+    )
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    def _record(evidence_id: str, verdict: str = "PASS") -> CapabilityEvidenceRecord:
+        return CapabilityEvidenceRecord(
+            evidence_id=evidence_id,
+            candidate_id_v2="cand2_" + "e" * 64,
+            model_revision=REVISION,
+            dimension="supports_tool_calling",
+            scope_type="GLOBAL",
+            scope_key=None,
+            fixture_id="capability_proof_examples",
+            manifest_version="foundation.v1",
+            evaluation_run_id="evalrun_cap_002",
+            verdict=verdict,
+            triggered_by="operator-a",
+            recorded_at="2026-09-05T01:00:00Z",
+        )
+
+    stores = [get_model_catalogue_repository()]
+    database_url = f"sqlite:///{tmp_path_factory.mktemp('capev') / 'capev.db'}"
+    upgrade_database_to_head(database_url)
+    stores.append(SqlAlchemyModelCatalogueRepository(database_url))
+
+    for store in stores:
+        store.save_capability_evidence(_record("capev_a"))
+        store.save_capability_evidence(_record("capev_b"))
+        rows = store.list_capability_evidence(
+            candidate_id_v2="cand2_" + "e" * 64, dimension="supports_tool_calling"
+        )
+        assert {row.evidence_id for row in rows} == {"capev_a", "capev_b"}
+        assert rows[0].scope_type == "GLOBAL" and rows[0].model_revision == REVISION
+        assert {row.evidence_id for row in store.list_all_capability_evidence(limit=10)} >= {
+            "capev_a",
+            "capev_b",
+        }
+        assert store.delete_capability_evidence(["capev_a", "missing"]) == 1
+        remaining = store.list_capability_evidence(
+            candidate_id_v2="cand2_" + "e" * 64, dimension="supports_tool_calling"
+        )
+        assert {row.evidence_id for row in remaining} == {"capev_b"}
+
+
+def test_applicable_evidence_skips_non_pass_and_revision_mismatch() -> None:
+    """The consumption filters, exercised directly: a FAIL row is never
+    evidence, and a row for another revision of the same candidate id shape
+    stays unknown."""
+
+    from app.contracts.model_catalogue import CapabilityEvidenceRecord
+
+    entry = _catalogued_entry()
+    repository = get_model_catalogue_repository()
+    repository.save_capability_evidence(
+        CapabilityEvidenceRecord(
+            evidence_id="capev_fail",
+            candidate_id_v2=entry.candidate_id_v2,
+            model_revision=REVISION,
+            dimension="supports_tool_calling",
+            scope_type="GLOBAL",
+            scope_key=None,
+            fixture_id="capability_proof_examples",
+            manifest_version="foundation.v1",
+            evaluation_run_id="evalrun_cap_003",
+            verdict="FAIL",
+            triggered_by=None,
+            recorded_at="2026-09-05T01:01:00Z",
+        )
+    )
+    repository.save_capability_evidence(
+        CapabilityEvidenceRecord(
+            evidence_id="capev_other_rev",
+            candidate_id_v2=entry.candidate_id_v2,
+            model_revision="claude-sonnet-5-2026-06",
+            dimension="supports_tool_calling",
+            scope_type="GLOBAL",
+            scope_key=None,
+            fixture_id="capability_proof_examples",
+            manifest_version="foundation.v1",
+            evaluation_run_id="evalrun_cap_004",
+            verdict="PASS",
+            triggered_by=None,
+            recorded_at="2026-09-05T01:02:00Z",
+        )
+    )
+
+    assert (
+        applicable_capability_evidence(
+            entry=entry, dimension="supports_tool_calling", output_contract_key=None
+        )
+        is None
+    )

--- a/tests/unit/test_eval_runtime_execution.py
+++ b/tests/unit/test_eval_runtime_execution.py
@@ -14,10 +14,10 @@ from app.contracts.prompts import PromptControlActionType
 from app.contracts.evals import EvaluationCaseOutcome
 from app.evals.fixture_manifest import EvaluationFixtureRuntimeCase
 from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+from app.services.eval_case_configuration import _apply_case_configuration
 from app.services.eval_runtime_execution import (
     _apply_prompt_rollback_for_evaluation,
     _apply_prompt_transition_for_evaluation,
-    _apply_case_configuration,
     _execute_fixture_case,
 )
 from app.services.evaluation_runtime_store import get_evaluation_runtime_store


### PR DESCRIPTION
Closing slice of #312: **authoritative scope-aware capability evidence exists, eligibility consumes exactly the matching scoped claim, and the layers stay distinct.**

## What lands

- **`CapabilityEvidenceRecord`** (migration 0073, control-plane evidence family with 7-year expiry wired into the lifecycle engine): one authoritative row per proof a fixture family declares, written only when a COMPLETED PASS run was served entirely by **one** candidate — binding the canonical candidate identity, exact revision, dimension, scope type/key, fixture family, manifest version, run, verdict and provenance. Mixed or unknown serving candidates yield nothing; a candidate that vanished from the catalogue binds nothing; unknown never upgrades into truth. Expired evidence honestly reverts the claim to unknown.
- **Eligibility consumes the scoped claim** through the existing `enforce_capability_requirements` seam, extending (never reversing) the shipped output-contract-scoped structured-output path: a PASS record applies at GLOBAL scope everywhere, at OUTPUT_CONTRACT scope only for exactly that contract, and only for the exact candidate AND revision — anything else stays `CAPABILITY_UNKNOWN`.
- **The layers remain distinct and documented** (new runbook section): declared = catalogue facts; observed = these records; certified = the existing governed promotion (evidence enables, never decides; no auto-promotion); eligibility = the decision-time check.
- **Two real module-budget splits fell out**: the evidence service is its own small module (`capability_evidence.py`), and the eval runtime's ~300-line hermetic case-configuration family moved to `eval_case_configuration.py` — the runtime module's ratcheted ceiling dropped **1470 → 1131**.

## Evidence

A PASS run over a declaring family records one claim per proof with the full binding; unknown/mixed serving candidates and undeclared families record nothing; vanished candidates bind nothing; the eligibility matrix proves the steering's core invariant (scoped structured-output evidence satisfies exactly its contract and neither other contracts nor the global question; GLOBAL evidence serves everywhere; revision drift stays unknown); lifecycle coverage invariant extended to the new table; 404 targeted tests, lint (with the ceiling ratcheted down), mypy, OpenAPI gate, migration smoke green; full coverage verdict-gated before push.
