### PR TITLE
feat(providers): emit the consumer's idea_workflow_output contract (#321)

### DIFF
--- a/contracts/ai-task-outputs/idea_explanation.pack.v1.json
+++ b/contracts/ai-task-outputs/idea_explanation.pack.v1.json
@@ -134,6 +134,81 @@
     },
     "workflow_pack_family": {
       "type": "string"
+    },
+    "idea_workflow_output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "output_id",
+        "explanation_text",
+        "claims",
+        "proposed_actions"
+      ],
+      "properties": {
+        "output_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "explanation_text": {
+          "type": "string",
+          "minLength": 1
+        },
+        "claims": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "claim_id",
+              "claim_text",
+              "source_product_ids"
+            ],
+            "properties": {
+              "claim_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "claim_text": {
+                "type": "string",
+                "minLength": 1
+              },
+              "source_product_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "proposed_actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "action_type",
+              "action_label"
+            ],
+            "properties": {
+              "action_type": {
+                "type": "string",
+                "enum": [
+                  "advisor_review",
+                  "request_missing_evidence"
+                ]
+              },
+              "action_label": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
     }
   },
   "required": [
@@ -149,6 +224,7 @@
     "family",
     "forbidden_actions",
     "human_review_required",
+    "idea_workflow_output",
     "lifecycle_status",
     "max_output_tokens",
     "output_label",

--- a/src/app/providers/idea_explanation_stub.py
+++ b/src/app/providers/idea_explanation_stub.py
@@ -54,8 +54,87 @@ def build_idea_explanation_stub_result(
             "Do not treat the explanation as suitability approval, final advice, rebalance authority, or client-ready communication.",
             "Escalate missing or unsupported evidence back to the source-owning Lotus service.",
         ],
+        "idea_workflow_output": _idea_workflow_output(
+            message=message,
+            request_id=_as_str(explanation_request.get("request_id")),
+            candidate_id=candidate_id,
+            score_policy_version=_as_str(redacted_evidence.get("score_policy_version")),
+            reason_codes=reason_codes,
+            source_product_ids=_source_product_ids(source_refs),
+        ),
     }
     return message, structured_output
+
+
+def _idea_workflow_output(
+    *,
+    message: str,
+    request_id: str,
+    candidate_id: str,
+    score_policy_version: str,
+    reason_codes: list[str],
+    source_product_ids: list[str],
+) -> dict[str, object]:
+    """Deterministic output in the consumer's shipped idea_workflow_output contract.
+
+    lotus-idea's map_lotus_ai_idea_workflow_output requires explanation_text to equal
+    the execution message, claims grounded only in the packet's own product ids, and
+    proposed actions whose labels satisfy its strict action-policy patterns.
+    """
+    if reason_codes:
+        claims: list[dict[str, object]] = [
+            {
+                "claim_id": f"reason-{index:02d}-{code.lower()}",
+                "claim_text": (
+                    f"Candidate {candidate_id} was surfaced with reason code {code} "
+                    f"under scoring policy {score_policy_version}."
+                ),
+                "source_product_ids": source_product_ids,
+            }
+            for index, code in enumerate(reason_codes, start=1)
+        ]
+    else:
+        claims = [
+            {
+                "claim_id": "score-policy",
+                "claim_text": (
+                    f"Candidate {candidate_id} was surfaced by deterministic "
+                    f"scoring policy {score_policy_version}."
+                ),
+                "source_product_ids": source_product_ids,
+            }
+        ]
+    proposed_actions: list[dict[str, object]] = [
+        {"action_type": "advisor_review", "action_label": "Review the evidence"}
+    ]
+    if not source_product_ids:
+        proposed_actions.append(
+            {
+                "action_type": "request_missing_evidence",
+                "action_label": "Request the missing governed evidence",
+            }
+        )
+    return {
+        "output_id": (
+            f"idea-explanation-output-{request_id}" if request_id else "idea-explanation-output"
+        ),
+        "explanation_text": message,
+        "claims": claims,
+        "proposed_actions": proposed_actions,
+    }
+
+
+def _source_product_ids(source_refs: object) -> list[str]:
+    if not isinstance(source_refs, list):
+        return []
+    product_ids: list[str] = []
+    for ref in source_refs:
+        if not isinstance(ref, dict):
+            continue
+        product_id = _as_str(ref.get("product_id"))
+        if product_id and product_id not in product_ids:
+            product_ids.append(product_id)
+    return product_ids
 
 
 def _string_list(value: object) -> list[str]:

--- a/tests/unit/test_idea_explanation_guardrails.py
+++ b/tests/unit/test_idea_explanation_guardrails.py
@@ -183,3 +183,86 @@ def test_idea_explanation_stub_coerces_malformed_lists_to_empty_output() -> None
     _, structured_output = result
     assert structured_output["reason_codes"] == []
     assert structured_output["requested_outputs"] == []
+
+
+def test_idea_explanation_stub_emits_consumer_idea_workflow_output_contract() -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+
+    result = build_idea_explanation_stub_result(context_payload=payload)
+
+    assert result is not None
+    message, structured_output = result
+    output = cast(dict[str, Any], structured_output["idea_workflow_output"])
+    assert output["output_id"] == "idea-explanation-output-idea-explanation-request-001"
+    assert output["explanation_text"] == message
+    claims = cast(list[dict[str, Any]], output["claims"])
+    assert [claim["claim_id"] for claim in claims] == [
+        "reason-01-high_cash_weight",
+        "reason-02-benchmark_drift_attention",
+    ]
+    assert all(
+        claim["source_product_ids"] == ["core-position-snapshot", "risk-concentration-snapshot"]
+        for claim in claims
+    )
+    assert "HIGH_CASH_WEIGHT" in claims[0]["claim_text"]
+    assert "idea-score-policy.v1" in claims[0]["claim_text"]
+    assert output["proposed_actions"] == [
+        {"action_type": "advisor_review", "action_label": "Review the evidence"}
+    ]
+
+
+def test_idea_explanation_stub_workflow_output_without_reason_codes_states_score_policy() -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    cast(dict[str, Any], payload["redacted_evidence_packet"])["reason_codes"] = []
+
+    result = build_idea_explanation_stub_result(context_payload=payload)
+
+    assert result is not None
+    _, structured_output = result
+    output = cast(dict[str, Any], structured_output["idea_workflow_output"])
+    claims = cast(list[dict[str, Any]], output["claims"])
+    assert [claim["claim_id"] for claim in claims] == ["score-policy"]
+    assert "idea-score-policy.v1" in claims[0]["claim_text"]
+
+
+def test_idea_explanation_stub_workflow_output_requests_evidence_when_refs_missing() -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    evidence = cast(dict[str, Any], payload["redacted_evidence_packet"])
+    evidence["source_refs"] = ["not-a-ref", {"product_id": "   "}]
+    cast(dict[str, Any], payload["explanation_request"])["request_id"] = ""
+
+    result = build_idea_explanation_stub_result(context_payload=payload)
+
+    assert result is not None
+    _, structured_output = result
+    output = cast(dict[str, Any], structured_output["idea_workflow_output"])
+    assert output["output_id"] == "idea-explanation-output"
+    claims = cast(list[dict[str, Any]], output["claims"])
+    assert all(claim["source_product_ids"] == [] for claim in claims)
+    assert output["proposed_actions"] == [
+        {"action_type": "advisor_review", "action_label": "Review the evidence"},
+        {
+            "action_type": "request_missing_evidence",
+            "action_label": "Request the missing governed evidence",
+        },
+    ]
+
+
+def test_idea_explanation_stub_workflow_output_deduplicates_product_ids_and_replays() -> None:
+    payload = cast(dict[str, Any], idea_explanation_payload())
+    evidence = cast(dict[str, Any], payload["redacted_evidence_packet"])
+    refs = cast(list[dict[str, Any]], evidence["source_refs"])
+    evidence["source_refs"] = refs + [dict(refs[0])]
+
+    first = build_idea_explanation_stub_result(context_payload=payload)
+    second = build_idea_explanation_stub_result(context_payload=payload)
+
+    assert first is not None
+    assert first == second
+    _, structured_output = first
+    output = cast(dict[str, Any], structured_output["idea_workflow_output"])
+    claims = cast(list[dict[str, Any]], output["claims"])
+    assert claims[0]["source_product_ids"] == [
+        "core-position-snapshot",
+        "risk-concentration-snapshot",
+    ]


### PR DESCRIPTION
Closes #321. Consumer journey #1 producer slice (lotus-idea#1222 chain).

## What
- `build_idea_explanation_stub_result` also emits `idea_workflow_output`: deterministic `output_id` from the request id, `explanation_text` byte-equal to the message, one claim per reason code (single score-policy claim when none) each citing the packet's actual deduplicated `source_refs[].product_id` values, `advisor_review` always plus `request_missing_evidence` when the packet carries no product ids. Pure function of the payload — replay-identical.
- `contracts/ai-task-outputs/idea_explanation.pack.v1.json` declares the key REQUIRED with the full nested shape (claim uniqueness left to the consumer; `action_type` enum bounded to the consumer's allowed review-gated vocabulary) — without this, the schema's `additionalProperties: false` would flip output validation fail-closed.

## Why
Without it the registered consumer's shipped mapper (`map_lotus_ai_idea_workflow_output`) can never accept a lotus-ai execution — stub or live — blocking the end-to-end idea-explanation journey and lotus-idea's own `workbench_product_proof_missing` certification blocker.

## Evidence
- Full coverage lane green (COV_EXIT=0, TOTAL 99%); lint + module budget + mypy (src+tests, 756 files) green.
- Grounding-safety analysis and a live cross-repo proof (this branch's output fed through lotus-idea's shipped mapper + action policy → ACCEPTED) recorded on #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)