### PR TITLE
fix(access): admit the canonical platform tenant for lotus-idea (#323)

### DIFF
--- a/alembic/versions/0074_lotus_idea_tenant_admission.py
+++ b/alembic/versions/0074_lotus_idea_tenant_admission.py
@@ -1,0 +1,47 @@
+"""Admit the canonical platform tenant for the lotus-idea caller.
+
+Real Idea candidates carry the platform's canonical tenant
+(`tenant-private-bank-sg`), but migration 0034 seeded the lotus-idea caller
+policy restricted to the lotus-ai-local proof fixture tenant only, so the
+first live idea-explanation journey execution was refused with
+BLOCKED_TENANT_NOT_ALLOWED (issue #323). Tenant admission stays RESTRICTED;
+only the admitted vocabulary aligns with platform truth. The proof fixture
+tenant is retained so existing runtime-proof evidence stays valid.
+
+Revision ID: 0074_lotus_idea_tenant_admission
+Revises: 0073_capability_evidence_records
+"""
+
+from alembic import op
+
+revision = "0074_lotus_idea_tenant_admission"
+down_revision = "0073_capability_evidence_records"
+branch_labels = None
+depends_on = None
+
+_ADMITTED = '["tenant-private-bank-sg", "tenant-sg-001"]'
+_PRIOR = '["tenant-sg-001"]'
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        UPDATE caller_policies
+        SET restricted_tenant_ids = '{_ADMITTED}',
+            updated_at = '2026-09-05T00:00:00Z'
+        WHERE caller_app = 'lotus-idea'
+          AND tenant_policy_mode = 'RESTRICTED'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"""
+        UPDATE caller_policies
+        SET restricted_tenant_ids = '{_PRIOR}',
+            updated_at = '2026-06-26T00:00:00Z'
+        WHERE caller_app = 'lotus-idea'
+          AND tenant_policy_mode = 'RESTRICTED'
+        """
+    )

--- a/src/app/repositories/memory_caller_policy_repository.py
+++ b/src/app/repositories/memory_caller_policy_repository.py
@@ -104,7 +104,9 @@ _DEFAULT_POLICIES = [
         allow_provider_control=False,
         allow_audit_read_all_tenants=False,
         tenant_policy_mode=TenantPolicyMode.RESTRICTED,
-        restricted_tenant_ids=["tenant-sg-001"],
+        # The canonical platform tenant carried by real Idea candidates, plus the
+        # lotus-ai-local runtime-proof fixture tenant (issue #323).
+        restricted_tenant_ids=["tenant-private-bank-sg", "tenant-sg-001"],
     ),
     CallerPolicyDescriptor(
         caller_app="lotus-workbench",

--- a/tests/unit/test_access_control_authorization.py
+++ b/tests/unit/test_access_control_authorization.py
@@ -256,3 +256,30 @@ def test_authorize_request_blocks_async_control_without_tenant_noise_for_non_ope
 
     assert decision.allowed is False
     assert decision.outcome == AuthorizationOutcome.BLOCKED_ASYNC_CONTROL_NOT_ALLOWED
+
+
+def test_authorize_request_admits_lotus_idea_canonical_platform_tenant() -> None:
+    """Issue #323: real Idea candidates carry the canonical platform tenant;
+    the first live idea-explanation journey execution was refused because the
+    caller policy admitted only the lotus-ai-local proof fixture tenant."""
+
+    decision = authorize_request(
+        caller_app="lotus-idea",
+        capability_type=AuthorizationCapabilityType.TASK_EXECUTION,
+        tenant_id="tenant-private-bank-sg",
+        task_id="explain.v1",
+    )
+
+    assert decision.allowed is True
+
+
+def test_authorize_request_still_blocks_lotus_idea_unadmitted_tenant() -> None:
+    decision = authorize_request(
+        caller_app="lotus-idea",
+        capability_type=AuthorizationCapabilityType.TASK_EXECUTION,
+        tenant_id="tenant-not-admitted",
+        task_id="explain.v1",
+    )
+
+    assert decision.allowed is False
+    assert decision.outcome == AuthorizationOutcome.BLOCKED_TENANT_NOT_ALLOWED

--- a/tests/unit/test_memory_caller_policy_repository.py
+++ b/tests/unit/test_memory_caller_policy_repository.py
@@ -44,7 +44,7 @@ def test_memory_caller_policy_repository_allows_lotus_idea_review_gated_explain(
     assert policy.allow_live_provider is False
     assert policy.allowed_task_ids == ["explain.v1"]
     assert policy.tenant_policy_mode.value == "RESTRICTED"
-    assert policy.restricted_tenant_ids == ["tenant-sg-001"]
+    assert policy.restricted_tenant_ids == ["tenant-private-bank-sg", "tenant-sg-001"]
 
 
 def test_memory_caller_policy_repository_returns_none_for_unknown_caller() -> None:

--- a/tests/unit/test_sqlalchemy_caller_policy_repository.py
+++ b/tests/unit/test_sqlalchemy_caller_policy_repository.py
@@ -52,7 +52,7 @@ def test_sqlalchemy_caller_policy_repository_survives_reopen(tmp_path: Path) -> 
     assert lotus_idea_policy.allowed_task_ids == ["explain.v1"]
     assert lotus_idea_policy.allow_live_provider is False
     assert lotus_idea_policy.tenant_policy_mode == "RESTRICTED"
-    assert lotus_idea_policy.restricted_tenant_ids == ["tenant-sg-001"]
+    assert lotus_idea_policy.restricted_tenant_ids == ["tenant-private-bank-sg", "tenant-sg-001"]
     assert lotus_platform_policy is not None
     assert lotus_platform_policy.allow_audit_read_all_tenants is True
     assert all(


### PR DESCRIPTION
Closes #323. Found by the first live end-to-end idea-explanation journey run (lotus-idea#1222).

## What
- Migration `0074_lotus_idea_tenant_admission`: re-seeds the `lotus-idea` caller policy to `restricted_tenant_ids=['tenant-private-bank-sg','tenant-sg-001']` — the canonical platform tenant real Idea candidates carry, plus the retained lotus-ai-local runtime-proof fixture tenant. `tenant_policy_mode` stays RESTRICTED (fail-closed unchanged; only the admitted vocabulary aligns with platform truth). Idempotent UPDATE; bounded downgrade restores the prior list.
- Memory-mode seed aligned identically.
- Tests: authorization-level admission of the canonical tenant + continued blocking of an unadmitted tenant (banking the exact live scenario), policy-seed assertions updated, and the sqlalchemy round-trip test (which migrates a real database to head) now proves 0074 applies and reads back correctly.

## Why
Live evidence: `POST /platform/workflow-packs/execute` → 403 `LOTUS_AI_CALLER_FORBIDDEN` (BLOCKED_TENANT_NOT_ALLOWED) for caller `lotus-idea` with the candidate's real tenant, while pack eligibility itself allowed the request — pure caller-policy tenant-vocabulary drift, the third such drift the canonical QA stack surfaced tonight. The consumer degraded honestly (EXPLANATION_UNAVAILABLE + deterministic fallback), so this blocked only the served path.

## Non-goals
`allow_live_provider` stays False (separate governed decision); no other caller policies touched.

## Evidence
Full local gates green: lint + module budget, mypy (src+tests), coverage lane COV_EXIT=0 at 99% (25109 statements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)