### PR TITLE
fix(identity): make candidate identity v2 authoritative at every boundary (#326)

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -53,18 +53,29 @@ thresholds. Evaluation and per-candidate routing install it through a contextvar
 override, so no code path reads mutable process settings mid-request.
 
 **Routing.** `LOTUS_AI_ROUTING_STRATEGY` is `fixed` (one configured identity) or
-`ordered_fallback` (configured primary, then one governed alternate). Both
-candidates pass the same fences under their own execution config: kill switches,
-per-provider circuit breaker, and governed catalogue binding. Quota counters and
-the budget envelope are request-scoped and charged once. Every execution records
-a routing decision — each candidate, its rejection reason where rejected, the
-selection, and the `fallback_path`. Whichever candidate serves, it is the one
-named on every surface: audit record, routing decision, response, cost, metrics
-labels, structured logs, tracing spans, bounded failure messages, breaker
-evidence, and the attested run ledger all carry the serving identity.
+`ordered_fallback`. The ordered candidate list comes from the versioned governed
+serving policy over catalogue entries when one exists (N candidates, order is
+policy — no weights, no optimizer, no cost/latency reordering); the configured
+primary-plus-alternate pair is only the ungoverned seed shape. Every candidate
+passes the same fences under its own frozen execution config: kill switches,
+candidate-scoped circuit breaker, and governed catalogue binding. Quota counters
+and the budget envelope are request-scoped and charged once. Every execution
+records a routing decision — each candidate, its rejection reason where
+rejected, the selection, and the `fallback_path`. Whichever candidate serves is
+the one named on every surface: audit record, routing decision, response, cost,
+metrics labels, structured logs, tracing spans, bounded failure messages,
+breaker evidence, and the attested run ledger.
 
 **Model catalogue.** Provider, family, revision, deployment, and SKU are
-first-class governed identity. Lifecycle state gates execution (a retired or
+first-class governed identity. The canonical candidate identity
+(`candidate_id_v2`, hash of the full serving tuple) is authoritative at the
+write, seed, bind and accounting boundaries: row identity is immutable (a write
+or reseed that would replace a row with a different canonical candidate is
+refused — governance posture never transfers across an identity change), live
+binding compares the structured tuple rather than the derived key, and new
+attempt debits are keyed by the canonical identity (`adbt2:`); the legacy
+colon-delimited row key survives only as row locator and historical reference.
+Lifecycle state gates execution (a retired or
 unapproved revision is refused with `MODEL_LIFECYCLE_INELIGIBLE`), catalogue rows
 are seeded from configuration and from the approved model-risk inventory, and
 revision drift is recorded from the provider echo. Identity-bound,
@@ -145,10 +156,12 @@ Primary areas:
    provider adapters and one shared execution transport (provider policy, quota,
    budget, and degradation state live in `src/app/services/`). Routing selects
    among candidates under `LOTUS_AI_ROUTING_STRATEGY`: `fixed` resolves the one
-   configured identity, `ordered_fallback` attempts a configured primary then one
-   governed alternate. Every execution records a routing decision — every
-   candidate, its rejection reason where rejected, the selection, and the
-   `fallback_path` — on its response, audit record, and evidence bundle.
+   configured identity; `ordered_fallback` walks the governed serving policy's
+   ordered candidates (deterministic order, never ranking), falling back to the
+   configured primary/alternate pair only when no policy exists. Every execution
+   records a routing decision — every candidate, its rejection reason where
+   rejected, the selection, and the `fallback_path` — on its response, audit
+   record, and evidence bundle.
 2. `src/app/prompts/`
    prompt registry and rollout state.
 3. `src/app/retrieval/`

--- a/src/app/contracts/model_catalogue.py
+++ b/src/app/contracts/model_catalogue.py
@@ -299,6 +299,15 @@ class ModelCatalogueSeedReport(BaseModel):
     created_count: int = Field(ge=0, description="Entries created by this pass.")
     updated_count: int = Field(ge=0, description="Existing entries whose seeded fields changed.")
     unchanged_count: int = Field(ge=0, description="Entries already up to date.")
+    identity_conflict_count: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Seed candidates refused because the stored row under the same legacy "
+            "row key holds a DIFFERENT canonical candidate identity; nothing was "
+            "overwritten and no governance posture was transferred (issue #326)."
+        ),
+    )
 
 
 class ModelCatalogueResponse(BaseModel):

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -331,6 +331,7 @@ def post_openai_compatible_response(
             candidate_entry_id=candidate_entry_id,
             attempt_index=attempt_index,
             debit=debit,
+            candidate_id_v2=candidate_id_v2,
         )
         return debit
 

--- a/src/app/services/model_catalogue.py
+++ b/src/app/services/model_catalogue.py
@@ -14,11 +14,13 @@ seeded field actually changed.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 from fastapi import HTTPException, status
 
 from app.config import settings
+from app.services.structured_logging import log_event
 from app.contracts.model_catalogue import (
     OPERATOR_TERMINAL_LIFECYCLE_STATES,
     ModelCatalogueEntry,
@@ -51,6 +53,7 @@ from app.services.provider_execution_config import (
     resolve_provider_execution_config,
 )
 
+_logger = logging.getLogger("app.services.model_catalogue")
 _LIVE_TEXT_MODES = frozenset(
     {
         ProviderExecutionMode.OPENAI.value,
@@ -74,6 +77,17 @@ _EXECUTION_INELIGIBLE_LIFECYCLE_STATES = frozenset(
 )
 
 
+class CandidateIdentityConflictError(ValueError):
+    """A write would replace a stored row with a DIFFERENT canonical candidate.
+
+    The legacy row key omits the model family and is delimiter-ambiguous, so
+    two distinct candidates can share it. Row identity is immutable at the
+    write authority (issue #326): governance posture never transfers across a
+    canonical-identity change, and the conflicting write is refused rather
+    than silently replacing the row.
+    """
+
+
 def upsert_model_catalogue_entry(entry: ModelCatalogueEntry) -> None:
     """Write one catalogue entry, enforcing the deterministic-identity guard."""
 
@@ -87,7 +101,16 @@ def upsert_model_catalogue_entry(entry: ModelCatalogueEntry) -> None:
             "model catalogue entry id must equal the identity derived from provider, "
             f"revision and deployment (expected '{expected_entry_id}', got '{entry.entry_id}')"
         )
-    get_model_catalogue_repository().upsert_entry(entry)
+    repository = get_model_catalogue_repository()
+    existing = repository.get_entry(entry.entry_id)
+    if existing is not None and existing.candidate_id_v2 != entry.candidate_id_v2:
+        raise CandidateIdentityConflictError(
+            f"catalogue row '{entry.entry_id}' holds canonical candidate "
+            f"'{existing.candidate_id_v2}'; refusing to replace it with "
+            f"'{entry.candidate_id_v2}' - row identity is immutable and governance "
+            "posture never transfers across a canonical-identity change"
+        )
+    repository.upsert_entry(entry)
 
 
 def build_seed_model_catalogue_entries() -> list[ModelCatalogueEntry]:
@@ -237,12 +260,25 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
     """Idempotently reconcile the store with the configured seed rows."""
 
     repository = get_model_catalogue_repository()
-    created = updated = unchanged = 0
+    created = updated = unchanged = identity_conflicts = 0
     for entry in build_seed_model_catalogue_entries():
         existing = repository.get_entry(entry.entry_id)
         if existing is None:
             upsert_model_catalogue_entry(entry)
             created += 1
+            continue
+        if existing.candidate_id_v2 != entry.candidate_id_v2:
+            # The stored row is a DIFFERENT canonical candidate sharing the
+            # ambiguous legacy row key (issue #326). Nothing may transfer:
+            # not the row, not its lifecycle, not its assessed capabilities.
+            log_event(
+                _logger,
+                "model_catalogue_seed_identity_conflict",
+                entry_id=entry.entry_id,
+                stored_candidate_id_v2=existing.candidate_id_v2,
+                seed_candidate_id_v2=entry.candidate_id_v2,
+            )
+            identity_conflicts += 1
             continue
         candidate = entry.model_copy(update={"created_at": existing.created_at})
         if (
@@ -268,6 +304,7 @@ def ensure_model_catalogue_seeded() -> ModelCatalogueSeedReport:
         created_count=created,
         updated_count=updated,
         unchanged_count=unchanged,
+        identity_conflict_count=identity_conflicts,
     )
 
 
@@ -580,6 +617,24 @@ def bind_live_text_model_catalogue_entry() -> ModelCatalogueEntry:
         raise ProviderExecutionError(
             category=ProviderFailureCategory.MODEL_NOT_CATALOGUED,
             message=f"No governed model-catalogue entry exists for '{entry_id}'.",
+        )
+    if (
+        entry.provider_id != provider_id
+        or entry.model_revision != model_revision
+        or entry.deployment != config.deployment
+    ):
+        # The legacy row key is delimiter-ambiguous, so a resolved row may be
+        # a different serving tuple than the one this execution requested
+        # (issue #326). Binding compares the structured tuple, never just the
+        # derived key.
+        raise ProviderExecutionError(
+            category=ProviderFailureCategory.MODEL_NOT_CATALOGUED,
+            message=(
+                f"Model-catalogue entry '{entry_id}' resolves to serving identity "
+                f"('{entry.provider_id}', '{entry.model_revision}', '{entry.deployment}'), "
+                f"which is not the requested ('{provider_id}', '{model_revision}', "
+                f"'{config.deployment}'); refusing an identity-mismatched binding."
+            ),
         )
     if entry.lifecycle_state in _EXECUTION_INELIGIBLE_LIFECYCLE_STATES:
         raise ProviderExecutionError(

--- a/src/app/services/provider_budget_policy.py
+++ b/src/app/services/provider_budget_policy.py
@@ -136,6 +136,28 @@ def enforce_provider_budget() -> None:
         )
 
 
+def _attempt_debit_id(
+    *,
+    execution_id: str,
+    candidate_entry_id: str,
+    attempt_index: int,
+    candidate_id_v2: str | None,
+) -> str:
+    """The idempotent identity of one attempt debit (issue #326).
+
+    When the caller names a complete candidate, the canonical identity is the
+    debit segment: the legacy entry id omits the model family and is
+    delimiter-ambiguous, so two DISTINCT candidates can share it and would
+    silently collapse into one reservation. Without a canonical identity the
+    caller named no candidate (provider-keyed debits), where the legacy
+    segment is unambiguous and stays for continuity with existing rows.
+    """
+
+    if candidate_id_v2:
+        return f"adbt2:{execution_id}:{candidate_id_v2}:{attempt_index}"
+    return f"adbt:{execution_id}:{candidate_entry_id}:{attempt_index}"
+
+
 def record_attempt_spend(
     *,
     execution_id: str,
@@ -165,7 +187,12 @@ def record_attempt_spend(
     repository = get_provider_operations_store()
     return repository.record_attempt_debit(
         ProviderAttemptDebitRecord(
-            debit_id=f"adbt:{execution_id}:{candidate_entry_id}:{attempt_index}",
+            debit_id=_attempt_debit_id(
+                execution_id=execution_id,
+                candidate_entry_id=candidate_entry_id,
+                attempt_index=attempt_index,
+                candidate_id_v2=candidate_id_v2,
+            ),
             provider_id=provider_id,
             basis=debit.basis,
             amount_usd=debit.amount_usd,
@@ -213,7 +240,12 @@ def reserve_attempt_spend(
     repository = get_provider_operations_store()
     return repository.reserve_attempt_debit(
         ProviderAttemptDebitRecord(
-            debit_id=f"adbt:{execution_id}:{candidate_entry_id}:{attempt_index}",
+            debit_id=_attempt_debit_id(
+                execution_id=execution_id,
+                candidate_entry_id=candidate_entry_id,
+                attempt_index=attempt_index,
+                candidate_id_v2=candidate_id_v2,
+            ),
             provider_id=provider_id,
             basis="RESERVED_MAX",
             amount_usd=reservation.amount_usd,
@@ -237,6 +269,7 @@ def settle_attempt_spend(
     candidate_entry_id: str,
     attempt_index: int,
     debit: AttemptDebit | None,
+    candidate_id_v2: str | None = None,
 ) -> bool:
     """Settle a reservation to the attempt's evidenced debit in one
     transaction with the counter adjustment (issue #300) - or release it to
@@ -247,7 +280,12 @@ def settle_attempt_spend(
     """
 
     repository = get_provider_operations_store()
-    debit_id = f"adbt:{execution_id}:{candidate_entry_id}:{attempt_index}"
+    debit_id = _attempt_debit_id(
+        execution_id=execution_id,
+        candidate_entry_id=candidate_entry_id,
+        attempt_index=attempt_index,
+        candidate_id_v2=candidate_id_v2,
+    )
     if debit is None:
         return repository.settle_attempt_debit(
             debit_id=debit_id,
@@ -277,7 +315,11 @@ def spent_for_execution(execution_id: str) -> float:
     attempt against exactly the number the envelope recorded."""
 
     repository = get_provider_operations_store()
-    return repository.sum_attempt_debits(debit_id_prefix=f"adbt:{execution_id}:")
+    # Both identity generations count: canonical-segment debits (adbt2) are
+    # the current form; legacy-segment rows remain readable history.
+    return repository.sum_attempt_debits(
+        debit_id_prefix=f"adbt2:{execution_id}:"
+    ) + repository.sum_attempt_debits(debit_id_prefix=f"adbt:{execution_id}:")
 
 
 def reset_provider_budget_state() -> None:

--- a/tests/integration/test_integrated_candidate_architecture.py
+++ b/tests/integration/test_integrated_candidate_architecture.py
@@ -299,14 +299,17 @@ def test_the_integrated_three_candidate_architecture_proof(
     rows = {
         row.debit_id: row
         for row in get_provider_operations_store().list_attempt_debits()
-        if row.debit_id.startswith("adbt:exec-proof-1:")
+        if row.debit_id.startswith("adbt2:exec-proof-1:")
     }
+    # The debit identity segment is the CANONICAL candidate (issue #326):
+    # distinct candidates can never collapse into one reservation, and the
+    # id resolves each debit to its exact serving tuple.
     assert set(rows) == {
-        f"adbt:exec-proof-1:{candidate_a.entry_id}:0",
-        f"adbt:exec-proof-1:{candidate_c.entry_id}:0",
+        f"adbt2:exec-proof-1:{candidate_a.candidate_id_v2}:0",
+        f"adbt2:exec-proof-1:{candidate_c.candidate_id_v2}:0",
     }
-    debit_a = rows[f"adbt:exec-proof-1:{candidate_a.entry_id}:0"]
-    debit_c = rows[f"adbt:exec-proof-1:{candidate_c.entry_id}:0"]
+    debit_a = rows[f"adbt2:exec-proof-1:{candidate_a.candidate_id_v2}:0"]
+    debit_c = rows[f"adbt2:exec-proof-1:{candidate_c.candidate_id_v2}:0"]
     assert debit_a.candidate_id_v2 == candidate_a.candidate_id_v2
     assert debit_c.candidate_id_v2 == candidate_c.candidate_id_v2
     assert debit_a.basis == "CONSERVATIVE_ESTIMATE"

--- a/tests/unit/test_attempt_billing.py
+++ b/tests/unit/test_attempt_billing.py
@@ -13,6 +13,7 @@ from urllib import error
 from pytest import MonkeyPatch, raises
 
 from app.config import settings
+from app.contracts.model_catalogue import derive_candidate_identity_v2
 from app.contracts.providers import ProviderExecutionResponse
 from app.providers.base import ProviderExecutionError
 from app.services.provider_operations_store import get_provider_operations_store
@@ -161,6 +162,20 @@ def _http_error(code: int) -> error.HTTPError:
     )
 
 
+_CANONICAL_GPT54 = derive_candidate_identity_v2(
+    provider_id="text.local",
+    model_family="gpt-5.4",
+    model_revision="gpt-5.4",
+    deployment=None,
+)
+
+
+def _debit_key(execution_id: str, attempt_index: int) -> str:
+    """The canonical-segment debit identity minted by the transport (issue #326)."""
+
+    return f"adbt2:{execution_id}:{_CANONICAL_GPT54}:{attempt_index}"
+
+
 def _run_transport(*, retry_limit: int, execution_id: str) -> "ProviderExecutionResponse":
     from app.providers.local_openai_compatible_text_provider import (
         LocalOpenAICompatibleTextProvider,
@@ -203,8 +218,8 @@ def test_served_execution_debits_each_attempt_and_projects_them(
     response = _run_transport(retry_limit=1, execution_id="exec-served")
 
     rows = {row.debit_id: row for row in get_provider_operations_store().list_attempt_debits()}
-    failed_row = rows["adbt:exec-served:text.local:gpt-5.4:0"]
-    served_row = rows["adbt:exec-served:text.local:gpt-5.4:1"]
+    failed_row = rows[_debit_key("exec-served", 0)]
+    served_row = rows[_debit_key("exec-served", 1)]
     # The full serving identity rides the durable evidence (issue #299).
     assert served_row.candidate_entry_id == "text.local:gpt-5.4"
     assert served_row.model_revision == "gpt-5.4"
@@ -246,11 +261,11 @@ def test_terminal_all_fail_execution_still_debits_every_billable_attempt(
     rows = [
         row
         for row in get_provider_operations_store().list_attempt_debits()
-        if row.debit_id.startswith("adbt:exec-allfail:")
+        if row.debit_id.startswith("adbt2:exec-allfail:")
     ]
     assert {row.debit_id for row in rows} == {
-        "adbt:exec-allfail:text.local:gpt-5.4:0",
-        "adbt:exec-allfail:text.local:gpt-5.4:1",
+        _debit_key("exec-allfail", 0),
+        _debit_key("exec-allfail", 1),
     }
     assert all(row.basis == "CONSERVATIVE_ESTIMATE" for row in rows)
     budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
@@ -280,17 +295,17 @@ def test_rate_limited_and_pre_connect_failures_never_debit(
     rows = {
         row.debit_id: row
         for row in get_provider_operations_store().list_attempt_debits()
-        if row.debit_id.startswith("adbt:exec-unbillable:")
+        if row.debit_id.startswith("adbt2:exec-unbillable:")
     }
     # Only the served attempt carries spend: 429 refused before generation
     # and the connection-level failure never reached a generating provider.
     # Their pre-attempt reservations (issue #300) settle to zero-amount
     # RELEASED rows - admitted-then-released is durable evidence, not spend.
-    assert rows["adbt:exec-unbillable:text.local:gpt-5.4:0"].basis == "RELEASED"
-    assert rows["adbt:exec-unbillable:text.local:gpt-5.4:0"].amount_usd == 0.0
-    assert rows["adbt:exec-unbillable:text.local:gpt-5.4:1"].basis == "RELEASED"
-    assert rows["adbt:exec-unbillable:text.local:gpt-5.4:1"].amount_usd == 0.0
-    assert rows["adbt:exec-unbillable:text.local:gpt-5.4:2"].basis == "ACTUAL_USAGE"
+    assert rows[_debit_key("exec-unbillable", 0)].basis == "RELEASED"
+    assert rows[_debit_key("exec-unbillable", 0)].amount_usd == 0.0
+    assert rows[_debit_key("exec-unbillable", 1)].basis == "RELEASED"
+    assert rows[_debit_key("exec-unbillable", 1)].amount_usd == 0.0
+    assert rows[_debit_key("exec-unbillable", 2)].basis == "ACTUAL_USAGE"
     assert response.estimated_cost_usd == 0.0035
     assert response.failed_attempt_cost_basis == "NONE"
     assert response.billed_attempt_count == 1
@@ -829,8 +844,6 @@ def test_debit_rows_carry_the_resolvable_canonical_reference(
     idempotency identity is never rewritten, and the canonical reference
     makes the row resolvable under identity v2."""
 
-    from app.contracts.model_catalogue import derive_candidate_identity_v2
-
     _seed_cost_scalars()
     monkeypatch.setattr("urllib.request.urlopen", lambda request, timeout: _Response(_SUCCESS_BODY))
 
@@ -839,10 +852,10 @@ def test_debit_rows_carry_the_resolvable_canonical_reference(
     rows = [
         row
         for row in get_provider_operations_store().list_attempt_debits()
-        if row.debit_id.startswith("adbt:exec-canonical-ref:")
+        if row.debit_id.startswith("adbt2:exec-canonical-ref:")
     ]
     assert len(rows) == 1
-    assert rows[0].debit_id == "adbt:exec-canonical-ref:text.local:gpt-5.4:0"
+    assert rows[0].debit_id == _debit_key("exec-canonical-ref", 0)
     assert rows[0].candidate_id_v2 == derive_candidate_identity_v2(
         provider_id="text.local",
         model_family="gpt-5.4",

--- a/tests/unit/test_candidate_identity_authority.py
+++ b/tests/unit/test_candidate_identity_authority.py
@@ -1,0 +1,404 @@
+"""Canonical candidate identity is authoritative at write, seed, bind and
+accounting boundaries (issue #326).
+
+The legacy row key omits the model family and is delimiter-ambiguous, so two
+DISTINCT canonical candidates can share it. These are the audit
+counterexamples, kept as permanent regressions: no overwrite, no governance
+inheritance, no identity-mismatched binding, and no debit collision.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import app.services.model_catalogue as catalogue_service
+import app.services.provider_budget_policy as budget_policy
+from app.contracts.model_catalogue import (
+    ModelCatalogueEntry,
+    ModelCatalogueSeedSource,
+    ModelLifecycleState,
+    derive_model_catalogue_entry_id,
+)
+from app.providers.base import ProviderExecutionError
+from app.repositories.memory_model_catalogue_repository import (
+    InMemoryModelCatalogueRepository,
+)
+from app.repositories.memory_provider_operations_repository import (
+    InMemoryProviderOperationsRepository,
+)
+from app.services.model_catalogue import (
+    CandidateIdentityConflictError,
+    bind_live_text_model_catalogue_entry,
+    ensure_model_catalogue_seeded,
+    upsert_model_catalogue_entry,
+)
+from app.services.provider_budget_policy import (
+    reserve_attempt_spend,
+    settle_attempt_spend,
+    spent_for_execution,
+)
+from app.services.provider_usage_accounting import AttemptDebit
+
+_NOW = "2026-09-05T00:00:00Z"
+
+
+def _entry(
+    family: str,
+    state: ModelLifecycleState,
+    *,
+    provider_id: str = "text.shared",
+    model_revision: str = "rev-1",
+    deployment: str | None = None,
+) -> ModelCatalogueEntry:
+    return ModelCatalogueEntry(
+        entry_id=derive_model_catalogue_entry_id(
+            provider_id=provider_id,
+            model_revision=model_revision,
+            deployment=deployment,
+        ),
+        provider_id=provider_id,
+        provider_mode="openai",
+        model_family=family,
+        model_revision=model_revision,
+        deployment=deployment,
+        lifecycle_state=state,
+        revision_pinned=True,
+        seed_source=ModelCatalogueSeedSource.SETTINGS_LIVE_TEXT,
+        created_at=_NOW,
+        last_updated_at=_NOW,
+    )
+
+
+@pytest.fixture()
+def catalogue_repo(monkeypatch: pytest.MonkeyPatch) -> InMemoryModelCatalogueRepository:
+    repository = InMemoryModelCatalogueRepository()
+    monkeypatch.setattr(catalogue_service, "get_model_catalogue_repository", lambda: repository)
+    return repository
+
+
+def test_upsert_refuses_replacing_a_different_canonical_candidate(
+    catalogue_repo: InMemoryModelCatalogueRepository,
+) -> None:
+    family_a = _entry("family-a", ModelLifecycleState.APPROVED)
+    family_b = _entry("family-b", ModelLifecycleState.CATALOGUED)
+    assert family_a.entry_id == family_b.entry_id
+    assert family_a.candidate_id_v2 != family_b.candidate_id_v2
+    upsert_model_catalogue_entry(family_a)
+
+    with pytest.raises(CandidateIdentityConflictError, match="row identity is immutable"):
+        upsert_model_catalogue_entry(family_b)
+
+    stored = catalogue_repo.get_entry(family_a.entry_id)
+    assert stored is not None
+    assert stored.model_family == "family-a"
+    assert stored.lifecycle_state is ModelLifecycleState.APPROVED
+
+
+def test_reseed_never_transfers_governance_posture_across_identities(
+    catalogue_repo: InMemoryModelCatalogueRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    family_a = _entry("family-a", ModelLifecycleState.APPROVED)
+    family_a.supports_tool_calling = True
+    family_a.candidate_id_v2 = ""
+    family_a = ModelCatalogueEntry.model_validate(family_a.model_dump())
+    upsert_model_catalogue_entry(family_a)
+
+    family_b = _entry("family-b", ModelLifecycleState.CATALOGUED)
+    monkeypatch.setattr(catalogue_service, "build_seed_model_catalogue_entries", lambda: [family_b])
+
+    report = ensure_model_catalogue_seeded()
+
+    assert report.identity_conflict_count == 1
+    assert report.created_count == report.updated_count == 0
+    stored = catalogue_repo.get_entry(family_a.entry_id)
+    assert stored is not None
+    assert stored.model_family == "family-a"
+    assert stored.lifecycle_state is ModelLifecycleState.APPROVED
+    assert stored.supports_tool_calling is True
+    assert catalogue_repo.get_entry_by_candidate_id(family_a.candidate_id_v2) is not None
+    assert catalogue_repo.get_entry_by_candidate_id(family_b.candidate_id_v2) is None
+
+
+def test_reseed_refuses_delimiter_collision_identities(
+    catalogue_repo: InMemoryModelCatalogueRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bare = _entry("qwen", ModelLifecycleState.APPROVED, model_revision="qwen3:8b")
+    deployed = _entry(
+        "qwen", ModelLifecycleState.CATALOGUED, model_revision="qwen3", deployment="8b"
+    )
+    assert bare.entry_id == deployed.entry_id
+    assert bare.candidate_id_v2 != deployed.candidate_id_v2
+    upsert_model_catalogue_entry(bare)
+    monkeypatch.setattr(catalogue_service, "build_seed_model_catalogue_entries", lambda: [deployed])
+
+    report = ensure_model_catalogue_seeded()
+
+    assert report.identity_conflict_count == 1
+    stored = catalogue_repo.get_entry(bare.entry_id)
+    assert stored is not None
+    assert stored.model_revision == "qwen3:8b"
+    assert stored.lifecycle_state is ModelLifecycleState.APPROVED
+
+
+def test_binding_refuses_an_identity_mismatched_row(
+    catalogue_repo: InMemoryModelCatalogueRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A legacy/SQL row can hold a drifted tuple under the requested key; the
+    # bind authority compares the structured tuple, never just the key.
+    drifted = _entry("family-a", ModelLifecycleState.APPROVED, model_revision="qwen3:8b")
+    catalogue_repo.upsert_entry(drifted)
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(catalogue_service, "ensure_model_catalogue_seeded", lambda: None)
+    monkeypatch.setattr(
+        catalogue_service,
+        "resolve_provider_execution_config",
+        lambda: SimpleNamespace(
+            provider_id="text.shared",
+            model_id="qwen3",
+            model_version="qwen3",
+            deployment="8b",
+        ),
+    )
+    monkeypatch.setattr(
+        catalogue_service,
+        "derive_model_catalogue_entry_id",
+        lambda **_: drifted.entry_id,
+    )
+
+    with pytest.raises(ProviderExecutionError, match="identity-mismatched binding"):
+        bind_live_text_model_catalogue_entry()
+
+
+@pytest.fixture()
+def operations_repo(monkeypatch: pytest.MonkeyPatch) -> InMemoryProviderOperationsRepository:
+    repository = InMemoryProviderOperationsRepository()
+    monkeypatch.setattr(budget_policy, "get_provider_operations_store", lambda: repository)
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        budget_policy,
+        "resolve_provider_execution_config",
+        lambda: SimpleNamespace(
+            enforcement=SimpleNamespace(hard_budget_usd=10.0, budget_enforced=True)
+        ),
+    )
+    return repository
+
+
+def _debit(amount: float) -> AttemptDebit:
+    return AttemptDebit(
+        amount_usd=amount,
+        basis="ACTUAL_USAGE",
+        input_tokens=1,
+        output_tokens=1,
+        rate_card_ref="identity-authority-test",
+    )
+
+
+def test_distinct_candidates_sharing_the_legacy_key_debit_separately(
+    operations_repo: InMemoryProviderOperationsRepository,
+) -> None:
+    family_a = _entry("family-a", ModelLifecycleState.APPROVED)
+    family_b = _entry("family-b", ModelLifecycleState.APPROVED)
+
+    def reserve(entry: ModelCatalogueEntry) -> str:
+        return reserve_attempt_spend(
+            execution_id="exec-identity",
+            candidate_entry_id=entry.entry_id,
+            provider_id=entry.provider_id,
+            model_revision=entry.model_revision,
+            attempt_index=0,
+            reservation=_debit(0.7),
+            candidate_id_v2=entry.candidate_id_v2,
+        )
+
+    assert reserve(family_a) == "RESERVED"
+    assert reserve(family_b) == "RESERVED"
+    assert settle_attempt_spend(
+        execution_id="exec-identity",
+        candidate_entry_id=family_a.entry_id,
+        attempt_index=0,
+        debit=_debit(0.7),
+        candidate_id_v2=family_a.candidate_id_v2,
+    )
+    assert settle_attempt_spend(
+        execution_id="exec-identity",
+        candidate_entry_id=family_b.entry_id,
+        attempt_index=0,
+        debit=_debit(0.5),
+        candidate_id_v2=family_b.candidate_id_v2,
+    )
+
+    rows = operations_repo.list_attempt_debits()
+    assert len(rows) == 2
+    assert {row.candidate_id_v2 for row in rows} == {
+        family_a.candidate_id_v2,
+        family_b.candidate_id_v2,
+    }
+    budget_state = operations_repo.get_budget_state(budget_key=budget_policy._BUDGET_KEY)
+    assert budget_state is not None
+    assert budget_state.current_spend_usd == pytest.approx(1.2)
+    assert spent_for_execution("exec-identity") == pytest.approx(1.2)
+
+
+def test_same_candidate_replay_stays_a_replay(
+    operations_repo: InMemoryProviderOperationsRepository,
+) -> None:
+    family_a = _entry("family-a", ModelLifecycleState.APPROVED)
+
+    def reserve() -> str:
+        return reserve_attempt_spend(
+            execution_id="exec-replay",
+            candidate_entry_id=family_a.entry_id,
+            provider_id=family_a.provider_id,
+            model_revision=family_a.model_revision,
+            attempt_index=0,
+            reservation=_debit(0.7),
+            candidate_id_v2=family_a.candidate_id_v2,
+        )
+
+    assert reserve() == "RESERVED"
+    assert reserve() == "DUPLICATE"
+    assert len(operations_repo.list_attempt_debits()) == 1
+
+
+def test_execution_spend_sums_canonical_and_legacy_debit_generations(
+    operations_repo: InMemoryProviderOperationsRepository,
+) -> None:
+    family_a = _entry("family-a", ModelLifecycleState.APPROVED)
+    assert (
+        reserve_attempt_spend(
+            execution_id="exec-mixed",
+            candidate_entry_id=family_a.entry_id,
+            provider_id=family_a.provider_id,
+            model_revision=family_a.model_revision,
+            attempt_index=0,
+            reservation=_debit(0.4),
+            candidate_id_v2=family_a.candidate_id_v2,
+        )
+        == "RESERVED"
+    )
+    # A provider-keyed debit (no candidate named) keeps the legacy identity.
+    assert (
+        reserve_attempt_spend(
+            execution_id="exec-mixed",
+            candidate_entry_id="text.shared",
+            provider_id="text.shared",
+            model_revision=None,
+            attempt_index=1,
+            reservation=_debit(0.3),
+            candidate_id_v2=None,
+        )
+        == "RESERVED"
+    )
+
+    rows = {row.debit_id for row in operations_repo.list_attempt_debits()}
+    assert any(debit_id.startswith("adbt2:exec-mixed:cand2_") for debit_id in rows)
+    assert any(debit_id.startswith("adbt:exec-mixed:text.shared:") for debit_id in rows)
+    assert spent_for_execution("exec-mixed") == pytest.approx(0.7)
+
+
+def test_sql_upsert_refuses_replacing_a_different_canonical_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.repositories.sqlalchemy_model_catalogue_repository import (
+        SqlAlchemyModelCatalogueRepository,
+    )
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    database_url = f"sqlite:///{Path(tmp_path) / 'identity-authority.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyModelCatalogueRepository(database_url)
+    monkeypatch.setattr(catalogue_service, "get_model_catalogue_repository", lambda: repository)
+    family_a = _entry("family-a", ModelLifecycleState.APPROVED)
+    family_b = _entry("family-b", ModelLifecycleState.CATALOGUED)
+    upsert_model_catalogue_entry(family_a)
+
+    with pytest.raises(CandidateIdentityConflictError):
+        upsert_model_catalogue_entry(family_b)
+
+    stored = repository.get_entry(family_a.entry_id)
+    assert stored is not None
+    assert stored.model_family == "family-a"
+    assert stored.lifecycle_state is ModelLifecycleState.APPROVED
+    assert repository.get_entry_by_candidate_id(family_b.candidate_id_v2) is None
+
+
+def test_sql_debit_lifecycle_keys_on_the_canonical_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from types import SimpleNamespace
+
+    from app.repositories.sqlalchemy_provider_operations_repository import (
+        SqlAlchemyProviderOperationsRepository,
+    )
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    database_url = f"sqlite:///{Path(tmp_path) / 'identity-debits.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyProviderOperationsRepository(database_url)
+    monkeypatch.setattr(budget_policy, "get_provider_operations_store", lambda: repository)
+    monkeypatch.setattr(
+        budget_policy,
+        "resolve_provider_execution_config",
+        lambda: SimpleNamespace(
+            enforcement=SimpleNamespace(hard_budget_usd=10.0, budget_enforced=True)
+        ),
+    )
+    family_a = _entry("family-a", ModelLifecycleState.APPROVED)
+    family_b = _entry("family-b", ModelLifecycleState.APPROVED)
+
+    for entry in (family_a, family_b):
+        assert (
+            reserve_attempt_spend(
+                execution_id="exec-sql",
+                candidate_entry_id=entry.entry_id,
+                provider_id=entry.provider_id,
+                model_revision=entry.model_revision,
+                attempt_index=0,
+                reservation=_debit(0.6),
+                candidate_id_v2=entry.candidate_id_v2,
+            )
+            == "RESERVED"
+        )
+    assert settle_attempt_spend(
+        execution_id="exec-sql",
+        candidate_entry_id=family_a.entry_id,
+        attempt_index=0,
+        debit=_debit(0.6),
+        candidate_id_v2=family_a.candidate_id_v2,
+    )
+    assert settle_attempt_spend(
+        execution_id="exec-sql",
+        candidate_entry_id=family_b.entry_id,
+        attempt_index=0,
+        debit=_debit(0.4),
+        candidate_id_v2=family_b.candidate_id_v2,
+    )
+    # A pre-existing legacy-format row still counts toward the execution.
+    assert (
+        reserve_attempt_spend(
+            execution_id="exec-sql",
+            candidate_entry_id="text.shared",
+            provider_id="text.shared",
+            model_revision=None,
+            attempt_index=1,
+            reservation=_debit(0.2),
+            candidate_id_v2=None,
+        )
+        == "RESERVED"
+    )
+
+    debit_ids = {row.debit_id for row in repository.list_attempt_debits()}
+    assert (
+        f"adbt2:exec-sql:{family_a.candidate_id_v2}:0" in debit_ids
+        and f"adbt2:exec-sql:{family_b.candidate_id_v2}:0" in debit_ids
+        and "adbt:exec-sql:text.shared:1" in debit_ids
+    )
+    assert spent_for_execution("exec-sql") == pytest.approx(1.2)

--- a/tests/unit/test_model_catalogue.py
+++ b/tests/unit/test_model_catalogue.py
@@ -173,18 +173,21 @@ def test_reseeding_is_idempotent_and_preserves_created_at(
     assert (second_report.created_count, second_report.updated_count) == (0, 0)
     assert second_report.unchanged_count == 1
 
-    # Same derived identity (text.local:qwen3:8b), different seeded content:
-    # the revision is now explicit and the family differs, so this must be an
-    # in-place update that keeps the original created_at.
+    # Same LEGACY row key (text.local:qwen3:8b) but a DIFFERENT canonical
+    # candidate: the family changes from "qwen3:8b" to "qwen3". Row identity
+    # is immutable at the write authority (issue #326) - the reseed refuses
+    # the replacement instead of silently transferring the row, and the
+    # stored candidate keeps its original identity and provenance.
     monkeypatch.setattr(settings, "live_text_model_version", "qwen3:8b")
     monkeypatch.setattr(settings, "live_text_model_id", "qwen3")
     third_report = ensure_model_catalogue_seeded()
-    assert (third_report.created_count, third_report.updated_count) == (0, 1)
-    updated_entry = get_model_catalogue_repository().get_entry("text.local:qwen3:8b")
-    assert updated_entry is not None
-    assert updated_entry.model_family == "qwen3"
-    assert updated_entry.revision_pinned is True
-    assert updated_entry.created_at == first_created_at
+    assert (third_report.created_count, third_report.updated_count) == (0, 0)
+    assert third_report.identity_conflict_count == 1
+    stored_entry = get_model_catalogue_repository().get_entry("text.local:qwen3:8b")
+    assert stored_entry is not None
+    assert stored_entry.model_family == "qwen3:8b"
+    assert stored_entry.revision_pinned is False
+    assert stored_entry.created_at == first_created_at
 
 
 def test_store_accessor_defaults_to_memory_and_reset_clears_state(


### PR DESCRIPTION
Closes #326. Deep-audit packet 1 (F1, P1 promotion blocker) — all audit probes reproduced on main `a975381` before this change.

## Consumer/operator outcome
A reseed or write can no longer silently replace a catalogue row with a DIFFERENT canonical candidate while inheriting its APPROVED lifecycle and capability flags; live binding can no longer serve an identity-mismatched row; and two distinct candidates can no longer collapse into one attempt debit (double-execution billed once, budget under-counted).

## Invariant repaired, and its single authority
Row identity is immutable and governance posture never transfers across a canonical-identity change — enforced at `upsert_model_catalogue_entry` (the one catalogue write authority; refusal type `CandidateIdentityConflictError`), at seed reconciliation (conflicts counted in the seed report, nothing inherited, nothing overwritten), at `bind_live_text_model_catalogue_entry` (structured-tuple comparison, not key equality), and at the debit identity minted in `provider_budget_policy` (`adbt2:{execution}:{candidate_id_v2}:{attempt}` whenever a candidate is named; provider-keyed debits keep their unambiguous legacy form).

## Simplification / removal
The defect-pinning test asserting cross-identity row replacement ("family differs, so this must be an in-place update") is rewritten to assert the refusal. No new framework; no schema change (both SQL uniqueness indexes stay as-is — the fix is at the authorities, per the audit's note that uniqueness does not make row identity immutable).

## Failing-before / passing-after
Audit probes 1–2 (catalogue reseed posture transfer; distinct-candidates debit collision) fail against the old behavior and are now permanent counterexamples in `tests/unit/test_candidate_identity_authority.py`: same-provider/same-revision/different-family AND delimiter (`qwen3:8b` vs `qwen3`+`8b`) collisions through writes, reseeding, binding, reservation and settlement — no overwrite, no lifecycle/capability transfer, no wrong binding, two distinct debits with correct budget movement, replay stays DUPLICATE — proven against BOTH the memory and migrated-SQLite repositories, plus a mixed-generation (`adbt2` + legacy) execution-spend sum for legacy-read compatibility.

## Compatibility & residuals
Additive seed-report field (`identity_conflict_count`, default 0). Existing legacy debit rows remain readable and countable (dual-prefix sums); no migration needed. Residual (out of scope, per audit): full COEXISTENCE of colliding candidates needs a canonical-PK row key — refusal is the fail-closed boundary until that is scheduled; `record_attempt_spend` looks caller-less and is a follow-up simplification candidate. Context doc updated (stale primary/alternate routing prose → governed N-candidate serving policy; canonical-identity authority documented).

## Gates
Local: lint + module budget, mypy (src+tests), coverage lane COV_EXIT=0 at 99% (25128 statements), integrated 3+‑candidate proof evolved to canonical debit identities and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)