### PR TITLE
fix(accepted-output): bind published output to the persisted artifact bytes (#328)

### DIFF
--- a/src/app/services/workflow_pack_run_accepted_output.py
+++ b/src/app/services/workflow_pack_run_accepted_output.py
@@ -70,6 +70,7 @@ REASON_RUN_NOT_ACCEPTED = "run_not_accepted"
 REASON_RUN_SUPERSEDED = "run_superseded"
 REASON_OUTPUT_ARTIFACT_MISSING = "output_artifact_missing"
 REASON_OUTPUT_ARTIFACT_MALFORMED = "output_artifact_malformed"
+REASON_OUTPUT_ARTIFACT_INTEGRITY = "output_artifact_integrity_mismatch"
 REASON_OUTPUT_NOT_VALIDATED = "output_not_validated"
 
 ACCEPTED_OUTPUT_REASON_CODES = frozenset(
@@ -80,6 +81,7 @@ ACCEPTED_OUTPUT_REASON_CODES = frozenset(
         REASON_RUN_SUPERSEDED,
         REASON_OUTPUT_ARTIFACT_MISSING,
         REASON_OUTPUT_ARTIFACT_MALFORMED,
+        REASON_OUTPUT_ARTIFACT_INTEGRITY,
         REASON_OUTPUT_NOT_VALIDATED,
     }
 )
@@ -236,6 +238,22 @@ def _load_intact_output_payload(record: WorkflowPackRunRecord) -> dict[str, Any]
         raise AcceptedOutputNotAvailableError(
             REASON_OUTPUT_ARTIFACT_MISSING,
             "The governed run-output artifact object is no longer retrievable.",
+        )
+    # The acceptance and VALIDATED evidence attach to the bytes that existed
+    # when the artifact was persisted. Publishing requires the loaded bytes to
+    # BE those bytes (issue #328): identity metadata alone cannot establish
+    # that, and the recorded checksum is never repaired at read time.
+    recorded_checksum = (summary_artifact.checksum_sha256 or "").strip().lower()
+    loaded_checksum = hashlib.sha256(stored_object.payload).hexdigest()
+    if (
+        not recorded_checksum
+        or loaded_checksum != recorded_checksum
+        or summary_artifact.byte_size != len(stored_object.payload)
+    ):
+        raise AcceptedOutputNotAvailableError(
+            REASON_OUTPUT_ARTIFACT_INTEGRITY,
+            "The governed run-output artifact bytes do not match the checksum and "
+            "size recorded when the output was persisted.",
         )
     try:
         payload = json.loads(stored_object.payload.decode("utf-8"))

--- a/tests/unit/test_workflow_pack_run_accepted_latest.py
+++ b/tests/unit/test_workflow_pack_run_accepted_latest.py
@@ -9,6 +9,7 @@ tenant isolation without an existence oracle.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Any
 
@@ -103,6 +104,31 @@ def _seed_run(
     artifact_intact: bool = True,
 ) -> None:
     store, objects = stores
+    raw: bytes | None = None
+    if artifact_intact:
+        structured: dict[str, Any] = {
+            "advisor_brief_status": "complete",
+            "coverage_state": "complete",
+            "portfolio_id": portfolio_id,
+            "period": "YTD",
+            "grounded_summary": f"Summary for {run_id}.",
+            "talking_points": [],
+            "risks_and_exceptions": [],
+        }
+        if as_of_date is not None:
+            structured["as_of_date"] = as_of_date
+        if reporting_currency is not None:
+            structured["reporting_currency"] = reporting_currency
+        raw = json.dumps(
+            {
+                "run_id": run_id,
+                "pack_id": "advisor_brief.pack",
+                "source_refs": [],
+                "evidence_types": [],
+                "structured_output": structured,
+            }
+        ).encode("utf-8")
+        objects.objects[f"runs/{run_id}.json"] = raw
     store.runs[run_id] = WorkflowPackRunRecord(
         run_id=run_id,
         pack_id="advisor_brief.pack",
@@ -134,8 +160,8 @@ def _seed_run(
                 lifecycle_status=ArtifactLifecycleStatus.RUNTIME_GENERATED,
                 retention_posture="retained_for_review",
                 media_type="application/json",
-                byte_size=512,
-                checksum_sha256="0" * 64,
+                byte_size=len(raw) if raw is not None else 512,
+                checksum_sha256=(hashlib.sha256(raw).hexdigest() if raw is not None else "0" * 64),
                 storage_backend=ArtifactStorageBackend.MEMORY,
                 storage_reference=f"artifact://runs/{run_id}.json",
                 created_at=created_at,
@@ -161,29 +187,6 @@ def _seed_run(
                 recorded_at=reviewed_at,
             )
         )
-    if artifact_intact:
-        structured: dict[str, Any] = {
-            "advisor_brief_status": "complete",
-            "coverage_state": "complete",
-            "portfolio_id": portfolio_id,
-            "period": "YTD",
-            "grounded_summary": f"Summary for {run_id}.",
-            "talking_points": [],
-            "risks_and_exceptions": [],
-        }
-        if as_of_date is not None:
-            structured["as_of_date"] = as_of_date
-        if reporting_currency is not None:
-            structured["reporting_currency"] = reporting_currency
-        objects.objects[f"runs/{run_id}.json"] = json.dumps(
-            {
-                "run_id": run_id,
-                "pack_id": "advisor_brief.pack",
-                "source_refs": [],
-                "evidence_types": [],
-                "structured_output": structured,
-            }
-        ).encode("utf-8")
 
 
 def _lookup(**overrides: Any) -> Any:
@@ -451,3 +454,27 @@ def test_envelope_is_identity_only_and_pins_the_projection_hash(
         "content_hash_algorithm",
         "notes",
     }
+
+
+def test_latest_accepted_withholds_tampered_artifact_bytes(
+    _stores: tuple[_Store, _ObjectStore],
+) -> None:
+    """Same run/pack ids, valid JSON, changed narrative: the acceptance and
+    validation evidence belong to the persisted bytes, so the latest-accepted
+    composition refuses the changed content (issue #328)."""
+
+    _seed_run(
+        _stores,
+        run_id="wfr-tampered",
+        created_at="2026-08-30T09:00:00Z",
+        reviewed_at="2026-08-30T09:05:00Z",
+    )
+    store, objects = _stores
+    tampered = json.loads(objects.objects["runs/wfr-tampered.json"].decode("utf-8"))
+    tampered["structured_output"]["grounded_summary"] = "A different unreviewed narrative."
+    objects.objects["runs/wfr-tampered.json"] = json.dumps(tampered).encode("utf-8")
+
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        _lookup()
+
+    assert excinfo.value.reason_code == "output_artifact_integrity_mismatch"

--- a/tests/unit/test_workflow_pack_run_accepted_output.py
+++ b/tests/unit/test_workflow_pack_run_accepted_output.py
@@ -7,6 +7,8 @@ determinism and sensitivity, directly against the service.
 
 from __future__ import annotations
 
+import dataclasses
+import hashlib
 import json
 from typing import Any
 
@@ -143,7 +145,13 @@ class _ObjectStoreStub:
         return _Stored()
 
 
-WireCallable = Callable[["WorkflowPackRunRecord | None", "dict[str, Any] | bytes | None"], None]
+WireCallable = Callable[..., None]
+
+
+def _serialize(payload: dict[str, Any] | bytes | None) -> bytes | None:
+    if isinstance(payload, dict):
+        return json.dumps(payload).encode("utf-8")
+    return payload
 
 
 @pytest.fixture
@@ -151,10 +159,28 @@ def _wired(monkeypatch: pytest.MonkeyPatch) -> WireCallable:
     def wire(
         record: WorkflowPackRunRecord | None,
         artifact_payload: dict[str, Any] | bytes | None,
+        *,
+        recorded_payload: dict[str, Any] | bytes | None = None,
     ) -> None:
-        raw = artifact_payload
-        if isinstance(raw, dict):
-            raw = json.dumps(raw).encode("utf-8")
+        raw = _serialize(artifact_payload)
+        # The descriptor records the checksum/size of the bytes that existed at
+        # persistence time (issue #328): by default that is what the store now
+        # holds; a tamper scenario records the ORIGINAL bytes while the store
+        # holds changed ones.
+        recorded = _serialize(recorded_payload) if recorded_payload is not None else raw
+        if record is not None and recorded is not None:
+            refreshed_refs = [
+                artifact.model_copy(
+                    update={
+                        "checksum_sha256": hashlib.sha256(recorded).hexdigest(),
+                        "byte_size": len(recorded),
+                    }
+                )
+                if artifact.artifact_type == "run_output_summary"
+                else artifact
+                for artifact in record.artifact_refs
+            ]
+            record = dataclasses.replace(record, artifact_refs=refreshed_refs)
         monkeypatch.setattr(module, "ensure_workflow_pack_run_store_ready", lambda: None)
         monkeypatch.setattr(module, "get_workflow_pack_run_store", lambda: _StoreStub(record))
         monkeypatch.setattr(module, "get_artifact_object_store", lambda: _ObjectStoreStub(raw))
@@ -243,13 +269,23 @@ def test_accepted_state_without_recorded_review_event_is_malformed(
     # Deliberately NOT using `_wired`: it stubs `_accepting_review_identity`, and
     # this pin is about that function refusing an ACCEPTED record whose event
     # ledger carries no review transition.
-    monkeypatch.setattr(module, "ensure_workflow_pack_run_store_ready", lambda: None)
-    monkeypatch.setattr(module, "get_workflow_pack_run_store", lambda: _StoreStub(_record()))
-    monkeypatch.setattr(
-        module,
-        "get_artifact_object_store",
-        lambda: _ObjectStoreStub(json.dumps(_artifact_payload()).encode("utf-8")),
+    raw = json.dumps(_artifact_payload()).encode("utf-8")
+    record = _record()
+    record = dataclasses.replace(
+        record,
+        artifact_refs=[
+            artifact.model_copy(
+                update={
+                    "checksum_sha256": hashlib.sha256(raw).hexdigest(),
+                    "byte_size": len(raw),
+                }
+            )
+            for artifact in record.artifact_refs
+        ],
     )
+    monkeypatch.setattr(module, "ensure_workflow_pack_run_store_ready", lambda: None)
+    monkeypatch.setattr(module, "get_workflow_pack_run_store", lambda: _StoreStub(record))
+    monkeypatch.setattr(module, "get_artifact_object_store", lambda: _ObjectStoreStub(raw))
     with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
         build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
     assert _reason(excinfo) == "output_artifact_malformed"
@@ -443,6 +479,7 @@ def test_every_refusal_reason_is_declared_in_the_vocabulary() -> None:
         module.REASON_RUN_SUPERSEDED,
         module.REASON_OUTPUT_ARTIFACT_MISSING,
         module.REASON_OUTPUT_ARTIFACT_MALFORMED,
+        module.REASON_OUTPUT_ARTIFACT_INTEGRITY,
         module.REASON_OUTPUT_NOT_VALIDATED,
     }
     assert raised == set(module.ACCEPTED_OUTPUT_REASON_CODES)
@@ -502,3 +539,47 @@ def test_incomplete_validation_evidence_fails_closed(missing: str, _wired: WireC
         build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
     assert _reason(excinfo) == "output_not_validated"
     assert missing in excinfo.value.message
+
+
+def test_tampered_bytes_with_original_checksum_are_refused(_wired: WireCallable) -> None:
+    original = _artifact_payload()
+    changed = _artifact_payload()
+    changed["structured_output"]["grounded_summary"] = "A different unreviewed narrative."
+    _wired(_record(), changed, recorded_payload=original)
+
+    with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+        module.build_workflow_pack_run_accepted_output(
+            run_id="wfr-accepted-001", caller_tenant_id=TENANT
+        )
+
+    assert _reason(excinfo) == module.REASON_OUTPUT_ARTIFACT_INTEGRITY
+
+
+def test_artifact_without_a_recorded_checksum_is_refused(_wired: WireCallable) -> None:
+    record = _record()
+    stripped_refs = [
+        artifact.model_copy(update={"checksum_sha256": ""}) for artifact in record.artifact_refs
+    ]
+    payload = _artifact_payload()
+    _wired(dataclasses.replace(record, artifact_refs=stripped_refs), payload)
+    # Undo the wire fixture's checksum refresh: this scenario is exactly "no
+    # recorded integrity evidence".
+    import app.services.workflow_pack_run_accepted_output as service_module
+
+    class _Store:
+        def get_run(self, *, run_id: str) -> Any:
+            return dataclasses.replace(record, artifact_refs=stripped_refs)
+
+        def list_events(self, *, run_id: str) -> list[Any]:
+            return []
+
+    import pytest as _pytest
+
+    with _pytest.MonkeyPatch.context() as mp:
+        mp.setattr(service_module, "get_workflow_pack_run_store", lambda: _Store())
+        with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
+            module.build_workflow_pack_run_accepted_output(
+                run_id="wfr-accepted-001", caller_tenant_id=TENANT
+            )
+
+    assert _reason(excinfo) == module.REASON_OUTPUT_ARTIFACT_INTEGRITY


### PR DESCRIPTION
Closes #328. Deep-audit packet 2 (F4, P1 — blocker for the exact-accepted-output guarantee); audit probe 7 reproduced on main before this change.

## Consumer/operator outcome
Report/Gateway can no longer receive changed content carrying the original acceptance and VALIDATED evidence: a syntactically valid artifact whose narrative changed after review is withheld with a bounded reason instead of published as the reviewed output.

## Invariant repaired, and its single authority
Published accepted output IS the persisted-at-acceptance bytes — enforced in `_load_intact_output_payload`, the one loader gating BOTH the direct accepted-output route and the latest-accepted composition: raw object bytes must match the artifact descriptor's recorded `checksum_sha256` and `byte_size`, an artifact with no recorded checksum is refused (integrity evidence is proven at persistence or absent — age is not evidence), and the recorded checksum is never repaired at read time. New bounded reason `output_artifact_integrity_mismatch` joins the published vocabulary.

## Simplification / removal
None beyond fixture honesty: the all-zero placeholder checksums (which made integrity undemonstrable, per the audit) are gone — every fixture computes the real checksum of the bytes it stores, with a `recorded_payload` seam for deliberate tamper scenarios.

## Failing-before / passing-after
Audit probe 7 (changed narrative loaded despite the recorded original checksum) is now a permanent counterexample on BOTH paths: `test_tampered_bytes_with_original_checksum_are_refused` (direct) and `test_latest_accepted_withholds_tampered_artifact_bytes` (composition), plus checksum-absent refusal; the valid-unmodified, wrong-tenant, superseded, malformed and review-ledger pins all still pass, and the integration accepted-latest API suite passes through the REAL persist path (whose recorded checksums match by construction — legitimate runs are unaffected).

## Compatibility & residuals
No schema or route change; the new reason code is additive to the published vocabulary (vocabulary test updated). Residual: provider-native deletion/retention confirmation and cross-repo consumption remain #115/report-side concerns — lotus-platform-cf is queued to verify lotus-report's accepted-output consumption against the new refusal.

## Gates
Local: lint + module budget, mypy (src+tests, unpiped), coverage lane COV_EXIT=0 at 99% (25114 statements), 43 accepted-path unit tests + 9 integration accepted-latest API tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)