### PR TITLE
fix(budget): the debit identity is stated at both ends, and there is one writer

### DIFF
--- a/src/app/services/provider_budget_policy.py
+++ b/src/app/services/provider_budget_policy.py
@@ -158,57 +158,6 @@ def _attempt_debit_id(
     return f"adbt:{execution_id}:{candidate_entry_id}:{attempt_index}"
 
 
-def record_attempt_spend(
-    *,
-    execution_id: str,
-    candidate_entry_id: str,
-    provider_id: str,
-    model_revision: str | None,
-    attempt_index: int,
-    debit: AttemptDebit,
-    candidate_id_v2: str | None = None,
-) -> bool:
-    """Durably debit one provider attempt at its boundary (issue #289).
-
-    The identity is derived from the execution/candidate/attempt context, so
-    recording is idempotent: a crash after the attempt loses nothing, and a
-    duplicate recording is a complete no-op. The budget counter advances in
-    the same transaction, which is why an execution whose every attempt
-    fails still moves the envelope - spend becomes real per attempt, not at
-    response settlement.
-
-    The candidate segment is the catalogue entry id, never the provider id
-    (issue #299): two model candidates at the same provider are normal
-    serving topology, and a provider-keyed identity would silently swallow
-    the second candidate's attempt 0 as a duplicate of the first's. The
-    row persists the full serving identity for later audit.
-    """
-
-    repository = get_provider_operations_store()
-    return repository.record_attempt_debit(
-        ProviderAttemptDebitRecord(
-            debit_id=_attempt_debit_id(
-                execution_id=execution_id,
-                candidate_entry_id=candidate_entry_id,
-                attempt_index=attempt_index,
-                candidate_id_v2=candidate_id_v2,
-            ),
-            provider_id=provider_id,
-            basis=debit.basis,
-            amount_usd=debit.amount_usd,
-            input_tokens=debit.input_tokens,
-            output_tokens=debit.output_tokens,
-            rate_card_ref=debit.rate_card_ref,
-            recorded_at=_utcnow(),
-            candidate_entry_id=candidate_entry_id,
-            model_revision=model_revision,
-            attempt_index=attempt_index,
-            candidate_id_v2=candidate_id_v2,
-        ),
-        budget_key=_BUDGET_KEY,
-    )
-
-
 def reserve_attempt_spend(
     *,
     execution_id: str,
@@ -217,10 +166,16 @@ def reserve_attempt_spend(
     model_revision: str | None,
     attempt_index: int,
     reservation: AttemptDebit,
-    candidate_id_v2: str | None = None,
+    candidate_id_v2: str | None,
 ) -> str:
     """Atomically reserve one attempt's governed maximum against the global
     budget row BEFORE the provider is called (issue #300).
+
+    ``candidate_id_v2`` has no default on purpose (follow-up to #333): the
+    debit identity diverges silently if one side of the reserve/settle pair
+    omits it, so every caller must STATE the canonical identity -- an
+    explicit ``None`` means the caller names no canonical candidate and the
+    legacy provider-keyed segment applies.
 
     "Hard" means enforceable under concurrency: the limit check, the
     reservation row (basis ``RESERVED_MAX``) and the counter advance are one
@@ -269,7 +224,7 @@ def settle_attempt_spend(
     candidate_entry_id: str,
     attempt_index: int,
     debit: AttemptDebit | None,
-    candidate_id_v2: str | None = None,
+    candidate_id_v2: str | None,
 ) -> bool:
     """Settle a reservation to the attempt's evidenced debit in one
     transaction with the counter adjustment (issue #300) - or release it to

--- a/tests/integration/test_provider_api_contract.py
+++ b/tests/integration/test_provider_api_contract.py
@@ -11,8 +11,6 @@ from app.contracts.providers import (
     ProviderExecutionResponse,
     ProviderFailureCategory,
 )
-from app.services.provider_budget_policy import record_attempt_spend
-from app.services.provider_usage_accounting import AttemptDebit
 from app.services.provider_degradation_state import record_provider_failure
 from app.services.provider_operations_store import reset_provider_operations_store_cache
 from app.services.provider_quota_policy import enforce_provider_quota
@@ -22,6 +20,7 @@ from app.services.eval_async_execution import run_next_evaluation_execution_job
 from app.services.eval_run_submission_service import submit_evaluation_run
 from app.contracts.evals import EvaluationRunSubmissionRequest
 from tests.support.migration_runner import upgrade_database_to_head
+from tests.support.budget_seeding import seed_settled_attempt_spend
 from tests.support.runtime_settings import override_runtime_settings
 from tests.unit.test_task_executor import _request
 from tests.support.caller_credentials import (
@@ -32,20 +31,7 @@ from tests.support.caller_credentials import (
 
 
 def _seed_attempt_spend(amount: float, *, execution_id: str) -> None:
-    record_attempt_spend(
-        execution_id=execution_id,
-        candidate_entry_id="text.openai:gpt-5.4",
-        provider_id="text.openai",
-        model_revision="gpt-5.4",
-        attempt_index=0,
-        debit=AttemptDebit(
-            amount_usd=amount,
-            basis="ACTUAL_USAGE",
-            input_tokens=100,
-            output_tokens=200,
-            rate_card_ref="default-live-text",
-        ),
-    )
+    seed_settled_attempt_spend(amount, execution_id=execution_id)
 
 
 def _budget_response(cost: float | None, *, stubbed: bool = False) -> ProviderExecutionResponse:

--- a/tests/support/budget_seeding.py
+++ b/tests/support/budget_seeding.py
@@ -1,0 +1,63 @@
+"""Seed settled provider spend through the one remaining debit lifecycle.
+
+``record_attempt_spend`` -- the uncoupled single-shot debit writer -- was
+removed in the follow-up to #333: reserve->settle is the complete lifecycle,
+and a second writer that skipped admission was exactly the kind of path the
+identity audit closes. Tests that need historical spend on the books seed it
+here, through the real pair, with enforcement suspended for the duration so
+history can exceed the configured limits (as real history can).
+"""
+
+from __future__ import annotations
+
+from app.config import settings
+from app.services.provider_budget_policy import (
+    reserve_attempt_spend,
+    settle_attempt_spend,
+)
+from app.services.provider_usage_accounting import AttemptDebit
+
+
+def seed_settled_attempt_spend(
+    amount_usd: float,
+    *,
+    execution_id: str,
+    attempt_index: int = 0,
+    input_tokens: int = 100,
+    output_tokens: int = 200,
+) -> bool:
+    """Reserve and settle one ACTUAL_USAGE debit; True when newly settled.
+
+    A repeat of the same attempt identity converges: the reservation reports
+    DUPLICATE and the settlement is a no-op, so the return value preserves
+    the old recorder's recorded/duplicate contract.
+    """
+
+    debit = AttemptDebit(
+        amount_usd=amount_usd,
+        basis="ACTUAL_USAGE",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        rate_card_ref="default-live-text",
+    )
+    previous = settings.live_text_budget_enforced
+    settings.live_text_budget_enforced = False
+    try:
+        reserve_attempt_spend(
+            execution_id=execution_id,
+            candidate_entry_id="text.openai:gpt-5.4",
+            provider_id="text.openai",
+            model_revision="gpt-5.4",
+            attempt_index=attempt_index,
+            reservation=debit,
+            candidate_id_v2=None,
+        )
+        return settle_attempt_spend(
+            execution_id=execution_id,
+            candidate_entry_id="text.openai:gpt-5.4",
+            attempt_index=attempt_index,
+            debit=debit,
+            candidate_id_v2=None,
+        )
+    finally:
+        settings.live_text_budget_enforced = previous

--- a/tests/unit/test_candidate_identity_v2.py
+++ b/tests/unit/test_candidate_identity_v2.py
@@ -297,3 +297,22 @@ def test_both_adapters_refuse_a_drifted_canonical_id(tmp_path: Path) -> None:
     repository = SqlAlchemyModelCatalogueRepository(database_url)
     with pytest.raises(ValueError, match="drifted"):
         repository.upsert_entry(drifted)
+
+
+def test_candidate_identity_v2_grammar_is_the_debit_segment_guarantee() -> None:
+    """The attempt-debit identity embeds candidate_id_v2 between colon
+    delimiters (``adbt2:{execution}:{candidate_id_v2}:{attempt}``). This
+    grammar is what keeps that segment delimiter-unambiguous -- the defect
+    the legacy entry-id segment had: ``cand2_`` plus exactly 64 hex digits,
+    colon-free by construction, for every input including hostile ones."""
+
+    import re as _re
+
+    for deployment in (None, "eu-west-1", "with:colons", "unicode-\u2603"):
+        identity = derive_candidate_identity_v2(
+            provider_id="provider:with:colons",
+            model_family="family:x",
+            model_revision="rev:1",
+            deployment=deployment,
+        )
+        assert _re.fullmatch(r"cand2_[0-9a-f]{64}", identity), identity

--- a/tests/unit/test_provider_activation_readiness.py
+++ b/tests/unit/test_provider_activation_readiness.py
@@ -97,22 +97,13 @@ def test_provider_activation_readiness_reports_hard_budget_blocking() -> None:
     settings.live_text_output_cost_per_1k_tokens = 0.03
     settings.live_text_hard_budget_usd = 1.0
 
-    from app.services.provider_budget_policy import record_attempt_spend
-    from app.services.provider_usage_accounting import AttemptDebit
+    from tests.support.budget_seeding import seed_settled_attempt_spend
 
-    record_attempt_spend(
+    seed_settled_attempt_spend(
+        1.0,
         execution_id="exec-activation-hard",
-        candidate_entry_id="text.openai:gpt-5.4",
-        provider_id="text.openai",
-        model_revision="gpt-5.4",
-        attempt_index=0,
-        debit=AttemptDebit(
-            amount_usd=1.0,
-            basis="ACTUAL_USAGE",
-            input_tokens=100,
-            output_tokens=200,
-            rate_card_ref="default-live-text",
-        ),
+        input_tokens=100,
+        output_tokens=200,
     )
 
     readiness = build_provider_activation_readiness()

--- a/tests/unit/test_provider_budget_policy.py
+++ b/tests/unit/test_provider_budget_policy.py
@@ -5,9 +5,8 @@ from app.contracts.providers import ProviderBudgetState
 from app.services.provider_budget_policy import (
     build_provider_budget_policy,
     enforce_provider_budget,
-    record_attempt_spend,
 )
-from app.services.provider_usage_accounting import AttemptDebit
+from tests.support.budget_seeding import seed_settled_attempt_spend
 from app.providers.base import ProviderExecutionError
 from app.services.provider_operations_store import reset_provider_operations_store_cache
 from app.services.rate_card_store import reset_rate_card_store_cache
@@ -17,19 +16,8 @@ from tests.support.migration_runner import upgrade_database_to_head
 def _seed_spend(
     amount: float, *, execution_id: str = "exec-budget-test", attempt_index: int = 0
 ) -> bool:
-    return record_attempt_spend(
-        execution_id=execution_id,
-        candidate_entry_id="text.openai:gpt-5.4",
-        provider_id="text.openai",
-        model_revision="gpt-5.4",
-        attempt_index=attempt_index,
-        debit=AttemptDebit(
-            amount_usd=amount,
-            basis="ACTUAL_USAGE",
-            input_tokens=100,
-            output_tokens=200,
-            rate_card_ref="default-live-text",
-        ),
+    return seed_settled_attempt_spend(
+        amount, execution_id=execution_id, attempt_index=attempt_index
     )
 
 
@@ -125,8 +113,10 @@ def test_provider_budget_policy_enforcement_rejects_invalid_configuration() -> N
 
 
 def test_recording_the_same_attempt_identity_twice_debits_once() -> None:
-    """Issue #289: the attempt identity makes recording idempotent - a
-    crash-and-retry of the recording call can never double-debit."""
+    """Issue #289, via the lifecycle (follow-up to #333): the same attempt
+    identity converges -- the second reservation reports DUPLICATE and the
+    second settlement is a no-op, so a crash-and-retry of the recording
+    sequence can never double-debit."""
 
     settings.live_text_budget_enforced = True
     settings.live_text_input_cost_per_1k_tokens = 0.01

--- a/tests/unit/test_provider_gateway.py
+++ b/tests/unit/test_provider_gateway.py
@@ -489,22 +489,13 @@ def test_execute_text_generation_rejects_live_provider_when_budget_is_exceeded()
     # Spend becomes real at the attempt boundary (issue #289), a layer this
     # test's fake adapter deliberately bypasses - seed the debit exactly as
     # the real transport records it, then prove the preflight blocks.
-    from app.services.provider_budget_policy import record_attempt_spend
-    from app.services.provider_usage_accounting import AttemptDebit
+    from tests.support.budget_seeding import seed_settled_attempt_spend
 
-    record_attempt_spend(
+    seed_settled_attempt_spend(
+        1.0,
         execution_id="exec-gateway-budget",
-        candidate_entry_id="text.openai:gpt-5.4",
-        provider_id="text.openai",
-        model_revision="gpt-5.4",
-        attempt_index=0,
-        debit=AttemptDebit(
-            amount_usd=1.0,
-            basis="ACTUAL_USAGE",
-            input_tokens=10,
-            output_tokens=20,
-            rate_card_ref="default-live-text",
-        ),
+        input_tokens=10,
+        output_tokens=20,
     )
 
     with pytest.raises(HTTPException) as exc_info:

--- a/tests/unit/test_provider_operations_control.py
+++ b/tests/unit/test_provider_operations_control.py
@@ -16,8 +16,7 @@ from app.contracts.provider_operations import (
     ProviderOperationsResetIntentRequest,
 )
 from app.http.authenticated_caller import AuthenticatedCaller
-from app.services.provider_budget_policy import record_attempt_spend
-from app.services.provider_usage_accounting import AttemptDebit
+from tests.support.budget_seeding import seed_settled_attempt_spend
 from app.services.provider_degradation_state import record_provider_failure
 from app.services.provider_operations_control import (
     approve_provider_operations_reset,
@@ -33,20 +32,7 @@ from tests.unit.test_task_executor import _request
 
 
 def _seed_attempt_spend(amount: float, *, execution_id: str) -> None:
-    record_attempt_spend(
-        execution_id=execution_id,
-        candidate_entry_id="text.openai:gpt-5.4",
-        provider_id="text.openai",
-        model_revision="gpt-5.4",
-        attempt_index=0,
-        debit=AttemptDebit(
-            amount_usd=amount,
-            basis="ACTUAL_USAGE",
-            input_tokens=100,
-            output_tokens=200,
-            rate_card_ref="default-live-text",
-        ),
-    )
+    seed_settled_attempt_spend(amount, execution_id=execution_id)
 
 
 def _budget_response(cost: float) -> ProviderExecutionResponse:

--- a/tests/unit/test_provider_operations_status.py
+++ b/tests/unit/test_provider_operations_status.py
@@ -45,23 +45,9 @@ def test_provider_operations_status_reports_soft_budget_state_when_live_path_is_
     settings.live_text_soft_budget_usd = 0.5
     settings.live_text_hard_budget_usd = 1.0
 
-    from app.services.provider_budget_policy import record_attempt_spend
-    from app.services.provider_usage_accounting import AttemptDebit
+    from tests.support.budget_seeding import seed_settled_attempt_spend
 
-    record_attempt_spend(
-        execution_id="exec-ops-status-soft",
-        candidate_entry_id="text.openai:gpt-5.4",
-        provider_id="text.openai",
-        model_revision="gpt-5.4",
-        attempt_index=0,
-        debit=AttemptDebit(
-            amount_usd=0.75,
-            basis="ACTUAL_USAGE",
-            input_tokens=100,
-            output_tokens=200,
-            rate_card_ref="default-live-text",
-        ),
-    )
+    seed_settled_attempt_spend(0.75, execution_id="exec-ops-status-soft")
 
     status = build_provider_operations_status()
 
@@ -252,23 +238,9 @@ def test_provider_operations_status_reports_hard_budget_blocked_state() -> None:
     settings.live_text_output_cost_per_1k_tokens = 0.03
     settings.live_text_hard_budget_usd = 1.0
 
-    from app.services.provider_budget_policy import record_attempt_spend
-    from app.services.provider_usage_accounting import AttemptDebit
+    from tests.support.budget_seeding import seed_settled_attempt_spend
 
-    record_attempt_spend(
-        execution_id="exec-ops-status-hard",
-        candidate_entry_id="text.openai:gpt-5.4",
-        provider_id="text.openai",
-        model_revision="gpt-5.4",
-        attempt_index=0,
-        debit=AttemptDebit(
-            amount_usd=1.0,
-            basis="ACTUAL_USAGE",
-            input_tokens=100,
-            output_tokens=200,
-            rate_card_ref="default-live-text",
-        ),
-    )
+    seed_settled_attempt_spend(1.0, execution_id="exec-ops-status-hard")
 
     status = build_provider_operations_status()
 


### PR DESCRIPTION
Follow-up to #333 (review finding by bb, accepted by the ai session); refs #326. Rebased onto #334's merge.

## What

- **`candidate_id_v2` is a required keyword on both `reserve_attempt_spend` and `settle_attempt_spend`** — the debit identity diverges silently if one side of the pair omits it: a reservation written under `adbt2:` that settlement looks up under `adbt:` is stranded RESERVED_MAX leaking into the budget sum forever. An explicit `None` stays legal and means the caller names no canonical candidate (legacy provider-keyed segment). The decision is documented once, on reserve.
- **`record_attempt_spend` deleted** — no src caller remained, and an uncoupled single-shot debit writer that skips admission is exactly the path the identity audit closes. Test seeding now goes through the real reserve→settle lifecycle via `tests/support/budget_seeding.py`, with enforcement suspended for the seed so history can exceed configured limits (as real history can). Six call sites across five test files rewired; the twice-recorded idempotency test now proves lifecycle convergence (DUPLICATE reservation + no-op settlement).
- **Grammar contract test**: `derive_candidate_identity_v2` output is pinned to `cand2_` + exactly 64 hex digits — colon-free by construction for every input including hostile ones — which is what keeps the `adbt2:` debit segment delimiter-unambiguous (the defect the legacy entry-id segment had).

## Evidence

- Affected suites green (95 tests across budget policy, identity authority/v2, activation readiness, gateway, operations control/status, attempt billing, provider api contract); ruff clean; mypy clean (758 files).
- Full unit suite green in the working clone except `test_only_governed_local_entrypoints_enable_header_identity`, which fails there purely on Windows MAX_PATH (the clone's deep temp path + demo capture filenames exceed the open() limit) — it passes in a short-path checkout; CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)