### PR TITLE
docs(tests): the seeding helper states its deliberate legacy mint

### DIFF
--- a/tests/support/budget_seeding.py
+++ b/tests/support/budget_seeding.py
@@ -31,6 +31,14 @@ def seed_settled_attempt_spend(
     A repeat of the same attempt identity converges: the reservation reports
     DUPLICATE and the settlement is a no-op, so the return value preserves
     the old recorder's recorded/duplicate contract.
+
+    The seed states ``candidate_id_v2=None`` DELIBERATELY, minting a
+    legacy ``adbt:`` provider-keyed row (issue #337): these seeds model
+    pre-#333 history, which the budget sum must keep counting, and the
+    fixture candidate exists in no catalogue -- deriving a canonical id for
+    it would fabricate an identity nothing ever served. A test that needs a
+    canonical-segment (``adbt2:``) row should execute the real transport
+    path against a catalogued candidate instead of copying this helper.
     """
 
     debit = AttemptDebit(


### PR DESCRIPTION
The bb half of #337 (split agreed with the ai session): the seeding helper's docstring now states that `candidate_id_v2=None` is deliberate — the seeds model pre-#333 history the budget sum must keep counting, the fixture candidate exists in no catalogue (deriving a canonical id would fabricate an identity nothing ever served), and tests needing `adbt2:` rows belong on the real transport path. Prefix check done: no test asserts an `adbt:` prefix on seeded rows. Docstring-only; call signature unchanged (packet 4 consumes, does not modify).

Refs #335, #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)