### PR TITLE
fix(governance): one owner per approved intent; recoverable erasure (#327)

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -132,7 +132,15 @@ deletion writes an append-only `data_lifecycle_events` row referencing content
 only by digest. Tenant erasure is a governed two-step `DATA_ERASURE` action
 yielding an Ed25519-signed receipt verifiable against the published attestation
 keys; erasure overrides retention, legal hold overrides erasure, and both are
-recorded. Minimisation caps the audit `result_preview` at persistence and ages
+recorded. Governed execution is single-owner (#327): approval claims the action
+atomically (`PENDING→CLAIMED`, one compare-and-set authority in the repository;
+a duplicated approval loses the claim and receives 409), executes, then
+finalizes `CLAIMED→EXECUTED` with a durable result payload. Erasure proves
+signing readiness before any deletion (a missing receipt key means zero rows
+erased, 503, still approvable), replays a lost receipt from the durable result
+without re-erasing, and recovers a crash-interrupted run through deterministic
+per-action/family lifecycle events — resumable only by the claiming credential
+with an explicit resume flag. Minimisation caps the audit `result_preview` at persistence and ages
 passing evaluation-case content at a declared shorter horizon.
 
 **Current limitations.** Capability requirements exist for latency (one governed

--- a/alembic/versions/0075_governed_action_claim_evidence.py
+++ b/alembic/versions/0075_governed_action_claim_evidence.py
@@ -1,0 +1,36 @@
+"""Claim and result evidence on governed actions.
+
+One approval session must atomically own a governed action's execution
+(issue #327): the CLAIMED transition carries the approver evidence from the
+instant of the claim, and the durable result payload makes evidence-bearing
+responses (an erasure receipt) retrievable after a lost response without
+re-executing the effect. Both columns are additive and nullable; existing
+rows are untouched historical evidence.
+
+Revision ID: 0075_governed_action_claim_evidence
+Revises: 0074_lotus_idea_tenant_admission
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0075_governed_action_claim_evidence"
+down_revision = "0074_lotus_idea_tenant_admission"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "provider_governed_actions",
+        sa.Column("claimed_at", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "provider_governed_actions",
+        sa.Column("result_payload", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("provider_governed_actions", "result_payload")
+    op.drop_column("provider_governed_actions", "claimed_at")

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -66,6 +66,10 @@ class GovernedActionType(str, Enum):
 
 class GovernedActionStatus(str, Enum):
     PENDING = "PENDING"
+    # An approver's atomic claim on a PENDING action (issue #327): exactly one
+    # approval session owns the transition to execution; a claim that survives
+    # a crash is resumable only by the claiming credential.
+    CLAIMED = "CLAIMED"
     EXECUTED = "EXECUTED"
     SUPERSEDED = "SUPERSEDED"
 
@@ -116,6 +120,23 @@ class GovernedActionRecord(BaseModel):
         description="Signing credential that authenticated the approver; must differ from the requester's.",
     )
     approver_attribution: str | None = Field(default=None, max_length=256)
+    claimed_at: str | None = Field(
+        default=None,
+        max_length=64,
+        description=(
+            "Instant the approver's atomic claim transitioned this action from "
+            "PENDING (issue #327); execution evidence begins here."
+        ),
+    )
+    result_payload: dict[str, object] | None = Field(
+        default=None,
+        description=(
+            "Durable domain result of the executed action (issue #327), persisted "
+            "with the EXECUTED transition so evidence-bearing responses (e.g. an "
+            "erasure receipt) are retrievable after a lost response without "
+            "re-executing the effect."
+        ),
+    )
     approved_at: str | None = Field(default=None, max_length=64)
     executed_at: str | None = Field(default=None, max_length=64)
     superseded_by_action_id: str | None = Field(default=None, max_length=64)

--- a/src/app/db/models.py
+++ b/src/app/db/models.py
@@ -315,6 +315,8 @@ class GovernedActionModel(Base):
     approved_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
     executed_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
     superseded_by_action_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    claimed_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    result_payload: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
 
 
 class ProviderOperationsEventModel(Base):

--- a/src/app/repositories/memory_provider_operations_repository.py
+++ b/src/app/repositories/memory_provider_operations_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 from collections.abc import Sequence
 
 from copy import deepcopy
@@ -22,6 +24,7 @@ from app.repositories.provider_operations_repository import (
 
 class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
     def __init__(self) -> None:
+        self._governed_action_transition_lock = threading.Lock()
         self._quota_states: dict[tuple[ProviderQuotaScope, str], ProviderQuotaStateRecord] = {}
         self._budget_states: dict[str, ProviderBudgetStateRecord] = {}
         self._degradation_states: dict[str, ProviderDegradationStateRecord] = {}
@@ -315,6 +318,22 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
         ]
         records.sort(key=lambda record: record.requested_at, reverse=True)
         return [record.model_copy(deep=True) for record in records[:limit]]
+
+    def transition_governed_action(
+        self,
+        *,
+        action_id: str,
+        expected_status: str,
+        record: GovernedActionRecord,
+    ) -> bool:
+        # Process-local store: a lock IS the atomicity boundary here; the SQL
+        # adapter carries the cross-replica guarantee (issue #327).
+        with self._governed_action_transition_lock:
+            current = self._governed_actions.get(action_id)
+            if current is None or current.status.value != expected_status:
+                return False
+            self._governed_actions[action_id] = record.model_copy(deep=True)
+            return True
 
     def upsert_governed_action(self, record: GovernedActionRecord) -> None:
         self._governed_actions[record.action_id] = record.model_copy(deep=True)

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -234,6 +234,18 @@ class ProviderOperationsRepository(Protocol):
     ) -> GovernedActionRecord | None:
         """Fetch the pending governed action for one action type and target, if any."""
 
+    def transition_governed_action(
+        self,
+        *,
+        action_id: str,
+        expected_status: str,
+        record: GovernedActionRecord,
+    ) -> bool:
+        """Atomically replace the action iff its CURRENT status equals
+        ``expected_status`` (issue #327). Returns False without writing when
+        the action moved concurrently - the caller lost the transition."""
+        ...
+
     def upsert_governed_action(self, record: GovernedActionRecord) -> None:
         """Persist one governed-action record by action id."""
 

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -711,6 +711,30 @@ class SqlAlchemyProviderOperationsRepository(
             query = query.order_by(GovernedActionModel.requested_at.desc()).limit(limit)
             return [_to_governed_action_record(model) for model in session.execute(query).scalars()]
 
+    def transition_governed_action(
+        self,
+        *,
+        action_id: str,
+        expected_status: str,
+        record: GovernedActionRecord,
+    ) -> bool:
+        # One guarded UPDATE in its own transaction (issue #327): the WHERE
+        # predicate on the CURRENT status is the cross-replica claim - two
+        # sessions cannot both move the same action out of expected_status.
+        payload = record.model_dump(mode="json")
+        payload.pop("action_id", None)
+        with self._session_factory() as session:
+            result = session.execute(
+                update(GovernedActionModel)
+                .where(
+                    GovernedActionModel.action_id == action_id,
+                    GovernedActionModel.status == expected_status,
+                )
+                .values(**payload)
+            )
+            session.commit()
+            return int(getattr(result, "rowcount", 0) or 0) == 1
+
     def upsert_governed_action(self, record: GovernedActionRecord) -> None:
         with self._session_factory() as session:
             model = session.get(GovernedActionModel, record.action_id)

--- a/src/app/services/data_lifecycle_erasure.py
+++ b/src/app/services/data_lifecycle_erasure.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 from base64 import urlsafe_b64encode
 from datetime import UTC, datetime
+from typing import cast
 from uuid import uuid4
 
 from fastapi import HTTPException, status
@@ -39,6 +40,7 @@ from app.contracts.data_lifecycle import (
 from app.contracts.governed_actions import (
     GovernedActionRecord,
     GovernedActionResponse,
+    GovernedActionStatus,
     GovernedActionType,
 )
 from app.contracts.workflow_run_attestation import WorkflowRunAttestationSignature
@@ -53,6 +55,7 @@ from app.services.governed_action_control import (
     approve_and_execute_governed_action,
     submit_governed_action,
 )
+from app.services.provider_operations_store import get_provider_operations_store
 from app.services.workflow_pack_run_store import get_workflow_pack_run_store
 from app.services.workflow_pack_queue_event_store import get_workflow_pack_queue_event_store
 from app.services.workflow_pack_task_flow_store import get_workflow_pack_task_flow_store
@@ -131,6 +134,31 @@ def approve_data_erasure(
     evidences and issues the signed receipt."""
 
     _require_provider_control_authorization(caller)
+    # Signing readiness BEFORE destructive work (issue #327/F3): a missing or
+    # malformed receipt key must mean ZERO deletion, not an unreceipted one.
+    try:
+        ConfiguredWorkflowRunAttestationKeys(settings=settings).signer()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "The erasure-receipt signing key is not available; nothing was "
+                "erased. Configure the attestation signing material and retry."
+            ),
+        ) from exc
+
+    # A lost response is recoverable without re-erasing: an EXECUTED action
+    # with the same hash returns the SAME evidenced outcome, re-signed from
+    # the durable result payload.
+    existing = get_provider_operations_store().get_governed_action(request.action_id)
+    if (
+        existing is not None
+        and existing.status is GovernedActionStatus.EXECUTED
+        and existing.action_hash == request.action_hash
+        and existing.result_payload is not None
+    ):
+        return _erasure_response_from_result(existing)
+
     outcome: dict[str, object] = {}
 
     def _execute_erasure(record: GovernedActionRecord) -> None:
@@ -148,6 +176,20 @@ def approve_data_erasure(
                 )
                 continue
             erased, unattributable = _ERASURE_EXECUTORS[family_id](tenant_id)
+            # Deterministic per-action/family evidence id (issue #327): a
+            # recovery re-run after a crash merges the first pass's durable
+            # count instead of reporting an honest-but-empty re-deletion.
+            event_id = _family_erasure_event_id(record.action_id, family_id)
+            prior_event = next(
+                (
+                    event
+                    for event in get_audit_store().list_lifecycle_events(limit=10000)
+                    if event.event_id == event_id
+                ),
+                None,
+            )
+            if prior_event is not None:
+                erased = max(erased, prior_event.row_count)
             results.append(
                 DataErasureFamilyResult(
                     family_id=family_id,
@@ -159,7 +201,7 @@ def approve_data_erasure(
             if erased:
                 get_audit_store().save_lifecycle_event(
                     DataLifecycleEventRecord(
-                        event_id=f"dle_{uuid4().hex[:16]}",
+                        event_id=event_id,
                         family_id=family_id,
                         action=DataLifecycleAction.ERASURE,
                         key_scope=f"tenant:{tenant_id}",
@@ -186,6 +228,13 @@ def approve_data_erasure(
         ),
         attribution=request.approved_by,
         execute=_execute_erasure,
+        result_payload_builder=lambda: {
+            "results": [
+                result.model_dump(mode="json")
+                for result in cast(list[DataErasureFamilyResult], outcome["results"])
+            ],
+            "executed_at": outcome["executed_at"],
+        },
     )
     results = outcome["results"]
     assert isinstance(results, list)
@@ -207,6 +256,45 @@ def approve_data_erasure(
             f"distinct credential `{executed.approver_key_id}`.",
             "Held families are listed on the receipt with held=true; the receipt "
             "signature verifies against the published attestation keys.",
+        ],
+    )
+
+
+def _family_erasure_event_id(action_id: str, family_id: str) -> str:
+    digest = hashlib.sha256(f"{action_id}:{family_id}".encode("utf-8")).hexdigest()[:24]
+    return f"dle_{digest}"
+
+
+def _erasure_response_from_result(record: GovernedActionRecord) -> DataErasureApprovalResponse:
+    """Rebuild the evidenced erasure outcome from the durable result payload.
+
+    Re-signing the same claims is retrieval, not re-erasure: the counts,
+    families and execution instant are exactly the ones the executed action
+    recorded (issue #327/F3).
+    """
+
+    payload = record.result_payload or {}
+    raw_results = payload.get("results")
+    results = [
+        DataErasureFamilyResult.model_validate(item)
+        for item in (raw_results if isinstance(raw_results, list) else [])
+    ]
+    receipt = _issue_receipt(
+        tenant_id=record.target,
+        reason=str(record.action_payload.get("reason")),
+        governed_action_id=record.action_id,
+        families=results,
+        executed_at=str(payload.get("executed_at")),
+    )
+    return DataErasureApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        receipt=receipt,
+        governed_action=record,
+        summary=[
+            f"Erasure of tenant `{record.target}` under governed action "
+            f"`{record.action_id}` was already executed; this is the evidenced "
+            "outcome re-signed from durable results, not a re-erasure.",
         ],
     )
 

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -98,13 +98,18 @@ def submit_governed_action(
     )
     prior = repository.get_pending_governed_action(action_type=action_type.value, target=target)
     if prior is not None:
-        repository.upsert_governed_action(
-            prior.model_copy(
+        # Guarded transition (issue #327): if the prior action was claimed or
+        # executed concurrently, supersession loses and that execution stands;
+        # this new request still records as the next pending intent.
+        repository.transition_governed_action(
+            action_id=prior.action_id,
+            expected_status=GovernedActionStatus.PENDING.value,
+            record=prior.model_copy(
                 update={
                     "status": GovernedActionStatus.SUPERSEDED,
                     "superseded_by_action_id": record.action_id,
                 }
-            )
+            ),
         )
     repository.upsert_governed_action(record)
     return record
@@ -119,6 +124,8 @@ def approve_and_execute_governed_action(
     current_payload_builder: Callable[[GovernedActionRecord], dict[str, str | None]],
     attribution: str | None,
     execute: Callable[[GovernedActionRecord], None],
+    result_payload_builder: Callable[[], dict[str, object]] | None = None,
+    resume_interrupted_claim: bool = False,
 ) -> GovernedActionRecord:
     """Validate a distinct verified approver against the exact action, then execute.
 
@@ -141,12 +148,21 @@ def approve_and_execute_governed_action(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No governed action exists for `{action_id}`.",
         )
-    if record.status is not GovernedActionStatus.PENDING:
+    # Resuming an interrupted claim is an EXPLICIT recovery intent, never an
+    # inference: a live claim raced by its own credential must refuse, or two
+    # same-credential approvals would both run the effect (issue #327).
+    resuming_own_claim = (
+        resume_interrupted_claim
+        and record.status is GovernedActionStatus.CLAIMED
+        and record.approver_key_id == caller.credential_key_id
+    )
+    if record.status is not GovernedActionStatus.PENDING and not resuming_own_claim:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
                 f"Governed action `{action_id}` is {record.status.value}; only a PENDING "
-                "action can be approved."
+                "action (or the claiming credential resuming its own interrupted claim) "
+                "can be approved."
             ),
         )
     if record.actor_class is not GovernedActorClass.HUMAN_APPROVED:
@@ -187,21 +203,65 @@ def approve_and_execute_governed_action(
             ),
         )
 
-    execute(record)
-
     now = _utc_now_iso()
-    executed = record.model_copy(
+    if resuming_own_claim:
+        claimed = record
+    else:
+        claimed = record.model_copy(
+            update={
+                "status": GovernedActionStatus.CLAIMED,
+                "approver_caller_app": caller.caller_app,
+                "approver_trust_source": caller.trust_source,
+                "approver_key_id": caller.credential_key_id,
+                "approver_attribution": attribution,
+                "approved_at": now,
+                "claimed_at": now,
+            }
+        )
+        # The atomic claim IS the transition ownership (issue #327): exactly
+        # one approval session moves PENDING to CLAIMED; a concurrent
+        # approval, supersession or execution makes this a refusal, never a
+        # second effect.
+        if not repository.transition_governed_action(
+            action_id=action_id,
+            expected_status=GovernedActionStatus.PENDING.value,
+            record=claimed,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Governed action `{action_id}` was claimed, superseded or executed "
+                    "concurrently; this approval did not execute."
+                ),
+            )
+
+    # The callback contract (issue #327): domain effects must be idempotent
+    # under the governed action identity - a crash between the claim and the
+    # EXECUTED write is recovered by the claiming credential re-approving,
+    # which re-invokes the callback.
+    execute(claimed)
+
+    executed = claimed.model_copy(
         update={
             "status": GovernedActionStatus.EXECUTED,
-            "approver_caller_app": caller.caller_app,
-            "approver_trust_source": caller.trust_source,
-            "approver_key_id": caller.credential_key_id,
-            "approver_attribution": attribution,
-            "approved_at": now,
-            "executed_at": now,
+            "executed_at": _utc_now_iso(),
+            "result_payload": (
+                result_payload_builder() if result_payload_builder is not None else None
+            ),
         }
     )
-    repository.upsert_governed_action(executed)
+    if not repository.transition_governed_action(
+        action_id=action_id,
+        expected_status=GovernedActionStatus.CLAIMED.value,
+        record=executed,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Governed action `{action_id}` left its claim while executing; the "
+                "domain effect ran but the execution evidence could not be finalized."
+            ),
+        )
     return executed
 
 

--- a/tests/unit/test_data_lifecycle_erasure.py
+++ b/tests/unit/test_data_lifecycle_erasure.py
@@ -270,3 +270,140 @@ def test_erasure_covers_attributed_async_jobs_and_artifacts_with_payloads(
     assert artifact_result.unattributable_count == 1
     # Fully attributed stores carry no unattributable claim.
     assert by_family["audit_evidence"].unattributable_count is None
+
+
+def test_missing_signing_key_means_zero_deletion(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Audit F3: signing readiness is validated BEFORE destructive work - an
+    absent receipt key refuses the approval with nothing erased and the
+    governed action still PENDING and approvable after the key is fixed."""
+
+    _seed_two_tenants()
+    monkeypatch.setattr(settings, "workflow_run_attestation_key_id", "")
+    pending = request_data_erasure(
+        DataErasureIntentRequest(tenant_id="tenant-b", reason="Off-boarding."),
+        GOVERNED_REQUESTER,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        approve_data_erasure(
+            DataErasureApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+
+    assert exc_info.value.status_code == 503
+    audit_records = get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=100)
+    assert any(record.tenant_id == "tenant-b" for record in audit_records)
+    from app.services.provider_operations_store import get_provider_operations_store
+
+    stored = get_provider_operations_store().get_governed_action(pending.governed_action.action_id)
+    assert stored is not None
+    assert stored.status.value == "PENDING"
+
+
+def test_lost_receipt_is_retrievable_from_durable_results_without_reerasing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Audit F3: a response lost after execution returns the SAME evidenced
+    outcome on retry - counts from the durable result payload, no second
+    deletion pass, no 409."""
+
+    _configure_attestation_keys(monkeypatch)
+    _seed_two_tenants()
+    first = _erase_tenant_b()
+    first_counts = {
+        family.family_id: family.erased_count for family in first.receipt.claims.families
+    }
+    assert any(count > 0 for count in first_counts.values())
+
+    retry = approve_data_erasure(
+        DataErasureApprovalRequest(
+            action_id=first.governed_action.action_id,
+            action_hash=first.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+
+    retry_counts = {
+        family.family_id: family.erased_count for family in retry.receipt.claims.families
+    }
+    assert retry_counts == first_counts
+    assert retry.governed_action.action_id == first.governed_action.action_id
+    assert retry.receipt.claims.executed_at == first.receipt.claims.executed_at
+    # Tenant A remains untouched by the retry.
+    audit_records = get_audit_store().list(scope=INTERNAL_AGGREGATE_AUDIT_SCOPE, limit=100)
+    assert any(record.tenant_id == "tenant-a" for record in audit_records)
+
+
+def test_crash_after_a_family_completes_recovers_the_evidenced_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Audit F3: a crash between families neither loses the completed family's
+    evidenced count nor forces a blind re-erasure - the deterministic per-
+    action/family lifecycle event carries the first pass's count into the
+    recovered receipt."""
+
+    _configure_attestation_keys(monkeypatch)
+    _seed_two_tenants()
+    pending = request_data_erasure(
+        DataErasureIntentRequest(tenant_id="tenant-b", reason="Off-boarding."),
+        GOVERNED_REQUESTER,
+    )
+
+    import app.services.data_lifecycle_erasure as erasure_module
+
+    original_executors = dict(erasure_module._ERASURE_EXECUTORS)
+    family_order = list(original_executors)
+    crash_on_entry = family_order[-1]
+
+    def _crashing(family_id: str) -> object:
+        executor = original_executors[family_id]
+
+        def run(tenant_id: str) -> tuple[int, int | None]:
+            # The crash lands BETWEEN families: every earlier family fully
+            # completed, including its durable lifecycle event.
+            if family_id == crash_on_entry:
+                raise RuntimeError("process died between families")
+            return executor(tenant_id)
+
+        return run
+
+    monkeypatch.setattr(
+        erasure_module,
+        "_ERASURE_EXECUTORS",
+        {family_id: _crashing(family_id) for family_id in family_order},
+    )
+
+    with pytest.raises(RuntimeError):
+        approve_data_erasure(
+            DataErasureApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+
+    # Recovery: the claiming credential retries with the original executors.
+    monkeypatch.setattr(erasure_module, "_ERASURE_EXECUTORS", original_executors)
+    monkeypatch.setattr(
+        erasure_module,
+        "approve_and_execute_governed_action",
+        lambda **kwargs: __import__(
+            "app.services.governed_action_control", fromlist=["x"]
+        ).approve_and_execute_governed_action(**kwargs, resume_interrupted_claim=True),
+    )
+    recovered = approve_data_erasure(
+        DataErasureApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+
+    counts = {family.family_id: family.erased_count for family in recovered.receipt.claims.families}
+    # Families that completed before the crash report their FIRST pass's
+    # evidenced counts, not an honest-but-empty re-deletion.
+    assert sum(counts.values()) > 0
+    assert any(counts[family_id] > 0 for family_id in family_order[:-1])

--- a/tests/unit/test_governed_action_control.py
+++ b/tests/unit/test_governed_action_control.py
@@ -169,7 +169,11 @@ def test_a_new_request_supersedes_the_pending_one() -> None:
     assert _approve(second).status is GovernedActionStatus.EXECUTED
 
 
-def test_a_failed_execution_leaves_the_action_pending() -> None:
+def test_a_failed_execution_leaves_the_claim_resumable_by_its_owner() -> None:
+    """The atomic claim precedes the effect (issue #327): a failed execution
+    leaves the action CLAIMED under the approver's evidence, resumable only by
+    that credential - never silently re-approvable by anyone else."""
+
     record = _submit()
 
     def _explode(pending: object) -> None:
@@ -179,8 +183,35 @@ def test_a_failed_execution_leaves_the_action_pending() -> None:
         _approve(record, execute=_explode)
     stored = get_provider_operations_store().get_governed_action(record.action_id)
     assert stored is not None
-    assert stored.status is GovernedActionStatus.PENDING
-    assert stored.approver_key_id is None
+    assert stored.status is GovernedActionStatus.CLAIMED
+    assert stored.approver_key_id == APPROVER.credential_key_id
+    assert stored.claimed_at is not None
+
+    # A different verified credential cannot take over the claim.
+    from types import SimpleNamespace
+
+    other = SimpleNamespace(
+        caller_app="operator-service",
+        trust_source="verified_service_jwt",
+        credential_key_id="key-other",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, caller=other)
+    assert exc_info.value.status_code == 409
+
+    # The claiming credential resumes EXPLICITLY: the (idempotent) effect
+    # re-runs and the action finalizes EXECUTED with the ORIGINAL claim
+    # evidence preserved.
+    effects: list[str] = []
+    executed = _approve(
+        record,
+        execute=lambda pending: effects.append(pending.action_id),
+        resume_interrupted_claim=True,
+    )
+    assert effects == [record.action_id]
+    assert executed.status is GovernedActionStatus.EXECUTED
+    assert executed.approver_key_id == APPROVER.credential_key_id
+    assert executed.claimed_at == stored.claimed_at
 
 
 def test_a_system_identity_cannot_originate_a_human_governed_action() -> None:
@@ -324,3 +355,63 @@ def test_governed_action_history_is_a_privileged_operator_read() -> None:
     assert len(allowed_events) == 1
     assert allowed_events[0].caller_app == "lotus-platform"
     assert allowed_events[0].returned_record_count == 1
+
+
+def test_approving_an_unknown_action_id_is_not_found() -> None:
+    record = _submit()
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, action_id="gact_does_not_exist")
+    assert exc_info.value.status_code == 404
+
+
+def test_losing_the_claim_race_refuses_without_running_the_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #327: the atomic PENDING->CLAIMED claim IS the execution
+    ownership. When a concurrent approval wins the transition between this
+    approval's read and its compare-and-set, this approval refuses with 409
+    and its domain callback never runs - the loser contributes no effect."""
+
+    record = _submit()
+    store = get_provider_operations_store()
+
+    def claim_already_taken(
+        *, action_id: str, expected_status: str, record: GovernedActionRecord
+    ) -> bool:
+        return False
+
+    monkeypatch.setattr(store, "transition_governed_action", claim_already_taken)
+    effects: list[str] = []
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, execute=lambda pending: effects.append(pending.action_id))
+    assert exc_info.value.status_code == 409
+    assert "did not execute" in exc_info.value.detail
+    assert effects == []
+
+
+def test_a_claim_lost_during_execution_cannot_finalize_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #327: EXECUTED evidence writes only over the caller's own live
+    claim (CLAIMED->EXECUTED compare-and-set). If the claim is gone by
+    finalization time, the domain effect has already run but the approval
+    reports 409 instead of stamping evidence over state it no longer owns."""
+
+    record = _submit()
+    store = get_provider_operations_store()
+    real_transition = store.transition_governed_action
+
+    def stolen_after_execution(
+        *, action_id: str, expected_status: str, record: GovernedActionRecord
+    ) -> bool:
+        if expected_status == GovernedActionStatus.CLAIMED.value:
+            return False
+        return real_transition(action_id=action_id, expected_status=expected_status, record=record)
+
+    monkeypatch.setattr(store, "transition_governed_action", stolen_after_execution)
+    effects: list[str] = []
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(record, execute=lambda pending: effects.append(pending.action_id))
+    assert exc_info.value.status_code == 409
+    assert "could not be finalized" in exc_info.value.detail
+    assert effects == [record.action_id]

--- a/tests/unit/test_governed_execution_ownership.py
+++ b/tests/unit/test_governed_execution_ownership.py
@@ -1,0 +1,229 @@
+"""One approved intent executes at most once, and destructive work is
+recoverable (issue #327, audit F2+F3).
+
+The atomic PENDING->CLAIMED transition is the single ownership authority:
+concurrent approvals cannot both run the effect, supersession cannot race an
+execution, an interrupted claim is resumable only by its owner, and an
+erasure whose receipt was lost is retrievable from durable results without
+re-erasing.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier, BrokenBarrierError
+
+import pytest
+from fastapi import HTTPException
+
+from app.contracts.governed_actions import (
+    GovernedActionStatus,
+    GovernedActionType,
+)
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
+from app.services.provider_operations_store import get_provider_operations_store
+from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
+
+_PAYLOAD: dict[str, str | None] = {
+    "action_type": GovernedActionType.PROVIDER_OPERATIONS_RESET.value,
+    "target": "live",
+}
+
+
+def _submit() -> object:
+    return submit_governed_action(
+        caller=GOVERNED_REQUESTER,
+        action_type=GovernedActionType.PROVIDER_OPERATIONS_RESET,
+        target="live",
+        payload=dict(_PAYLOAD),
+        attribution=None,
+    )
+
+
+def _approve(record: object, execute: object) -> object:
+    return approve_and_execute_governed_action(
+        caller=GOVERNED_APPROVER,
+        action_id=record.action_id,  # type: ignore[attr-defined]
+        expected_target="live",
+        expected_hash=record.action_hash,  # type: ignore[attr-defined]
+        current_payload_builder=lambda pending: dict(pending.action_payload),
+        attribution=None,
+        execute=execute,  # type: ignore[arg-type]
+    )
+
+
+def test_concurrent_approvals_execute_the_effect_exactly_once() -> None:
+    """The audit probe, inverted: two simultaneous approvals raced the old
+    read-check-execute flow into two domain effects. The atomic claim admits
+    exactly one; the loser is a bounded 409, never a second effect."""
+
+    pending = _submit()
+    barrier = Barrier(2, timeout=2)
+    effects: list[str] = []
+
+    def _effect(record: object) -> None:
+        try:
+            # Only ONE approval may reach the effect now; the barrier that
+            # proved the race in the audit probe must therefore time out.
+            barrier.wait()
+        except BrokenBarrierError:
+            pass
+        effects.append(record.action_id)  # type: ignore[attr-defined]
+
+    outcomes: list[object] = []
+
+    def _attempt(_: int) -> None:
+        try:
+            outcomes.append(_approve(pending, _effect))
+        except HTTPException as exc:
+            outcomes.append(exc.status_code)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(_attempt, range(2)))
+
+    assert len(effects) == 1
+    assert sorted(o if isinstance(o, int) else 0 for o in outcomes) == [0, 409]
+    stored = get_provider_operations_store().get_governed_action(
+        pending.action_id  # type: ignore[attr-defined]
+    )
+    assert stored is not None
+    assert stored.status is GovernedActionStatus.EXECUTED
+
+
+def test_supersession_cannot_race_a_claimed_execution() -> None:
+    """Submitting a replacement intent while the prior action is mid-execution
+    must not un-claim it: the guarded supersession loses and the executed
+    action's evidence stands, while the new intent records as PENDING."""
+
+    first = _submit()
+    replacement_holder: dict[str, object] = {}
+
+    def _effect_and_supersede(record: object) -> None:
+        # A concurrent submission arrives while the effect is running.
+        replacement_holder["record"] = _submit()
+
+    executed = _approve(first, _effect_and_supersede)
+    assert executed.status is GovernedActionStatus.EXECUTED  # type: ignore[attr-defined]
+
+    store = get_provider_operations_store()
+    stored_first = store.get_governed_action(first.action_id)  # type: ignore[attr-defined]
+    assert stored_first is not None
+    assert stored_first.status is GovernedActionStatus.EXECUTED
+    assert stored_first.superseded_by_action_id is None
+    replacement = replacement_holder["record"]
+    stored_second = store.get_governed_action(replacement.action_id)  # type: ignore[attr-defined]
+    assert stored_second is not None
+    assert stored_second.status is GovernedActionStatus.PENDING
+
+
+def test_a_stale_approval_after_supersession_is_refused() -> None:
+    first = _submit()
+    second = _submit()
+    assert second.action_id != first.action_id  # type: ignore[attr-defined]
+
+    with pytest.raises(HTTPException) as exc_info:
+        _approve(first, lambda record: None)
+    assert exc_info.value.status_code == 409
+
+    stored = get_provider_operations_store().get_governed_action(
+        first.action_id  # type: ignore[attr-defined]
+    )
+    assert stored is not None
+    assert stored.status is GovernedActionStatus.SUPERSEDED
+
+
+def test_crash_after_effect_recovers_to_one_logical_outcome() -> None:
+    """A process death between the effect and the EXECUTED write leaves a
+    CLAIMED action whose effect already happened. The claiming credential's
+    retry re-invokes the callback - idempotent under the action identity per
+    the documented contract - and finalizes with one logical outcome."""
+
+    pending = _submit()
+    performed: set[str] = set()
+
+    def _idempotent_effect_then_crash(record: object) -> None:
+        performed.add(record.action_id)  # type: ignore[attr-defined]
+        raise RuntimeError("process died before the EXECUTED write")
+
+    with pytest.raises(RuntimeError):
+        _approve(pending, _idempotent_effect_then_crash)
+    assert performed == {pending.action_id}  # type: ignore[attr-defined]
+
+    executed = approve_and_execute_governed_action(
+        caller=GOVERNED_APPROVER,
+        action_id=pending.action_id,  # type: ignore[attr-defined]
+        expected_target="live",
+        expected_hash=pending.action_hash,  # type: ignore[attr-defined]
+        current_payload_builder=lambda record: dict(record.action_payload),
+        attribution=None,
+        execute=lambda record: performed.add(record.action_id),
+        resume_interrupted_claim=True,
+    )
+    assert executed.status is GovernedActionStatus.EXECUTED
+    assert performed == {pending.action_id}  # type: ignore[attr-defined]
+    assert executed.requester_key_id == GOVERNED_REQUESTER.credential_key_id
+    assert executed.approver_key_id == GOVERNED_APPROVER.credential_key_id
+    assert executed.action_hash == pending.action_hash  # type: ignore[attr-defined]
+
+
+def test_sql_claim_is_a_guarded_single_winner_across_sessions(tmp_path: Path) -> None:
+    """Two INDEPENDENT SQL sessions (separate repository instances on one
+    database) race the same PENDING action: the guarded UPDATE admits exactly
+    one claim; the other returns False without writing."""
+
+    from app.repositories.sqlalchemy_provider_operations_repository import (
+        SqlAlchemyProviderOperationsRepository,
+    )
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    database_url = f"sqlite:///{tmp_path / 'governed-claims.db'}"
+    upgrade_database_to_head(database_url)
+    session_a = SqlAlchemyProviderOperationsRepository(database_url)
+    session_b = SqlAlchemyProviderOperationsRepository(database_url)
+
+    from app.contracts.governed_actions import (
+        GovernedActionRecord,
+        GovernedActorClass,
+    )
+
+    pending = GovernedActionRecord(
+        action_id="gact_sql_claim_race",
+        action_type=GovernedActionType.PROVIDER_OPERATIONS_RESET,
+        actor_class=GovernedActorClass.HUMAN_APPROVED,
+        status=GovernedActionStatus.PENDING,
+        target="live",
+        action_hash="a" * 64,
+        action_payload=dict(_PAYLOAD),
+        requester_caller_app="operator-service",
+        requester_trust_source="verified_service_jwt",
+        requester_key_id="key-a",
+        requested_at="2026-09-05T00:00:00Z",
+    )
+    session_a.upsert_governed_action(pending)
+    claim_a = pending.model_copy(
+        update={"status": GovernedActionStatus.CLAIMED, "approver_key_id": "key-b"}
+    )
+    claim_b = pending.model_copy(
+        update={"status": GovernedActionStatus.CLAIMED, "approver_key_id": "key-c"}
+    )
+
+    won_a = session_a.transition_governed_action(
+        action_id=pending.action_id,
+        expected_status=GovernedActionStatus.PENDING.value,
+        record=claim_a,
+    )
+    won_b = session_b.transition_governed_action(
+        action_id=pending.action_id,
+        expected_status=GovernedActionStatus.PENDING.value,
+        record=claim_b,
+    )
+
+    assert (won_a, won_b) == (True, False)
+    stored = session_b.get_governed_action(pending.action_id)
+    assert stored is not None
+    assert stored.status is GovernedActionStatus.CLAIMED
+    assert stored.approver_key_id == "key-b"


### PR DESCRIPTION
Closes #327. Packet 3 of the 2026-09-05 deep-audit corrective sequence (F2 + F3).

## Consumer / operator outcome
An approver whose approval is duplicated (double-click, retried request, two operators) can no longer cause two destructive executions of one pending intent: exactly one execution happens, the loser receives 409. An erasure whose receipt is lost after execution gets the SAME evidenced receipt back on retry — same counts, same executed_at — with no second deletion pass; an erasure that cannot be signed is refused BEFORE anything is deleted (503, action still PENDING and approvable once the key is fixed); a crash between families recovers the completed families' first-pass evidenced counts instead of blind re-erasure or an honest-but-empty re-deletion.

## Invariant + single transition authority
One owner per approved intent: every governed execution is preceded by an atomic PENDING→CLAIMED claim (compare-and-set on status), and finalized by CLAIMED→EXECUTED. `transition_governed_action(action_id, expected_status, record)` is the ONLY status-transition authority (guarded UPDATE + rowcount in SQL; lock-held CAS in memory); approve, supersede, and finalize all route through it. Resuming an interrupted claim is never inferred: it requires the same approver credential AND an explicit `resume_interrupted_claim=True`.

## Simplification
No new framework: one new status (CLAIMED), one CAS primitive on the existing repository protocol, one `result_payload` column for durable outcomes. Erasure receipt recovery reuses the governed-action record itself (result_payload + action_hash match) rather than a parallel receipt store. Deterministic lifecycle-event ids (`dle_` from action+family) replace uuid4 events, making recovery a lookup instead of a scan.

## Failing-before / passing-after
Audit probes 4–5 inverted into tests (all fail on main, pass here):
- `tests/unit/test_governed_execution_ownership.py` (5): concurrent approvals → exactly one effect + one 409; supersession-vs-claimed race; stale approval after supersession → 409; crash-after-effect + explicit resume → one logical outcome, original requester/approver/hash preserved; SQL two-session guarded claim (one winner).
- `tests/unit/test_data_lifecycle_erasure.py` (+3): missing signing key → 503, zero deletion, still PENDING; lost receipt retry → identical counts/executed_at, no re-erasure; crash between families → recovery merges first-pass counts.
- `tests/unit/test_governed_action_control.py`: the "failed execution leaves PENDING" pin is rewritten to "leaves the claim resumable by its owner" — CLAIMED with approver evidence, other credentials 409, explicit resume finalizes with the original claimed_at. Plus three branch pins the thread-race tests cannot reach deterministically: unknown action id → 404; claim CAS lost between read and compare-and-set → 409 with zero effects; claim lost during execution → the effect ran but evidence finalization refuses with 409 rather than stamping over state it no longer owns.

## Compatibility + residuals
Additive migration 0075 (nullable `claimed_at`, `result_payload`); CLAIMED is a new enum value no existing row holds; no API shape changes. Residual: provider-native deletion confirmation stays external (#115). Unknown-usage settlement exposure is packet 4 (#329), not touched here.
