### PR TITLE
fix(budget): unresolved exposure never releases hard headroom; exclusive resume ownership (#329)

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -80,7 +80,14 @@ unapproved revision is refused with `MODEL_LIFECYCLE_INELIGIBLE`), catalogue row
 are seeded from configuration and from the approved model-risk inventory, and
 revision drift is recorded from the provider echo. Identity-bound,
 effective-dated rate cards price executions and carry cost posture onto audit
-records.
+records. The hard budget is admission-honest (#329): each attempt atomically
+reserves its provable maximum before the provider is called; only trustworthy
+provider-reported usage (or proven non-billability) settles a reservation
+down. Unknown usage holds the reserved maximum as `UNRESOLVED_MAX` exposure —
+estimates are reported, never released against — until a governed four-eyes
+`BUDGET_RECONCILIATION` settles it to a provider-evidenced charge, and an
+enforced budget that cannot price a candidate refuses admission rather than
+reserving nothing.
 
 **Output validation.** Every provider output — structured channel and narrative
 message — passes one deterministic validator before safety redaction: evidence
@@ -140,7 +147,15 @@ signing readiness before any deletion (a missing receipt key means zero rows
 erased, 503, still approvable), replays a lost receipt from the durable result
 without re-erasing, and recovers a crash-interrupted run through deterministic
 per-action/family lifecycle events — resumable only by the claiming credential
-with an explicit resume flag. Minimisation caps the audit `result_preview` at persistence and ages
+with an explicit public resume flag, and resuming is itself exclusive: it
+rotates the claim instant under a compare-and-set, so concurrent resumes admit
+one winner before any effect, a superseded still-running executor cannot stamp
+evidence over the takeover (finalization is fenced to the owner's instant),
+and uncertain prior effects converge through the idempotent-callback contract.
+A claim whose credential disappears stays frozen by design — no timeout or
+lease may re-open the one-owner window; the operator recovery affordance is a
+governed four-eyes claim-release action (#340), which composes on the same
+fence (release and resume are CAS transitions racing on one claim instant). Minimisation caps the audit `result_preview` at persistence and ages
 passing evaluation-case content at a declared shorter horizon.
 
 **Current limitations.** Capability requirements exist for latency (one governed

--- a/src/app/contracts/data_lifecycle.py
+++ b/src/app/contracts/data_lifecycle.py
@@ -76,6 +76,14 @@ class DataErasureApprovalRequest(BaseModel):
     action_id: str = Field(min_length=1, max_length=64)
     action_hash: str = Field(min_length=64, max_length=64)
     approved_by: str | None = Field(default=None, max_length=256)
+    resume_interrupted_claim: bool = Field(
+        default=False,
+        description=(
+            "Explicit recovery intent (issue #327): resume a claim this same "
+            "credential holds after a crash. Never inferred; refused for any "
+            "other credential's claim."
+        ),
+    )
 
 
 class DataErasureFamilyResult(BaseModel):

--- a/src/app/contracts/governed_actions.py
+++ b/src/app/contracts/governed_actions.py
@@ -62,6 +62,11 @@ class GovernedActionType(str, Enum):
     # explicitly SYSTEM_ORIGINATED rather than dressing a service string up
     # as an approval (issue #157).
     ASYNC_QUEUE_RECOVERY = "ASYNC_QUEUE_RECOVERY"
+    # Settling an unresolved billable exposure to an operator-evidenced
+    # charge releases hard-budget admission headroom (issue #329) -
+    # risk-increasing, so it takes the two-step flow. Holding exposure is the
+    # automatic safe direction and needs no approval.
+    BUDGET_RECONCILIATION = "BUDGET_RECONCILIATION"
 
 
 class GovernedActionStatus(str, Enum):

--- a/src/app/contracts/providers.py
+++ b/src/app/contracts/providers.py
@@ -6,6 +6,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from app.contracts.capability_requirements import CapabilityRequirements
+from app.contracts.governed_actions import GovernedActionRecord
 
 
 from app.contracts.evals import EvaluationApprovalGateSummaryDescriptor
@@ -452,6 +453,66 @@ class ProviderBudgetPolicyResponse(BaseModel):
         default_factory=list,
         description="Human-readable notes describing how tracked spend is compared against configured budget thresholds.",
     )
+
+
+class BudgetReconciliationIntentRequest(BaseModel):
+    """Step one of governed budget reconciliation (issue #329).
+
+    Settling an unresolved billable exposure to an evidenced charge releases
+    hard-budget admission headroom - risk-increasing, so a verified requester
+    states the evidence and a distinct verified credential approves the exact
+    hash. Caller identity comes from the credential, never the body.
+    """
+
+    debit_id: str = Field(min_length=1, max_length=256)
+    evidenced_amount_usd: float = Field(
+        ge=0.0,
+        description="The charge the provider's own billing evidence establishes for this attempt.",
+    )
+    evidence_ref: str = Field(
+        min_length=1,
+        max_length=512,
+        description="Where the evidenced charge can be verified (invoice line, billing-console export, usage report).",
+    )
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    requested_by: str | None = Field(
+        default=None,
+        max_length=256,
+        description="Claimed operator name; recorded as unverified attribution.",
+    )
+
+
+class BudgetReconciliationApprovalRequest(BaseModel):
+    """Step two: a distinct verified credential approves the exact pending action."""
+
+    action_id: str = Field(min_length=1, max_length=64)
+    action_hash: str = Field(min_length=64, max_length=64)
+    approved_by: str | None = Field(default=None, max_length=256)
+    resume_interrupted_claim: bool = Field(
+        default=False,
+        description=(
+            "Explicit recovery intent (issue #327): resume a claim this same "
+            "credential holds after a crash. Never inferred; refused for any "
+            "other credential's claim."
+        ),
+    )
+
+
+class BudgetReconciliationApprovalResponse(BaseModel):
+    service: str = Field(description="Service name emitting the reconciliation outcome.")
+    version: str = Field(description="Current lotus-ai service version.")
+    governed_action: GovernedActionRecord = Field(
+        description="The executed governed action carrying requester and approver evidence."
+    )
+    debit_id: str = Field(description="The reconciled attempt-debit identity.")
+    evidenced_amount_usd: float = Field(
+        description="The charge the exposure settled to, from operator evidence."
+    )
+    released_amount_usd: float = Field(
+        description="Hard-budget headroom released by this reconciliation (held maximum minus evidenced charge)."
+    )
+    summary: list[str] = Field(default_factory=list)
 
 
 class ProviderConfigurationStatusDescriptor(BaseModel):

--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -46,6 +46,7 @@ from app.providers.advisor_brief_quality_guardrails import (
     normalize_advisor_brief_output,
 )
 from app.services.provider_budget_policy import (
+    require_priceable_admission,
     reserve_attempt_spend,
     settle_attempt_spend,
     spent_for_execution,
@@ -401,6 +402,10 @@ def post_openai_compatible_response(
             max_output_tokens=payload_max_output,
             model_revision=model_revision,
         )
+        # An enforced hard budget that cannot price this candidate fails
+        # closed (issue #329): an unpriceable attempt must not slip past the
+        # limit by reserving nothing.
+        require_priceable_admission(reservation)
         if reservation is not None:
             admission = reserve_attempt_spend(
                 execution_id=debit_execution_id,

--- a/src/app/repositories/memory_provider_operations_repository.py
+++ b/src/app/repositories/memory_provider_operations_repository.py
@@ -97,17 +97,6 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
         self._budget_states[budget_key] = deepcopy(updated)
         return deepcopy(updated)
 
-    def record_attempt_debit(self, record: ProviderAttemptDebitRecord, *, budget_key: str) -> bool:
-        if record.debit_id in self._attempt_debits:
-            return False
-        self._attempt_debits[record.debit_id] = deepcopy(record)
-        self.add_budget_spend(
-            budget_key=budget_key,
-            amount_usd=record.amount_usd,
-            updated_at=record.recorded_at,
-        )
-        return True
-
     def reserve_attempt_debit(
         self,
         record: ProviderAttemptDebitRecord,
@@ -162,6 +151,54 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
             updated_at=settled_at,
         )
         return True
+
+    def hold_attempt_debit_unresolved(self, *, debit_id: str, held_at: str) -> bool:
+        row = self._attempt_debits.get(debit_id)
+        if row is None or row.basis != "RESERVED_MAX":
+            return False
+        # The reserved amount stays on the row AND in the counter: unknown
+        # usage is unresolved exposure, not evidence of a smaller bill.
+        self._attempt_debits[debit_id] = replace(
+            row,
+            basis="UNRESOLVED_MAX",
+            recorded_at=held_at,
+        )
+        return True
+
+    def reconcile_attempt_debit(
+        self,
+        *,
+        debit_id: str,
+        budget_key: str,
+        amount_usd: float,
+        input_tokens: int | None,
+        output_tokens: int | None,
+        rate_card_ref: str | None,
+        reconciled_at: str,
+    ) -> bool:
+        row = self._attempt_debits.get(debit_id)
+        if row is None or row.basis not in ("UNRESOLVED_MAX", "RESERVED_MAX"):
+            return False
+        delta = round(amount_usd - row.amount_usd, 8)
+        self._attempt_debits[debit_id] = replace(
+            row,
+            basis="RECONCILED",
+            amount_usd=amount_usd,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            rate_card_ref=rate_card_ref if rate_card_ref is not None else row.rate_card_ref,
+            recorded_at=reconciled_at,
+        )
+        self.add_budget_spend(
+            budget_key=budget_key,
+            amount_usd=delta,
+            updated_at=reconciled_at,
+        )
+        return True
+
+    def get_attempt_debit(self, *, debit_id: str) -> ProviderAttemptDebitRecord | None:
+        record = self._attempt_debits.get(debit_id)
+        return deepcopy(record) if record is not None else None
 
     def list_attempt_debits(self, *, limit: int = 100) -> Sequence[ProviderAttemptDebitRecord]:
         records = sorted(
@@ -325,12 +362,15 @@ class InMemoryProviderOperationsRepository(ProviderOperationsRepository):
         action_id: str,
         expected_status: str,
         record: GovernedActionRecord,
+        expected_claimed_at: str | None = None,
     ) -> bool:
         # Process-local store: a lock IS the atomicity boundary here; the SQL
         # adapter carries the cross-replica guarantee (issue #327).
         with self._governed_action_transition_lock:
             current = self._governed_actions.get(action_id)
             if current is None or current.status.value != expected_status:
+                return False
+            if expected_claimed_at is not None and current.claimed_at != expected_claimed_at:
                 return False
             self._governed_actions[action_id] = record.model_copy(deep=True)
             return True

--- a/src/app/repositories/provider_operations_repository.py
+++ b/src/app/repositories/provider_operations_repository.py
@@ -130,11 +130,6 @@ class ProviderOperationsRepository(Protocol):
     ) -> ProviderBudgetStateRecord:
         """Atomically add spend to one provider budget state record and return the updated value."""
 
-    def record_attempt_debit(self, record: ProviderAttemptDebitRecord, *, budget_key: str) -> bool:
-        """Durably record one attempt debit and advance the budget counter
-        together (issue #289). Returns False - a complete no-op, counter
-        untouched - when the debit identity is already recorded."""
-
     def reserve_attempt_debit(
         self,
         record: ProviderAttemptDebitRecord,
@@ -170,6 +165,36 @@ class ProviderOperationsRepository(Protocol):
         is a complete no-op returning False, and a crash before settlement
         leaves the conservative reservation standing (over-counting is the
         safe direction)."""
+
+    def hold_attempt_debit_unresolved(self, *, debit_id: str, held_at: str) -> bool:
+        """Mark one reserved debit's billable exposure UNRESOLVED (issue
+        #329): basis moves ``RESERVED_MAX`` → ``UNRESOLVED_MAX`` and NOTHING
+        else changes - the reserved amount stays on the row and in the
+        budget counter, because no usage evidence arrived to release it.
+        Returns False - a complete no-op - unless the row is still
+        ``RESERVED_MAX`` (idempotent under crash-retry)."""
+
+    def reconcile_attempt_debit(
+        self,
+        *,
+        debit_id: str,
+        budget_key: str,
+        amount_usd: float,
+        input_tokens: int | None,
+        output_tokens: int | None,
+        rate_card_ref: str | None,
+        reconciled_at: str,
+    ) -> bool:
+        """Settle one unresolved exposure (``UNRESOLVED_MAX``, or a
+        ``RESERVED_MAX`` row orphaned by a crash) to an evidenced charge in
+        ONE transaction with the counter adjustment (issue #329): basis
+        becomes ``RECONCILED``. Only the governed reconciliation path calls
+        this - it is the sole way unresolved exposure releases hard
+        admission capacity. A second reconciliation is a no-op returning
+        False."""
+
+    def get_attempt_debit(self, *, debit_id: str) -> ProviderAttemptDebitRecord | None:
+        """Fetch one attempt-debit evidence row by its identity."""
 
     def list_attempt_debits(self, *, limit: int = 100) -> Sequence[ProviderAttemptDebitRecord]:
         """Attempt-debit evidence, newest first."""
@@ -240,10 +265,16 @@ class ProviderOperationsRepository(Protocol):
         action_id: str,
         expected_status: str,
         record: GovernedActionRecord,
+        expected_claimed_at: str | None = None,
     ) -> bool:
         """Atomically replace the action iff its CURRENT status equals
-        ``expected_status`` (issue #327). Returns False without writing when
-        the action moved concurrently - the caller lost the transition."""
+        ``expected_status`` (issue #327) - and, when ``expected_claimed_at``
+        is provided, iff the current claim instant equals it too. The claim
+        instant is the exclusive-ownership fence for everything that races on
+        a live claim (resume, finalization, and #340's release): each owner
+        rotates it on acquisition, so a competitor holding the stale instant
+        loses by construction. Returns False without writing when the action
+        moved concurrently - the caller lost the transition."""
         ...
 
     def upsert_governed_action(self, record: GovernedActionRecord) -> None:

--- a/src/app/repositories/sqlalchemy_provider_operations_repository.py
+++ b/src/app/repositories/sqlalchemy_provider_operations_repository.py
@@ -165,56 +165,6 @@ class SqlAlchemyProviderOperationsRepository(
                     continue
         raise RuntimeError("Failed to add provider budget spend atomically.")
 
-    def record_attempt_debit(self, record: ProviderAttemptDebitRecord, *, budget_key: str) -> bool:
-        """Debit row and budget counter advance in ONE transaction: a crash
-        between them cannot happen, and a duplicate identity is a complete
-        no-op (the counter is untouched)."""
-
-        with self._session_factory() as session:
-            existing = session.get(ProviderAttemptDebitModel, record.debit_id)
-            if existing is not None:
-                return False
-            session.add(
-                ProviderAttemptDebitModel(
-                    debit_id=record.debit_id,
-                    provider_id=record.provider_id,
-                    basis=record.basis,
-                    amount_usd=record.amount_usd,
-                    input_tokens=record.input_tokens,
-                    output_tokens=record.output_tokens,
-                    rate_card_ref=record.rate_card_ref,
-                    recorded_at=record.recorded_at,
-                    candidate_entry_id=record.candidate_entry_id,
-                    model_revision=record.model_revision,
-                    attempt_index=record.attempt_index,
-                    candidate_id_v2=record.candidate_id_v2,
-                )
-            )
-            budget = session.execute(
-                select(ProviderBudgetStateModel)
-                .where(ProviderBudgetStateModel.budget_key == budget_key)
-                .with_for_update()
-            ).scalar_one_or_none()
-            if budget is None:
-                session.add(
-                    ProviderBudgetStateModel(
-                        budget_key=budget_key,
-                        current_spend_usd=round(record.amount_usd, 8),
-                        updated_at=record.recorded_at,
-                    )
-                )
-            else:
-                budget.current_spend_usd = round(budget.current_spend_usd + record.amount_usd, 8)
-                budget.updated_at = record.recorded_at
-            try:
-                session.commit()
-            except IntegrityError:
-                # A concurrent recorder won the same identity: their debit
-                # stands, ours is the duplicate.
-                session.rollback()
-                return False
-            return True
-
     def reserve_attempt_debit(
         self,
         record: ProviderAttemptDebitRecord,
@@ -392,6 +342,87 @@ class SqlAlchemyProviderOperationsRepository(
             session.commit()
             return True
 
+    def hold_attempt_debit_unresolved(self, *, debit_id: str, held_at: str) -> bool:
+        for _ in range(4):
+            try:
+                with self._session_factory() as session:
+                    # Guarded on the reserved basis: exactly one transition
+                    # wins the row, and the amount - the reserved maximum -
+                    # never changes, so the counter needs no adjustment.
+                    result = session.execute(
+                        update(ProviderAttemptDebitModel)
+                        .where(
+                            ProviderAttemptDebitModel.debit_id == debit_id,
+                            ProviderAttemptDebitModel.basis == "RESERVED_MAX",
+                        )
+                        .values(basis="UNRESOLVED_MAX", recorded_at=held_at)
+                    )
+                    session.commit()
+                    return int(getattr(result, "rowcount", 0) or 0) == 1
+            except OperationalError:
+                continue
+        raise RuntimeError("Failed to hold provider attempt debit unresolved atomically.")
+
+    def reconcile_attempt_debit(
+        self,
+        *,
+        debit_id: str,
+        budget_key: str,
+        amount_usd: float,
+        input_tokens: int | None,
+        output_tokens: int | None,
+        rate_card_ref: str | None,
+        reconciled_at: str,
+    ) -> bool:
+        for _ in range(4):
+            try:
+                with self._session_factory() as session:
+                    row = session.get(ProviderAttemptDebitModel, debit_id)
+                    if row is None or row.basis not in ("UNRESOLVED_MAX", "RESERVED_MAX"):
+                        return False
+                    held_amount = row.amount_usd
+                    held_basis = row.basis
+                    delta = round(amount_usd - held_amount, 8)
+                    values: dict[str, object] = {
+                        "basis": "RECONCILED",
+                        "amount_usd": amount_usd,
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "recorded_at": reconciled_at,
+                    }
+                    if rate_card_ref is not None:
+                        values["rate_card_ref"] = rate_card_ref
+                    # Guarded on the held basis AND amount: one reconciliation
+                    # wins the row, so the counter adjustment applies exactly
+                    # once (atomic on every backend).
+                    result = session.execute(
+                        update(ProviderAttemptDebitModel)
+                        .where(
+                            ProviderAttemptDebitModel.debit_id == debit_id,
+                            ProviderAttemptDebitModel.basis == held_basis,
+                            ProviderAttemptDebitModel.amount_usd == held_amount,
+                        )
+                        .values(**values)
+                    )
+                    if int(getattr(result, "rowcount", 0) or 0) == 0:
+                        session.rollback()
+                        return False
+                    session.execute(
+                        update(ProviderBudgetStateModel)
+                        .where(ProviderBudgetStateModel.budget_key == budget_key)
+                        .values(
+                            current_spend_usd=func.round(
+                                ProviderBudgetStateModel.current_spend_usd + delta, 8
+                            ),
+                            updated_at=reconciled_at,
+                        )
+                    )
+                    session.commit()
+                    return True
+            except OperationalError:
+                continue
+        raise RuntimeError("Failed to reconcile provider attempt debit atomically.")
+
     def list_attempt_debits(self, *, limit: int = 100) -> Sequence[ProviderAttemptDebitRecord]:
         with self._session_factory() as session:
             models = session.scalars(
@@ -419,6 +450,26 @@ class SqlAlchemyProviderOperationsRepository(
                 )
                 for model in models
             ]
+
+    def get_attempt_debit(self, *, debit_id: str) -> ProviderAttemptDebitRecord | None:
+        with self._session_factory() as session:
+            model = session.get(ProviderAttemptDebitModel, debit_id)
+            if model is None:
+                return None
+            return ProviderAttemptDebitRecord(
+                debit_id=model.debit_id,
+                provider_id=model.provider_id,
+                basis=model.basis,
+                amount_usd=model.amount_usd,
+                input_tokens=model.input_tokens,
+                output_tokens=model.output_tokens,
+                rate_card_ref=model.rate_card_ref,
+                recorded_at=model.recorded_at,
+                candidate_entry_id=model.candidate_entry_id,
+                model_revision=model.model_revision,
+                attempt_index=model.attempt_index,
+                candidate_id_v2=model.candidate_id_v2,
+            )
 
     def delete_attempt_debits(self, debit_ids: Sequence[str]) -> int:
         if not debit_ids:
@@ -717,21 +768,23 @@ class SqlAlchemyProviderOperationsRepository(
         action_id: str,
         expected_status: str,
         record: GovernedActionRecord,
+        expected_claimed_at: str | None = None,
     ) -> bool:
         # One guarded UPDATE in its own transaction (issue #327): the WHERE
         # predicate on the CURRENT status is the cross-replica claim - two
         # sessions cannot both move the same action out of expected_status.
+        # When a claim instant is expected, it fences everything racing on a
+        # LIVE claim (resume/finalize/release) to a single winner.
         payload = record.model_dump(mode="json")
         payload.pop("action_id", None)
         with self._session_factory() as session:
-            result = session.execute(
-                update(GovernedActionModel)
-                .where(
-                    GovernedActionModel.action_id == action_id,
-                    GovernedActionModel.status == expected_status,
-                )
-                .values(**payload)
+            statement = update(GovernedActionModel).where(
+                GovernedActionModel.action_id == action_id,
+                GovernedActionModel.status == expected_status,
             )
+            if expected_claimed_at is not None:
+                statement = statement.where(GovernedActionModel.claimed_at == expected_claimed_at)
+            result = session.execute(statement.values(**payload))
             session.commit()
             return int(getattr(result, "rowcount", 0) or 0) == 1
 

--- a/src/app/routers/platform.py
+++ b/src/app/routers/platform.py
@@ -12,6 +12,15 @@ from app.contracts.governed_actions import (
     GovernedActionResponse,
     GovernedActionStatus,
 )
+from app.contracts.providers import (
+    BudgetReconciliationApprovalRequest,
+    BudgetReconciliationApprovalResponse,
+    BudgetReconciliationIntentRequest,
+)
+from app.services.budget_reconciliation import (
+    approve_budget_reconciliation,
+    request_budget_reconciliation,
+)
 from app.services.data_lifecycle_erasure import approve_data_erasure, request_data_erasure
 from app.http.authenticated_caller import AuthenticatedCallerDependency
 from app.services.governed_action_control import build_governed_action_history
@@ -218,6 +227,70 @@ async def approve_data_erasure_route(
     authenticated_caller: AuthenticatedCallerDependency,
 ) -> DataErasureApprovalResponse:
     return approve_data_erasure(request, authenticated_caller)
+
+
+@router.post(
+    "/provider-budget/reconciliation-requests",
+    response_model=GovernedActionResponse,
+    operation_id="requestBudgetReconciliation",
+    summary="Request governed reconciliation of unresolved billable exposure",
+    description=(
+        "Step one of governed budget reconciliation (issue #329): records a pending "
+        "intent under the requester's verified credential to settle one unresolved "
+        "attempt debit (basis UNRESOLVED_MAX, or a crash-orphaned RESERVED_MAX) to a "
+        "provider-evidenced charge, and returns the action hash a distinct verified "
+        "credential must approve. The held maximum stays in the hard-budget counter "
+        "until the approval executes."
+    ),
+    responses={
+        200: {"description": "Reconciliation intent recorded and pending approval."},
+        403: {
+            "description": "Caller is not authorized for provider control, or carries no "
+            "verified credential."
+        },
+        404: {"description": "No attempt debit exists for the given id."},
+        409: {"description": "The debit is not unresolved exposure."},
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def request_budget_reconciliation_route(
+    request: BudgetReconciliationIntentRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> GovernedActionResponse:
+    return request_budget_reconciliation(request, authenticated_caller)
+
+
+@router.post(
+    "/provider-budget/reconciliation-approvals",
+    response_model=BudgetReconciliationApprovalResponse,
+    operation_id="approveBudgetReconciliation",
+    summary="Approve and execute a pending budget reconciliation",
+    description=(
+        "Step two of governed budget reconciliation (issue #329): a verified credential "
+        "DISTINCT from the requester's approves the exact pending action hash, which "
+        "settles the exposure to the evidenced charge (basis RECONCILED) and releases "
+        "the difference from the hard-budget counter - the only path that returns "
+        "unresolved admission capacity."
+    ),
+    responses={
+        200: {"description": "Reconciliation executed; released amount returned."},
+        403: {
+            "description": "Caller is not authorized, carries no verified credential, or is "
+            "the same credential that requested the action."
+        },
+        404: {"description": "No pending action exists for the given id."},
+        409: {
+            "description": "The action hash does not match, or the exposure was resolved "
+            "by other means since the request."
+        },
+        500: {"description": "Unexpected server error."},
+    },
+)
+async def approve_budget_reconciliation_route(
+    request: BudgetReconciliationApprovalRequest,
+    authenticated_caller: AuthenticatedCallerDependency,
+) -> BudgetReconciliationApprovalResponse:
+    return approve_budget_reconciliation(request, authenticated_caller)
 
 
 @router.get(

--- a/src/app/services/budget_reconciliation.py
+++ b/src/app/services/budget_reconciliation.py
@@ -1,0 +1,301 @@
+"""Governed reconciliation of unresolved billable exposure (issue #329).
+
+An attempt that carried billable risk but never revealed trustworthy usage
+holds its reserved maximum in the hard-budget counter (basis
+``UNRESOLVED_MAX``): nothing established that the provider billed less, so
+the estimate is reporting posture, never settlement evidence. The ONLY way
+that headroom returns is this two-step governed action: an operator states
+the provider-evidenced charge (invoice line, billing-console export) under
+one verified credential, and a distinct verified credential approves the
+exact hash. Releasing admission capacity is risk-increasing; holding it is
+the automatic safe direction and needs no approval.
+
+The freshness hash pins the exposure's basis at request time: if usage
+evidence or another reconciliation resolves the row between request and
+approval, the rebuilt payload no longer matches and the approval refuses
+instead of double-releasing.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from app.config import settings
+from app.contracts.access_control import AuthorizationCapabilityType
+from app.contracts.governed_actions import (
+    GovernedActionRecord,
+    GovernedActionResponse,
+    GovernedActionStatus,
+    GovernedActionType,
+)
+from app.contracts.providers import (
+    BudgetReconciliationApprovalRequest,
+    BudgetReconciliationApprovalResponse,
+    BudgetReconciliationIntentRequest,
+)
+from app.http.authenticated_caller import AuthenticatedCaller
+from app.services.access_control_authorization import authorize_request, require_authorized
+from app.services.governed_action_control import (
+    approve_and_execute_governed_action,
+    submit_governed_action,
+)
+from app.services.provider_budget_policy import reconcile_attempt_spend
+from app.services.provider_operations_store import get_provider_operations_store
+
+_RECONCILABLE_BASES = ("UNRESOLVED_MAX", "RESERVED_MAX")
+
+
+def _require_provider_control_authorization(caller: AuthenticatedCaller) -> None:
+    require_authorized(
+        authorize_request(
+            caller_app=caller.caller_app,
+            capability_type=AuthorizationCapabilityType.PROVIDER_CONTROL,
+        )
+    )
+
+
+def _amount_str(value: float) -> str:
+    return f"{value:.8f}"
+
+
+def _reconciliation_payload(
+    *,
+    debit_id: str,
+    evidenced_amount_usd: float,
+    evidence_ref: str,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    exposure_basis: str,
+    held_amount_usd: float,
+) -> dict[str, str | None]:
+    """The exact action the approver signs off on: the debit, the evidenced
+    charge, where to verify it, and the exposure's basis AND held amount at
+    request time - a row resolved or changed by other means between request
+    and approval rebuilds to a different hash and refuses. The pinned held
+    amount is also what makes a crash-recovery replay report the true
+    released difference after the row itself has been overwritten."""
+
+    return {
+        "action_type": GovernedActionType.BUDGET_RECONCILIATION.value,
+        "debit_id": debit_id,
+        "evidenced_amount_usd": _amount_str(evidenced_amount_usd),
+        "evidence_ref": evidence_ref,
+        "input_tokens": str(input_tokens) if input_tokens is not None else None,
+        "output_tokens": str(output_tokens) if output_tokens is not None else None,
+        "exposure_basis": exposure_basis,
+        "held_amount_usd": _amount_str(held_amount_usd),
+    }
+
+
+def request_budget_reconciliation(
+    request: BudgetReconciliationIntentRequest, caller: AuthenticatedCaller
+) -> GovernedActionResponse:
+    """Step one: record the reconciliation intent under the requester's credential."""
+
+    _require_provider_control_authorization(caller)
+    row = get_provider_operations_store().get_attempt_debit(debit_id=request.debit_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No attempt debit exists for `{request.debit_id}`.",
+        )
+    if row.basis not in _RECONCILABLE_BASES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Attempt debit `{request.debit_id}` is {row.basis}, not unresolved "
+                "exposure; only UNRESOLVED_MAX (or a crash-orphaned RESERVED_MAX) "
+                "reconciles."
+            ),
+        )
+    record = submit_governed_action(
+        caller=caller,
+        action_type=GovernedActionType.BUDGET_RECONCILIATION,
+        target=request.debit_id,
+        payload=_reconciliation_payload(
+            debit_id=request.debit_id,
+            evidenced_amount_usd=request.evidenced_amount_usd,
+            evidence_ref=request.evidence_ref,
+            input_tokens=request.input_tokens,
+            output_tokens=request.output_tokens,
+            exposure_basis=row.basis,
+            held_amount_usd=row.amount_usd,
+        ),
+        attribution=request.requested_by,
+    )
+    return GovernedActionResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        summary=[
+            f"Reconciliation of debit `{request.debit_id}` ({row.basis}, "
+            f"{_amount_str(row.amount_usd)} USD held) to the evidenced charge "
+            f"{_amount_str(request.evidenced_amount_usd)} USD is pending approval.",
+            "A distinct verified credential must approve action "
+            f"`{record.action_id}` with hash `{record.action_hash}`.",
+            "The held maximum stays in the budget counter until the approval executes.",
+        ],
+    )
+
+
+def approve_budget_reconciliation(
+    request: BudgetReconciliationApprovalRequest, caller: AuthenticatedCaller
+) -> BudgetReconciliationApprovalResponse:
+    """Step two: a distinct verified credential approves; execution settles
+    the exposure to the evidenced charge and releases the difference."""
+
+    _require_provider_control_authorization(caller)
+    store = get_provider_operations_store()
+
+    # A lost response is recoverable without a second release: an EXECUTED
+    # action with the same hash returns the SAME evidenced outcome.
+    existing = store.get_governed_action(request.action_id)
+    if (
+        existing is not None
+        and existing.status is GovernedActionStatus.EXECUTED
+        and existing.action_hash == request.action_hash
+        and existing.result_payload is not None
+    ):
+        return _reconciliation_response_from_result(existing)
+
+    def _rebuild_payload(record: GovernedActionRecord) -> dict[str, str | None]:
+        debit_id = str(record.action_payload.get("debit_id"))
+        row = store.get_attempt_debit(debit_id=debit_id)
+        raw_input = record.action_payload.get("input_tokens")
+        raw_output = record.action_payload.get("output_tokens")
+        return _reconciliation_payload(
+            debit_id=debit_id,
+            evidenced_amount_usd=float(  # monetary-float-ok: parses the hash-pinned decimal string back into the envelope's float form
+                str(record.action_payload.get("evidenced_amount_usd"))
+            ),
+            evidence_ref=str(record.action_payload.get("evidence_ref")),
+            input_tokens=int(raw_input) if raw_input is not None else None,
+            output_tokens=int(raw_output) if raw_output is not None else None,
+            # A deleted or already-resolved row rebuilds to a different
+            # basis (and a changed amount to a different held figure), so the
+            # pending approval stops matching - the 409 says the action
+            # changed, which is the truth.
+            exposure_basis=row.basis if row is not None else "ABSENT",
+            held_amount_usd=row.amount_usd if row is not None else 0.0,
+        )
+
+    outcome: dict[str, str] = {}
+
+    def _execute_reconciliation(record: GovernedActionRecord) -> None:
+        debit_id = str(record.action_payload.get("debit_id"))
+        evidenced = float(  # monetary-float-ok: parses the hash-pinned decimal string back into the envelope's float form
+            str(record.action_payload.get("evidenced_amount_usd"))
+        )
+        raw_input = record.action_payload.get("input_tokens")
+        raw_output = record.action_payload.get("output_tokens")
+        # The held maximum comes from the HASH-PINNED payload, not the live
+        # row: after a crash between the counter release and the EXECUTED
+        # write, the row already carries the evidenced amount, and only the
+        # pinned figure lets the recovery replay report the true release.
+        held_amount = float(  # monetary-float-ok: parses the hash-pinned decimal string
+            str(record.action_payload.get("held_amount_usd"))
+        )
+        settled = reconcile_attempt_spend(
+            debit_id=debit_id,
+            evidenced_amount_usd=evidenced,
+            input_tokens=int(raw_input) if raw_input is not None else None,
+            output_tokens=int(raw_output) if raw_output is not None else None,
+            rate_card_ref=None,
+        )
+        if not settled:
+            # Idempotent under the action identity: a crash between the
+            # counter release and the EXECUTED write converges here on the
+            # claiming credential's resume.
+            current = store.get_attempt_debit(debit_id=debit_id)
+            if not (
+                current is not None
+                and current.basis == "RECONCILED"
+                and round(current.amount_usd, 8) == round(evidenced, 8)
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"Attempt debit `{debit_id}` was resolved by other means while "
+                        "this approval executed; no release was applied."
+                    ),
+                )
+        outcome["debit_id"] = debit_id
+        outcome["evidenced_amount_usd"] = _amount_str(evidenced)
+        outcome["released_amount_usd"] = _amount_str(round(held_amount - evidenced, 8))
+
+    executed = approve_and_execute_governed_action(
+        caller=caller,
+        action_id=request.action_id,
+        expected_target=_expected_target(request),
+        expected_hash=request.action_hash,
+        current_payload_builder=_rebuild_payload,
+        attribution=request.approved_by,
+        execute=_execute_reconciliation,
+        result_payload_builder=lambda: dict(outcome),
+        resume_interrupted_claim=request.resume_interrupted_claim,
+    )
+    evidenced_usd = float(
+        outcome["evidenced_amount_usd"]
+    )  # monetary-float-ok: restates the executed outcome
+    released_usd = float(
+        outcome["released_amount_usd"]
+    )  # monetary-float-ok: restates the executed outcome
+    return _build_response(
+        executed,
+        debit_id=outcome["debit_id"],
+        evidenced_amount_usd=evidenced_usd,
+        released_amount_usd=released_usd,
+    )
+
+
+def _expected_target(request: BudgetReconciliationApprovalRequest) -> str:
+    record = get_provider_operations_store().get_governed_action(request.action_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No governed action exists for `{request.action_id}`.",
+        )
+    return record.target
+
+
+def _reconciliation_response_from_result(
+    record: GovernedActionRecord,
+) -> BudgetReconciliationApprovalResponse:
+    payload = record.result_payload or {}
+    evidenced_usd = float(
+        str(payload.get("evidenced_amount_usd"))
+    )  # monetary-float-ok: replays the durable result
+    released_usd = float(
+        str(payload.get("released_amount_usd"))
+    )  # monetary-float-ok: replays the durable result
+    return _build_response(
+        record,
+        debit_id=str(payload.get("debit_id")),
+        evidenced_amount_usd=evidenced_usd,
+        released_amount_usd=released_usd,
+    )
+
+
+def _build_response(
+    record: GovernedActionRecord,
+    *,
+    debit_id: str,
+    evidenced_amount_usd: float,
+    released_amount_usd: float,
+) -> BudgetReconciliationApprovalResponse:
+    return BudgetReconciliationApprovalResponse(
+        service=settings.service_name,
+        version=settings.service_version,
+        governed_action=record,
+        debit_id=debit_id,
+        evidenced_amount_usd=evidenced_amount_usd,
+        released_amount_usd=released_amount_usd,
+        summary=[
+            f"Debit `{debit_id}` reconciled to the evidenced charge "
+            f"{_amount_str(evidenced_amount_usd)} USD under governed action "
+            f"`{record.action_id}`.",
+            f"Hard-budget headroom released: {_amount_str(released_amount_usd)} USD.",
+            f"Requested under credential `{record.requester_key_id}` and approved under "
+            f"distinct credential `{record.approver_key_id}`.",
+        ],
+    )

--- a/src/app/services/data_lifecycle_erasure.py
+++ b/src/app/services/data_lifecycle_erasure.py
@@ -235,6 +235,7 @@ def approve_data_erasure(
             ],
             "executed_at": outcome["executed_at"],
         },
+        resume_interrupted_claim=request.resume_interrupted_claim,
     )
     results = outcome["results"]
     assert isinstance(results, list)

--- a/src/app/services/governed_action_control.py
+++ b/src/app/services/governed_action_control.py
@@ -186,7 +186,15 @@ def approve_and_execute_governed_action(
                 "to the exact action requested; review the pending action and approve its hash."
             ),
         )
-    if compute_governed_action_hash(current_payload_builder(record)) != record.action_hash:
+    # Freshness guards the window BEFORE the claim: live domain state must
+    # still match what the approver reviewed. On the claiming credential's
+    # explicit resume the claim already validated this hash, and the executed
+    # effect may legitimately have changed the very state the rebuild reads -
+    # re-checking would refuse every crash recovery. The execute callback
+    # remains responsible for converging idempotently on resumed state.
+    if not resuming_own_claim and (
+        compute_governed_action_hash(current_payload_builder(record)) != record.action_hash
+    ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
@@ -205,7 +213,39 @@ def approve_and_execute_governed_action(
 
     now = _utc_now_iso()
     if resuming_own_claim:
-        claimed = record
+        # Exclusive resume ownership (issue #327 follow-up): the credential
+        # match proves WHO may resume, not that the original executor
+        # stopped. Rotating the claim instant under a compare-and-set is the
+        # single-writer step - exactly one resumer (racing another resume,
+        # a still-running executor's finalization, or #340's release) wins
+        # BEFORE any effect runs; every competitor holds the stale instant
+        # and loses by construction.
+        stale_claim_instant = record.claimed_at
+        # The fence needs STRICT inequality: the winner's write must
+        # invalidate every competitor's expected value. Wall-clock
+        # microseconds can collide with the instant being replaced, so the
+        # rotation regenerates until it differs from the stale instant -
+        # a rotation equal to what it replaces would be a no-op fence.
+        # (Competitors expecting the SAME stale value need no such guard:
+        # whichever distinct value wins, their compare-and-set fails.)
+        rotated_claim_instant = now
+        while rotated_claim_instant == stale_claim_instant:
+            rotated_claim_instant = _utc_now_iso()
+        claimed = record.model_copy(update={"claimed_at": rotated_claim_instant})
+        if stale_claim_instant is None or not repository.transition_governed_action(
+            action_id=action_id,
+            expected_status=GovernedActionStatus.CLAIMED.value,
+            record=claimed,
+            expected_claimed_at=stale_claim_instant,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Governed action `{action_id}` changed hands while this resume "
+                    "started (another resume, a finalization, or a release won); "
+                    "this approval did not execute."
+                ),
+            )
     else:
         claimed = record.model_copy(
             update={
@@ -250,10 +290,15 @@ def approve_and_execute_governed_action(
             ),
         }
     )
+    # Finalization is fenced to THIS caller's claim instant: an executor
+    # whose claim was taken over (a resume rotated it) must not stamp
+    # evidence over state it no longer owns - the new owner's finalization
+    # is the one that lands.
     if not repository.transition_governed_action(
         action_id=action_id,
         expected_status=GovernedActionStatus.CLAIMED.value,
         record=executed,
+        expected_claimed_at=claimed.claimed_at,
     ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/src/app/services/provider_budget_policy.py
+++ b/src/app/services/provider_budget_policy.py
@@ -107,7 +107,9 @@ def parse_provider_budget_policy() -> ParsedProviderBudgetPolicy:
         findings=findings,
         usage_to_budget_notes=[
             "Tracked spend is recorded durably per provider attempt at the attempt boundary (issue #289): actual usage debits as actual, billable-risk failures debit conservatively, and an execution whose every attempt fails still moves the envelope.",
-            "Hard-limit admission is an atomic per-attempt check-and-reserve on the budget row (issue #300): each attempt reserves its governed maximum (input bounded by request-body bytes, output by the enforced cap) in one store transaction before the provider is called, then settles to the evidenced amount - concurrent replicas cannot jointly overshoot the limit, and a crash before settlement leaves the conservative reservation counted.",
+            "Hard-limit admission is an atomic per-attempt check-and-reserve on the budget row (issue #300): each attempt reserves its governed maximum in one store transaction before the provider is called - concurrent replicas cannot jointly overshoot the limit, and a crash before settlement leaves the conservative reservation counted.",
+            "The reserved maximum assumes tokenization at no finer than one token per byte of the request body plus the provider-enforced output cap under the effective rate card (issue #329); the claim holds for byte-level or coarser tokenizers and does not cover provider-side minimum-billing or non-token charges.",
+            "Only trustworthy provider-reported usage settles a reservation down; a billable-risk attempt without usage holds its reserved maximum as UNRESOLVED_MAX exposure (issue #329) - estimates are reported but never release hard admission capacity - until governed four-eyes reconciliation settles it to a provider-evidenced charge.",
             "Soft budget posture is advisory and inspectable; hard budget posture is blocking when enforcement is enabled.",
             "Tracked spend now flows through the configured provider-operations store so budget posture can remain durable when the SQL-backed provider-operations path is enabled.",
         ],
@@ -226,12 +228,26 @@ def settle_attempt_spend(
     debit: AttemptDebit | None,
     candidate_id_v2: str | None,
 ) -> bool:
-    """Settle a reservation to the attempt's evidenced debit in one
-    transaction with the counter adjustment (issue #300) - or release it to
-    zero (basis ``RELEASED``) when the attempt proved non-billable (429,
-    pre-connect failure). Idempotent: only a still-reserved row settles. A
-    crash before settlement leaves the conservative reservation standing -
-    over-counting is the safe direction for a hard limit.
+    """Resolve a reservation with the attempt's evidence in one transaction
+    with the counter adjustment (issue #300), in evidence order (issue #329):
+
+    - trustworthy provider-reported usage (basis ``ACTUAL_USAGE``) settles to
+      the evidenced amount - the only evidence that may RELEASE hard
+      admission capacity at the attempt boundary;
+    - a proven non-billable attempt (429, pre-connect; ``debit is None``)
+      releases to zero, basis ``RELEASED``;
+    - a billable-risk attempt WITHOUT usage (timeout, 5xx, usage withheld -
+      basis ``CONSERVATIVE_ESTIMATE``) holds: the row moves to
+      ``UNRESOLVED_MAX`` and the reserved maximum stays in the counter.
+      The estimate is reporting posture, not settlement evidence - nothing
+      establishes the provider consumed only the ~4-bytes/token guess, so
+      releasing headroom against it would let two admitted maxima jointly
+      exceed the hard limit. Unresolved exposure releases only through
+      governed reconciliation (``reconcile_attempt_spend``).
+
+    Idempotent: only a still-reserved row resolves. A crash before
+    resolution leaves the conservative reservation standing - over-counting
+    is the safe direction for a hard limit.
     """
 
     repository = get_provider_operations_store()
@@ -252,6 +268,20 @@ def settle_attempt_spend(
             rate_card_ref=None,
             settled_at=_utcnow(),
         )
+    # The invariant enforced where it is stated: ACTUAL_USAGE is the ONLY
+    # basis that may release capacity at the attempt boundary. Every other
+    # basis (CONSERVATIVE_ESTIMATE today; MIXED/NONE should they ever reach
+    # settlement) holds - non-usage evidence never settles a reservation
+    # down. Note the ``debit is None`` branch above is scoped to PROVEN
+    # non-billability (429, pre-connect); an attempt whose settle-time
+    # pricing returns None despite billable risk (rate card expired
+    # mid-attempt) also reaches it - a narrow window tracked with the
+    # governance-recovery hardening (#340 era), not silently widened here.
+    if debit.basis != "ACTUAL_USAGE":
+        return repository.hold_attempt_debit_unresolved(
+            debit_id=debit_id,
+            held_at=_utcnow(),
+        )
     return repository.settle_attempt_debit(
         debit_id=debit_id,
         budget_key=_BUDGET_KEY,
@@ -261,6 +291,54 @@ def settle_attempt_spend(
         output_tokens=debit.output_tokens,
         rate_card_ref=debit.rate_card_ref,
         settled_at=_utcnow(),
+    )
+
+
+def reconcile_attempt_spend(
+    *,
+    debit_id: str,
+    evidenced_amount_usd: float,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    rate_card_ref: str | None,
+) -> bool:
+    """Settle one unresolved billable exposure to an operator-evidenced
+    charge (issue #329). This is the ONLY path that releases unresolved
+    reservation capacity, and it is reachable only through the governed
+    four-eyes reconciliation action - releasing hard-budget headroom is
+    risk-increasing. Returns False when the row is not unresolved (already
+    reconciled - retry convergence - or settled by usage evidence)."""
+
+    repository = get_provider_operations_store()
+    return repository.reconcile_attempt_debit(
+        debit_id=debit_id,
+        budget_key=_BUDGET_KEY,
+        amount_usd=evidenced_amount_usd,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        rate_card_ref=rate_card_ref,
+        reconciled_at=_utcnow(),
+    )
+
+
+def require_priceable_admission(reservation: AttemptDebit | None) -> None:
+    """Fail closed when an enforced hard budget cannot price an attempt
+    (issue #329): admitting an unpriceable attempt would bypass the limit
+    silently. With enforcement off, unpriceable attempts stay the explicit
+    cost-unknown posture and proceed."""
+
+    if reservation is not None:
+        return
+    enforcement = resolve_provider_execution_config().enforcement
+    if not enforcement.budget_enforced:
+        return
+    raise ProviderExecutionError(
+        category=ProviderFailureCategory.INVALID_BUDGET_CONFIGURATION,
+        message=(
+            "The live-provider hard budget is enforced but no effective rate card "
+            "prices this candidate; admission fails closed rather than bypassing "
+            "the limit."
+        ),
     )
 
 

--- a/tests/integration/test_budget_reconciliation_api_contract.py
+++ b/tests/integration/test_budget_reconciliation_api_contract.py
@@ -1,0 +1,167 @@
+"""API contract for governed budget reconciliation (issue #329).
+
+The unit suite proves the hold/release semantics; this contract proves the
+HTTP wiring: verified-credential enforcement on both routes, the pending step
+releasing nothing, the distinct-credential approval settling the exposure to
+the evidenced charge, and an unknown action refusing with 404.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.contracts.model_catalogue import derive_candidate_identity_v2
+from app.services.provider_budget_policy import (
+    reserve_attempt_spend,
+    settle_attempt_spend,
+)
+from app.services.provider_operations_store import get_provider_operations_store
+from app.services.provider_usage_accounting import AttemptDebit
+from tests.support.caller_credentials import (
+    generate_caller_signing_key,
+    mint_caller_credential,
+    public_keys_setting,
+)
+
+_REQUESTER_KEY = generate_caller_signing_key()
+_APPROVER_KEY = generate_caller_signing_key()
+_PUBLIC_KEYS = public_keys_setting(
+    **{"budget-ops-alpha": _REQUESTER_KEY, "budget-ops-beta": _APPROVER_KEY}
+)
+_REQUESTER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_REQUESTER_KEY,
+        key_id="budget-ops-alpha",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+_APPROVER_HEADERS = {
+    "Authorization": "Bearer "
+    + mint_caller_credential(
+        signing_key=_APPROVER_KEY,
+        key_id="budget-ops-beta",
+        subject="lotus-platform",
+        expires_in_seconds=3600,
+    )
+}
+
+_CANONICAL = derive_candidate_identity_v2(
+    provider_id="text.openai",
+    model_family="gpt-5.4",
+    model_revision="gpt-5.4",
+    deployment=None,
+)
+
+
+def _seed_unresolved_exposure() -> str:
+    """One held reservation on the books, exactly as a timeout leaves it."""
+
+    settings.live_text_budget_enforced = True
+    settings.live_text_hard_budget_usd = 1.50
+    settings.live_text_input_cost_per_1k_tokens = 0.01
+    settings.live_text_output_cost_per_1k_tokens = 0.03
+    debit = AttemptDebit(
+        amount_usd=1.10,
+        basis="CONSERVATIVE_ESTIMATE",
+        input_tokens=200,
+        output_tokens=512,
+        rate_card_ref="default-live-text",
+    )
+    reserved = reserve_attempt_spend(
+        execution_id="exec-api-rec",
+        candidate_entry_id="text.openai:gpt-5.4",
+        provider_id="text.openai",
+        model_revision="gpt-5.4",
+        attempt_index=0,
+        reservation=debit,
+        candidate_id_v2=_CANONICAL,
+    )
+    assert reserved == "RESERVED"
+    assert (
+        settle_attempt_spend(
+            execution_id="exec-api-rec",
+            candidate_entry_id="text.openai:gpt-5.4",
+            attempt_index=0,
+            debit=AttemptDebit(
+                amount_usd=0.35,
+                basis="CONSERVATIVE_ESTIMATE",
+                input_tokens=50,
+                output_tokens=512,
+                rate_card_ref="default-live-text",
+            ),
+            candidate_id_v2=_CANONICAL,
+        )
+        is True
+    )
+    return f"adbt2:exec-api-rec:{_CANONICAL}:0"
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "caller_trust_mode", "verified_service_jwt")
+    monkeypatch.setattr(settings, "caller_jwt_issuer", "https://platform.lotus/issuer")
+    monkeypatch.setattr(settings, "caller_jwt_audience", "lotus-ai")
+    monkeypatch.setattr(settings, "caller_jwt_public_keys", _PUBLIC_KEYS)
+
+
+def test_reconciliation_routes_execute_the_governed_flow(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure(monkeypatch)
+    debit_id = _seed_unresolved_exposure()
+
+    unverified = client.post(
+        "/platform/provider-budget/reconciliation-requests",
+        json={
+            "debit_id": debit_id,
+            "evidenced_amount_usd": 0.42,
+            "evidence_ref": "invoice 2026-09/line 17",
+        },
+    )
+    assert unverified.status_code == 401
+
+    pending = client.post(
+        "/platform/provider-budget/reconciliation-requests",
+        json={
+            "debit_id": debit_id,
+            "evidenced_amount_usd": 0.42,
+            "evidence_ref": "invoice 2026-09/line 17",
+            "requested_by": "ops.user@lotus",
+        },
+        headers=_REQUESTER_HEADERS,
+    )
+    assert pending.status_code == 200
+    action = pending.json()["governed_action"]
+    assert action["status"] == "PENDING"
+    # The pending step releases nothing.
+    state = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
+    assert state is not None
+    assert state.current_spend_usd == 1.10
+
+    unknown = client.post(
+        "/platform/provider-budget/reconciliation-approvals",
+        json={"action_id": "gact_does_not_exist", "action_hash": "0" * 64},
+        headers=_APPROVER_HEADERS,
+    )
+    assert unknown.status_code == 404
+
+    approved = client.post(
+        "/platform/provider-budget/reconciliation-approvals",
+        json={"action_id": action["action_id"], "action_hash": action["action_hash"]},
+        headers=_APPROVER_HEADERS,
+    )
+    assert approved.status_code == 200
+    body = approved.json()
+    assert body["evidenced_amount_usd"] == 0.42
+    assert body["released_amount_usd"] == 0.68
+    assert body["governed_action"]["status"] == "EXECUTED"
+
+    state = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
+    assert state is not None
+    assert state.current_spend_usd == 0.42
+    row = get_provider_operations_store().get_attempt_debit(debit_id=debit_id)
+    assert row is not None
+    assert row.basis == "RECONCILED"

--- a/tests/integration/test_integrated_candidate_architecture.py
+++ b/tests/integration/test_integrated_candidate_architecture.py
@@ -312,7 +312,10 @@ def test_the_integrated_three_candidate_architecture_proof(
     debit_c = rows[f"adbt2:exec-proof-1:{candidate_c.candidate_id_v2}:0"]
     assert debit_a.candidate_id_v2 == candidate_a.candidate_id_v2
     assert debit_c.candidate_id_v2 == candidate_c.candidate_id_v2
-    assert debit_a.basis == "CONSERVATIVE_ESTIMATE"
+    # Candidate A failed without usage evidence, so its row HOLDS the
+    # reserved maximum as unresolved exposure (issue #329) - only candidate
+    # C's provider-reported usage settled to an evidenced amount.
+    assert debit_a.basis == "UNRESOLVED_MAX"
     assert debit_c.basis == "ACTUAL_USAGE"
     budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
     assert budget is not None

--- a/tests/unit/test_attempt_billing.py
+++ b/tests/unit/test_attempt_billing.py
@@ -200,8 +200,10 @@ def test_served_execution_debits_each_attempt_and_projects_them(
     monkeypatch: MonkeyPatch,
 ) -> None:
     """Fails once with a 5xx, succeeds on retry: BOTH attempts are durable
-    debit rows, the budget envelope moved at each boundary, and the response
-    figures equal the recorded evidence - spend was real before settlement."""
+    debit rows and the budget envelope moved at each boundary. The 5xx
+    attempt revealed no usage, so its row HOLDS the reserved maximum as
+    UNRESOLVED_MAX exposure (issue #329) - the response reports the estimate,
+    but the estimate releases nothing."""
 
     _seed_cost_scalars()
     _quiet_backoff(monkeypatch)
@@ -225,27 +227,39 @@ def test_served_execution_debits_each_attempt_and_projects_them(
     assert served_row.model_revision == "gpt-5.4"
     assert served_row.attempt_index == 1
     assert served_row.provider_id == "text.local"
-    assert failed_row.basis == "CONSERVATIVE_ESTIMATE"
+    assert failed_row.basis == "UNRESOLVED_MAX"
     assert failed_row.output_tokens == 512
     assert served_row.basis == "ACTUAL_USAGE"
     assert served_row.amount_usd == 0.0035
 
-    assert response.failed_attempt_cost_usd == failed_row.amount_usd
-    assert response.estimated_cost_usd == round(failed_row.amount_usd + served_row.amount_usd, 8)
+    # The response reports the ESTIMATE for the failed attempt - honest
+    # reporting posture - while the durable row holds the larger reserved
+    # maximum: the three-way distinction between estimate, unresolved
+    # reservation, and evidenced charge is visible in one execution.
+    assert response.failed_attempt_cost_usd is not None
+    assert failed_row.amount_usd > response.failed_attempt_cost_usd
+    assert response.estimated_cost_usd == round(
+        response.failed_attempt_cost_usd + served_row.amount_usd, 8
+    )
     assert response.failed_attempt_cost_basis == "CONSERVATIVE_ESTIMATE"
     assert response.billed_attempt_count == 2
     assert response.structured_output["estimated_cost_usd"] == response.estimated_cost_usd
 
     budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
     assert budget is not None
-    assert budget.current_spend_usd == response.estimated_cost_usd
+    # The counter keeps the unresolved maximum, not the estimate: unknown
+    # usage never releases hard admission capacity at the boundary.
+    assert budget.current_spend_usd == round(failed_row.amount_usd + served_row.amount_usd, 8)
+    assert budget.current_spend_usd > response.estimated_cost_usd
 
 
 def test_terminal_all_fail_execution_still_debits_every_billable_attempt(
     monkeypatch: MonkeyPatch,
 ) -> None:
     """The steering's P1 case: no success ever exists, yet both billable-risk
-    attempts moved the envelope at their boundaries."""
+    attempts moved the envelope at their boundaries - and with no usage ever
+    revealed, both rows hold their reserved maxima as UNRESOLVED_MAX
+    exposure (issue #329) rather than releasing to the heuristic estimate."""
 
     _seed_cost_scalars()
     _quiet_backoff(monkeypatch)
@@ -267,7 +281,7 @@ def test_terminal_all_fail_execution_still_debits_every_billable_attempt(
         _debit_key("exec-allfail", 0),
         _debit_key("exec-allfail", 1),
     }
-    assert all(row.basis == "CONSERVATIVE_ESTIMATE" for row in rows)
+    assert all(row.basis == "UNRESOLVED_MAX" for row in rows)
     budget = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
     assert budget is not None
     assert budget.current_spend_usd == round(sum(row.amount_usd for row in rows), 8)

--- a/tests/unit/test_budget_exposure.py
+++ b/tests/unit/test_budget_exposure.py
@@ -1,0 +1,522 @@
+"""Unresolved billable exposure never releases hard admission capacity (issue #329).
+
+Deep-audit F5 inverted: after a billable-risk failure WITHOUT usage evidence,
+settlement used to release the reservation down to the ~4-bytes/token
+heuristic - so a 1.50 USD hard limit could admit two 1.10 USD maxima. These
+tests pin the closure: unknown usage HOLDS the reserved maximum
+(``UNRESOLVED_MAX``), estimates are reporting posture only, and the sole
+release path is the governed four-eyes reconciliation to a provider-evidenced
+charge.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from app.config import settings
+from app.contracts.model_catalogue import derive_candidate_identity_v2
+from app.contracts.providers import (
+    BudgetReconciliationApprovalRequest,
+    BudgetReconciliationIntentRequest,
+    ProviderFailureCategory,
+)
+from app.providers.base import ProviderExecutionError
+from app.repositories.provider_operations_repository import ProviderAttemptDebitRecord
+from app.services.budget_reconciliation import (
+    approve_budget_reconciliation,
+    request_budget_reconciliation,
+)
+from app.services.provider_budget_policy import (
+    require_priceable_admission,
+    reserve_attempt_spend,
+    settle_attempt_spend,
+    spent_for_execution,
+)
+from app.services.provider_operations_store import get_provider_operations_store
+from app.services.provider_usage_accounting import AttemptDebit
+from tests.support.governed_control import GOVERNED_APPROVER, GOVERNED_REQUESTER
+
+_CANONICAL = derive_candidate_identity_v2(
+    provider_id="text.openai",
+    model_family="gpt-5.4",
+    model_revision="gpt-5.4",
+    deployment=None,
+)
+
+
+def _enforce(hard_limit: float) -> None:
+    settings.live_text_budget_enforced = True
+    settings.live_text_hard_budget_usd = hard_limit
+    settings.live_text_input_cost_per_1k_tokens = 0.01
+    settings.live_text_output_cost_per_1k_tokens = 0.03
+
+
+def _debit(amount: float, *, basis: str = "CONSERVATIVE_ESTIMATE") -> AttemptDebit:
+    return AttemptDebit(
+        amount_usd=amount,
+        basis=basis,  # type: ignore[arg-type]
+        input_tokens=200,
+        output_tokens=512,
+        rate_card_ref="default-live-text",
+    )
+
+
+def _reserve(execution_id: str, amount: float, *, attempt_index: int = 0) -> str:
+    return reserve_attempt_spend(
+        execution_id=execution_id,
+        candidate_entry_id="text.openai:gpt-5.4",
+        provider_id="text.openai",
+        model_revision="gpt-5.4",
+        attempt_index=attempt_index,
+        reservation=_debit(amount),
+        candidate_id_v2=_CANONICAL,
+    )
+
+
+def _settle(execution_id: str, debit: AttemptDebit | None, *, attempt_index: int = 0) -> bool:
+    return settle_attempt_spend(
+        execution_id=execution_id,
+        candidate_entry_id="text.openai:gpt-5.4",
+        attempt_index=attempt_index,
+        debit=debit,
+        candidate_id_v2=_CANONICAL,
+    )
+
+
+def _debit_id(execution_id: str, *, attempt_index: int = 0) -> str:
+    return f"adbt2:{execution_id}:{_CANONICAL}:{attempt_index}"
+
+
+def _counter() -> float:
+    state = get_provider_operations_store().get_budget_state(budget_key="live_text_generation")
+    return state.current_spend_usd if state is not None else 0.0
+
+
+def test_unknown_usage_holds_the_reservation_and_the_next_maximum_is_refused() -> None:
+    """The audit probe, inverted: reserve 1.10 against a 1.50 hard limit,
+    settle a timeout's unknown usage - the counter keeps 1.10, the row is
+    UNRESOLVED_MAX, and a second 1.10 maximum is REFUSED. Two admitted
+    maxima can no longer jointly exceed the limit."""
+
+    _enforce(1.50)
+    assert _reserve("exec-a", 1.10) == "RESERVED"
+
+    # Timeout/5xx/usage-withheld all reach settlement as an estimate debit.
+    assert _settle("exec-a", _debit(0.35)) is True
+
+    row = get_provider_operations_store().get_attempt_debit(debit_id=_debit_id("exec-a"))
+    assert row is not None
+    assert row.basis == "UNRESOLVED_MAX"
+    assert row.amount_usd == 1.10
+    assert _counter() == 1.10
+
+    assert _reserve("exec-b", 1.10) == "REFUSED"
+    # The exposure also counts against the caller's own execution ceiling,
+    # so a retry or fallback admission sees the honest number.
+    assert spent_for_execution("exec-a") == 1.10
+
+
+def test_usage_evidence_and_proven_non_billability_still_release() -> None:
+    """The hold is scoped to UNKNOWN usage: provider-reported usage settles
+    down to the evidenced amount, and a proven non-billable attempt (429,
+    pre-connect) releases to zero exactly as before."""
+
+    _enforce(1.50)
+    assert _reserve("exec-usage", 1.10) == "RESERVED"
+    assert _settle("exec-usage", _debit(0.20, basis="ACTUAL_USAGE")) is True
+    row = get_provider_operations_store().get_attempt_debit(debit_id=_debit_id("exec-usage"))
+    assert row is not None
+    assert row.basis == "ACTUAL_USAGE"
+    assert _counter() == 0.20
+
+    assert _reserve("exec-nobill", 1.10) == "RESERVED"
+    assert _settle("exec-nobill", None) is True
+    released = get_provider_operations_store().get_attempt_debit(debit_id=_debit_id("exec-nobill"))
+    assert released is not None
+    assert released.basis == "RELEASED"
+    assert _counter() == 0.20
+
+
+def test_holding_is_idempotent_and_a_second_resolution_is_a_noop() -> None:
+    _enforce(1.50)
+    assert _reserve("exec-idem", 1.10) == "RESERVED"
+    assert _settle("exec-idem", _debit(0.35)) is True
+    # Crash-retry of the same settlement converges without touching state.
+    assert _settle("exec-idem", _debit(0.35)) is False
+    # Late usage evidence cannot silently rewrite held exposure either: the
+    # governed reconciliation is the only path off UNRESOLVED_MAX.
+    assert _settle("exec-idem", _debit(0.20, basis="ACTUAL_USAGE")) is False
+    assert _counter() == 1.10
+
+
+def test_governed_reconciliation_is_the_only_release_and_it_takes_four_eyes() -> None:
+    """Exposure settles to the provider-evidenced charge through the
+    two-step governed action: distinct credentials, exact hash, counter
+    released once, retry converges on the same evidenced outcome."""
+
+    _enforce(1.50)
+    assert _reserve("exec-rec", 1.10) == "RESERVED"
+    assert _settle("exec-rec", _debit(0.35)) is True
+    debit_id = _debit_id("exec-rec")
+
+    pending = request_budget_reconciliation(
+        BudgetReconciliationIntentRequest(
+            debit_id=debit_id,
+            evidenced_amount_usd=0.42,
+            evidence_ref="invoice 2026-09/line 17",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    # The requester's own credential cannot approve.
+    with pytest.raises(HTTPException) as exc_info:
+        approve_budget_reconciliation(
+            BudgetReconciliationApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert exc_info.value.status_code == 403
+    assert _counter() == 1.10
+
+    approved = approve_budget_reconciliation(
+        BudgetReconciliationApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert approved.evidenced_amount_usd == 0.42
+    assert approved.released_amount_usd == 0.68
+    assert _counter() == 0.42
+    row = get_provider_operations_store().get_attempt_debit(debit_id=debit_id)
+    assert row is not None
+    assert row.basis == "RECONCILED"
+    assert row.amount_usd == 0.42
+
+    # A lost response retried returns the SAME evidenced outcome - no second
+    # release.
+    replay = approve_budget_reconciliation(
+        BudgetReconciliationApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert replay.released_amount_usd == 0.68
+    assert replay.governed_action.action_id == approved.governed_action.action_id
+    assert _counter() == 0.42
+
+
+def test_a_crash_orphaned_reservation_reconciles_too() -> None:
+    """A crash before any settlement leaves RESERVED_MAX standing - the safe
+    direction - and the same governed path resolves it to evidence."""
+
+    _enforce(1.50)
+    assert _reserve("exec-crash", 1.10) == "RESERVED"
+
+    pending = request_budget_reconciliation(
+        BudgetReconciliationIntentRequest(
+            debit_id=_debit_id("exec-crash"),
+            evidenced_amount_usd=0.0,
+            evidence_ref="billing console: attempt never billed",
+        ),
+        GOVERNED_REQUESTER,
+    )
+    approved = approve_budget_reconciliation(
+        BudgetReconciliationApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert approved.released_amount_usd == 1.10
+    assert _counter() == 0.0
+
+
+def test_an_approval_reviewed_against_one_exposure_state_cannot_execute_another() -> None:
+    """Freshness: the request pins the exposure's basis into the hash. If
+    the row resolves by other means between request and approval, the
+    rebuilt payload no longer matches and the approval refuses instead of
+    double-releasing."""
+
+    _enforce(1.50)
+    assert _reserve("exec-fresh", 1.10) == "RESERVED"
+    pending = request_budget_reconciliation(
+        BudgetReconciliationIntentRequest(
+            debit_id=_debit_id("exec-fresh"),
+            evidenced_amount_usd=0.10,
+            evidence_ref="invoice draft",
+        ),
+        GOVERNED_REQUESTER,
+    )
+    # Usage evidence arrives late and settles the crash-orphaned reservation.
+    assert _settle("exec-fresh", _debit(0.20, basis="ACTUAL_USAGE")) is True
+    assert _counter() == 0.20
+
+    with pytest.raises(HTTPException) as exc_info:
+        approve_budget_reconciliation(
+            BudgetReconciliationApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+    assert exc_info.value.status_code == 409
+    assert _counter() == 0.20
+
+
+def test_reconciliation_requests_validate_the_exposure() -> None:
+    _enforce(1.50)
+    with pytest.raises(HTTPException) as missing:
+        request_budget_reconciliation(
+            BudgetReconciliationIntentRequest(
+                debit_id="adbt2:absent:cand2_missing:0",
+                evidenced_amount_usd=0.10,
+                evidence_ref="nothing",
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert missing.value.status_code == 404
+
+    assert _reserve("exec-settled", 1.10) == "RESERVED"
+    assert _settle("exec-settled", _debit(0.20, basis="ACTUAL_USAGE")) is True
+    with pytest.raises(HTTPException) as settled:
+        request_budget_reconciliation(
+            BudgetReconciliationIntentRequest(
+                debit_id=_debit_id("exec-settled"),
+                evidenced_amount_usd=0.10,
+                evidence_ref="invoice",
+            ),
+            GOVERNED_REQUESTER,
+        )
+    assert settled.value.status_code == 409
+
+
+def test_an_enforced_budget_that_cannot_price_the_attempt_fails_closed() -> None:
+    """An unpriceable candidate under an enforced hard budget must refuse
+    admission, not bypass the limit by reserving nothing."""
+
+    settings.live_text_budget_enforced = True
+    settings.live_text_hard_budget_usd = 1.50
+    with pytest.raises(ProviderExecutionError) as exc_info:
+        require_priceable_admission(None)
+    assert exc_info.value.category is ProviderFailureCategory.INVALID_BUDGET_CONFIGURATION
+
+    settings.live_text_budget_enforced = False
+    require_priceable_admission(None)
+    require_priceable_admission(_debit(0.10))
+
+
+def test_sql_concurrent_reconciliation_releases_exactly_once(tmp_path: Path) -> None:
+    """Two replicas approving reconciliation of the same exposure: the
+    guarded basis+amount compare-and-set lets exactly one adjust the
+    counter."""
+
+    from app.repositories.sqlalchemy_provider_operations_repository import (
+        SqlAlchemyProviderOperationsRepository,
+    )
+    from tests.support.migration_runner import upgrade_database_to_head
+
+    database_url = f"sqlite:///{tmp_path / 'lotus-ai-exposure.db'}"
+    upgrade_database_to_head(database_url)
+    repository = SqlAlchemyProviderOperationsRepository(database_url)
+
+    record = ProviderAttemptDebitRecord(
+        debit_id="adbt2:exec-sql:cand2_x:0",
+        provider_id="text.openai",
+        basis="RESERVED_MAX",
+        amount_usd=1.10,
+        input_tokens=200,
+        output_tokens=512,
+        rate_card_ref="default-live-text",
+        recorded_at="2026-09-05T00:00:00Z",
+        candidate_entry_id="text.openai:gpt-5.4",
+        model_revision="gpt-5.4",
+        attempt_index=0,
+    )
+    assert (
+        repository.reserve_attempt_debit(
+            record, budget_key="live_text_generation", hard_limit_usd=None
+        )
+        == "RESERVED"
+    )
+    assert (
+        repository.hold_attempt_debit_unresolved(
+            debit_id=record.debit_id, held_at="2026-09-05T00:00:01Z"
+        )
+        is True
+    )
+    # Idempotent: a crash-retry of the hold is a no-op.
+    assert (
+        repository.hold_attempt_debit_unresolved(
+            debit_id=record.debit_id, held_at="2026-09-05T00:00:02Z"
+        )
+        is False
+    )
+
+    def _reconcile(session_tag: str) -> bool:
+        own = SqlAlchemyProviderOperationsRepository(database_url)
+        return own.reconcile_attempt_debit(
+            debit_id=record.debit_id,
+            budget_key="live_text_generation",
+            amount_usd=0.42,
+            input_tokens=100,
+            output_tokens=40,
+            rate_card_ref="default-live-text",
+            reconciled_at=f"2026-09-05T00:00:03Z+{session_tag}",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = list(pool.map(_reconcile, ["a", "b"]))
+    assert sorted(outcomes) == [False, True]
+    # A reconciliation arriving AFTER resolution refuses deterministically
+    # at the basis check, and a missing row reads as absent, not an error.
+    assert _reconcile("late") is False
+    assert repository.get_attempt_debit(debit_id="adbt2:absent:cand2_none:0") is None
+
+    budget = repository.get_budget_state(budget_key="live_text_generation")
+    assert budget is not None
+    assert budget.current_spend_usd == 0.42
+    row = repository.get_attempt_debit(debit_id=record.debit_id)
+    assert row is not None
+    assert row.basis == "RECONCILED"
+
+
+def test_a_served_response_with_usage_withheld_holds_its_maximum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Usage-missing SUCCESS is the same unknown: the served attempt's row
+    holds the reserved maximum while the response honestly reports what it
+    can."""
+
+    from tests.unit.test_attempt_billing import (
+        _Response,
+        _debit_key,
+        _run_transport,
+        _seed_cost_scalars,
+    )
+
+    _seed_cost_scalars()
+    body = b'{"id": "resp_nousage", "model": "gpt-5.4", "output_text": "OK"}'
+    monkeypatch.setattr("urllib.request.urlopen", lambda request, timeout: _Response(body))
+
+    response = _run_transport(retry_limit=0, execution_id="exec-withheld")
+    assert response.failure_category is None
+    # The provider withheld usage: the response can honestly report none.
+    assert response.output_tokens is None
+
+    row = get_provider_operations_store().get_attempt_debit(debit_id=_debit_key("exec-withheld", 0))
+    assert row is not None
+    assert row.basis == "UNRESOLVED_MAX"
+    assert _counter() == row.amount_usd
+
+
+def test_an_exposure_resolved_mid_execution_applies_no_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The narrow race between the claim and the counter release: if the
+    guarded reconcile CAS loses (the row left its held basis after the
+    freshness rebuild), the approval refuses and no release is applied."""
+
+    _enforce(1.50)
+    assert _reserve("exec-race", 1.10) == "RESERVED"
+    assert _settle("exec-race", _debit(0.35)) is True
+    pending = request_budget_reconciliation(
+        BudgetReconciliationIntentRequest(
+            debit_id=_debit_id("exec-race"),
+            evidenced_amount_usd=0.42,
+            evidence_ref="invoice",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    import app.services.budget_reconciliation as reconciliation_module
+
+    monkeypatch.setattr(reconciliation_module, "reconcile_attempt_spend", lambda **kwargs: False)
+    with pytest.raises(HTTPException) as exc_info:
+        approve_budget_reconciliation(
+            BudgetReconciliationApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+    assert exc_info.value.status_code == 409
+    assert "no release was applied" in exc_info.value.detail
+    assert _counter() == 1.10
+
+
+def test_a_crash_between_release_and_evidence_recovers_the_true_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Crash after the counter released but before EXECUTED evidence wrote:
+    the claiming credential resumes through the PUBLIC contract field, the
+    guarded reconcile converges as a no-op, and the replayed response
+    reports the TRUE released difference from the hash-pinned held amount -
+    with the counter adjusted exactly once."""
+
+    _enforce(1.50)
+    assert _reserve("exec-resume", 1.10) == "RESERVED"
+    assert _settle("exec-resume", _debit(0.35)) is True
+    pending = request_budget_reconciliation(
+        BudgetReconciliationIntentRequest(
+            debit_id=_debit_id("exec-resume"),
+            evidenced_amount_usd=0.42,
+            evidence_ref="invoice",
+        ),
+        GOVERNED_REQUESTER,
+    )
+
+    store = get_provider_operations_store()
+    real_transition = store.transition_governed_action
+    from app.contracts.governed_actions import GovernedActionRecord, GovernedActionStatus
+
+    def crash_before_evidence(
+        *,
+        action_id: str,
+        expected_status: str,
+        record: GovernedActionRecord,
+        expected_claimed_at: str | None = None,
+    ) -> bool:
+        if expected_status == GovernedActionStatus.CLAIMED.value:
+            return False
+        return real_transition(
+            action_id=action_id,
+            expected_status=expected_status,
+            record=record,
+            expected_claimed_at=expected_claimed_at,
+        )
+
+    monkeypatch.setattr(store, "transition_governed_action", crash_before_evidence)
+    with pytest.raises(HTTPException) as exc_info:
+        approve_budget_reconciliation(
+            BudgetReconciliationApprovalRequest(
+                action_id=pending.governed_action.action_id,
+                action_hash=pending.governed_action.action_hash,
+            ),
+            GOVERNED_APPROVER,
+        )
+    assert exc_info.value.status_code == 409
+    # The release already happened; the evidence write did not.
+    assert _counter() == 0.42
+
+    monkeypatch.setattr(store, "transition_governed_action", real_transition)
+    recovered = approve_budget_reconciliation(
+        BudgetReconciliationApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+            resume_interrupted_claim=True,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert recovered.evidenced_amount_usd == 0.42
+    assert recovered.released_amount_usd == 0.68
+    assert recovered.governed_action.status is GovernedActionStatus.EXECUTED
+    # Released exactly once.
+    assert _counter() == 0.42

--- a/tests/unit/test_data_lifecycle_engine.py
+++ b/tests/unit/test_data_lifecycle_engine.py
@@ -579,12 +579,14 @@ def _seed_control_plane_matrix() -> None:
 
     from app.repositories.provider_operations_repository import ProviderAttemptDebitRecord
 
+    # Seeded through the one remaining debit lifecycle (issue #329): reserve
+    # then settle, ending in the same ACTUAL_USAGE evidence rows as before.
     for debit_id, age in (("adbt_old", 2600), ("adbt_young", 10)):
-        ops.record_attempt_debit(
+        ops.reserve_attempt_debit(
             ProviderAttemptDebitRecord(
                 debit_id=debit_id,
                 provider_id="text.openai",
-                basis="ACTUAL_USAGE",
+                basis="RESERVED_MAX",
                 amount_usd=0.001,
                 input_tokens=10,
                 output_tokens=10,
@@ -592,6 +594,17 @@ def _seed_control_plane_matrix() -> None:
                 recorded_at=_iso(age),
             ),
             budget_key="live_text_generation",
+            hard_limit_usd=None,
+        )
+        ops.settle_attempt_debit(
+            debit_id=debit_id,
+            budget_key="live_text_generation",
+            basis="ACTUAL_USAGE",
+            amount_usd=0.001,
+            input_tokens=10,
+            output_tokens=10,
+            rate_card_ref="default-live-text",
+            settled_at=_iso(age),
         )
 
     def _gact(action_id: str, status: "GovernedActionStatus", age: int) -> None:

--- a/tests/unit/test_data_lifecycle_erasure.py
+++ b/tests/unit/test_data_lifecycle_erasure.py
@@ -385,19 +385,14 @@ def test_crash_after_a_family_completes_recovers_the_evidenced_counts(
             GOVERNED_APPROVER,
         )
 
-    # Recovery: the claiming credential retries with the original executors.
+    # Recovery: the claiming credential retries with the original executors,
+    # stating the explicit resume intent through the PUBLIC contract field.
     monkeypatch.setattr(erasure_module, "_ERASURE_EXECUTORS", original_executors)
-    monkeypatch.setattr(
-        erasure_module,
-        "approve_and_execute_governed_action",
-        lambda **kwargs: __import__(
-            "app.services.governed_action_control", fromlist=["x"]
-        ).approve_and_execute_governed_action(**kwargs, resume_interrupted_claim=True),
-    )
     recovered = approve_data_erasure(
         DataErasureApprovalRequest(
             action_id=pending.governed_action.action_id,
             action_hash=pending.governed_action.action_hash,
+            resume_interrupted_claim=True,
         ),
         GOVERNED_APPROVER,
     )

--- a/tests/unit/test_governed_action_control.py
+++ b/tests/unit/test_governed_action_control.py
@@ -211,7 +211,11 @@ def test_a_failed_execution_leaves_the_claim_resumable_by_its_owner() -> None:
     assert effects == [record.action_id]
     assert executed.status is GovernedActionStatus.EXECUTED
     assert executed.approver_key_id == APPROVER.credential_key_id
-    assert executed.claimed_at == stored.claimed_at
+    # Resume ROTATES the claim instant - that rotation is the exclusive-
+    # ownership fence; the original approval evidence is what stays stable.
+    assert executed.claimed_at is not None
+    assert executed.claimed_at != stored.claimed_at
+    assert executed.approved_at == stored.approved_at
 
 
 def test_a_system_identity_cannot_originate_a_human_governed_action() -> None:
@@ -402,11 +406,20 @@ def test_a_claim_lost_during_execution_cannot_finalize_evidence(
     real_transition = store.transition_governed_action
 
     def stolen_after_execution(
-        *, action_id: str, expected_status: str, record: GovernedActionRecord
+        *,
+        action_id: str,
+        expected_status: str,
+        record: GovernedActionRecord,
+        expected_claimed_at: str | None = None,
     ) -> bool:
         if expected_status == GovernedActionStatus.CLAIMED.value:
             return False
-        return real_transition(action_id=action_id, expected_status=expected_status, record=record)
+        return real_transition(
+            action_id=action_id,
+            expected_status=expected_status,
+            record=record,
+            expected_claimed_at=expected_claimed_at,
+        )
 
     monkeypatch.setattr(store, "transition_governed_action", stolen_after_execution)
     effects: list[str] = []
@@ -415,3 +428,40 @@ def test_a_claim_lost_during_execution_cannot_finalize_evidence(
     assert exc_info.value.status_code == 409
     assert "could not be finalized" in exc_info.value.detail
     assert effects == [record.action_id]
+
+
+def test_a_same_tick_rotation_never_reuses_the_stale_instant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fence is strict inequality (bb's review question on #329's PR):
+    if the wall clock returns the SAME instant as the stale claim, the
+    rotation regenerates until it differs - a rotation equal to what it
+    replaces would be a no-op fence letting a same-tick competitor pass."""
+
+    record = _submit()
+
+    def _explode(pending: object) -> None:
+        raise RuntimeError("first execution died")
+
+    with pytest.raises(RuntimeError):
+        _approve(record, execute=_explode)
+    stored = get_provider_operations_store().get_governed_action(record.action_id)
+    assert stored is not None
+    stale_instant = stored.claimed_at
+    assert stale_instant is not None
+
+    import app.services.governed_action_control as control_module
+
+    # Freeze the clock ON the stale instant for two ticks, then advance.
+    ticks = iter([stale_instant, stale_instant, "2099-01-01T00:00:00.000001+00:00"])
+    real_now = control_module._utc_now_iso
+    monkeypatch.setattr(
+        control_module,
+        "_utc_now_iso",
+        lambda: next(ticks, real_now()),
+    )
+
+    executed = _approve(record, execute=lambda pending: None, resume_interrupted_claim=True)
+    assert executed.status is GovernedActionStatus.EXECUTED
+    assert executed.claimed_at == "2099-01-01T00:00:00.000001+00:00"
+    assert executed.claimed_at != stale_instant

--- a/tests/unit/test_governed_execution_ownership.py
+++ b/tests/unit/test_governed_execution_ownership.py
@@ -18,6 +18,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.contracts.governed_actions import (
+    GovernedActionRecord,
     GovernedActionStatus,
     GovernedActionType,
 )
@@ -44,7 +45,7 @@ def _submit() -> object:
     )
 
 
-def _approve(record: object, execute: object) -> object:
+def _approve(record: object, execute: object, *, resume_interrupted_claim: bool = False) -> object:
     return approve_and_execute_governed_action(
         caller=GOVERNED_APPROVER,
         action_id=record.action_id,  # type: ignore[attr-defined]
@@ -53,6 +54,7 @@ def _approve(record: object, execute: object) -> object:
         current_payload_builder=lambda pending: dict(pending.action_payload),
         attribution=None,
         execute=execute,  # type: ignore[arg-type]
+        resume_interrupted_claim=resume_interrupted_claim,
     )
 
 
@@ -227,3 +229,172 @@ def test_sql_claim_is_a_guarded_single_winner_across_sessions(tmp_path: Path) ->
     assert stored is not None
     assert stored.status is GovernedActionStatus.CLAIMED
     assert stored.approver_key_id == "key-b"
+
+    # The resume/finalize/release fence, cross-session: both sessions hold
+    # the SAME stale claim instant; the guarded UPDATE on (status,
+    # claimed_at) admits exactly one rotation, and a finalization fenced to
+    # the stale instant loses to the rotated one. (SQLite here; the guarded
+    # single-statement UPDATE is backend-generic - PostgreSQL applies the
+    # same row-level atomicity.)
+    with_claim = claim_a.model_copy(update={"claimed_at": "2026-09-05T00:01:00Z"})
+    session_a.upsert_governed_action(with_claim)
+    rotate_a = with_claim.model_copy(update={"claimed_at": "2026-09-05T00:02:00Z"})
+    rotate_b = with_claim.model_copy(update={"claimed_at": "2026-09-05T00:02:01Z"})
+    rotated_a = session_a.transition_governed_action(
+        action_id=pending.action_id,
+        expected_status=GovernedActionStatus.CLAIMED.value,
+        record=rotate_a,
+        expected_claimed_at="2026-09-05T00:01:00Z",
+    )
+    rotated_b = session_b.transition_governed_action(
+        action_id=pending.action_id,
+        expected_status=GovernedActionStatus.CLAIMED.value,
+        record=rotate_b,
+        expected_claimed_at="2026-09-05T00:01:00Z",
+    )
+    assert (rotated_a, rotated_b) == (True, False)
+
+    stale_finalize = session_b.transition_governed_action(
+        action_id=pending.action_id,
+        expected_status=GovernedActionStatus.CLAIMED.value,
+        record=with_claim.model_copy(update={"status": GovernedActionStatus.EXECUTED}),
+        expected_claimed_at="2026-09-05T00:01:00Z",
+    )
+    owned_finalize = session_a.transition_governed_action(
+        action_id=pending.action_id,
+        expected_status=GovernedActionStatus.CLAIMED.value,
+        record=rotate_a.model_copy(update={"status": GovernedActionStatus.EXECUTED}),
+        expected_claimed_at="2026-09-05T00:02:00Z",
+    )
+    assert (stale_finalize, owned_finalize) == (False, True)
+
+
+def test_concurrent_resumes_take_exclusive_ownership_before_effects() -> None:
+    """The resume-side variant of the two-owner window: credential identity
+    does not prove the original executor stopped, so resuming must acquire
+    exclusive execution ownership by CAS BEFORE effects run - exactly one
+    resumer enters the callback, the loser refuses with 409, and exactly one
+    EXECUTED evidence write exists."""
+
+    pending = _submit()
+
+    def _explode(record: object) -> None:
+        raise RuntimeError("first execution died")
+
+    with pytest.raises(RuntimeError):
+        _approve(pending, execute=_explode)
+    claimed = get_provider_operations_store().get_governed_action(
+        pending.action_id  # type: ignore[attr-defined]
+    )
+    assert claimed is not None
+    assert claimed.status is GovernedActionStatus.CLAIMED
+
+    entries: list[str] = []
+    outcomes: list[object] = []
+    store = get_provider_operations_store()
+    real_get = store.get_governed_action
+    # Both resumers must READ THE SAME stale claim instant before either
+    # rotates it - the exact interleaving the audit probe drove. The gated
+    # read guarantees the race reaches the compare-and-set.
+    read_together = Barrier(2, timeout=5)
+
+    def _gated_get(action_id: str) -> GovernedActionRecord | None:
+        result = real_get(action_id)
+        if result is not None and result.status is GovernedActionStatus.CLAIMED:
+            try:
+                read_together.wait()
+            except BrokenBarrierError:
+                pass
+        return result
+
+    store.get_governed_action = _gated_get  # type: ignore[method-assign]
+    try:
+
+        def _resume() -> None:
+            try:
+                outcomes.append(
+                    _approve(
+                        pending,
+                        execute=lambda record: entries.append(record.action_id),
+                        resume_interrupted_claim=True,
+                    )
+                )
+            except HTTPException as exc:
+                outcomes.append(exc.status_code)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(_resume), pool.submit(_resume)]
+            for future in futures:
+                future.result()
+    finally:
+        store.get_governed_action = real_get  # type: ignore[method-assign]
+
+    # Exclusive ownership BEFORE effects: one entry, not two - the loser is
+    # refused at the rotation compare-and-set, never after its effect.
+    assert entries == [pending.action_id]  # type: ignore[attr-defined]
+    assert sorted(x for x in outcomes if isinstance(x, int)) == [409]
+    final = real_get(pending.action_id)  # type: ignore[attr-defined]
+    assert final is not None
+    assert final.status is GovernedActionStatus.EXECUTED
+
+
+def test_resume_versus_a_still_running_executor_yields_one_evidence_write() -> None:
+    """A resumer cannot know whether the prior executor died or is merely
+    slow. Taking over a live claim is therefore LEGAL - the rotation fence
+    guarantees what matters: the superseded executor's finalization loses
+    (409 after its effect), the taker's lands, the callback stays idempotent
+    under the action identity, and exactly one evidence write exists."""
+
+    from threading import Event
+
+    pending = _submit()
+
+    def _explode(record: object) -> None:
+        raise RuntimeError("first execution died")
+
+    with pytest.raises(RuntimeError):
+        _approve(pending, execute=_explode)
+
+    performed: set[str] = set()
+    first_entered = Event()
+    release_first = Event()
+    first_outcome: list[object] = []
+
+    def _slow_idempotent_effect(record: object) -> None:
+        performed.add(record.action_id)  # type: ignore[attr-defined]
+        first_entered.set()
+        release_first.wait(timeout=5)
+
+    def _first_resume() -> None:
+        try:
+            first_outcome.append(
+                _approve(pending, execute=_slow_idempotent_effect, resume_interrupted_claim=True)
+            )
+        except HTTPException as exc:
+            first_outcome.append(exc.status_code)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_first_resume)
+        assert first_entered.wait(timeout=5)
+        # The takeover: a second resume by the owner credential, reading the
+        # FRESH instant, rotates it and completes while the first executor
+        # is still running.
+        taken_over = _approve(
+            pending,
+            execute=lambda record: performed.add(record.action_id),
+            resume_interrupted_claim=True,
+        )
+        release_first.set()
+        future.result()
+
+    assert taken_over.status is GovernedActionStatus.EXECUTED  # type: ignore[attr-defined]
+    # The superseded executor ran its (idempotent) effect but could NOT
+    # stamp evidence over the taker's ownership.
+    assert first_outcome == [409]
+    assert performed == {pending.action_id}  # type: ignore[attr-defined]
+    final = get_provider_operations_store().get_governed_action(
+        pending.action_id  # type: ignore[attr-defined]
+    )
+    assert final is not None
+    assert final.status is GovernedActionStatus.EXECUTED
+    assert final.executed_at == taken_over.executed_at  # type: ignore[attr-defined]

--- a/tests/unit/test_sqlalchemy_provider_operations_repository.py
+++ b/tests/unit/test_sqlalchemy_provider_operations_repository.py
@@ -160,8 +160,9 @@ def test_sqlalchemy_provider_operations_repository_applies_atomic_mutations(
 def test_sqlalchemy_attempt_debits_are_idempotent_and_transactional(
     tmp_path: Path,
 ) -> None:
-    """Issue #289: the debit row and the budget counter advance together in
-    one transaction, a duplicate identity is a complete no-op, and deleting
+    """Issues #289/#300/#329: the debit row and the budget counter move
+    together in one transaction through the reserve->settle lifecycle, a
+    duplicate identity at either step is a complete no-op, and deleting
     evidence never reverses the counter."""
 
     database_url = f"sqlite:///{tmp_path / 'lotus-ai-provider-debits.db'}"
@@ -171,8 +172,8 @@ def test_sqlalchemy_attempt_debits_are_idempotent_and_transactional(
     debit = ProviderAttemptDebitRecord(
         debit_id="adbt:exec-sql:text.openai:gpt-5.4:0",
         provider_id="text.openai",
-        basis="CONSERVATIVE_ESTIMATE",
-        amount_usd=0.01736,
+        basis="RESERVED_MAX",
+        amount_usd=0.05,
         input_tokens=200,
         output_tokens=512,
         rate_card_ref="default-live-text",
@@ -182,8 +183,44 @@ def test_sqlalchemy_attempt_debits_are_idempotent_and_transactional(
         attempt_index=0,
     )
 
-    assert repository.record_attempt_debit(debit, budget_key="live_text_generation") is True
-    assert repository.record_attempt_debit(debit, budget_key="live_text_generation") is False
+    assert (
+        repository.reserve_attempt_debit(
+            debit, budget_key="live_text_generation", hard_limit_usd=None
+        )
+        == "RESERVED"
+    )
+    assert (
+        repository.reserve_attempt_debit(
+            debit, budget_key="live_text_generation", hard_limit_usd=None
+        )
+        == "DUPLICATE"
+    )
+    assert (
+        repository.settle_attempt_debit(
+            debit_id=debit.debit_id,
+            budget_key="live_text_generation",
+            basis="ACTUAL_USAGE",
+            amount_usd=0.01736,
+            input_tokens=200,
+            output_tokens=512,
+            rate_card_ref="default-live-text",
+            settled_at="2026-03-23T00:00:01Z",
+        )
+        is True
+    )
+    assert (
+        repository.settle_attempt_debit(
+            debit_id=debit.debit_id,
+            budget_key="live_text_generation",
+            basis="ACTUAL_USAGE",
+            amount_usd=0.01736,
+            input_tokens=200,
+            output_tokens=512,
+            rate_card_ref="default-live-text",
+            settled_at="2026-03-23T00:00:02Z",
+        )
+        is False
+    )
 
     budget = repository.get_budget_state(budget_key="live_text_generation")
     assert budget is not None
@@ -191,7 +228,7 @@ def test_sqlalchemy_attempt_debits_are_idempotent_and_transactional(
 
     rows = repository.list_attempt_debits(limit=10)
     assert [row.debit_id for row in rows] == ["adbt:exec-sql:text.openai:gpt-5.4:0"]
-    assert rows[0].basis == "CONSERVATIVE_ESTIMATE"
+    assert rows[0].basis == "ACTUAL_USAGE"
     assert rows[0].input_tokens == 200
     # The serving identity round-trips (issue #299): a later audit can name
     # the catalogue entry, provider, revision and attempt from the row alone.


### PR DESCRIPTION
Closes #329, closes #337. Packet 4 of the 2026-09-05 deep-audit corrective sequence (F5), plus the user-directed resume-ownership correction to #327's recovery semantics (relayed 2026-09-05; #340 updated with the composition).

## Consumer / operator outcome
A hard budget is now actually hard under failure: a timeout, 5xx, or usage-withheld response can no longer manufacture admission headroom. The audit probe's scenario — reserve 1.10 against a 1.50 limit, settle unknown usage to a 0.35 heuristic, admit a second 1.10 maximum (2.20 jointly admitted) — now ends with the second maximum REFUSED. Operators resolve stuck exposure explicitly: a governed four-eyes reconciliation settles it to a provider-evidenced charge (invoice/billing export) and releases exactly the difference, once. Callers see honest numbers: the per-execution ceiling counts unresolved maxima, so retries and fallbacks admit against reality.

## Invariant + single authority
Only evidence moves the budget counter downward. `settle_attempt_spend` resolves in evidence order: provider-reported usage settles (ACTUAL_USAGE), proven non-billability releases (RELEASED), unknown usage HOLDS (`RESERVED_MAX → UNRESOLVED_MAX`, amount and counter untouched — the estimate is reporting posture, never settlement evidence). The ONLY release path for held exposure is `reconcile_attempt_spend`, reachable solely through the governed `BUDGET_RECONCILIATION` two-step action (rides #327's claim machinery; releasing headroom is risk-increasing, holding is the automatic safe direction). The reconciliation hash pins the exposure's basis AND held amount at request time — a row resolved or changed by other means refuses at approval. An enforced budget that cannot price a candidate fails closed at admission (`require_priceable_admission`) instead of reserving nothing.

## Simplification
No new framework: one basis transition (hold) that changes nothing but the label, one guarded reconcile CAS mirroring the existing settle CAS, and a reconciliation service that is a thin composition over the #327 governed-action primitive. The uncoupled repo-level `record_attempt_debit` writer is DELETED across protocol/memory/SQL (the #337 split's remaining half) — reserve→settle is the one debit lifecycle, and its former test seedings now go through it. Completing #327: `resume_interrupted_claim` is now a public contract field on both approval requests (erasure + reconciliation) rather than test-only reachability, and the freshness rebuild is correctly scoped to the pre-claim window (an owner's explicit resume no longer 409s against state its own effect changed).

## Exclusive resume ownership (directive)
Credential identity proves WHO may resume, not that the original executor stopped. Resuming now acquires exclusive execution ownership BEFORE effects: it rotates the claim instant under a compare-and-set (`transition_governed_action` gains `expected_claimed_at` — no migration, no epoch column), and finalization is fenced to the owner's instant. Consequences, each pinned by a test: concurrent resumers holding the same stale instant admit exactly one pre-effect (gated-read barrier probe — the loser 409s before its callback); a resumer reading the fresh instant is a *legitimate takeover* of a possibly-dead executor (dead is indistinguishable from slow) — the superseded executor's effect stays idempotent-convergent and its finalization loses, so exactly one evidence write exists; the live-state freshness rebuild is scoped to the pre-claim window (an owner's resume no longer 409s against state its own effect changed); no unfenced timeout, no silent claim reset — orphaned claims stay frozen pending #340, whose release composes on this same CAS. `resume_interrupted_claim` becomes a public field on both approval contracts (erasure + reconciliation) *in the same PR as its fence* — recovery is exposed only once it is safe. Cross-session SQL proof included (SQLite; the guarded single-statement UPDATE is backend-generic — a dedicated PostgreSQL concurrency harness is a stated residual, not present in the unit lane). Same-tick safety (bb's review question): rotation enforces strict inequality against the stale instant it replaces — regenerated until distinct, so a wall-clock collision can never mint a no-op fence; pinned with a frozen-clock test.

## Failing-before / passing-after
`tests/unit/test_budget_exposure.py` (12 tests, audit probe 3 inverted): probe inversion (hold + second-maximum REFUSED + ceiling honesty); usage/non-billable still release; hold idempotency + late-usage cannot rewrite held exposure; governed reconciliation end-to-end (four-eyes 403, release-once, lost-response replay); crash-orphaned RESERVED_MAX reconciles; freshness (resolved-by-other-means → 409); request validation (404/409); fail-closed unpriceable admission; SQL two-session reconcile (exactly one winner) + hold idempotency; usage-withheld SUCCESS holds; mid-execution race applies no release; crash-between-release-and-evidence recovers the TRUE released amount through the public resume field with the counter adjusted exactly once. Rewritten pins: `test_attempt_billing` (5xx row now UNRESOLVED_MAX; estimate visibly smaller than held row; counter > response estimate), repo contract test now pins the reserve→settle lifecycle, lifecycle-engine seeding migrated.

## Compatibility + residuals
No schema migration (new bases are strings in the existing column); two additive endpoints; additive request fields with safe defaults. Row-basis vocabulary now three-way truthful: RESERVED_MAX (in flight/crash-orphaned), UNRESOLVED_MAX (complete, usage unknown), ACTUAL_USAGE/RELEASED/RECONCILED (evidenced) — posture notes state the tokenization assumptions behind the reserved maximum (≥1 token/byte + enforced output cap; excludes minimum-billing/non-token charges). Residuals: provider-side billing confirmation stays external (#115); orphaned-claim recovery is #340; packet 5 (F6/F7/F8) next.
