### PR TITLE
fix(ci): gate audit measures linear history, not merge settings

### DIFF
--- a/scripts/audit_main_gate_coverage.py
+++ b/scripts/audit_main_gate_coverage.py
@@ -40,38 +40,41 @@ def _gh(*args: str) -> str:
     return completed.stdout
 
 
-def assert_rebase_only_merging() -> None:
-    """The per-commit enumeration is only correct under rebase merging."""
-
-    raw = _gh(
-        "api",
-        f"repos/{REPOSITORY}",
-        "--jq",
-        "{squash: .allow_squash_merge, merge: .allow_merge_commit, rebase: .allow_rebase_merge}",
-    )
-    settings = json.loads(raw)
-    if settings != {"squash": False, "merge": False, "rebase": True}:
-        raise AuditError(
-            "main-gate coverage assumes rebase-only merging; repository merge settings are "
-            f"{settings} - update the dispatcher enumeration before changing them"
-        )
-
-
 def main_commits(limit: int) -> list[str]:
-    """The most recent commits on main, newest first.
+    """The most recent commits on main, newest first - with linear history
+    verified DIRECTLY on the audited window.
 
-    Listing by ``sha=main`` walks first parents, which enumerates exactly the
-    commits on main ONLY because history is linear - the rebase-only assertion
-    above is what guarantees that. Do not loosen one without the other.
+    The per-commit enumeration is only correct when history is linear. The
+    old proxy (asserting the repository's rebase-only merge settings) broke
+    when the workflow token stopped being able to read those fields - every
+    ``allow_*`` value returned null and the audit failed closed daily while
+    real coverage was unknown. Measuring the invariant itself is stronger:
+    a merge commit in the window fails the audit the day it lands, named by
+    sha, with no dependence on token permissions or settings drift.
     """
 
     raw = _gh(
         "api",
         f"repos/{REPOSITORY}/commits?sha=main&per_page={limit}",
         "--jq",
-        ".[].sha",
+        r'.[] | "\(.sha) \(.parents | length)"',
     )
-    commits = [line.strip() for line in raw.splitlines() if line.strip()]
+    commits: list[str] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        sha, _, parent_count = line.strip().partition(" ")
+        # A 0-parent root commit would also refuse here; acceptable - this
+        # repository's history is far deeper than any audit window, and an
+        # audit that somehow reaches the root SHOULD stop rather than trust
+        # an enumeration premise it can no longer distinguish.
+        if parent_count != "1":
+            raise AuditError(
+                f"main commit {sha} has {parent_count} parents; the per-commit "
+                "enumeration assumes linear (rebase-only) history - audit the "
+                "merge that produced it before trusting gate coverage"
+            )
+        commits.append(sha)
     if not commits:
         raise AuditError("no commits returned for main; coverage is unknown")
     return commits
@@ -108,7 +111,6 @@ def main() -> int:
     arguments = parser.parse_args()
 
     try:
-        assert_rebase_only_merging()
         commits = main_commits(arguments.limit)
         gaps = [sha for sha in commits if not has_verdict_bearing_run(sha)]
     except AuditError as error:

--- a/tests/unit/test_main_gate_coverage_audit.py
+++ b/tests/unit/test_main_gate_coverage_audit.py
@@ -2,8 +2,8 @@
 
 An audit that reports success when it could not verify anything is worse
 than no audit: it manufactures false assurance. These tests pin the
-failure modes - missing tool, unreadable listings, non-rebase merge
-settings, and runs that reached no verdict.
+failure modes - missing tool, unreadable listings, a merge commit breaking
+the linear-history enumeration premise, and runs that reached no verdict.
 """
 
 import json
@@ -41,20 +41,21 @@ def _fake_gh(monkeypatch: pytest.MonkeyPatch, responses: dict[str, object]) -> N
     monkeypatch.setattr(audit.subprocess, "run", run)
 
 
-REBASE_ONLY = json.dumps({"squash": False, "merge": False, "rebase": True})
-
-
 def test_a_missing_gh_cli_is_a_failure_not_a_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(audit.shutil, "which", lambda _name: None)
     monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
     assert audit.main() == 1
 
 
-def test_non_rebase_merge_settings_refuse_to_audit(monkeypatch: pytest.MonkeyPatch) -> None:
-    _fake_gh(
-        monkeypatch,
-        {"repos/sgajbi/lotus-ai": json.dumps({"squash": True, "merge": False, "rebase": True})},
-    )
+def test_a_merge_commit_in_the_window_refuses_to_trust_enumeration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-commit enumeration is only correct over linear history - the
+    audit measures that invariant directly (the old proxy asserted the
+    repository's merge settings, which the workflow token can no longer
+    read). A two-parent commit refuses the whole audit, named by sha."""
+
+    _fake_gh(monkeypatch, {"repos/sgajbi/lotus-ai/commits": "abc123 2\ndef456 1\n"})
     monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])
     assert audit.main() == 1
 
@@ -63,8 +64,7 @@ def test_unreadable_run_listing_is_a_failure(monkeypatch: pytest.MonkeyPatch) ->
     _fake_gh(
         monkeypatch,
         {
-            "repos/sgajbi/lotus-ai/commits": "abc123\n",
-            "repos/sgajbi/lotus-ai": REBASE_ONLY,
+            "repos/sgajbi/lotus-ai/commits": "abc123 1\n",
             "run": _Completed(returncode=1, stderr="API rate limit exceeded"),
         },
     )
@@ -78,8 +78,7 @@ def test_a_run_without_a_verdict_does_not_count_as_coverage(
     _fake_gh(
         monkeypatch,
         {
-            "repos/sgajbi/lotus-ai/commits": "abc123\n",
-            "repos/sgajbi/lotus-ai": REBASE_ONLY,
+            "repos/sgajbi/lotus-ai/commits": "abc123 1\n",
             "run": json.dumps([{"status": "completed", "conclusion": "cancelled"}]),
         },
     )
@@ -91,8 +90,7 @@ def test_a_verdict_bearing_run_is_coverage(monkeypatch: pytest.MonkeyPatch) -> N
     _fake_gh(
         monkeypatch,
         {
-            "repos/sgajbi/lotus-ai/commits": "abc123\n",
-            "repos/sgajbi/lotus-ai": REBASE_ONLY,
+            "repos/sgajbi/lotus-ai/commits": "abc123 1\n",
             "run": json.dumps([{"status": "completed", "conclusion": "success"}]),
         },
     )
@@ -105,7 +103,6 @@ def test_an_empty_commit_listing_is_a_failure(monkeypatch: pytest.MonkeyPatch) -
         monkeypatch,
         {
             "repos/sgajbi/lotus-ai/commits": "\n",
-            "repos/sgajbi/lotus-ai": REBASE_ONLY,
         },
     )
     monkeypatch.setattr(sys, "argv", ["audit", "--fail-on-gap"])


### PR DESCRIPTION
The daily **Main Gate Coverage Audit has been red for five consecutive days** (Sep 1–5: runs 33503465775 / 33623744575 / 33748425650 / 33867126066 / 33960985192) — not because gate coverage regressed, but because the workflow token stopped being able to read the repository's `allow_*` merge settings: all three fields return null and `assert_rebase_only_merging` fails closed on the unreadable proxy. Meanwhile actual coverage went unmeasured — a dead gate hiding its own blindness.

**Fix: measure the invariant, not the setting.** The settings assertion existed to guarantee linear history so the per-commit enumeration is correct. The audit now verifies that directly: every audited main commit must have exactly one parent (fetched in the same commits call it already makes, under plain read permission). A merge commit fails the audit the day it lands, named by sha — strictly stronger than the settings proxy (which could not see an already-landed merge commit at all), and immune to token-scope and settings drift.

Simplification: `assert_rebase_only_merging` deleted; one call site removed; no new permissions required.

Verified live against the repo: `--limit 10` → `main gate coverage: 10/10 commits verdict-bearing` (also confirming the releasability dispatcher gated all recent merges, including today's packet merges).

Residual: the five red runs stay red as historical fact; the next scheduled run (Sep 6, ~11:15Z) is the closure evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)