### PR TITLE
fix(budget): non-billability is stated, never inferred from pricing (#346)

### DIFF
--- a/src/app/providers/openai_compatible_text_transport.py
+++ b/src/app/providers/openai_compatible_text_transport.py
@@ -319,8 +319,11 @@ def post_openai_compatible_response(
         """Settle this attempt's pre-attempt reservation to its evidenced
         debit (issue #300): actual usage, the conservative estimate for a
         billable-risk failure, or a zero-amount release when the attempt
-        proved non-billable (429, pre-connect). Where no rate card priced a
-        reservation there is nothing to settle and nothing was ever owed."""
+        proved non-billable (429, pre-connect). Non-billability is STATED
+        via ``billable_risk`` (issue #346), never inferred from pricing
+        availability: a billable-risk attempt whose settle-time pricing
+        returns None (rate card expired mid-attempt) holds its reserved
+        maximum instead of releasing."""
 
         debit = price_attempt(
             input_tokens=input_tokens,
@@ -331,12 +334,25 @@ def post_openai_compatible_response(
             max_output_tokens=payload_max_output,
             model_revision=model_revision,
         )
+        if debit is None and billable_risk and input_tokens is not None:
+            # Served (or usage-revealing) attempt that cannot be priced: the
+            # observed usage is operator evidence for the governed
+            # reconciliation that will settle the held exposure.
+            log_event(
+                _logger,
+                "attempt_exposure_held_unpriceable",
+                execution_id=debit_execution_id,
+                attempt_index=attempt_index,
+                observed_input_tokens=input_tokens,
+                observed_output_tokens=output_tokens,
+            )
         settle_attempt_spend(
             execution_id=debit_execution_id,
             candidate_entry_id=candidate_entry_id,
             attempt_index=attempt_index,
             debit=debit,
             candidate_id_v2=candidate_id_v2,
+            billable_risk=billable_risk,
         )
         return debit
 

--- a/src/app/services/provider_budget_policy.py
+++ b/src/app/services/provider_budget_policy.py
@@ -109,7 +109,7 @@ def parse_provider_budget_policy() -> ParsedProviderBudgetPolicy:
             "Tracked spend is recorded durably per provider attempt at the attempt boundary (issue #289): actual usage debits as actual, billable-risk failures debit conservatively, and an execution whose every attempt fails still moves the envelope.",
             "Hard-limit admission is an atomic per-attempt check-and-reserve on the budget row (issue #300): each attempt reserves its governed maximum in one store transaction before the provider is called - concurrent replicas cannot jointly overshoot the limit, and a crash before settlement leaves the conservative reservation counted.",
             "The reserved maximum assumes tokenization at no finer than one token per byte of the request body plus the provider-enforced output cap under the effective rate card (issue #329); the claim holds for byte-level or coarser tokenizers and does not cover provider-side minimum-billing or non-token charges.",
-            "Only trustworthy provider-reported usage settles a reservation down; a billable-risk attempt without usage holds its reserved maximum as UNRESOLVED_MAX exposure (issue #329) - estimates are reported but never release hard admission capacity - until governed four-eyes reconciliation settles it to a provider-evidenced charge.",
+            "Only trustworthy provider-reported usage priced by an effective rate card settles a reservation down; a billable-risk attempt without a priceable amount - usage withheld OR the rate card expired before settlement - holds its reserved maximum as UNRESOLVED_MAX exposure (issues #329/#346). RELEASED is reachable only from STATED non-billability (429, pre-connect), never inferred from pricing availability; estimates are reported but never release hard admission capacity; release happens only through governed four-eyes reconciliation to a provider-evidenced charge.",
             "Soft budget posture is advisory and inspectable; hard budget posture is blocking when enforcement is enabled.",
             "Tracked spend now flows through the configured provider-operations store so budget posture can remain durable when the SQL-backed provider-operations path is enabled.",
         ],
@@ -227,15 +227,25 @@ def settle_attempt_spend(
     attempt_index: int,
     debit: AttemptDebit | None,
     candidate_id_v2: str | None,
+    billable_risk: bool,
 ) -> bool:
     """Resolve a reservation with the attempt's evidence in one transaction
-    with the counter adjustment (issue #300), in evidence order (issue #329):
+    with the counter adjustment (issue #300), in evidence order (issues
+    #329/#346):
 
-    - trustworthy provider-reported usage (basis ``ACTUAL_USAGE``) settles to
-      the evidenced amount - the only evidence that may RELEASE hard
-      admission capacity at the attempt boundary;
-    - a proven non-billable attempt (429, pre-connect; ``debit is None``)
-      releases to zero, basis ``RELEASED``;
+    - trustworthy provider-reported usage priced by an effective rate card
+      (basis ``ACTUAL_USAGE``) settles to the evidenced amount - the only
+      evidence that may RELEASE hard admission capacity at the attempt
+      boundary;
+    - a PROVEN non-billable attempt (429, pre-connect:
+      ``billable_risk=False``) releases to zero, basis ``RELEASED``. The
+      caller STATES non-billability explicitly (issue #346) - it is never
+      inferred from pricing availability, because ``debit is None`` has two
+      producers: proven non-billability AND a rate card that expired before
+      settlement. Unpriceable billable exposure (``debit is None`` with
+      ``billable_risk=True`` - including a SERVED response whose usage
+      cannot be priced) holds its reserved maximum with the reservation's
+      provenance (tokens, rate_card_ref) intact on the row;
     - a billable-risk attempt WITHOUT usage (timeout, 5xx, usage withheld -
       basis ``CONSERVATIVE_ESTIMATE``) holds: the row moves to
       ``UNRESOLVED_MAX`` and the reserved maximum stays in the counter.
@@ -258,6 +268,14 @@ def settle_attempt_spend(
         candidate_id_v2=candidate_id_v2,
     )
     if debit is None:
+        if billable_risk:
+            # Rate card expired between admission and settlement: the
+            # attempt may have billed, and no price exists to evidence an
+            # amount - the reservation holds until governed reconciliation.
+            return repository.hold_attempt_debit_unresolved(
+                debit_id=debit_id,
+                held_at=_utcnow(),
+            )
         return repository.settle_attempt_debit(
             debit_id=debit_id,
             budget_key=_BUDGET_KEY,
@@ -272,11 +290,7 @@ def settle_attempt_spend(
     # basis that may release capacity at the attempt boundary. Every other
     # basis (CONSERVATIVE_ESTIMATE today; MIXED/NONE should they ever reach
     # settlement) holds - non-usage evidence never settles a reservation
-    # down. Note the ``debit is None`` branch above is scoped to PROVEN
-    # non-billability (429, pre-connect); an attempt whose settle-time
-    # pricing returns None despite billable risk (rate card expired
-    # mid-attempt) also reaches it - a narrow window tracked with the
-    # governance-recovery hardening (#340 era), not silently widened here.
+    # down.
     if debit.basis != "ACTUAL_USAGE":
         return repository.hold_attempt_debit_unresolved(
             debit_id=debit_id,

--- a/tests/integration/test_budget_reconciliation_api_contract.py
+++ b/tests/integration/test_budget_reconciliation_api_contract.py
@@ -94,6 +94,7 @@ def _seed_unresolved_exposure() -> str:
                 rate_card_ref="default-live-text",
             ),
             candidate_id_v2=_CANONICAL,
+            billable_risk=True,
         )
         is True
     )

--- a/tests/support/budget_seeding.py
+++ b/tests/support/budget_seeding.py
@@ -66,6 +66,7 @@ def seed_settled_attempt_spend(
             attempt_index=attempt_index,
             debit=debit,
             candidate_id_v2=None,
+            billable_risk=True,
         )
     finally:
         settings.live_text_budget_enforced = previous

--- a/tests/unit/test_budget_exposure.py
+++ b/tests/unit/test_budget_exposure.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi import HTTPException
@@ -77,13 +78,20 @@ def _reserve(execution_id: str, amount: float, *, attempt_index: int = 0) -> str
     )
 
 
-def _settle(execution_id: str, debit: AttemptDebit | None, *, attempt_index: int = 0) -> bool:
+def _settle(
+    execution_id: str,
+    debit: AttemptDebit | None,
+    *,
+    attempt_index: int = 0,
+    billable_risk: bool = True,
+) -> bool:
     return settle_attempt_spend(
         execution_id=execution_id,
         candidate_entry_id="text.openai:gpt-5.4",
         attempt_index=attempt_index,
         debit=debit,
         candidate_id_v2=_CANONICAL,
+        billable_risk=billable_risk,
     )
 
 
@@ -134,7 +142,7 @@ def test_usage_evidence_and_proven_non_billability_still_release() -> None:
     assert _counter() == 0.20
 
     assert _reserve("exec-nobill", 1.10) == "RESERVED"
-    assert _settle("exec-nobill", None) is True
+    assert _settle("exec-nobill", None, billable_risk=False) is True
     released = get_provider_operations_store().get_attempt_debit(debit_id=_debit_id("exec-nobill"))
     assert released is not None
     assert released.basis == "RELEASED"
@@ -520,3 +528,113 @@ def test_a_crash_between_release_and_evidence_recovers_the_true_outcome(
     assert recovered.governed_action.status is GovernedActionStatus.EXECUTED
     # Released exactly once.
     assert _counter() == 0.42
+
+
+def test_unpriceable_billable_exposure_holds_with_provenance_intact() -> None:
+    """Issue #346: the rate card expiring between admission and settlement
+    must not release the reservation - debit-None has TWO producers, and
+    only stated non-billability releases. The held row keeps the
+    reservation's provenance (tokens, rate_card_ref) for reconciliation."""
+
+    _enforce(1.50)
+    assert _reserve("exec-expiry", 1.10) == "RESERVED"
+
+    # Timeout/5xx after the card expired: pricing returns None, risk stands.
+    assert _settle("exec-expiry", None, billable_risk=True) is True
+    row = get_provider_operations_store().get_attempt_debit(debit_id=_debit_id("exec-expiry"))
+    assert row is not None
+    assert row.basis == "UNRESOLVED_MAX"
+    assert row.amount_usd == 1.10
+    assert row.input_tokens == 200
+    assert row.output_tokens == 512
+    assert row.rate_card_ref == "default-live-text"
+    assert _counter() == 1.10
+
+    # The audit reproduction inverted: the next 1.10 maximum is REFUSED and
+    # the caller's execution ceiling sees the held exposure.
+    assert _reserve("exec-expiry-b", 1.10) == "REFUSED"
+    assert spent_for_execution("exec-expiry") == 1.10
+
+    # Replay without double adjustment: the second settle is a no-op.
+    assert _settle("exec-expiry", None, billable_risk=True) is False
+    assert _counter() == 1.10
+
+    # Governed reconciliation restores headroom exactly once.
+    pending = request_budget_reconciliation(
+        BudgetReconciliationIntentRequest(
+            debit_id=_debit_id("exec-expiry"),
+            evidenced_amount_usd=0.30,
+            evidence_ref="invoice after card renewal",
+        ),
+        GOVERNED_REQUESTER,
+    )
+    approved = approve_budget_reconciliation(
+        BudgetReconciliationApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert approved.released_amount_usd == 0.80
+    assert _counter() == 0.30
+    replay = approve_budget_reconciliation(
+        BudgetReconciliationApprovalRequest(
+            action_id=pending.governed_action.action_id,
+            action_hash=pending.governed_action.action_hash,
+        ),
+        GOVERNED_APPROVER,
+    )
+    assert replay.released_amount_usd == 0.80
+    assert _counter() == 0.30
+
+
+def test_rate_expiry_during_a_served_response_holds_and_logs_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #346, the decision stated: provider-reported usage WITHOUT an
+    effective rate card is not an evidenced amount - the served attempt
+    holds its reserved maximum, and the observed usage is logged as
+    reconciliation input evidence."""
+
+    from tests.unit.test_attempt_billing import (
+        _Response,
+        _SUCCESS_BODY,
+        _debit_key,
+        _run_transport,
+        _seed_cost_scalars,
+    )
+    import app.services.provider_usage_accounting as accounting
+
+    _seed_cost_scalars()
+    real_estimate = accounting.estimate_live_text_cost
+    calls = {"count": 0}
+
+    def _expiring_estimate(**kwargs: Any) -> Any:
+        calls["count"] += 1
+        if calls["count"] > 1:
+            # The card expired after admission priced the reservation.
+            return accounting.UNKNOWN_COST
+        return real_estimate(**kwargs)
+
+    monkeypatch.setattr(accounting, "estimate_live_text_cost", _expiring_estimate)
+    monkeypatch.setattr("urllib.request.urlopen", lambda request, timeout: _Response(_SUCCESS_BODY))
+
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="app.provider"):
+        response = _run_transport(retry_limit=0, execution_id="exec-served-expiry")
+    assert response.failure_category is None
+    # The observed usage rides operator evidence for reconciliation.
+    assert any(
+        "attempt_exposure_held_unpriceable" in record.getMessage() for record in caplog.records
+    )
+
+    row = get_provider_operations_store().get_attempt_debit(
+        debit_id=_debit_key("exec-served-expiry", 0)
+    )
+    assert row is not None
+    assert row.basis == "UNRESOLVED_MAX"
+    # Reservation provenance, not the served usage: the held amount is the
+    # admitted maximum and its tokens are the reservation's bounds.
+    assert row.output_tokens == 512

--- a/tests/unit/test_candidate_identity_authority.py
+++ b/tests/unit/test_candidate_identity_authority.py
@@ -226,6 +226,7 @@ def test_distinct_candidates_sharing_the_legacy_key_debit_separately(
         attempt_index=0,
         debit=_debit(0.7),
         candidate_id_v2=family_a.candidate_id_v2,
+        billable_risk=True,
     )
     assert settle_attempt_spend(
         execution_id="exec-identity",
@@ -233,6 +234,7 @@ def test_distinct_candidates_sharing_the_legacy_key_debit_separately(
         attempt_index=0,
         debit=_debit(0.5),
         candidate_id_v2=family_b.candidate_id_v2,
+        billable_risk=True,
     )
 
     rows = operations_repo.list_attempt_debits()
@@ -373,6 +375,7 @@ def test_sql_debit_lifecycle_keys_on_the_canonical_identity(
         attempt_index=0,
         debit=_debit(0.6),
         candidate_id_v2=family_a.candidate_id_v2,
+        billable_risk=True,
     )
     assert settle_attempt_spend(
         execution_id="exec-sql",
@@ -380,6 +383,7 @@ def test_sql_debit_lifecycle_keys_on_the_canonical_identity(
         attempt_index=0,
         debit=_debit(0.4),
         candidate_id_v2=family_b.candidate_id_v2,
+        billable_risk=True,
     )
     # A pre-existing legacy-format row still counts toward the execution.
     assert (


### PR DESCRIPTION
Closes #346. User-directed follow-up to #329 (packet 4b, controller #246).

## Consumer / operator outcome
The reproduction is closed: reserve 1.10 under a 1.50 hard limit, let the rate card expire mid-call, settle unknown usage — the reservation now HOLDS instead of releasing to zero, and the next 1.10 maximum is REFUSED. A rate-card expiry can no longer manufacture admission headroom.

## Invariant + single authority
Evidence honesty rides the settle call: `settle_attempt_spend` takes `billable_risk` as a REQUIRED keyword (the #333/#335 precedent — both ends state what they know). `debit is None` had two producers (proven non-billability AND cannot-price-now); the distinction is now stated by the transport at the call site, never inferred from pricing availability. **RELEASED is reachable ONLY from stated non-billability** (429, pre-connect). Unpriceable billable exposure holds its reserved maximum with reservation provenance (tokens, rate_card_ref) intact on the row. **Decision stated:** a SERVED response whose usage cannot be priced HOLDS — usage tokens without a price are not an evidenced amount; the observed usage is logged (`attempt_exposure_held_unpriceable`) as reconciliation input evidence. Preserved untouched: hold semantics, release-once accounting, four-eyes reconciliation, canonical debit identity, resume fencing.

## Failing-before / passing-after
`tests/unit/test_budget_exposure.py` (+2, now 16): rate expiry during timeout/5xx — hold with provenance intact, next maximum REFUSED, execution ceiling honest, replay no-op, governed reconciliation restores 0.80 exactly once with replay convergence; rate expiry during SUCCESS — transport-level (card expires after admission priced the reservation), served attempt holds, observed usage logged (caplog-pinned). Genuine 429/pre-connect release re-pinned with `billable_risk=False` stated. Posture note updated: RELEASED only from stated non-billability.

## Compatibility + residuals
Signature change is compile-enforced on every caller (transport, seeder, all test sites). No schema or API changes. Residuals: PostgreSQL proofs stay explicit under #344; Idea live-provider enablement stays separately governed. Lane green 377/25437 (98.52%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)