### PR TITLE
fix(evidence): pin producing manifest version; gate on committed runs (#332)

### DIFF
--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -441,6 +441,8 @@ Observed-capability truth is scope-aware (issue #312) and layered — never one 
 
 Fixture families declare proofs in the manifest as `proves: [{dimension, scope_type, scope_key?}]`, validated fail-closed (governed dimension vocabulary; `scope_key` required for non-GLOBAL scopes and forbidden for GLOBAL). A family that declares nothing proves nothing.
 
+Two evidence boundaries hold at the run seam (issue #332): claims write only when the CURRENT manifest version equals the version the run executed under (a queued run across a fixture change yields no evidence, with a logged refusal — proof-producing content is pinned, never re-established from newer declarations), and a claim is applicable only while its producing run exists as a COMMITTED `COMPLETED` PASS record — the write happens after the run's terminal persistence, and the read side independently verifies the committed run, so evidence orphaned by a mid-write failure is never honored. **The version guard's stated precondition**: `manifest_version` is an operator-maintained label, not a content digest - the manifest gate validates structure, not content-to-version binding, so an unbumped fixture edit (or a version flipped back) defeats the pin. Every fixture-content change MUST bump `manifest_version` (hold that line in review); content-derived versioning is the recorded upgrade path if the label proves unreliable.
+
 ## Governed Actions
 
 One reusable governance pattern covers every high-impact control-plane action; there are no domain-specific approval frameworks. The rule is the **direction of risk**:

--- a/src/app/services/capability_evidence.py
+++ b/src/app/services/capability_evidence.py
@@ -10,6 +10,8 @@ never makes it, and unknown never upgrades into truth.
 
 from __future__ import annotations
 
+import logging
+
 from datetime import UTC, datetime
 
 from app.contracts.evals import CapabilityEvidenceScopeType, EvaluationRunVerdict
@@ -19,6 +21,8 @@ from app.repositories.evaluation_runtime_repository import (
     EvaluationRunRecord,
 )
 from app.services.model_catalogue_store import get_model_catalogue_repository
+
+_logger = logging.getLogger(__name__)
 
 
 def record_capability_evidence_for_pass_run(
@@ -34,6 +38,21 @@ def record_capability_evidence_for_pass_run(
     from app.evals.fixture_manifest import load_evaluation_fixture_manifest
 
     manifest = load_evaluation_fixture_manifest()
+    if manifest.manifest_version != run.manifest_version:
+        # Version pinning, fail-closed (issue #332): the run executed under
+        # one manifest version but the CURRENT manifest is another - loading
+        # today's declarations would label them with the run's version,
+        # certifying content the run never exercised. A queued run across a
+        # fixture change yields no evidence, loudly.
+        _logger.warning(
+            "capability evidence refused: run %s executed under manifest %s "
+            "but the current manifest is %s - proof-producing content cannot "
+            "be re-established",
+            run.run_id,
+            run.manifest_version,
+            manifest.manifest_version,
+        )
+        return
     fixture = next((f for f in manifest.fixture_families if f.fixture_id == run.fixture_id), None)
     if fixture is None or not fixture.proves:
         return
@@ -79,13 +98,27 @@ def applicable_capability_evidence(
     evidence stays unknown - never widened, never inferred.
     """
 
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
     repository = get_model_catalogue_repository()
+    runtime_store = get_evaluation_runtime_store()
     for record in repository.list_capability_evidence(
         candidate_id_v2=entry.candidate_id_v2, dimension=dimension
     ):
         if record.verdict != EvaluationRunVerdict.PASS.value:
             continue
         if record.model_revision != entry.model_revision:
+            continue
+        # Committed-producing-run contingency (issue #332): a claim is
+        # applicable only when its producing run exists as a COMPLETED PASS
+        # record - evidence orphaned by a failure between claim creation and
+        # run commitment (or surviving a deleted run) is never honored.
+        producing_run = runtime_store.get_run(run_id=record.evaluation_run_id)
+        if (
+            producing_run is None
+            or producing_run.lifecycle_status != "COMPLETED"
+            or producing_run.verdict != EvaluationRunVerdict.PASS.value
+        ):
             continue
         if record.scope_type == CapabilityEvidenceScopeType.GLOBAL.value:
             return record

--- a/src/app/services/eval_runtime_execution.py
+++ b/src/app/services/eval_runtime_execution.py
@@ -142,8 +142,6 @@ def execute_runtime_backed_evaluation_run(
         if all(result.outcome == EvaluationCaseOutcome.PASS.value for result in persisted_results)
         else EvaluationRunVerdict.FAIL
     )
-    if verdict == EvaluationRunVerdict.PASS:
-        record_capability_evidence_for_pass_run(run=run, results=persisted_results)
     completed_at = _utcnow_iso()
     store.save_attempt(
         EvaluationRunAttemptRecord(
@@ -173,6 +171,8 @@ def execute_runtime_backed_evaluation_run(
             case_count=run.case_count,
         )
     )
+    if verdict == EvaluationRunVerdict.PASS:
+        record_capability_evidence_for_pass_run(run=run, results=persisted_results)
     return EvaluationExecutionResult(
         run_id=run.run_id,
         attempt_id=attempt.attempt_id,

--- a/tests/integration/test_integrated_candidate_architecture.py
+++ b/tests/integration/test_integrated_candidate_architecture.py
@@ -95,6 +95,24 @@ def _governed_add(entry_id: str) -> None:
 
 
 def _observed_evidence(entry: ModelCatalogueEntry, run_id: str) -> None:
+    from app.repositories.evaluation_runtime_repository import EvaluationRunRecord
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+    # The claim's producing run must exist as COMMITTED truth (issue #332).
+    get_evaluation_runtime_store().save_run(
+        EvaluationRunRecord(
+            run_id=run_id,
+            fixture_id="capability_proof_examples",
+            manifest_version="foundation.v1",
+            lifecycle_status="COMPLETED",
+            triggered_by="operator-a",
+            submitted_at="2026-09-04T00:00:00Z",
+            async_job_id=None,
+            latest_message="done",
+            verdict="PASS",
+            case_count=1,
+        )
+    )
     get_model_catalogue_repository().save_capability_evidence(
         CapabilityEvidenceRecord(
             evidence_id=f"capev_proof_{entry.candidate_id_v2[:12]}",

--- a/tests/unit/test_capability_evidence.py
+++ b/tests/unit/test_capability_evidence.py
@@ -83,6 +83,16 @@ def _run(fixture_id: str = "capability_proof_examples") -> EvaluationRunRecord:
     )
 
 
+def _commit_run(run: EvaluationRunRecord) -> None:
+    """Persist the producing run as COMMITTED truth (issue #332): applicable
+    evidence requires a COMPLETED PASS run record, so read-side tests seed
+    exactly what the runtime writes."""
+
+    from app.services.evaluation_runtime_store import get_evaluation_runtime_store
+
+    get_evaluation_runtime_store().save_run(run)
+
+
 def _case(case_id: str, candidate_id_v2: str | None) -> EvaluationCaseResultRecord:
     return EvaluationCaseResultRecord(
         case_result_id=f"attempt_{case_id}",
@@ -197,8 +207,10 @@ def test_eligibility_consumes_exactly_the_matching_scoped_claim(
 
     entry = _catalogued_entry()
     _declaring_manifest(monkeypatch)
+    producing_run = _run()
+    _commit_run(producing_run)
     record_capability_evidence_for_pass_run(
-        run=_run(),
+        run=producing_run,
         results=[_case("case_001", entry.candidate_id_v2)],
     )
 
@@ -346,6 +358,9 @@ def test_applicable_evidence_skips_non_pass_and_revision_mismatch() -> None:
     from app.contracts.model_catalogue import CapabilityEvidenceRecord
 
     entry = _catalogued_entry()
+    from dataclasses import replace as _dc_replace
+
+    _commit_run(_dc_replace(_run(), run_id="evalrun_cap_003"))
     repository = get_model_catalogue_repository()
     repository.save_capability_evidence(
         CapabilityEvidenceRecord(
@@ -386,3 +401,90 @@ def test_applicable_evidence_skips_non_pass_and_revision_mismatch() -> None:
         )
         is None
     )
+
+
+def test_a_queued_run_across_a_fixture_change_yields_no_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Audit boundary 1 (issue #332): the writer loads the CURRENT manifest
+    but the run executed under another version - labeling today's
+    declarations with the run's version would certify content the run never
+    exercised. The mismatch refuses loudly and writes nothing."""
+
+    import logging
+    from dataclasses import replace as _dc_replace
+
+    entry = _catalogued_entry()
+    _declaring_manifest(monkeypatch)
+    stale_run = _dc_replace(_run(), manifest_version="foundation.v0-before-change")
+
+    with caplog.at_level(logging.WARNING, logger="app.services.capability_evidence"):
+        record_capability_evidence_for_pass_run(
+            run=stale_run,
+            results=[_case("case_001", entry.candidate_id_v2)],
+        )
+
+    assert (
+        get_model_catalogue_repository().list_capability_evidence(
+            candidate_id_v2=entry.candidate_id_v2, dimension="supports_tool_calling"
+        )
+        == []
+    )
+    assert any("capability evidence refused" in r.getMessage() for r in caplog.records)
+
+
+def test_evidence_orphaned_by_an_uncommitted_run_is_never_applicable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Audit boundary 2 (issue #332): a claim whose producing run never
+    committed (crash between claim creation and terminal persistence, or a
+    run later removed) is never honored - the read side requires a
+    COMPLETED PASS run record."""
+
+    entry = _catalogued_entry()
+    _declaring_manifest(monkeypatch)
+    # Claims written, but the producing run is NEVER committed to the store.
+    record_capability_evidence_for_pass_run(
+        run=_run(),
+        results=[_case("case_001", entry.candidate_id_v2)],
+    )
+    assert (
+        applicable_capability_evidence(
+            entry=entry, dimension="supports_tool_calling", output_contract_key=None
+        )
+        is None
+    )
+
+    # Committing the producing run makes the SAME claims applicable - the
+    # gate is contingency, not deletion.
+    _commit_run(_run())
+    applicable = applicable_capability_evidence(
+        entry=entry, dimension="supports_tool_calling", output_contract_key=None
+    )
+    assert applicable is not None
+    assert applicable.evaluation_run_id == "evalrun_cap_001"
+
+
+def test_a_failed_or_incomplete_producing_run_never_backs_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dataclasses import replace as _dc_replace
+
+    entry = _catalogued_entry()
+    _declaring_manifest(monkeypatch)
+    record_capability_evidence_for_pass_run(
+        run=_run(),
+        results=[_case("case_001", entry.candidate_id_v2)],
+    )
+    for broken in (
+        _dc_replace(_run(), lifecycle_status="FAILED", verdict="FAIL"),
+        _dc_replace(_run(), lifecycle_status="RUNNING", verdict="PASS"),
+    ):
+        _commit_run(broken)
+        assert (
+            applicable_capability_evidence(
+                entry=entry, dimension="supports_tool_calling", output_contract_key=None
+            )
+            is None
+        ), broken.lifecycle_status


### PR DESCRIPTION
Packet 6a of the 2026-09-05 deep-audit corrective sequence (the two evidence boundaries; #332 stays open on packet 6b's expert-review dependency).

## Consumer / operator outcome
A capability claim can no longer certify content its producing run never exercised, and can no longer survive its producing run's failure: a queued evaluation run that crosses a fixture-manifest change yields no evidence (with a logged refusal naming both versions), and a claim is honored only while its producing run exists as a committed `COMPLETED` PASS record.

## Invariant + single authority
Two boundaries at the run seam, no new mechanism: (1) **version pinning, fail-closed** — the writer refuses when the loaded manifest version differs from the version the run executed under; proof-producing content is pinned, never re-established from newer declarations (the residual claim-time window is stated in the runbook, not hidden). (2) **Committed-run contingency, both sides** — the claims write AFTER the run's terminal persistence, and `applicable_capability_evidence` independently verifies the committed `COMPLETED` PASS producing run before honoring any record. Contingency, not deletion: committing the producing run retroactively honors the same claims — deliberate, since the claims themselves were validly produced.

## Simplification
The write-ordering rationale lives in the runbook's Capability Evidence section rather than an inline comment (the module-budget ratchet enforced that placement, and it is the better home). Read-side test seeding gains one `_commit_run` helper mirroring exactly what the runtime writes.

## Failing-before / passing-after
`tests/unit/test_capability_evidence.py` (+3, now 9): queued-run-across-fixture-change → zero claims + logged refusal; evidence orphaned by an uncommitted run → never applicable, then applicable once the run commits; `FAILED`/`RUNNING` producing runs → never applicable. The integrated three-candidate proof and the eligibility tests now seed their producing runs — the gate caught every direct-seeding site.

## Compatibility + residuals
No schema, API, or contract changes; the evidence record shape is untouched. Residual: packet 6b — the first declaring fixture family (Idea corpus) requires an expert-reviewed corpus with measured advisor comprehension and stays open on #332; no auto-promotion and no ranking optimizer, per the steering. Lane green 377/25447 (98.52%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)