### PR TITLE
fix(artifacts): one verified reader for summary bytes; checksum grammar pinned (#336)

### DIFF
--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -269,6 +269,8 @@ Before treating the artifact backbone as stronger governed rollout posture:
 6. confirm the embedded `artifact_runtime` and `artifact_governance` blocks in `GET /platform/runtime-status` match the detailed artifact views
 7. treat artifact archive posture as a reviewable metadata transition rather than ad hoc payload deletion or raw filesystem cleanup
 
+Two artifact-integrity boundaries (issue #336): the checksum grammar is bare lowercase hex, pinned by the `ArtifactDescriptor` contract at persistence — a writer adopting the `sha256:<hex>` travel form is refused when it writes, not discovered as a full accepted-output outage at read. And `run_output_summary` bytes have ONE read authority — `load_verified_summary_object` (checksum + byte-size verification, never repaired at read time) — used by the accepted-output surface and every projection reader (consumer view, source events); do not add a raw artifact/download or export path that resolves a `storage_reference` directly, and review any new `storage_reference` consumer against this monopoly (queue request-snapshot and recovery reads resolve their OWN artifact types, not run output summaries).
+
 ## Observability Governance
 
 Before treating the in-service observability layer as governed rollout posture:

--- a/src/app/contracts/artifacts.py
+++ b/src/app/contracts/artifacts.py
@@ -37,7 +37,15 @@ class ArtifactDescriptor(BaseModel):
     )
     media_type: str = Field(description="Media type for the stored payload.")
     byte_size: int = Field(description="Persisted payload size in bytes.")
-    checksum_sha256: str = Field(description="SHA-256 checksum of the stored payload.")
+    checksum_sha256: str = Field(
+        # Bare lowercase hex, pinned at the contract (issue #336): the read
+        # gate compares against a bare hexdigest, so a writer adopting the
+        # platform's `sha256:<hex>` travel form would fail-closed the whole
+        # accepted-output surface. The grammar refuses that drift at
+        # persistence instead.
+        pattern=r"^[0-9a-f]{64}$",
+        description="SHA-256 checksum of the stored payload (bare lowercase hex).",
+    )
     storage_backend: ArtifactStorageBackend = Field(
         description="Configured object-store backend holding the payload bytes."
     )

--- a/src/app/services/workflow_pack_run_accepted_output.py
+++ b/src/app/services/workflow_pack_run_accepted_output.py
@@ -43,8 +43,13 @@ from app.contracts.workflow_pack_runs import (
     WorkflowPackRunRuntimeState,
 )
 from app.repositories.workflow_pack_run_repository import WorkflowPackRunRecord
-from app.services.artifact_store import get_artifact_object_store
 from app.services.workflow_pack_run_ledger import ensure_workflow_pack_run_store_ready
+from app.services.workflow_pack_run_output_summary import (
+    SummaryArtifactMissingError,
+    SummaryIntegrityMismatchError,
+    SummaryObjectMissingError,
+    load_verified_summary_object,
+)
 from app.services.workflow_pack_run_store import get_workflow_pack_run_store
 from app.services.workflow_pack_run_review_summary import (
     build_workflow_pack_run_review_summary,
@@ -217,44 +222,28 @@ def _accepting_review_identity(*, store: Any, run_id: str) -> AdvisorBriefAccept
 
 
 def _load_intact_output_payload(record: WorkflowPackRunRecord) -> dict[str, Any]:
-    summary_artifact = next(
-        (
-            artifact
-            for artifact in record.artifact_refs
-            if artifact.domain == "workflow_pack"
-            and artifact.artifact_type == "run_output_summary"
-            and artifact.storage_reference
-        ),
-        None,
-    )
-    if summary_artifact is None:
+    # The acceptance and VALIDATED evidence attach to the bytes that existed
+    # when the artifact was persisted. Publishing requires the loaded bytes to
+    # BE those bytes (issue #328); resolution goes through the ONE verified
+    # summary reader (issue #336) so no second path can bypass the gate.
+    try:
+        _, stored_object = load_verified_summary_object(record.artifact_refs)
+    except SummaryArtifactMissingError as exc:
         raise AcceptedOutputNotAvailableError(
             REASON_OUTPUT_ARTIFACT_MISSING,
             "The governed run-output artifact is not linked to this run.",
-        )
-    _, _, object_key = summary_artifact.storage_reference.partition("://")
-    stored_object = get_artifact_object_store().get_object(object_key=object_key)
-    if stored_object is None:
+        ) from exc
+    except SummaryObjectMissingError as exc:
         raise AcceptedOutputNotAvailableError(
             REASON_OUTPUT_ARTIFACT_MISSING,
             "The governed run-output artifact object is no longer retrievable.",
-        )
-    # The acceptance and VALIDATED evidence attach to the bytes that existed
-    # when the artifact was persisted. Publishing requires the loaded bytes to
-    # BE those bytes (issue #328): identity metadata alone cannot establish
-    # that, and the recorded checksum is never repaired at read time.
-    recorded_checksum = (summary_artifact.checksum_sha256 or "").strip().lower()
-    loaded_checksum = hashlib.sha256(stored_object.payload).hexdigest()
-    if (
-        not recorded_checksum
-        or loaded_checksum != recorded_checksum
-        or summary_artifact.byte_size != len(stored_object.payload)
-    ):
+        ) from exc
+    except SummaryIntegrityMismatchError as exc:
         raise AcceptedOutputNotAvailableError(
             REASON_OUTPUT_ARTIFACT_INTEGRITY,
             "The governed run-output artifact bytes do not match the checksum and "
             "size recorded when the output was persisted.",
-        )
+        ) from exc
     try:
         payload = json.loads(stored_object.payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/src/app/services/workflow_pack_run_output_summary.py
+++ b/src/app/services/workflow_pack_run_output_summary.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 from typing import Any
 
 from app.contracts.artifacts import ArtifactDescriptor
@@ -8,10 +10,33 @@ from app.contracts.workflow_pack_runs import WorkflowPackIdeaLineageDescriptor
 from app.services.artifact_object_store import StoredArtifactObject
 from app.services.artifact_store import get_artifact_object_store
 
+_logger = logging.getLogger(__name__)
 
-def load_workflow_pack_run_output_summary(
+
+class SummaryArtifactMissingError(RuntimeError):
+    """No run_output_summary artifact is linked to the run."""
+
+
+class SummaryObjectMissingError(RuntimeError):
+    """The linked artifact's object bytes are no longer retrievable."""
+
+
+class SummaryIntegrityMismatchError(RuntimeError):
+    """The loaded bytes do not match the recorded checksum and size."""
+
+
+def load_verified_summary_object(
     artifact_refs: list[ArtifactDescriptor],
-) -> dict[str, Any]:
+) -> tuple[ArtifactDescriptor, StoredArtifactObject]:
+    """THE single read authority for run_output_summary bytes (issue #336).
+
+    Every consumer of summary bytes - the accepted-output surface and the
+    projection readers alike - resolves them through this function, so the
+    #328 integrity guarantee (loaded bytes ARE the persisted bytes; the
+    recorded checksum is never repaired at read time) cannot be bypassed by
+    a second resolution path.
+    """
+
     summary_artifact = next(
         (
             artifact
@@ -23,12 +48,36 @@ def load_workflow_pack_run_output_summary(
         None,
     )
     if summary_artifact is None:
-        return {}
+        raise SummaryArtifactMissingError()
     _, _, object_key = summary_artifact.storage_reference.partition("://")
-    stored_object: StoredArtifactObject | None = get_artifact_object_store().get_object(
-        object_key=object_key
-    )
+    stored_object = get_artifact_object_store().get_object(object_key=object_key)
     if stored_object is None:
+        raise SummaryObjectMissingError()
+    recorded_checksum = (summary_artifact.checksum_sha256 or "").strip().lower()
+    loaded_checksum = hashlib.sha256(stored_object.payload).hexdigest()
+    if (
+        not recorded_checksum
+        or loaded_checksum != recorded_checksum
+        or summary_artifact.byte_size != len(stored_object.payload)
+    ):
+        raise SummaryIntegrityMismatchError()
+    return summary_artifact, stored_object
+
+
+def load_workflow_pack_run_output_summary(
+    artifact_refs: list[ArtifactDescriptor],
+) -> dict[str, Any]:
+    try:
+        _, stored_object = load_verified_summary_object(artifact_refs)
+    except (SummaryArtifactMissingError, SummaryObjectMissingError):
+        return {}
+    except SummaryIntegrityMismatchError:
+        # Fail-closed for projections: tampered bytes are never served, the
+        # surface degrades to absent, and the mismatch is operator-visible.
+        _logger.warning(
+            "run_output_summary integrity mismatch: projection withheld "
+            "(bytes do not match the recorded checksum/size)"
+        )
         return {}
     try:
         payload = json.loads(stored_object.payload.decode("utf-8"))

--- a/tests/support/workflow_pack_run_builders.py
+++ b/tests/support/workflow_pack_run_builders.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+
 from app.contracts.artifacts import (
     ArtifactDescriptor,
     ArtifactLifecycleStatus,
@@ -102,7 +104,7 @@ def build_workflow_pack_run_descriptor(
                 retention_posture="retained_for_review",
                 media_type="application/json",
                 byte_size=128,
-                checksum_sha256=f"sha256:{index}",
+                checksum_sha256=hashlib.sha256(f"{run_id}:{index}".encode("utf-8")).hexdigest(),
                 storage_backend=ArtifactStorageBackend.MEMORY,
                 storage_reference=f"memory://{run_id}/{index}",
                 created_at=created_at,

--- a/tests/unit/test_artifact_integrity_boundaries.py
+++ b/tests/unit/test_artifact_integrity_boundaries.py
@@ -1,0 +1,117 @@
+"""Accepted-output integrity drift seams (issue #336, follow-ups to #328/#334).
+
+Two boundaries: the WRITE side is pinned to bare-hex checksum grammar at the
+contract, and the READ side has exactly one authority for run_output_summary
+bytes - every consumer (accepted-output surface and projection readers)
+resolves through `load_verified_summary_object`, so tampered bytes are
+withheld everywhere, not just on the surface #328 repaired.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from app.contracts.artifacts import ArtifactDescriptor
+from app.services import workflow_pack_run_output_summary as summary_module
+from app.services.artifact_payloads import persist_json_artifact
+from app.services.workflow_pack_run_output_summary import (
+    SummaryIntegrityMismatchError,
+    load_verified_summary_object,
+    load_workflow_pack_run_output_summary,
+)
+
+
+def _descriptor(checksum: str) -> dict[str, object]:
+    return {
+        "artifact_id": "artifact_test_0001",
+        "domain": "workflow_pack",
+        "artifact_type": "run_output_summary",
+        "source_object_kind": "workflow_pack_run",
+        "source_object_id": "wfr-grammar-001",
+        "lifecycle_status": "runtime_generated",
+        "retention_posture": "active",
+        "media_type": "application/json",
+        "byte_size": 2,
+        "checksum_sha256": checksum,
+        "storage_backend": "memory",
+        "storage_reference": "memory://workflow_pack/run/wfr-grammar-001/a.json",
+        "created_at": "2026-09-06T00:00:00Z",
+        "created_by": "worker",
+    }
+
+
+def test_checksum_grammar_is_pinned_to_bare_lowercase_hex() -> None:
+    """A writer adopting the platform's `sha256:<hex>` travel form would
+    fail-closed the whole accepted-output surface; the contract refuses the
+    drift at persistence instead."""
+
+    bare = hashlib.sha256(b"ok").hexdigest()
+    ArtifactDescriptor.model_validate(_descriptor(bare))
+
+    for drifted in (f"sha256:{bare}", bare.upper(), bare[:63], ""):
+        with pytest.raises(ValidationError):
+            ArtifactDescriptor.model_validate(_descriptor(drifted))
+
+
+def test_persisted_artifact_round_trips_through_the_verified_reader() -> None:
+    payload = json.dumps({"pack_id": "idea_explanation.pack"}).encode("utf-8")
+    descriptor = persist_json_artifact(
+        domain="workflow_pack",
+        artifact_type="run_output_summary",
+        source_object_kind="workflow_pack_run",
+        source_object_id="wfr-roundtrip-001",
+        created_at="2026-09-06T00:00:00Z",
+        created_by="worker",
+        payload_json=payload,
+    )
+    loaded_descriptor, stored_object = load_verified_summary_object([descriptor])
+    assert loaded_descriptor.artifact_id == descriptor.artifact_id
+    assert stored_object.payload == payload
+
+
+def test_tampered_summary_bytes_are_withheld_from_projections(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The read monopoly in action: the projection readers (consumer view,
+    source events) resolve through the same verified reader, so tampered
+    bytes degrade the projection to absent - logged, never served."""
+
+    payload = json.dumps({"pack_id": "idea_explanation.pack"}).encode("utf-8")
+    descriptor = persist_json_artifact(
+        domain="workflow_pack",
+        artifact_type="run_output_summary",
+        source_object_kind="workflow_pack_run",
+        source_object_id="wfr-tamper-001",
+        created_at="2026-09-06T00:00:00Z",
+        created_by="worker",
+        payload_json=payload,
+    )
+
+    from app.services.artifact_store import get_artifact_object_store
+
+    real_store = get_artifact_object_store()
+    real_object = real_store.get_object(object_key=descriptor.storage_reference.partition("://")[2])
+    assert real_object is not None
+    tampered = type(real_object)(
+        object_key=real_object.object_key,
+        payload=b'{"pack_id": "idea_explanation.pack", "tampered": true}',
+        content_type=real_object.content_type,
+    )
+
+    class _TamperedStore:
+        def get_object(self, *, object_key: str) -> object:
+            return tampered
+
+    monkeypatch.setattr(summary_module, "get_artifact_object_store", lambda: _TamperedStore())
+
+    with pytest.raises(SummaryIntegrityMismatchError):
+        load_verified_summary_object([descriptor])
+    with caplog.at_level(logging.WARNING):
+        assert load_workflow_pack_run_output_summary([descriptor]) == {}
+    assert any("integrity mismatch" in r.getMessage() for r in caplog.records)

--- a/tests/unit/test_workflow_pack_run_accepted_latest.py
+++ b/tests/unit/test_workflow_pack_run_accepted_latest.py
@@ -27,6 +27,7 @@ from app.repositories.workflow_pack_run_repository import (
 )
 from app.services import workflow_pack_run_accepted_latest as module
 from app.services import workflow_pack_run_accepted_output as output_module
+from app.services import workflow_pack_run_output_summary as summary_module
 from app.services.workflow_pack_run_accepted_latest import (
     AcceptedLatestNotFoundError,
     build_workflow_pack_run_accepted_latest,
@@ -85,7 +86,7 @@ def _stores(monkeypatch: pytest.MonkeyPatch) -> tuple[_Store, _ObjectStore]:
     for target in (module, output_module):
         monkeypatch.setattr(target, "ensure_workflow_pack_run_store_ready", lambda: None)
         monkeypatch.setattr(target, "get_workflow_pack_run_store", lambda: store)
-    monkeypatch.setattr(output_module, "get_artifact_object_store", lambda: objects)
+    monkeypatch.setattr(summary_module, "get_artifact_object_store", lambda: objects)
     return store, objects
 
 

--- a/tests/unit/test_workflow_pack_run_accepted_output.py
+++ b/tests/unit/test_workflow_pack_run_accepted_output.py
@@ -26,6 +26,7 @@ from app.contracts.workflow_pack_run_accepted_output import (
 )
 from app.repositories.workflow_pack_run_repository import WorkflowPackRunRecord
 from app.services import workflow_pack_run_accepted_output as module
+from app.services import workflow_pack_run_output_summary as summary_module
 from app.services.workflow_pack_run_accepted_output import (
     AcceptedOutputNotAvailableError,
     AcceptedOutputNotFoundError,
@@ -183,7 +184,9 @@ def _wired(monkeypatch: pytest.MonkeyPatch) -> WireCallable:
             record = dataclasses.replace(record, artifact_refs=refreshed_refs)
         monkeypatch.setattr(module, "ensure_workflow_pack_run_store_ready", lambda: None)
         monkeypatch.setattr(module, "get_workflow_pack_run_store", lambda: _StoreStub(record))
-        monkeypatch.setattr(module, "get_artifact_object_store", lambda: _ObjectStoreStub(raw))
+        monkeypatch.setattr(
+            summary_module, "get_artifact_object_store", lambda: _ObjectStoreStub(raw)
+        )
         monkeypatch.setattr(
             module,
             "_accepting_review_identity",
@@ -285,7 +288,7 @@ def test_accepted_state_without_recorded_review_event_is_malformed(
     )
     monkeypatch.setattr(module, "ensure_workflow_pack_run_store_ready", lambda: None)
     monkeypatch.setattr(module, "get_workflow_pack_run_store", lambda: _StoreStub(record))
-    monkeypatch.setattr(module, "get_artifact_object_store", lambda: _ObjectStoreStub(raw))
+    monkeypatch.setattr(summary_module, "get_artifact_object_store", lambda: _ObjectStoreStub(raw))
     with pytest.raises(AcceptedOutputNotAvailableError) as excinfo:
         build_workflow_pack_run_accepted_output(run_id="wfr-accepted-001", caller_tenant_id=TENANT)
     assert _reason(excinfo) == "output_artifact_malformed"

--- a/tests/unit/test_workflow_pack_run_output_summary.py
+++ b/tests/unit/test_workflow_pack_run_output_summary.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+
 from app.contracts.artifacts import (
     ArtifactDescriptor,
     ArtifactLifecycleStatus,
@@ -23,7 +25,7 @@ def _summary_artifact(storage_reference: str) -> ArtifactDescriptor:
         retention_posture="active",
         media_type="application/json",
         byte_size=2,
-        checksum_sha256="sha256-test",
+        checksum_sha256=hashlib.sha256(b"summary-test").hexdigest(),
         storage_backend=ArtifactStorageBackend.MEMORY,
         storage_reference=storage_reference,
         created_at="2026-04-21T12:00:00Z",


### PR DESCRIPTION
Closes #336 (follow-ups to #328/#334 — both drift seams, and the read-monopoly audit found the monopoly actually broken).

## Consumer / operator outcome
Tampered or corrupted run-output bytes are now withheld EVERYWHERE, not just on the accepted-output surface: the consumer-view and source-events projections previously read `run_output_summary` bytes with no integrity gate — a tampered artifact would have served fabricated idea-lineage facts into projection surfaces. And a future artifact writer adopting the platform's `sha256:<hex>` travel form is refused at persistence instead of silently fail-closing the entire accepted-output surface at read.

## Invariant + single authority
`load_verified_summary_object` is THE read authority for `run_output_summary` bytes (checksum + byte-size verification against the recorded descriptor; the recorded checksum is never repaired at read time): the accepted-output loader delegates to it (typed errors mapped onto its exact pre-existing bounded refusal reasons — all pinned messages unchanged), and the projection reader resolves through it, degrading to absent on mismatch with a logged withholding. The audit of remaining `storage_reference` consumers is recorded in the runbook: queue request-snapshot and recovery reads resolve their own artifact types, not summaries. Write side: `ArtifactDescriptor.checksum_sha256` pins `^[0-9a-f]{64}$` at the contract.

## Simplification
The accepted-output loader shrinks to error-mapping over the shared authority — one verification implementation where there were about to be two.

## Failing-before / passing-after
`tests/unit/test_artifact_integrity_boundaries.py` (new, 3): grammar refusals (prefixed/uppercase/truncated/empty) with a persist→verified-load round trip; tampered bytes refused by the authority and withheld from projections with the logged refusal. The grammar pin immediately caught the shared test builder minting `sha256:{index}` checksums — exactly the drift class it refuses — now valid deterministic digests; repo-wide constructor sweep clean. All pinned accepted-output refusal messages unchanged (suites re-point their object-store stubs at the single authority).

## Compatibility + residuals
The contract pattern is a WIDENING refusal only for invalid data — every checksum the real writer ever produced (bare `hexdigest()`) passes; no schema/API changes. Residual: none within scope; #351 (manifest content digest) and #340/#344 continue the backlog. Lane green 379/25463 (98.51%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)