### PR TITLE
feat(quality): adopt the branch-protection policy gate

### DIFF
--- a/.github/workflows/main-gate-coverage-audit.yml
+++ b/.github/workflows/main-gate-coverage-audit.yml
@@ -32,3 +32,20 @@ jobs:
           python scripts/audit_main_gate_coverage.py \
             --limit "${{ github.event.inputs.limit || '50' }}" \
             --fail-on-gap
+      - name: Enforce Branch Protection Policy
+        # Runs even when the audit above failed: two independent delivery
+        # controls, and a skipped check reads as absent rather than as a
+        # refusal.
+        if: ${{ !cancelled() }}
+        env:
+          # github.token cannot carry administration:read, which the branch
+          # protection endpoint requires; a repository PAT can. A missing or
+          # unauthorized token FAILS this step rather than passing it
+          # silently - a silent pass without the token is exactly the
+          # gate-liveness defect this control exists to prevent. No Lotus
+          # repository holds an Actions secret as of 2026-09-06, so this
+          # step fails closed until an operator provisions one (issue #358).
+          GH_TOKEN: ${{ secrets.LOTUS_AUTOMERGE_TOKEN }}
+        # Invoked BARE: piping through tee would report tee's exit status and
+        # leave the checker able to raise beneath a green check.
+        run: python scripts/check_branch_protection_policy.py

--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -86,6 +86,8 @@ jobs:
         run: make eval-run-gate
       - name: Async Job Gate
         run: make async-job-gate
+      - name: Branch Protection Policy Gate (offline shape)
+        run: make branch-protection-policy-gate
       - name: Migration Smoke
         env:
           LOTUS_AI_DATABASE_URL: "sqlite:///:memory:"

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -51,6 +51,8 @@ jobs:
         run: make eval-run-gate
       - name: Async Job Gate
         run: make async-job-gate
+      - name: Branch Protection Policy Gate (offline shape)
+        run: make branch-protection-policy-gate
       - name: Migration Smoke
         env:
           LOTUS_AI_DATABASE_URL: "sqlite:///:memory:"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dependency-lock-replay-check lint module-budget-guard monetary-float-guard runtime-purity-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply data-lifecycle-run runtime-mode-smoke test test-unit test-integration test-e2e test-postgres test-coverage coverage-gate security-audit check ci docker-build clean
+.PHONY: install dependency-lock-replay-check lint module-budget-guard monetary-float-guard runtime-purity-guard verify-dependencies typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke migration-apply data-lifecycle-run branch-protection-policy-gate runtime-mode-smoke test test-unit test-integration test-e2e test-postgres test-coverage coverage-gate security-audit check ci docker-build clean
 
 install:
 	python -m pip install --upgrade pip
@@ -37,6 +37,12 @@ openapi-gate:
 
 eval-manifest-gate:
 	python scripts/validate_eval_fixture_manifest.py
+
+# Offline shape only - the live comparison needs administration:read and runs
+# in the scheduled audit (issue #358). This keeps the policy table itself from
+# rotting in the blocking lane.
+branch-protection-policy-gate:
+	python scripts/check_branch_protection_policy.py --offline
 
 eval-run-gate:
 	python scripts/validate_eval_run_artifacts.py
@@ -87,7 +93,7 @@ test-coverage:
 security-audit:
 	python scripts/dependency_health_check.py
 
-check: lint typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke runtime-mode-smoke test
+check: lint typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate branch-protection-policy-gate migration-smoke runtime-mode-smoke test
 
 ci: verify-dependencies dependency-lock-replay-check lint typecheck openapi-gate eval-manifest-gate eval-run-gate async-job-gate rfc0002-idea-proof-gate migration-smoke runtime-mode-smoke security-audit test-coverage docker-build
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -177,7 +177,12 @@ the fail-closed fence lane (`make test-postgres`, #344), racing two independent
 database sessions per scenario and mirroring a SQLite counterpart so backend
 drift stays visible. The retry path is certified rather than assumed: one
 scenario forces a REPEATABLE READ conflict and asserts the observed SQLSTATE
-40001 before convergence, and fails if retry handling is removed.
+40001 before convergence, and fails if retry handling is removed. The delivery
+controls that admit those merges are themselves declared and compared:
+`quality/branch_protection_policy.v1.json` records main's governed posture
+field by field, its offline shape runs in both blocking lanes, and the daily
+audit compares it against live protection (scheduled-only and PAT-gated while
+one declared context is still pending an operator write — issue #358).
 
 **Current limitations.** Capability requirements exist for latency (one governed
 end-to-end budget), structured output, and tool calling (catalogue-evidence

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,18 @@ python_version = 3.12
 strict = True
 mypy_path = src
 files = src, tests
+
+# Verbatim lifts of the platform branch-protection policy gate (issue #358).
+# The canonical implementation lives with the reference adopter
+# (lotus-gateway's scripts/check_branch_protection_policy.py and its unit
+# tests) and is deliberately kept BYTE-IDENTICAL here: the pattern's value is
+# that a canonical fix propagates to every adopter by re-lifting, and its
+# specified parity check compares content hashes. Annotating these two files
+# locally would fork the copy on arrival and defeat exactly that. The
+# exemption names two files and nothing else - locally authored code, this
+# repository's own policy table included, stays strict.
+[mypy-scripts.check_branch_protection_policy]
+disable_error_code = no-any-return
+
+[mypy-tests.unit.test_branch_protection_policy]
+disable_error_code = no-untyped-def, type-arg, union-attr

--- a/quality/branch_protection_policy.v1.json
+++ b/quality/branch_protection_policy.v1.json
@@ -1,0 +1,62 @@
+{
+  "contract_id": "lotus-branch-protection-policy",
+  "contract_version": "1.0.0",
+  "repository": "sgajbi/lotus-ai",
+  "protected_branch": "main",
+  "review_authority": {
+    "review_lead": "the lotus-ai campaign session, reviewed by the lotus-platform ecosystem-lead session (lotus-platform-bb) on the exact PR head",
+    "mergeable_meaning": "an exact-head VERDICT of mergeable means every required context is green on the current head and every review thread on that head is resolved, re-queried immediately before the merge rather than inferred from an earlier run",
+    "escalation": "unresolved disagreements escalate to the repository owner (sgajbi), who is the sole accepted collaborator and the only actor who can change branch protection"
+  },
+  "expected": {
+    "enforce_admins": true,
+    "required_linear_history": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "required_conversation_resolution": true,
+    "required_status_checks": {
+      "strict": true,
+      "contexts": [
+        "PR Merge Gate / Workflow Lint",
+        "PR Merge Gate / Lint Typecheck Security",
+        "PR Merge Gate / Tests (unit)",
+        "PR Merge Gate / Tests (integration)",
+        "PR Merge Gate / Tests (e2e)",
+        "PR Merge Gate / Runtime Mode Smoke",
+        "PR Merge Gate / PostgreSQL Fence Proof",
+        "PR Merge Gate / Coverage Gate (Combined)",
+        "PR Merge Gate / Validate Docker Build"
+      ]
+    },
+    "required_pull_request_reviews": {
+      "present": true,
+      "required_approving_review_count": 0,
+      "dismiss_stale_reviews": true,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "bypass_pull_request_allowances": {
+        "users": [],
+        "teams": [],
+        "apps": []
+      }
+    },
+    "restrictions_present": false,
+    "codeowners_present": false
+  },
+  "documented_exceptions": [
+    {
+      "field": "required_pull_request_reviews.required_approving_review_count",
+      "value": 0,
+      "reason": "the repository has a single accepted collaborator; requiring a non-author approval would hard-lock main rather than strengthen it, and naming that collaborator in CODEOWNERS would record an independent-review control that does not exist",
+      "compensating_controls": "nine required green contexts, enforce_admins, strict up-to-date branches, required conversation resolution, and linear history apply to every merge including the administrator's; every PR additionally carries an exact-head review verdict from a separate session",
+      "retires_when": "a second accepted reviewer identity exists; then raise required_approving_review_count to 1, add CODEOWNERS, and update this policy in the same change"
+    },
+    {
+      "field": "required_status_checks.contexts.PR Merge Gate / PostgreSQL Fence Proof",
+      "value": "declared required in this policy, not yet present in live protection",
+      "reason": "this policy is adopted from KNOWN DRIFT and states the target posture. The PostgreSQL fence proof (issue #344) certifies the governed-claim and hard-budget compare-and-set fences on the production database engine; it must be a required context, but only the repository owner can write branch protection and that write is pending. Declaring the target here makes the gap self-reporting every day instead of living in a merged PR body.",
+      "compensating_controls": "the fence job runs on every PR and on main, and PR Merge Gate / Coverage Gate (Combined) - which IS live-required - runs with if: always() and asserts every upstream job succeeded, so a fence failure produces a FAILED required check naming postgres-fence-proof(failure) rather than a silently skipped dependent (evidence: lotus-ai#344 comment 5555913071)",
+      "retires_when": "the owner adds 'PR Merge Gate / PostgreSQL Fence Proof' to main's required_status_checks contexts; the scheduled live comparison then passes on this field and the blocking pre-merge step tracked in issue #358 lands in the same change"
+    }
+  ]
+}

--- a/scripts/check_branch_protection_policy.py
+++ b/scripts/check_branch_protection_policy.py
@@ -1,0 +1,275 @@
+"""Assert that live branch protection matches the documented policy, field by field.
+
+An undocumented protection exception is indistinguishable from a misconfiguration,
+and a policy document that outlives the configuration it describes is worse than
+none. This gate fails in both drift directions: when live protection weakens
+relative to `quality/branch_protection_policy.v1.json`, and when the documented
+zero-approval exception is removed without the configuration strengthening.
+
+The policy document is the only repository-specific input, so a sibling
+repository can lift this script verbatim and edit the table. Absent settings are
+compared as absent, never coerced to false (a missing
+`required_pull_request_reviews` block and `required_approving_review_count: 0`
+are different postures and must be distinguishable).
+
+Usage:
+  python scripts/check_branch_protection_policy.py --offline   # document shape only
+  python scripts/check_branch_protection_policy.py             # live comparison (needs gh auth)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+POLICY_PATH = Path(__file__).resolve().parents[1] / "quality" / "branch_protection_policy.v1.json"
+
+_REQUIRED_EXCEPTION_KEYS = {"field", "value", "reason", "compensating_controls", "retires_when"}
+
+# Every field the live comparison reads. Without these lists an edit could drop
+# a field, pass --offline in the blocking lane, and only fail hours later in the
+# scheduled live run.
+_BYPASS_CATEGORIES = ("users", "teams", "apps")
+
+_REQUIRED_REVIEW_KEYS = (
+    "required_approving_review_count",
+    "dismiss_stale_reviews",
+    "require_code_owner_reviews",
+    "require_last_push_approval",
+    "bypass_pull_request_allowances",
+)
+
+_BOOLEAN_REVIEW_KEYS = (
+    "present",
+    "dismiss_stale_reviews",
+    "require_code_owner_reviews",
+    "require_last_push_approval",
+)
+
+_BOOLEAN_EXPECTED_KEYS = (
+    "enforce_admins",
+    "required_linear_history",
+    "allow_force_pushes",
+    "allow_deletions",
+    "required_conversation_resolution",
+    "restrictions_present",
+    "codeowners_present",
+)
+
+_REQUIRED_EXPECTED_KEYS = (
+    "enforce_admins",
+    "required_linear_history",
+    "allow_force_pushes",
+    "allow_deletions",
+    "required_conversation_resolution",
+    "required_status_checks",
+    "required_pull_request_reviews",
+    "restrictions_present",
+    "codeowners_present",
+)
+
+
+def load_policy(path: Path = POLICY_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_policy_document(policy: dict[str, Any]) -> list[str]:
+    """Offline shape check: the document must be complete enough to gate against."""
+    issues: list[str] = []
+    for key in ("repository", "protected_branch", "expected", "documented_exceptions"):
+        if key not in policy:
+            issues.append(f"policy is missing required key: {key}")
+    authority = policy.get("review_authority", {})
+    for key in ("review_lead", "mergeable_meaning", "escalation"):
+        if not str(authority.get(key, "")).strip():
+            issues.append(f"review_authority.{key} must be documented")
+    expected = policy.get("expected", {})
+    for key in _REQUIRED_EXPECTED_KEYS:
+        if key not in expected:
+            issues.append(f"expected.{key} must be declared")
+    checks = expected.get("required_status_checks", {})
+    for key in ("strict", "contexts"):
+        if key not in checks:
+            issues.append(f"expected.required_status_checks.{key} must be declared")
+    contexts = checks.get("contexts")
+    if "contexts" in checks:
+        if not isinstance(contexts, list) or not all(isinstance(c, str) for c in contexts):
+            issues.append(
+                "expected.required_status_checks.contexts must be a list of strings: "
+                "a bare string would be compared character by character"
+            )
+        elif not contexts:
+            issues.append(
+                "expected.required_status_checks.contexts is empty: nothing would be required"
+            )
+    if "strict" in checks and not isinstance(checks["strict"], bool):
+        issues.append("expected.required_status_checks.strict must be a boolean")
+    for key in _BOOLEAN_EXPECTED_KEYS:
+        if key in expected and not isinstance(expected[key], bool):
+            issues.append(f"expected.{key} must be a boolean")
+    declared_reviews = expected.get("required_pull_request_reviews", {})
+    if "present" not in declared_reviews:
+        issues.append("expected.required_pull_request_reviews.present must be declared")
+    elif declared_reviews.get("present"):
+        for key in _REQUIRED_REVIEW_KEYS:
+            if key not in declared_reviews:
+                issues.append(f"expected.required_pull_request_reviews.{key} must be declared")
+        for key in _BOOLEAN_REVIEW_KEYS:
+            if key in declared_reviews and not isinstance(declared_reviews[key], bool):
+                issues.append(f"expected.required_pull_request_reviews.{key} must be a boolean")
+        count = declared_reviews.get("required_approving_review_count")
+        if count is not None and (isinstance(count, bool) or not isinstance(count, int)):
+            issues.append(
+                "expected.required_pull_request_reviews."
+                "required_approving_review_count must be an integer"
+            )
+        bypass = declared_reviews.get("bypass_pull_request_allowances", {})
+        for category in _BYPASS_CATEGORIES:
+            if category not in bypass:
+                issues.append(
+                    "expected.required_pull_request_reviews."
+                    f"bypass_pull_request_allowances.{category} must be declared"
+                )
+            elif not isinstance(bypass[category], list):
+                issues.append(
+                    "expected.required_pull_request_reviews."
+                    f"bypass_pull_request_allowances.{category} must be a list"
+                )
+    for exception in policy.get("documented_exceptions", []):
+        missing = _REQUIRED_EXCEPTION_KEYS - set(exception)
+        if missing:
+            issues.append(f"documented exception is missing keys: {sorted(missing)}")
+    if declared_reviews.get("required_approving_review_count") == 0 and not any(
+        e.get("field") == "required_pull_request_reviews.required_approving_review_count"
+        for e in policy.get("documented_exceptions", [])
+    ):
+        issues.append(
+            "required_approving_review_count is 0 without a documented exception: "
+            "either strengthen protection or document the deliberate deviation"
+        )
+    return issues
+
+
+def fetch_live_protection(repository: str, branch: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repository}/branches/{branch}/protection"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def resolve_effective_codeowners(repo_root: Path) -> Path | None:
+    """Return the CODEOWNERS file GitHub would apply, or None if there is none.
+
+    GitHub does not merge the recognized locations: it uses the first file it
+    finds, in this order. A stale or empty file in an earlier location shadows a
+    valid one later, so presence-anywhere is not the posture GitHub enforces.
+    """
+    for location in (".github", "", "docs"):
+        candidate = repo_root / location / "CODEOWNERS" if location else repo_root / "CODEOWNERS"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _enabled(node: Any) -> Any:
+    return node.get("enabled") if isinstance(node, dict) else node
+
+
+def compare_live_to_policy(policy: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    expected = policy["expected"]
+    issues: list[str] = []
+
+    scalar_fields = {
+        "enforce_admins": _enabled(live.get("enforce_admins")),
+        "required_linear_history": _enabled(live.get("required_linear_history")),
+        "allow_force_pushes": _enabled(live.get("allow_force_pushes")),
+        "allow_deletions": _enabled(live.get("allow_deletions")),
+        "required_conversation_resolution": _enabled(live.get("required_conversation_resolution")),
+        "restrictions_present": live.get("restrictions") is not None,
+    }
+    for name, actual in scalar_fields.items():
+        if actual != expected[name]:
+            issues.append(f"{name}: live={actual!r} policy={expected[name]!r}")
+
+    checks = live.get("required_status_checks") or {}
+    if checks.get("strict") != expected["required_status_checks"]["strict"]:
+        issues.append(f"required_status_checks.strict: live={checks.get('strict')!r}")
+    live_contexts = sorted(checks.get("contexts") or [])
+    policy_contexts = sorted(expected["required_status_checks"]["contexts"])
+    if live_contexts != policy_contexts:
+        issues.append(
+            f"required_status_checks.contexts differ: live={live_contexts} policy={policy_contexts}"
+        )
+
+    reviews = live.get("required_pull_request_reviews")
+    expected_reviews = expected["required_pull_request_reviews"]
+    if (reviews is not None) != expected_reviews["present"]:
+        issues.append(
+            "required_pull_request_reviews block presence: "
+            f"live={'present' if reviews is not None else 'ABSENT'} "
+            f"policy={'present' if expected_reviews['present'] else 'ABSENT'}"
+        )
+    elif reviews is not None:
+        for key in (
+            "required_approving_review_count",
+            "dismiss_stale_reviews",
+            "require_code_owner_reviews",
+            "require_last_push_approval",
+        ):
+            if reviews.get(key) != expected_reviews[key]:
+                issues.append(
+                    f"required_pull_request_reviews.{key}: "
+                    f"live={reviews.get(key)!r} policy={expected_reviews[key]!r}"
+                )
+        live_bypass = reviews.get("bypass_pull_request_allowances") or {}
+        expected_bypass = expected_reviews["bypass_pull_request_allowances"]
+        actual_bypass = {
+            "users": sorted(u.get("login", "") for u in live_bypass.get("users", [])),
+            "teams": sorted(t.get("slug", "") for t in live_bypass.get("teams", [])),
+            "apps": sorted(a.get("slug", "") for a in live_bypass.get("apps", [])),
+        }
+        if actual_bypass != {k: sorted(v) for k, v in expected_bypass.items()}:
+            issues.append(
+                "required_pull_request_reviews.bypass_pull_request_allowances: "
+                f"live={actual_bypass!r} policy={expected_bypass!r}"
+            )
+
+    effective_codeowners = resolve_effective_codeowners(Path(__file__).resolve().parents[1])
+    codeowners = effective_codeowners is not None
+    if codeowners != expected["codeowners_present"]:
+        issues.append(
+            f"CODEOWNERS presence: live={codeowners} policy={expected['codeowners_present']}"
+        )
+
+    return issues
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--offline", action="store_true", help="validate the policy document only")
+    args = parser.parse_args()
+
+    policy = load_policy()
+    issues = validate_policy_document(policy)
+    if not args.offline and not issues:
+        live = fetch_live_protection(policy["repository"], policy["protected_branch"])
+        issues.extend(compare_live_to_policy(policy, live))
+
+    if issues:
+        print("Branch-protection policy gate failed:")
+        for issue in issues:
+            print(f"  - {issue}")
+        return 1
+    mode = "document shape" if args.offline else "live configuration"
+    print(f"Branch-protection policy gate passed ({mode}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_branch_protection_policy.py
+++ b/tests/unit/test_branch_protection_policy.py
@@ -1,0 +1,223 @@
+"""The documented branch-protection policy must stay complete and self-consistent.
+
+The live comparison runs in CI where a token exists; these offline checks keep
+the policy document itself honest so the live gate always has a valid table to
+compare against, and so the zero-approval exception cannot be silently deleted
+while the configuration stays weak.
+"""
+
+import copy
+
+from scripts.check_branch_protection_policy import (
+    compare_live_to_policy,
+    load_policy,
+    resolve_effective_codeowners,
+    validate_policy_document,
+)
+
+
+def _live_matching_policy(policy: dict) -> dict:
+    expected = policy["expected"]
+    return {
+        "enforce_admins": {"enabled": expected["enforce_admins"]},
+        "required_linear_history": {"enabled": expected["required_linear_history"]},
+        "allow_force_pushes": {"enabled": expected["allow_force_pushes"]},
+        "allow_deletions": {"enabled": expected["allow_deletions"]},
+        "required_conversation_resolution": {
+            "enabled": expected["required_conversation_resolution"]
+        },
+        "restrictions": {"users": []} if expected["restrictions_present"] else None,
+        "required_status_checks": {
+            "strict": expected["required_status_checks"]["strict"],
+            "contexts": list(expected["required_status_checks"]["contexts"]),
+        },
+        "required_pull_request_reviews": (
+            {
+                key: expected["required_pull_request_reviews"][key]
+                for key in (
+                    "required_approving_review_count",
+                    "dismiss_stale_reviews",
+                    "require_code_owner_reviews",
+                    "require_last_push_approval",
+                )
+            }
+            if expected["required_pull_request_reviews"]["present"]
+            else None
+        ),
+    }
+
+
+def test_policy_document_is_complete() -> None:
+    assert validate_policy_document(load_policy()) == []
+
+
+def test_zero_approval_count_requires_a_documented_exception() -> None:
+    policy = copy.deepcopy(load_policy())
+    policy["documented_exceptions"] = []
+
+    issues = validate_policy_document(policy)
+
+    assert any("documented exception" in issue for issue in issues)
+
+
+def test_matching_live_configuration_passes() -> None:
+    policy = load_policy()
+
+    assert compare_live_to_policy(policy, _live_matching_policy(policy)) == []
+
+
+def test_weakened_live_protection_fails() -> None:
+    policy = load_policy()
+    live = _live_matching_policy(policy)
+    live["enforce_admins"] = {"enabled": False}
+    live["required_status_checks"]["contexts"] = live["required_status_checks"]["contexts"][:-1]
+
+    issues = compare_live_to_policy(policy, live)
+
+    assert any(issue.startswith("enforce_admins") for issue in issues)
+    assert any("contexts differ" in issue for issue in issues)
+
+
+def test_absent_reviews_block_is_distinguished_from_zero_count() -> None:
+    # The render#66 drift class: a missing required_pull_request_reviews block
+    # must be reported as ABSENT, never conflated with a present zero-count.
+    policy = load_policy()
+    live = _live_matching_policy(policy)
+    live["required_pull_request_reviews"] = None
+
+    issues = compare_live_to_policy(policy, live)
+
+    assert any("ABSENT" in issue for issue in issues)
+
+
+def test_codeowners_resolution_follows_github_precedence(tmp_path):
+    """A .github/ file wins over root and docs/, as GitHub resolves it."""
+    for location in (".github", "docs"):
+        (tmp_path / location).mkdir()
+    (tmp_path / "CODEOWNERS").write_text("* @root\n", encoding="utf-8")
+    (tmp_path / "docs" / "CODEOWNERS").write_text("* @docs\n", encoding="utf-8")
+
+    assert resolve_effective_codeowners(tmp_path) == tmp_path / "CODEOWNERS"
+
+    (tmp_path / ".github" / "CODEOWNERS").write_text("", encoding="utf-8")
+    effective = resolve_effective_codeowners(tmp_path)
+    assert effective == tmp_path / ".github" / "CODEOWNERS"
+    assert effective.read_text(encoding="utf-8") == "", (
+        "an empty higher-precedence file must shadow the valid lower ones, "
+        "because that is the posture GitHub applies"
+    )
+
+
+def test_codeowners_resolution_reports_absence(tmp_path):
+    assert resolve_effective_codeowners(tmp_path) is None
+
+
+def test_offline_validation_rejects_a_policy_missing_expected_fields():
+    """--offline is the only PR-time gate; it must not accept a gutted policy."""
+    policy = load_policy()
+    for field in ("enforce_admins", "required_status_checks", "required_pull_request_reviews"):
+        incomplete = copy.deepcopy(policy)
+        del incomplete["expected"][field]
+        issues = validate_policy_document(incomplete)
+        assert any(f"expected.{field} must be declared" in issue for issue in issues), (
+            f"removing expected.{field} passed the offline gate"
+        )
+
+
+def test_offline_validation_rejects_an_empty_required_context_list():
+    policy = copy.deepcopy(load_policy())
+    policy["expected"]["required_status_checks"]["contexts"] = []
+    issues = validate_policy_document(policy)
+    assert any("contexts is empty" in issue for issue in issues)
+
+
+def test_offline_validation_rejects_missing_nested_fields():
+    """Deleting a nested field must not pass offline and crash the live run."""
+    policy = load_policy()
+    cases = [
+        (("required_status_checks", "strict"), "expected.required_status_checks.strict"),
+        (("required_status_checks", "contexts"), "expected.required_status_checks.contexts"),
+        (
+            ("required_pull_request_reviews", "present"),
+            "expected.required_pull_request_reviews.present",
+        ),
+        (
+            ("required_pull_request_reviews", "dismiss_stale_reviews"),
+            "expected.required_pull_request_reviews.dismiss_stale_reviews",
+        ),
+        (
+            ("required_pull_request_reviews", "bypass_pull_request_allowances"),
+            "expected.required_pull_request_reviews.bypass_pull_request_allowances",
+        ),
+    ]
+    for (parent, field), expected_message in cases:
+        incomplete = copy.deepcopy(policy)
+        del incomplete["expected"][parent][field]
+        issues = validate_policy_document(incomplete)
+        assert any(expected_message in issue for issue in issues), (
+            f"removing expected.{parent}.{field} passed the offline gate"
+        )
+
+
+def test_offline_validation_requires_each_bypass_category():
+    """The live comparison builds all three categories; offline must demand them."""
+    policy = load_policy()
+    for category in ("users", "teams", "apps"):
+        incomplete = copy.deepcopy(policy)
+        del incomplete["expected"]["required_pull_request_reviews"][
+            "bypass_pull_request_allowances"
+        ][category]
+        issues = validate_policy_document(incomplete)
+        assert any(
+            f"bypass_pull_request_allowances.{category} must be declared" in issue
+            for issue in issues
+        ), f"removing bypass_pull_request_allowances.{category} passed the offline gate"
+
+
+def test_offline_validation_rejects_wrong_value_types():
+    """A bare string would be compared character by character after merge."""
+    policy = copy.deepcopy(load_policy())
+    policy["expected"]["required_status_checks"]["contexts"] = "PR Merge Gate / Coverage"
+    assert any("must be a list of strings" in issue for issue in validate_policy_document(policy))
+
+    policy = copy.deepcopy(load_policy())
+    policy["expected"]["required_status_checks"]["strict"] = "true"
+    assert any(
+        "required_status_checks.strict must be a boolean" in issue
+        for issue in validate_policy_document(policy)
+    )
+
+    policy = copy.deepcopy(load_policy())
+    policy["expected"]["enforce_admins"] = "true"
+    assert any(
+        "expected.enforce_admins must be a boolean" in issue
+        for issue in validate_policy_document(policy)
+    )
+
+
+def test_offline_validation_rejects_wrong_review_value_types():
+    """A string "true" or "0" would merge and mismatch only in the live run."""
+    base = load_policy()
+
+    policy = copy.deepcopy(base)
+    policy["expected"]["required_pull_request_reviews"]["dismiss_stale_reviews"] = "true"
+    assert any(
+        "dismiss_stale_reviews must be a boolean" in issue
+        for issue in validate_policy_document(policy)
+    )
+
+    policy = copy.deepcopy(base)
+    policy["expected"]["required_pull_request_reviews"]["required_approving_review_count"] = "0"
+    assert any(
+        "required_approving_review_count must be an integer" in issue
+        for issue in validate_policy_document(policy)
+    )
+
+    policy = copy.deepcopy(base)
+    policy["expected"]["required_pull_request_reviews"]["bypass_pull_request_allowances"][
+        "users"
+    ] = "nobody"
+    assert any(
+        "bypass_pull_request_allowances.users must be a list" in issue
+        for issue in validate_policy_document(policy)
+    )

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -20,10 +20,10 @@ local run has proven. **No workflow invokes `make check` or `make ci`.** The lan
 targets, measured across `.github/workflows/*.yml` on `main`:
 
 ```
-async-job-gate   docker-build   eval-manifest-gate   eval-run-gate   install
-lint             migration-smoke   openapi-gate      runtime-mode-smoke
-security-audit   test-postgres  test-unit           typecheck
-verify-dependencies
+async-job-gate   branch-protection-policy-gate     docker-build
+eval-manifest-gate   eval-run-gate   install   lint   migration-smoke
+openapi-gate   runtime-mode-smoke   security-audit   test-postgres
+test-unit   typecheck   verify-dependencies
 ```
 
 Two consequences to keep in mind:
@@ -44,6 +44,7 @@ relying on the lanes to repeat it.
 - `make rfc0002-idea-proof-gate` - RFC-0002 Idea explanation local-dev proof gate
 - `make runtime-mode-smoke` - targeted startup and runtime-mode smoke
 - `make test-postgres` - CAS fence proofs on real PostgreSQL (see below)
+- `make branch-protection-policy-gate` - branch-protection policy shape (see below)
 - `make migration-apply` - apply Alembic migrations
 - `make docker-build` - Docker build validation
 
@@ -63,9 +64,10 @@ relying on the lanes to repeat it.
 5. evaluation run artifact validation,
 6. async job artifact validation,
 7. RFC-0002 Idea explanation local-dev proof validation,
-8. migration smoke,
-9. runtime-mode smoke,
-10. unit-test execution.
+8. branch-protection policy document shape,
+9. migration smoke,
+10. runtime-mode smoke,
+11. unit-test execution.
 
 The RFC-0002 proof gate executes `idea_explanation.pack@v1` through the governed HTTP boundary,
 accepts the review-gated run, validates source-safe consumer/source-event evidence, and proves that
@@ -120,6 +122,41 @@ Three gates deserve special attention because they are easy to misread:
 
 These keep the evidence layer truthful. They are part of the product contract for `lotus-ai`, not
 just developer convenience.
+
+## Branch Protection Policy Gate
+
+Live branch protection is configuration that nothing exercises: if `enforce_admins`, the required
+contexts, or conversation resolution were silently weakened, every merge would still look normal.
+`quality/branch_protection_policy.v1.json` declares main's governed posture field by field, and
+`scripts/check_branch_protection_policy.py` compares live protection against it, failing in **both**
+drift directions — when protection weakens, and when an exception's text is removed without the
+configuration strengthening. Both the checker and its unit tests are **verbatim lifts** of the
+platform reference (`lotus-gateway`), kept byte-identical so a canonical fix propagates by
+re-lifting; the policy table is the only repository-specific input. `mypy.ini` carries a narrow,
+named exemption for exactly those two files for that reason.
+
+`make branch-protection-policy-gate` runs the **offline shape check** and is part of `make check`
+and both blocking merge lanes, so the table cannot rot. The **live comparison** runs in the daily
+`Main Gate Coverage Audit`, invoked bare — piping it through `tee` would report `tee`'s exit status
+and let the checker raise beneath a green check.
+
+Two honest limits apply today, both tracked in issue #358:
+
+1. **The live comparison is scheduled, not blocking.** The pattern requires a blocking pre-merge home
+   because a scheduled-only run cannot stop a merge. This adoption begins from *known drift*, which
+   the pattern's drift-first transition rule permits: a blocking live step today would deadlock every
+   PR on an operator action that has not happened. The blocking step is a committed follow-up for
+   when the drift clears.
+2. **It authenticates with a PAT that does not exist yet.** `github.token` cannot carry
+   `administration: read`. Until an operator provisions `LOTUS_AUTOMERGE_TOKEN`, the step fails
+   closed on authentication — deliberately, because a silent pass without the token is the exact
+   gate-liveness defect this control exists to prevent.
+
+The declared posture is the **target**, so the table currently reports one real divergence:
+`PR Merge Gate / PostgreSQL Fence Proof` is declared required but is not yet in live protection.
+That is recorded as a documented exception with its compensating control (Coverage Gate is
+live-required and fails explicitly when the fence fails) and a `retires_when` naming the operator
+write. The gap now reports itself daily instead of living in a merged PR body.
 
 ## PostgreSQL Fence Proof
 


### PR DESCRIPTION
Adopts the promoted platform pattern (`lotus-platform` `codex/skills/lotus-ci-enforcement-governance`, `references/branch-protection-policy-gate.md`) under the standing cross-repo consistency steer. Reference implementation `lotus-gateway#737`; second adopter `lotus-render#281`.

## Consumer/operator outcome
Main's delivery-control posture stops being configuration that nothing exercises. It is declared field by field, compared against live protection daily, and any divergence is reported with a remediation command — including the one divergence that exists right now.

## Invariant, and the single authority enforcing it
**Invariant:** live branch protection matches the declared posture, and every deliberate deviation carries a reason, a compensating control, and a retirement condition.

**Authority:** `quality/branch_protection_policy.v1.json` is the only repository-specific input; `scripts/check_branch_protection_policy.py` is the sole comparator and fails in **both** drift directions — protection weakening, and exception text being removed without the configuration strengthening.

## Verbatim lift, and the one place it bit
The checker and its unit tests are byte-identical to the canonical implementation (verified by SHA-256 against `lotus-gateway`), because the pattern's value is that a canonical fix propagates by re-lifting rather than being re-derived per adopter.

lotus-ai's mypy is **stricter** than the reference repository's, so the lift does not typecheck here as-authored (12 errors: `no-any-return`, `no-untyped-def`, `type-arg`, `union-attr`).

*Correction, on the record (caught in review):* an earlier description of mine called that `union-attr` a genuine `Path | None` dereference. It is not. At test line 105 the preceding `assert effective == tmp_path / ".github" / "CODEOWNERS"` guarantees non-None at runtime - had resolution returned `None` that assert fails first and line 105 never executes. Mypy simply cannot narrow through an equality assert. The canonical implementation therefore has **no latent crash**; it has one line strict mypy cannot prove. That makes this adopter friction to fix centrally, not a bug report - a single `assert effective is not None` would free every strict adopter from needing the exemption at all. Annotating the files locally would fork the copy on arrival and defeat the parity the pattern depends on — so `mypy.ini` carries a narrow exemption naming exactly those two modules and exactly those error codes, with the reason recorded in the file. Locally authored code, this repository's policy table included, stays strict. **This is an adoption friction the reference does not mention; flagged for the pattern owner** — the next adopter with a strict mypy config will hit it too.

## Wiring
| Piece | Home | Why |
|---|---|---|
| Offline shape check | `make check` + both blocking lanes | the table cannot rot unnoticed |
| Live comparison | daily `Main Gate Coverage Audit`, invoked **bare** | piping through `tee` reports `tee`'s status — how the reference shipped fail-open |
| Document tests | 13 lifted unit tests in the blocking unit lane | zero-approval exception cannot be silently deleted |

## Failing-before / passing-after
The live comparison run locally against real protection reports **exactly one** divergence, and nothing else — which is itself the evidence that every other declared field matches:

```
required_status_checks.contexts differ:
  live   = [... eight contexts ...]
  policy = [... same eight ..., PR Merge Gate / PostgreSQL Fence Proof]
```

That is the residual I flagged when closing #344, now self-reporting instead of living in a merged PR body. It is a documented exception with its compensating control (Coverage Gate **is** live-required and, since #357, fails explicitly naming `postgres-fence-proof(failure)`) and a `retires_when` naming the operator write. Filed with its exact remediation command as **#358** — not attempted, because protection writes are operator-gated.

## Two limits stated, not papered over
1. **Scheduled, not blocking.** The pattern requires a blocking pre-merge home. This adoption takes its explicit drift-first transition rule: a blocking live step today would deadlock every PR on an operator action that has not happened. The blocking step is a committed follow-up in #358.
2. **PAT does not exist.** `github.token` cannot carry `administration: read`. No Lotus repository holds an Actions secret (measured 2026-09-06), so the scheduled step fails closed on authentication until one is provisioned — deliberately.

Per the pattern's adoption record, this is **partial scaffolding**: the baseline (table, comparison, offline tests, wiring, token rules). The central-comparison, re-evaluation, ruleset-binding, and checker-parity mechanics are specified extensions with no implementation anywhere, and I claim none of them.

## Compatibility
Additive. No production code touched; no existing gate's behaviour changed. Wiki and engineering context updated to match what is actually enforced, including both limits above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
