### PR TITLE
fix(quality): re-lift the typed canonical and drop the mypy exemption (#360)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,18 +3,3 @@ python_version = 3.12
 strict = True
 mypy_path = src
 files = src, tests
-
-# Verbatim lifts of the platform branch-protection policy gate (issue #358).
-# The canonical implementation lives with the reference adopter
-# (lotus-gateway's scripts/check_branch_protection_policy.py and its unit
-# tests) and is deliberately kept BYTE-IDENTICAL here: the pattern's value is
-# that a canonical fix propagates to every adopter by re-lifting, and its
-# specified parity check compares content hashes. Annotating these two files
-# locally would fork the copy on arrival and defeat exactly that. The
-# exemption names two files and nothing else - locally authored code, this
-# repository's own policy table included, stays strict.
-[mypy-scripts.check_branch_protection_policy]
-disable_error_code = no-any-return
-
-[mypy-tests.unit.test_branch_protection_policy]
-disable_error_code = no-untyped-def, type-arg, union-attr

--- a/scripts/check_branch_protection_policy.py
+++ b/scripts/check_branch_protection_policy.py
@@ -73,7 +73,8 @@ _REQUIRED_EXPECTED_KEYS = (
 
 
 def load_policy(path: Path = POLICY_PATH) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    policy: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return policy
 
 
 def validate_policy_document(policy: dict[str, Any]) -> list[str]:
@@ -160,7 +161,8 @@ def fetch_live_protection(repository: str, branch: str) -> dict[str, Any]:
         text=True,
         check=True,
     )
-    return json.loads(result.stdout)
+    payload: dict[str, Any] = json.loads(result.stdout)
+    return payload
 
 
 def resolve_effective_codeowners(repo_root: Path) -> Path | None:

--- a/tests/unit/test_branch_protection_policy.py
+++ b/tests/unit/test_branch_protection_policy.py
@@ -7,6 +7,8 @@ while the configuration stays weak.
 """
 
 import copy
+from pathlib import Path
+from typing import Any
 
 from scripts.check_branch_protection_policy import (
     compare_live_to_policy,
@@ -16,7 +18,7 @@ from scripts.check_branch_protection_policy import (
 )
 
 
-def _live_matching_policy(policy: dict) -> dict:
+def _live_matching_policy(policy: dict[str, Any]) -> dict[str, Any]:
     expected = policy["expected"]
     return {
         "enforce_admins": {"enabled": expected["enforce_admins"]},
@@ -90,7 +92,7 @@ def test_absent_reviews_block_is_distinguished_from_zero_count() -> None:
     assert any("ABSENT" in issue for issue in issues)
 
 
-def test_codeowners_resolution_follows_github_precedence(tmp_path):
+def test_codeowners_resolution_follows_github_precedence(tmp_path: Path) -> None:
     """A .github/ file wins over root and docs/, as GitHub resolves it."""
     for location in (".github", "docs"):
         (tmp_path / location).mkdir()
@@ -102,17 +104,18 @@ def test_codeowners_resolution_follows_github_precedence(tmp_path):
     (tmp_path / ".github" / "CODEOWNERS").write_text("", encoding="utf-8")
     effective = resolve_effective_codeowners(tmp_path)
     assert effective == tmp_path / ".github" / "CODEOWNERS"
+    assert effective is not None  # equality above guarantees this; mypy cannot narrow it
     assert effective.read_text(encoding="utf-8") == "", (
         "an empty higher-precedence file must shadow the valid lower ones, "
         "because that is the posture GitHub applies"
     )
 
 
-def test_codeowners_resolution_reports_absence(tmp_path):
+def test_codeowners_resolution_reports_absence(tmp_path: Path) -> None:
     assert resolve_effective_codeowners(tmp_path) is None
 
 
-def test_offline_validation_rejects_a_policy_missing_expected_fields():
+def test_offline_validation_rejects_a_policy_missing_expected_fields() -> None:
     """--offline is the only PR-time gate; it must not accept a gutted policy."""
     policy = load_policy()
     for field in ("enforce_admins", "required_status_checks", "required_pull_request_reviews"):
@@ -124,14 +127,14 @@ def test_offline_validation_rejects_a_policy_missing_expected_fields():
         )
 
 
-def test_offline_validation_rejects_an_empty_required_context_list():
+def test_offline_validation_rejects_an_empty_required_context_list() -> None:
     policy = copy.deepcopy(load_policy())
     policy["expected"]["required_status_checks"]["contexts"] = []
     issues = validate_policy_document(policy)
     assert any("contexts is empty" in issue for issue in issues)
 
 
-def test_offline_validation_rejects_missing_nested_fields():
+def test_offline_validation_rejects_missing_nested_fields() -> None:
     """Deleting a nested field must not pass offline and crash the live run."""
     policy = load_policy()
     cases = [
@@ -159,7 +162,7 @@ def test_offline_validation_rejects_missing_nested_fields():
         )
 
 
-def test_offline_validation_requires_each_bypass_category():
+def test_offline_validation_requires_each_bypass_category() -> None:
     """The live comparison builds all three categories; offline must demand them."""
     policy = load_policy()
     for category in ("users", "teams", "apps"):
@@ -174,7 +177,7 @@ def test_offline_validation_requires_each_bypass_category():
         ), f"removing bypass_pull_request_allowances.{category} passed the offline gate"
 
 
-def test_offline_validation_rejects_wrong_value_types():
+def test_offline_validation_rejects_wrong_value_types() -> None:
     """A bare string would be compared character by character after merge."""
     policy = copy.deepcopy(load_policy())
     policy["expected"]["required_status_checks"]["contexts"] = "PR Merge Gate / Coverage"
@@ -195,7 +198,7 @@ def test_offline_validation_rejects_wrong_value_types():
     )
 
 
-def test_offline_validation_rejects_wrong_review_value_types():
+def test_offline_validation_rejects_wrong_review_value_types() -> None:
     """A string "true" or "0" would merge and mismatch only in the live run."""
     base = load_policy()
 

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -131,16 +131,28 @@ contexts, or conversation resolution were silently weakened, every merge would s
 `scripts/check_branch_protection_policy.py` compares live protection against it, failing in **both**
 drift directions — when protection weakens, and when an exception's text is removed without the
 configuration strengthening. Both the checker and its unit tests are **verbatim lifts** of the
-platform reference (`lotus-gateway`), kept byte-identical so a canonical fix propagates by
-re-lifting; the policy table is the only repository-specific input. `mypy.ini` carries a narrow,
-named exemption for exactly those two files for that reason.
+platform reference (`lotus-gateway`), kept byte-identical — git-object identical to that
+repository's `main` — so a canonical fix propagates by re-lifting rather than being re-derived
+here; the policy table is the only repository-specific input. The checker is typed strict-clean
+upstream, so this repository needs **no mypy exemption** for it: the lift is verbatim with no
+local edits at all.
 
 `make branch-protection-policy-gate` runs the **offline shape check** and is part of `make check`
-and both blocking merge lanes, so the table cannot rot. The **live comparison** runs in the daily
-`Main Gate Coverage Audit`, invoked bare — piping it through `tee` would report `tee`'s exit status
-and let the checker raise beneath a green check.
+and both blocking merge lanes, so the table cannot rot. Offline validation checks the *document*,
+never live protection — a green offline gate is not evidence that live protection matches the
+declared posture, and must never be read as certification of it. The **live comparison** runs in
+the daily `Main Gate Coverage Audit`, invoked bare — piping it through `tee` would report `tee`'s
+exit status and let the checker raise beneath a green check.
 
-Two honest limits apply today, both tracked in issue #358:
+**Carried upstream limitation (`lotus-gateway#740`).** The checker compares required-context
+*names* but not their source-app bindings (`required_status_checks.checks[].app_id`). A required
+check whose binding is removed or replaced keeps its name, so the comparison reports a clean match
+while a different GitHub App — or a legacy commit status — could satisfy protection in its place.
+This is stated rather than fixed here on purpose: implementing a local version would fork this
+repository's copy from the canonical control, and a forked copy stops receiving canonical fixes
+silently. The fix is consumed from upstream when it lands.
+
+Two further limits apply today, both tracked in issue #358:
 
 1. **The live comparison is scheduled, not blocking.** The pattern requires a blocking pre-merge home
    because a scheduled-only run cannot stop a merge. This adoption begins from *known drift*, which
@@ -152,11 +164,17 @@ Two honest limits apply today, both tracked in issue #358:
    closed on authentication — deliberately, because a silent pass without the token is the exact
    gate-liveness defect this control exists to prevent.
 
+Both limits are **operator-dependent**: neither the branch-protection write nor the credential can
+be made by this repository's automation, and neither is claimed as done.
+
 The declared posture is the **target**, so the table currently reports one real divergence:
 `PR Merge Gate / PostgreSQL Fence Proof` is declared required but is not yet in live protection.
-That is recorded as a documented exception with its compensating control (Coverage Gate is
-live-required and fails explicitly when the fence fails) and a `retires_when` naming the operator
-write. The gap now reports itself daily instead of living in a merged PR body.
+That is recorded as a documented exception with its compensating control — `PR Merge Gate /
+Coverage Gate (Combined)` **is** live-required and runs with `if: always()`, asserting every
+upstream job succeeded, so a fence failure produces a failed required check naming
+`postgres-fence-proof(failure)` — and a `retires_when` naming the operator write. Fence
+enforcement therefore holds today through that required gate; the gap now reports itself daily
+instead of living in a merged PR body.
 
 ## PostgreSQL Fence Proof
 


### PR DESCRIPTION
Closes #360. Executes the user directive's substance.

**Timing, stated plainly:** the directive says *"before merging #359"*, but #359 had already merged (main `5dbb3ff`) when it arrived. Nothing is lost — the requirement is that lotus-ai ends up on the typed canonical with no exemptions, byte-verified and gates rerun, which is exactly what this delivers. I am not claiming to have done it beforehand.

## Consumer/operator outcome
The adoption story becomes literally true rather than aspirational: **lift verbatim, no local edits, no exemptions.**

## Byte parity — verified on git objects, not working trees
Re-lifted from gateway's **merged** `main` (`4eecdd3b`), never from the open head. A CRLF checkout differs on a raw hash while being identical in content, so the comparison is on objects:

| File | Object at lotus-ai HEAD | Object at gateway `origin/main` | Normalized sha256 |
|---|---|---|---|
| `scripts/check_branch_protection_policy.py` | `72797e78…` | `72797e78…` ✅ | `02cbe14ffdf8787f` |
| `tests/unit/test_branch_protection_policy.py` | `90369b5a…` | `90369b5a…` ✅ | `53cc6b296b90b318` |

Verified **after** committing, so the commit's line-ending normalization is proven not to have broken parity. Both normalized hashes independently match those measured by the render adopter on the same bytes.

## Exemption deleted, not narrowed
`mypy.ini` returns to an unexempted strict posture — no per-module sections, no disabled error codes. **Strict mypy passes across 774 files.** This is the result the typed canonical was meant to produce for strict adopters, and it matches render's outcome exactly (no residue difference between two strict adopters on the same bytes).

## Gates rerun
| Gate | Result |
|---|---|
| `make typecheck` (strict, no exemption) | ✅ 774 files |
| `make lint` | ✅ |
| `make branch-protection-policy-gate` (offline) | ✅ |
| 13 lifted document tests | ✅ |
| Live comparison | ✅ unchanged — still exactly one divergence |

## Directive clauses held
- **PostgreSQL fence enforcement preserved.** Untouched, and now stated explicitly in the wiki: `PR Merge Gate / Coverage Gate (Combined)` **is** live-required and runs `if: always()` asserting every upstream job, so a fence failure produces a failed required check naming `postgres-fence-proof(failure)`. Enforcement holds today.
- **#358 stays explicitly operator-dependent.** The wiki now states that neither the branch-protection write nor the credential can be made by this repository's automation, and that **offline validation checks the document, never live protection — a green offline gate is not certification that live protection matches the declared posture.**
- **gateway#740 carried, not forked.** The checker compares required-context *names* but not their source-app bindings (`required_status_checks.checks[].app_id`), so a rebound context keeps its name and reports a clean match. Documented as a carried upstream limitation. Deliberately **not** implemented locally: a local version is a fork, and forks stop receiving canonical fixes silently — which is precisely how a sibling adopter's checker fell 102 lines behind. Consumed from upstream when it lands.
- **Dependencies stay accurately open.** #332 (expert-reviewed corpus and measured advisor comprehension), #115 (provider retention/deletion confirmation), #122 (live certification), #126 — none of these are touched, closed, or implied by anything here.

## Compatibility
Test and CI tooling only; no production code. Wiki parity in the same change. Exact-main validation follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)