### PR TITLE
docs: Current-State Summary, fake heading, and machine-independent paths

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -26,6 +26,43 @@ This repository owns:
 
 It does not own portfolio, performance, risk, advisory, or management domain truth.
 
+## Current-State Summary
+
+What is true right now, as distinct from what the architecture is. Keep this
+section short and dated; when an item resolves, delete it rather than growing a
+changelog.
+
+**As of 2026-09-06:**
+
+1. **Proven and merged.** The governed-execution ownership arc is complete
+   end to end — claim, resume fence, and governed claim release on one
+   compare-and-set (#327, #340) — with seven transition fences certified on
+   real PostgreSQL and the retry path certified by an observed SQLSTATE
+   `40001` (#344). Accepted-output reads resolve through a single verified
+   authority (#336), and capability evidence is guarded by a manifest content
+   digest as well as its version label (#351).
+2. **Enforced, with a stated gap.** `quality/branch_protection_policy.v1.json`
+   declares main's target posture and is compared daily against live
+   protection. One divergence is reported by design: the PostgreSQL fence job
+   is declared required but not yet in live protection (#358). Enforcement
+   currently runs through the live-required Coverage Gate, which fails naming
+   the upstream job.
+3. **Blocked on operators, not on engineering.** #358 needs a branch-protection
+   write and a `LOTUS_AUTOMERGE_TOKEN` with `administration: read`; no Lotus
+   repository holds an Actions secret.
+4. **Blocked on external evidence.** The first declaring evaluation fixture
+   family (#332) needs an expert-reviewed corpus and measured advisor
+   comprehension — a technical fixture pass cannot supply either. #115
+   (provider-native retention/deletion confirmation), #122 (live Idea
+   certification), and #126 remain externally owned.
+5. **Carried upstream limitation.** The branch-protection checker compares
+   required-context names but not their source-app bindings
+   (`lotus-gateway#740`). Stated, deliberately not fixed locally: the checker
+   is a verbatim lift, and a local fix would fork it.
+
+Nothing above is a live-provider or attested-production claim. Stub and
+local-only journeys are never certification.
+
 ## Current Architecture
 
 What `lotus-ai` is today, as one control plane rather than a set of subsystems.
@@ -195,7 +232,7 @@ await concrete enforcement stories. Dual control binds two distinct verified
 service credentials, not verified human principals — the platform identity
 dependency recorded on #157's closure. Twenty-one activation/evidence readiness
 modules still predate the readiness catalog (the runbook family converted in
-#154; consolidation is #284). Provider-side retention execution and external
+issue #154; consolidation is #284). Provider-side retention execution and external
 certification evidence remain externally blocked (#115, #122, #126). Forward
 priorities live on the North Star execution board (#246).
 

--- a/demo/lotus-performance-first-use-case/README.md
+++ b/demo/lotus-performance-first-use-case/README.md
@@ -11,11 +11,11 @@ This demo shows the first bounded `lotus-ai` use case end to end:
 
 The demo writes every invoked API input and output to:
 
-- [generated/captures](/C:/Users/Sandeep/projects/lotus-ai/demo/lotus-performance-first-use-case/generated/captures)
+- [generated/captures](generated/captures)
 
 It also stores local runtime logs and demo state in:
 
-- [generated/runtime](/C:/Users/Sandeep/projects/lotus-ai/demo/lotus-performance-first-use-case/generated/runtime)
+- [generated/runtime](generated/runtime)
 
 That runtime directory is scratch space for local reruns and keeps only a checked-in `.gitignore`.
 
@@ -65,10 +65,10 @@ powershell -ExecutionPolicy Bypass -File demo/lotus-performance-first-use-case/r
 
 ## Key Files
 
-- [run-demo.ps1](/C:/Users/Sandeep/projects/lotus-ai/demo/lotus-performance-first-use-case/run-demo.ps1)
-- [requests/lotus-performance-twr.request.json](/C:/Users/Sandeep/projects/lotus-ai/demo/lotus-performance-first-use-case/requests/lotus-performance-twr.request.json)
-- [requests/lotus-ai-explain.request.json](/C:/Users/Sandeep/projects/lotus-ai/demo/lotus-performance-first-use-case/requests/lotus-ai-explain.request.json)
-- [requests/lotus-ai-first-use-case-eval.request.json](/C:/Users/Sandeep/projects/lotus-ai/demo/lotus-performance-first-use-case/requests/lotus-ai-first-use-case-eval.request.json)
+- [run-demo.ps1](run-demo.ps1)
+- [requests/lotus-performance-twr.request.json](requests/lotus-performance-twr.request.json)
+- [requests/lotus-ai-explain.request.json](requests/lotus-ai-explain.request.json)
+- [requests/lotus-ai-first-use-case-eval.request.json](requests/lotus-ai-first-use-case-eval.request.json)
 
 ## Expected Outcome
 

--- a/docs/architecture/feature-status-and-roadmap.md
+++ b/docs/architecture/feature-status-and-roadmap.md
@@ -332,20 +332,20 @@ In practical feature terms, the roadmap is:
 
 For a new engineer:
 
-1. [README](C:/Users/Sandeep/projects/lotus-ai/README.md)
-2. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md)
+1. [README](../../README.md)
+2. [system-overview.md](system-overview.md)
 3. this document
-4. [phased-roadmap.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/phased-roadmap.md)
-5. [docs/rfcs/README.md](C:/Users/Sandeep/projects/lotus-ai/docs/rfcs/README.md)
+4. [phased-roadmap.md](phased-roadmap.md)
+5. [docs/rfcs/README.md](../rfcs/README.md)
 
 For someone integrating a client app:
 
-1. [integration-guide.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/integration-guide.md)
-2. [task-execution-contract.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/task-execution-contract.md)
+1. [integration-guide.md](../guides/integration-guide.md)
+2. [task-execution-contract.md](../guides/task-execution-contract.md)
 3. this document
 
 For an operator:
 
-1. [service-operations.md](C:/Users/Sandeep/projects/lotus-ai/docs/runbooks/service-operations.md)
-2. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md)
+1. [service-operations.md](../runbooks/service-operations.md)
+2. [system-overview.md](system-overview.md)
 3. this document

--- a/docs/architecture/phased-roadmap.md
+++ b/docs/architecture/phased-roadmap.md
@@ -4,7 +4,7 @@ This roadmap is the canonical execution plan for `lotus-ai`.
 
 For the current implementation snapshot and near-term roadmap by feature area, read:
 
-- [feature-status-and-roadmap.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/feature-status-and-roadmap.md)
+- [feature-status-and-roadmap.md](feature-status-and-roadmap.md)
 
 The guiding principle is:
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -26,7 +26,7 @@ The service is intentionally being built in layers.
 
 The required scalability posture is documented separately in:
 
-- [scalability-and-deployment-model.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/scalability-and-deployment-model.md)
+- [scalability-and-deployment-model.md](scalability-and-deployment-model.md)
 
 That document should be treated as a strict architecture rule, not optional guidance.
 

--- a/docs/evals/evaluation-strategy.md
+++ b/docs/evals/evaluation-strategy.md
@@ -117,7 +117,7 @@ That gate validates:
 
 The source of truth for fixture inventory is now:
 
-1. [fixture-manifest.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixture-manifest.json)
+1. [fixture-manifest.json](fixture-manifest.json)
 
 This manifest is versioned so evaluation catalog and runtime status surfaces can point to a governed
 artifact instead of only hardcoded service metadata.
@@ -135,27 +135,27 @@ That gate validates:
 
 The first concrete staged fixture asset now exists at:
 
-1. [basic_cases.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixtures/explain.v1/basic_cases.json)
+1. [basic_cases.json](fixtures/explain.v1/basic_cases.json)
 
 The second concrete staged fixture asset now exists at:
 
-1. [basic_cases.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixtures/summarize.v1/basic_cases.json)
+1. [basic_cases.json](fixtures/summarize.v1/basic_cases.json)
 
 The first retrieval-oriented staged fixture asset now exists at:
 
-1. [basic_cases.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixtures/retrieval.search/basic_cases.json)
+1. [basic_cases.json](fixtures/retrieval.search/basic_cases.json)
 
 The first provider-policy staged fixture asset now exists at:
 
-1. [basic_cases.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixtures/providers.policy/basic_cases.json)
+1. [basic_cases.json](fixtures/providers.policy/basic_cases.json)
 
 The first safety-policy staged fixture asset now exists at:
 
-1. [basic_cases.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixtures/safety.policy/basic_cases.json)
+1. [basic_cases.json](fixtures/safety.policy/basic_cases.json)
 
 The task-capability contract fixture asset now exists at:
 
-1. [basic_cases.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixtures/tasks.contracts/basic_cases.json)
+1. [basic_cases.json](fixtures/tasks.contracts/basic_cases.json)
 
 This gives the platform real file-backed fixture families for task capability contracts, `explain.v1`,
 `summarize.v1`, governed retrieval citation/refusal behavior, provider-policy behavior, and

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -135,8 +135,9 @@ LOTUS_AI_PROVIDER_MODE=disabled
 
 Then recreate the API and worker containers:
 
+Run these from the repository root:
+
 ```powershell
-cd C:\Users\Sandeep\projects\lotus-ai
 docker compose up -d --force-recreate lotus-ai lotus-ai-worker
 ```
 
@@ -430,7 +431,7 @@ If retrieval is used:
 3. platform docs and approved standards should be favored over ad hoc notes.
 ## Provider Switching Runbook
 
-Use [provider-mode-switching.md](C:/Users/Sandeep/projects/lotus-ai/docs/runbooks/provider-mode-switching.md) as the authoritative operator procedure for:
+Use [provider-mode-switching.md](../runbooks/provider-mode-switching.md) as the authoritative operator procedure for:
 
 1. switching between `disabled`, `openai`, and `local_openai_compatible`,
 2. bringing up developer-local Ollama,

--- a/docs/guides/retrieval-and-vector-store.md
+++ b/docs/guides/retrieval-and-vector-store.md
@@ -144,7 +144,7 @@ Retrieval evaluation is now staged with file-backed fixture inventory.
 
 Current staged retrieval evaluation assets:
 
-1. [basic_cases.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixtures/retrieval.search/basic_cases.json)
+1. [basic_cases.json](../evals/fixtures/retrieval.search/basic_cases.json)
 
 These fixtures now validate runtime-backed live retrieval approval posture:
 

--- a/docs/rfcs/RFC-0001-shared-ai-platform-service.md
+++ b/docs/rfcs/RFC-0001-shared-ai-platform-service.md
@@ -101,17 +101,17 @@ Implemented foundation scope includes:
 
 | Original requirement | Implemented reality | Evidence |
 | --- | --- | --- |
-| Separate shared AI service exists | `lotus-ai` is a standalone FastAPI backend with its own contracts, routers, startup policy, and metadata surfaces | [main.py](C:/Users/Sandeep/projects/lotus-ai/src/app/main.py#L1), [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1) |
-| Clear ownership boundary versus domain apps | Service docs and contracts consistently position `lotus-ai` as assistive/governed infrastructure rather than business truth | [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1), [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md#L1) |
-| Contract-first architecture | API and internal boundaries are modeled explicitly through `contracts`, routers, and service-layer orchestration | [contracts](C:/Users/Sandeep/projects/lotus-ai/src/app/contracts), [routers](C:/Users/Sandeep/projects/lotus-ai/src/app/routers), [services](C:/Users/Sandeep/projects/lotus-ai/src/app/services) |
-| Shared provider layer | Provider gateway, policy, governance, and runtime posture exist even while live execution remains disabled | [provider_gateway.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/provider_gateway.py#L1), [providers.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/providers.py#L1) |
-| Shared prompt layer | Prompt registry, runtime selection, and governance/readiness surfaces exist | [prompts.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/prompts.py#L1), [prompt_runtime.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/prompt_runtime.py#L1) |
-| Shared retrieval layer | Retrieval metadata, governance, execution, and retrieval-backed task behavior exist in bounded form | [retrieval.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/retrieval.py#L1), [retrieval_service.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/retrieval_service.py#L1), [task_execution_contract.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/task-execution-contract.md#L1) |
-| Shared safety layer | Safety posture is modeled explicitly and reflected in runtime and audit behavior | [safety.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/safety.py#L1), [task_execution_mapping.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/task_execution_mapping.py#L1) |
-| Shared audit and telemetry posture | Audit persistence and bounded audit inspection are implemented | [audit.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/audit.py#L1), [sqlalchemy_audit_repository.py](C:/Users/Sandeep/projects/lotus-ai/src/app/repositories/sqlalchemy_audit_repository.py#L1) |
-| Shared evaluation harnesses | Eval catalog, eval runtime, run artifacts, validation gates, and fixture manifest are implemented | [evals.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/evals.py#L1), [fixture-manifest.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/fixture-manifest.json#L1), [run-artifacts.json](C:/Users/Sandeep/projects/lotus-ai/docs/evals/run-artifacts.json#L1) |
-| Shared async platform posture | Async contracts, job artifacts, submission path, and governance/readiness surfaces are implemented | [async_runtime.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/async_runtime.py#L1), [job-artifacts.json](C:/Users/Sandeep/projects/lotus-ai/docs/async/job-artifacts.json#L1) |
-| Reusable AI task APIs | Bounded task APIs exist with real execution pipeline and dedicated inspection surfaces | [tasks.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/tasks.py#L1), [task_runtime.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/task_runtime.py#L1) |
+| Separate shared AI service exists | `lotus-ai` is a standalone FastAPI backend with its own contracts, routers, startup policy, and metadata surfaces | [main.py](../../src/app/main.py#L1), [README.md](../../README.md#L1) |
+| Clear ownership boundary versus domain apps | Service docs and contracts consistently position `lotus-ai` as assistive/governed infrastructure rather than business truth | [README.md](../../README.md#L1), [system-overview.md](../architecture/system-overview.md#L1) |
+| Contract-first architecture | API and internal boundaries are modeled explicitly through `contracts`, routers, and service-layer orchestration | [contracts](../../src/app/contracts), [routers](../../src/app/routers), [services](../../src/app/services) |
+| Shared provider layer | Provider gateway, policy, governance, and runtime posture exist even while live execution remains disabled | [provider_gateway.py](../../src/app/services/provider_gateway.py#L1), [providers.py](../../src/app/routers/providers.py#L1) |
+| Shared prompt layer | Prompt registry, runtime selection, and governance/readiness surfaces exist | [prompts.py](../../src/app/routers/prompts.py#L1), [prompt_runtime.py](../../src/app/services/prompt_runtime.py#L1) |
+| Shared retrieval layer | Retrieval metadata, governance, execution, and retrieval-backed task behavior exist in bounded form | [retrieval.py](../../src/app/routers/retrieval.py#L1), [retrieval_service.py](../../src/app/services/retrieval_service.py#L1), [task_execution_contract.md](../guides/task-execution-contract.md#L1) |
+| Shared safety layer | Safety posture is modeled explicitly and reflected in runtime and audit behavior | [safety.py](../../src/app/routers/safety.py#L1), [task_execution_mapping.py](../../src/app/services/task_execution_mapping.py#L1) |
+| Shared audit and telemetry posture | Audit persistence and bounded audit inspection are implemented | [audit.py](../../src/app/routers/audit.py#L1), [sqlalchemy_audit_repository.py](../../src/app/repositories/sqlalchemy_audit_repository.py#L1) |
+| Shared evaluation harnesses | Eval catalog, eval runtime, run artifacts, validation gates, and fixture manifest are implemented | [evals.py](../../src/app/routers/evals.py#L1), [fixture-manifest.json](../evals/fixture-manifest.json#L1), [run-artifacts.json](../evals/run-artifacts.json#L1) |
+| Shared async platform posture | Async contracts, job artifacts, submission path, and governance/readiness surfaces are implemented | [async_runtime.py](../../src/app/routers/async_runtime.py#L1), [job-artifacts.json](../async/job-artifacts.json#L1) |
+| Reusable AI task APIs | Bounded task APIs exist with real execution pipeline and dedicated inspection surfaces | [tasks.py](../../src/app/routers/tasks.py#L1), [task_runtime.py](../../src/app/routers/task_runtime.py#L1) |
 
 ## Current Reality
 
@@ -150,9 +150,9 @@ Implemented.
 
 Evidence:
 
-1. [main.py](C:/Users/Sandeep/projects/lotus-ai/src/app/main.py#L1)
-2. [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1)
-3. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md#L1)
+1. [main.py](../../src/app/main.py#L1)
+2. [README.md](../../README.md#L1)
+3. [system-overview.md](../architecture/system-overview.md#L1)
 
 ### 2. The repo clearly documents what it does and does not own.
 
@@ -160,9 +160,9 @@ Implemented.
 
 Evidence:
 
-1. [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1)
-2. [RFC-0001-shared-ai-platform-service.md](C:/Users/Sandeep/projects/lotus-ai/docs/rfcs/RFC-0001-shared-ai-platform-service.md#L1)
-3. [decision-log.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/decision-log.md#L1)
+1. [README.md](../../README.md#L1)
+2. [RFC-0001-shared-ai-platform-service.md](RFC-0001-shared-ai-platform-service.md#L1)
+3. [decision-log.md](../architecture/decision-log.md#L1)
 
 ### 3. The platform can depend on `lotus-ai` for shared AI infrastructure without moving domain logic into it.
 
@@ -170,9 +170,9 @@ Implemented.
 
 Evidence:
 
-1. [tasks.py](C:/Users/Sandeep/projects/lotus-ai/src/app/routers/tasks.py#L1)
-2. [task_execution_pipeline.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/task_execution_pipeline.py#L1)
-3. [system-overview.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/system-overview.md#L1)
+1. [tasks.py](../../src/app/routers/tasks.py#L1)
+2. [task_execution_pipeline.py](../../src/app/services/task_execution_pipeline.py#L1)
+3. [system-overview.md](../architecture/system-overview.md#L1)
 
 ## Close-Out Notes
 

--- a/docs/rfcs/RFC-0005-durable-provider-operations-state.md
+++ b/docs/rfcs/RFC-0005-durable-provider-operations-state.md
@@ -42,9 +42,9 @@ That makes the current control plane good for contract hardening, but not yet go
 
 Today provider operations state is held in process-local globals:
 
-1. quota counters in [provider_quota_policy.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/provider_quota_policy.py#L1),
-2. spend totals in [provider_budget_policy.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/provider_budget_policy.py#L1),
-3. degradation and circuit-breaker counters in [provider_degradation_state.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/provider_degradation_state.py#L1).
+1. quota counters in [provider_quota_policy.py](../../src/app/services/provider_quota_policy.py#L1),
+2. spend totals in [provider_budget_policy.py](../../src/app/services/provider_budget_policy.py#L1),
+3. degradation and circuit-breaker counters in [provider_degradation_state.py](../../src/app/services/provider_degradation_state.py#L1).
 
 That creates real limitations:
 

--- a/docs/rfcs/RFC-0006-durable-async-execution-backbone.md
+++ b/docs/rfcs/RFC-0006-durable-async-execution-backbone.md
@@ -45,9 +45,9 @@ This RFC should stop at the durable async backbone itself. Higher-level consumer
 
 Today async behavior is still mostly a governed contract shell:
 
-1. submissions are rejected in [async_submission_service.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/async_submission_service.py#L1),
-2. job catalogs and detail views are read from static governed artifacts in [async_job_service.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/async_job_service.py#L1),
-3. the current registry loader in [job_registry.py](C:/Users/Sandeep/projects/lotus-ai/src/app/async_runtime/job_registry.py#L1) validates docs, not runtime execution state.
+1. submissions are rejected in [async_submission_service.py](../../src/app/services/async_submission_service.py#L1),
+2. job catalogs and detail views are read from static governed artifacts in [async_job_service.py](../../src/app/services/async_job_service.py#L1),
+3. the current registry loader in [job_registry.py](../../src/app/async_runtime/job_registry.py#L1) validates docs, not runtime execution state.
 
 This creates real limitations:
 

--- a/docs/rfcs/RFC-0007-runtime-backed-evaluation-execution-and-approval-gates.md
+++ b/docs/rfcs/RFC-0007-runtime-backed-evaluation-execution-and-approval-gates.md
@@ -38,9 +38,9 @@ Without runtime-backed evaluation execution:
 
 Today evaluation posture is still largely documentation-backed:
 
-1. run catalogs and detail views are loaded from static governed artifacts in [eval_run_service.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/eval_run_service.py#L1),
-2. recorded runs come from manifest files in [run_registry.py](C:/Users/Sandeep/projects/lotus-ai/src/app/evals/run_registry.py#L1),
-3. evaluation runtime status explicitly says no live runner is active in [eval_status.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/eval_status.py#L1),
+1. run catalogs and detail views are loaded from static governed artifacts in [eval_run_service.py](../../src/app/services/eval_run_service.py#L1),
+2. recorded runs come from manifest files in [run_registry.py](../../src/app/evals/run_registry.py#L1),
+3. evaluation runtime status explicitly says no live runner is active in [eval_status.py](../../src/app/services/eval_status.py#L1),
 4. rollout evidence for retrieval and provider governance is therefore stronger than foundation scaffolding, but weaker than authoritative runtime truth.
 
 This creates real limitations:

--- a/docs/rfcs/RFC-0008-governed-live-retrieval-activation.md
+++ b/docs/rfcs/RFC-0008-governed-live-retrieval-activation.md
@@ -46,8 +46,8 @@ At proposal time the retrieval layer had an asymmetry:
 
 At proposal time the code made that gap explicit:
 
-1. [retrieval_execution_status.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/retrieval_execution_status.py#L1) reports `live_search_enabled=False` even when retrieval mode is enabled,
-2. [retrieval_gateway.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/retrieval_gateway.py#L1) returns catalog-only hits when retrieval is disabled and a `503` when retrieval is enabled because no live backend is wired,
+1. [retrieval_execution_status.py](../../src/app/services/retrieval_execution_status.py#L1) reports `live_search_enabled=False` even when retrieval mode is enabled,
+2. [retrieval_gateway.py](../../src/app/services/retrieval_gateway.py#L1) returns catalog-only hits when retrieval is disabled and a `503` when retrieval is enabled because no live backend is wired,
 3. retrieval activation and runbook surfaces therefore describe a rollout target that the service still cannot actually execute.
 
 This leaves `lotus-ai` short of the runtime behavior a shared AI platform needs:

--- a/docs/rfcs/RFC-0009-runtime-safety-enforcement-and-redaction.md
+++ b/docs/rfcs/RFC-0009-runtime-safety-enforcement-and-redaction.md
@@ -27,9 +27,9 @@ The platform now has:
 
 But safety posture still has a hard limit:
 
-1. [safety_policy.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/safety_policy.py#L1) marks `runtime_redaction_engine` as `DOCUMENTED`,
-2. [safety_runtime.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/safety_runtime.py#L1) only records static control metadata rather than enforcing redaction,
-3. [safety_status.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/safety_status.py#L1) reports `runtime_redaction_active=False`,
+1. [safety_policy.py](../../src/app/services/safety_policy.py#L1) marks `runtime_redaction_engine` as `DOCUMENTED`,
+2. [safety_runtime.py](../../src/app/services/safety_runtime.py#L1) only records static control metadata rather than enforcing redaction,
+3. [safety_status.py](../../src/app/services/safety_status.py#L1) reports `runtime_redaction_active=False`,
 4. the runbooks and runtime status are honest, but the platform still relies on calling applications to do too much of the last-mile safety work.
 
 Once live provider and retrieval paths are materially useful, this becomes the next highest-risk and highest-value gap to close.

--- a/docs/rfcs/RFC-0010-governed-prompt-activation-and-rollback.md
+++ b/docs/rfcs/RFC-0010-governed-prompt-activation-and-rollback.md
@@ -27,10 +27,10 @@ The platform already has:
 
 But prompt activation is still intentionally blocked:
 
-1. [prompt_governance.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/prompt_governance.py#L1) reports `runtime_mutation_enabled=False` and `promotion_write_api_enabled=False`,
-2. [prompt_activation_readiness.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/prompt_activation_readiness.py#L1) explicitly says no live approval and rollback workflow exists,
-3. [prompt_runbook_readiness.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/prompt_runbook_readiness.py#L1) shows change review and rollback still not ready,
-4. [prompt_evidence_readiness.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/prompt_evidence_readiness.py#L1) shows no runtime-backed regression or rollback evidence pack yet.
+1. [prompt_governance.py](../../src/app/services/prompt_governance.py#L1) reports `runtime_mutation_enabled=False` and `promotion_write_api_enabled=False`,
+2. [prompt_activation_readiness.py](../../src/app/services/prompt_activation_readiness.py#L1) explicitly says no live approval and rollback workflow exists,
+3. [prompt_activation_readiness.py](../../src/app/services/prompt_activation_readiness.py#L1) shows change review and rollback still not ready,
+4. [prompt_evidence_readiness.py](../../src/app/services/prompt_evidence_readiness.py#L1) shows no runtime-backed regression or rollback evidence pack yet.
 
 That means the platform can execute with fixed prompts, but cannot yet govern prompt evolution as a first-class enterprise runtime capability.
 

--- a/docs/rfcs/RFC-0011-dedicated-worker-fleet-and-managed-queue.md
+++ b/docs/rfcs/RFC-0011-dedicated-worker-fleet-and-managed-queue.md
@@ -29,9 +29,9 @@ The platform now has:
 
 But the active runtime still uses an in-process worker path:
 
-1. [async_worker_execution_service.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/async_worker_execution_service.py#L1) marks `in_process_stub` as the active worker execution,
-2. [async_queue_backend_service.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/async_queue_backend_service.py#L1) marks `service_database` as the active queue backend and keeps `redis_queue` disabled,
-3. [scalability-and-deployment-model.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/scalability-and-deployment-model.md#L1) already states that API-serving and worker concerns should scale independently.
+1. [async_worker_execution_service.py](../../src/app/services/async_worker_execution_service.py#L1) marks `in_process_stub` as the active worker execution,
+2. [async_queue_backend_service.py](../../src/app/services/async_queue_backend_service.py#L1) marks `service_database` as the active queue backend and keeps `redis_queue` disabled,
+3. [scalability-and-deployment-model.md](../architecture/scalability-and-deployment-model.md#L1) already states that API-serving and worker concerns should scale independently.
 
 That means the async control plane is durable, but the operational deployment model is not yet complete.
 

--- a/docs/rfcs/RFC-0014-governed-artifact-and-object-storage-backbone.md
+++ b/docs/rfcs/RFC-0014-governed-artifact-and-object-storage-backbone.md
@@ -35,7 +35,7 @@ This is acceptable while payloads remain small, but it does not scale well for:
 
 The architecture already documents the target:
 
-1. [scalability-and-deployment-model.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/scalability-and-deployment-model.md#L1) explicitly calls for object storage once evaluation, retrieval, or trace payloads outgrow relational storage.
+1. [scalability-and-deployment-model.md](../architecture/scalability-and-deployment-model.md#L1) explicitly calls for object storage once evaluation, retrieval, or trace payloads outgrow relational storage.
 
 ## Problem Statement
 

--- a/docs/rfcs/RFC-0016-first-production-use-case-onboarding.md
+++ b/docs/rfcs/RFC-0016-first-production-use-case-onboarding.md
@@ -27,9 +27,9 @@ The architecture and integration guidance have consistently pointed toward one p
 
 The current docs already identify the preferred first integration path:
 
-1. [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1) says cross-app adoption should start with one Lotus app integration,
-2. [integration-guide.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/integration-guide.md#L1) highlights `lotus-performance` analytics commentary as a strong bounded integration candidate,
-3. [phased-roadmap.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/phased-roadmap.md#L1) now identifies `lotus-performance` analytics commentary as the preferred first integration.
+1. [README.md](../../README.md#L1) says cross-app adoption should start with one Lotus app integration,
+2. [integration-guide.md](../guides/integration-guide.md#L1) highlights `lotus-performance` analytics commentary as a strong bounded integration candidate,
+3. [phased-roadmap.md](../architecture/phased-roadmap.md#L1) now identifies `lotus-performance` analytics commentary as the preferred first integration.
 
 Without a real first-use-case RFC:
 

--- a/docs/rfcs/RFC-0018-governed-embeddings-and-provider-expansion.md
+++ b/docs/rfcs/RFC-0018-governed-embeddings-and-provider-expansion.md
@@ -26,10 +26,10 @@ But the provider layer is still materially incomplete for the next phase of plat
 
 Current code and docs make the gap explicit:
 
-1. [provider_policy.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/provider_policy.py#L1) allows `openai` only for text generation, while embeddings are limited to `disabled` and `stub`,
-2. [provider_catalog.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/provider_catalog.py#L1) exposes only `embeddings.stub`,
-3. [retrieval_activation_readiness.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/retrieval_activation_readiness.py#L1) explicitly calls out embedding-provider execution as part of future retrieval rollout,
-4. [README.md](C:/Users/Sandeep/projects/lotus-ai/README.md#L1) still says live retrieval search remains disabled until embeddings and vector indexing are wired.
+1. [provider_policy.py](../../src/app/services/provider_policy.py#L1) allows `openai` only for text generation, while embeddings are limited to `disabled` and `stub`,
+2. [provider_catalog.py](../../src/app/services/provider_catalog.py#L1) exposes only `embeddings.stub`,
+3. [retrieval_activation_readiness.py](../../src/app/services/retrieval_activation_readiness.py#L1) explicitly calls out embedding-provider execution as part of future retrieval rollout,
+4. [README.md](../../README.md#L1) still says live retrieval search remains disabled until embeddings and vector indexing are wired.
 
 This means the provider platform is still asymmetric:
 

--- a/docs/rfcs/RFC-0019-governed-document-ingestion-and-corpus-refresh.md
+++ b/docs/rfcs/RFC-0019-governed-document-ingestion-and-corpus-refresh.md
@@ -22,10 +22,10 @@ But corpus growth is still constrained by staged, repository-managed content rat
 
 The architecture and retrieval docs already point toward this gap:
 
-1. [scalability-and-deployment-model.md](C:/Users/Sandeep/projects/lotus-ai/docs/architecture/scalability-and-deployment-model.md#L1) explicitly names large document ingestion as async-capable work,
-2. [retrieval-and-vector-store.md](C:/Users/Sandeep/projects/lotus-ai/docs/guides/retrieval-and-vector-store.md#L1) still says live embedding generation, runtime vector writes, and production retrieval execution remain incomplete,
-3. [retrieval_runbook_readiness.py](C:/Users/Sandeep/projects/lotus-ai/src/app/services/retrieval_runbook_readiness.py#L1) still calls out reindex, replay, failure recovery, and corpus refresh as incomplete,
-4. current retrieval job detail in [job_registry.py](C:/Users/Sandeep/projects/lotus-ai/src/app/retrieval/job_registry.py#L1) centers on indexing staged sources, not on governed ingestion of new document material.
+1. [scalability-and-deployment-model.md](../architecture/scalability-and-deployment-model.md#L1) explicitly names large document ingestion as async-capable work,
+2. [retrieval-and-vector-store.md](../guides/retrieval-and-vector-store.md#L1) still says live embedding generation, runtime vector writes, and production retrieval execution remain incomplete,
+3. [retrieval_activation_readiness.py](../../src/app/services/retrieval_activation_readiness.py#L1) still calls out reindex, replay, failure recovery, and corpus refresh as incomplete,
+4. current retrieval job detail in [job_registry.py](../../src/app/retrieval/job_registry.py#L1) centers on indexing staged sources, not on governed ingestion of new document material.
 
 This means retrieval will eventually hit a product ceiling unless corpus onboarding becomes a first-class platform capability.
 

--- a/docs/rfcs/RFC-0031-governed-agent-workflow-packs-and-bounded-ai-runtime.md
+++ b/docs/rfcs/RFC-0031-governed-agent-workflow-packs-and-bounded-ai-runtime.md
@@ -678,8 +678,7 @@ These packs must still avoid inventing new analytical truth.
 
 ## OpenClaw Reference Findings
 
-This RFC was tightened after a local review of the cloned `openclaw` repository under
-`c:\Users\Sandeep\projects\openclaw`.
+This RFC was tightened after a local review of a local checkout of the external `openclaw` repository.
 
 The following findings materially informed the design:
 

--- a/docs/rfcs/RFC-0097-slice-6-task-flow-heartbeat-attention-review.md
+++ b/docs/rfcs/RFC-0097-slice-6-task-flow-heartbeat-attention-review.md
@@ -34,7 +34,7 @@ flows without becoming a separate task-flow authority.
    - 106 passed.
 4. `git diff --check`
    - passed with existing CRLF normalization warnings only.
-5. `powershell -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai`
+5. `powershell -ExecutionPolicy Bypass -File <lotus-platform>/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-ai`
    - reported expected branch-local drift for `Platform-Surfaces.md`; publish after merge to `main`.
 
 ## Remaining RFC-0097 Gaps

--- a/docs/runbooks/provider-mode-switching.md
+++ b/docs/runbooks/provider-mode-switching.md
@@ -6,6 +6,9 @@ This runbook defines the approved operator procedure for switching `lotus-ai` be
 2. managed OpenAI execution,
 3. local OpenAI-compatible execution.
 
+**Prerequisite:** run every command below from the repository root, with Docker running and
+the `.env` file already carrying the target mode's settings.
+
 Use this runbook together with:
 
 1. `GET /platform/providers/operator-profile`
@@ -49,7 +52,6 @@ LOTUS_AI_PROVIDER_MODE=disabled
 Switch procedure:
 
 ```powershell
-cd C:\Users\Sandeep\projects\lotus-ai
 docker compose up -d --force-recreate lotus-ai lotus-ai-worker
 ```
 
@@ -85,7 +87,6 @@ LOTUS_AI_PROVIDER_MAX_OUTPUT_TOKENS=4096
 Switch procedure:
 
 ```powershell
-cd C:\Users\Sandeep\projects\lotus-ai
 docker compose up -d --force-recreate lotus-ai lotus-ai-worker
 ```
 
@@ -107,7 +108,6 @@ Use when:
 Bring up Ollama:
 
 ```powershell
-cd C:\Users\Sandeep\projects\lotus-ai
 docker compose --profile local-llm up -d ollama
 docker compose exec ollama ollama pull qwen3:8b
 ```
@@ -129,7 +129,6 @@ LOTUS_AI_PROVIDER_MAX_OUTPUT_TOKENS=4096
 Switch procedure:
 
 ```powershell
-cd C:\Users\Sandeep\projects\lotus-ai
 docker compose up -d --force-recreate lotus-ai lotus-ai-worker
 ```
 

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -514,7 +514,7 @@ Before any future live-provider activation slice:
 
 Authoritative procedure:
 
-1. use [provider-mode-switching.md](C:/Users/Sandeep/projects/lotus-ai/docs/runbooks/provider-mode-switching.md)
+1. use [provider-mode-switching.md](provider-mode-switching.md)
 2. treat `/platform/providers/operator-profile` as the summary-first operator surface for active mode and verification steps
 3. do not treat `.env` changes alone as a completed switch; container recreation plus task-level verification is required
 


### PR DESCRIPTION
Two findings from the cross-repo context audit against the Repository-Engineering-Context contract.

## 1. Missing `Current-State Summary` (contract section, 10/11 → 11/11)
`Current Architecture` and `Architecture And Module Map` both answer *what the repository is*. What is **proven, enforced, and blocked right now** had no home — which matters here, because that is exactly the class of claim I spent today correcting in the runbook and wiki.

Added as its own section rather than by renaming an architecture section: they are different questions and there is content for both. It is explicitly short and dated, with an instruction to delete resolved items rather than grow a changelog.

**Every issue state in it was verified against GitHub, not recalled:** #327, #340, #344, #336, #351 all CLOSED as described; #358, #332, #115, #122, #126 all OPEN as described.

It also restates the boundary that matters most for this repository: nothing in it is a live-provider or attested-production claim, and stub or local-only journeys are never certification.

## 2. A fake H1 heading
Line 198 began `#154;`, so markdown rendered it as a top-level heading — the document outline carried a section titled *"154; consolidation is #284). Provider-side retention execution and external"*. Any reader or tool navigating by heading saw it as structure.

Reflowed to `issue #154`. Repository-wide recheck of `^#[0-9]` across the context doc, `docs/`, `wiki/`, and `README.md` now returns **0**.

This is the escape-corruption shape again: invisible in the source you are editing, wrong in the artifact that gets consumed.

## Verification
`make lint` clean; deployment-baseline pin suite passes; every cited issue state checked via `gh`; fake-heading scan returns zero.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 3. Machine-independent paths (directive 1, point 6)

Added in `d0d576c`. The documentation carried **93 markdown links written as absolute checkout paths under a personal home directory**, plus **7 hardcoded command paths** — all broken for any reader who is not the original author on the original machine. This is the same shape as the fake heading above: invisible in the source you are editing, wrong only in the artifact someone else consumes.

| Fix | Count |
|---|---|
| Absolute links → repository-relative (computed per document, not pattern-substituted) | 93 across 20 files |
| `cd <absolute path>` removed; working directory stated as a prerequisite instead | 5 |
| Machine-specific prefixes on external references (openclaw checkout, Sync-RepoWikis) | 2 |

**Two stale links surfaced once the absolute paths were gone and could actually be checked:** RFC-0010 and RFC-0019 cited `*_runbook_readiness.py` modules that no longer exist. Repointed to the `*_activation_readiness.py` successors. They were broken *before* this change — the absolute form pointed at the same missing files — so the conversion exposed them rather than causing them.

**Verified:** zero machine-specific references remain across all markdown (searching `sandeep`, `C:\`, `/c/Users`, and drive-letter prefixes returns 0), and all 197 relative links resolve. The only residual "broken" links are `wiki/` bare-name forms, which are the **correct** form for published GitHub wikis — a `Page.md` link there serves raw markdown and a `../path` 404s.

## Scope note

Per directive 1 point 3 and directive 2 point 1, I have **not** authored a `CLAUDE.md` router here. That convention is being refined centrally and piloted in one repository first; inventing a second structure in this repo is precisely what those points forbid. Ready to adopt it once it lands.
