### PR TITLE
docs: make onboarding reproducible on a machine that is not this one

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,40 @@ maintained in [feature status and roadmap](docs/architecture/feature-status-and-
 
 ## Quick Start
 
-Prerequisites: Python 3.13, `make`, and Docker (for the prod-shaped stack).
+Prerequisites, each pinned by a source you can check:
 
-```powershell
+| Tool | Version | Needed for | Where that version is pinned |
+| --- | --- | --- | --- |
+| Python | 3.12 | everything | `pyproject.toml` (`requires-python = ">=3.12"`), `mypy.ini`, ruff `target-version`, all three CI lanes, and the `Dockerfile` base image |
+| `make` | any | every repo-native command | `Makefile` |
+| Docker | any current release | the prod-shaped stack, `make docker-build`, `make test-postgres` | `docker-compose.yml`, `Dockerfile` |
+
+`>=3.12` permits newer interpreters, but every gate — CI, type checking, lint target, and the
+runtime image — runs 3.12, so 3.12 is what reproduces the gates locally.
+
+Two tools are deliberately *not* prerequisites: `uv` is a dev dependency installed by
+`make install`, and `gh` is needed only for the main-gate coverage audit and the live
+branch-protection comparison, never for `make check`.
+
+From a fresh checkout, create and activate a virtual environment first — `make install` installs
+into whichever interpreter `python` resolves to, and installing into a system Python fails outright
+on distributions that follow PEP 668:
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate          # Windows PowerShell: .venv\Scripts\Activate.ps1
+```
+
+Then, from the repository root:
+
+```bash
 make install
 make check
 uvicorn app.main:app --reload --port 8140
 ```
+
+Dependencies install from `requirements-dev.lock.txt` under `--require-hashes`, so the resulting
+environment is identical on any machine.
 
 Expected result: `make check` finishes green (lint, typecheck, fast tests), and
 `http://localhost:8140/docs` serves the interactive API documentation. For the prod-shaped local

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -10,11 +10,33 @@ There are two useful local postures for `lotus-ai`:
 Use the first when you are changing code quickly. Use the second when you need to exercise runtime
 and durability behavior more truthfully.
 
+## Prerequisites
+
+| Tool | Version | Needed for | Where that version is pinned |
+| --- | --- | --- | --- |
+| Python | 3.12 | everything | `pyproject.toml` (`requires-python = ">=3.12"`), `mypy.ini`, ruff `target-version`, all three CI lanes, and the `Dockerfile` base image |
+| `make` | any | every repo-native command | `Makefile` |
+| Docker | any current release | the prod-shaped stack, `make docker-build`, `make test-postgres` | `docker-compose.yml`, `Dockerfile` |
+
+`>=3.12` permits newer interpreters, but every gate runs 3.12, so 3.12 is what reproduces the
+gates locally. `uv` and `gh` are not prerequisites: `uv` is a dev dependency installed by
+`make install`, and `gh` is needed only for the main-gate coverage audit and the live
+branch-protection comparison.
+
 ## Fast Local Loop
 
-Install dependencies:
+From a fresh checkout, create and activate a virtual environment first — `make install` installs
+into whichever interpreter `python` resolves to, and installing into a system Python fails outright
+on distributions that follow PEP 668:
 
-```powershell
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate          # Windows PowerShell: .venv\Scripts\Activate.ps1
+```
+
+Then install dependencies from the repository root:
+
+```bash
 make install
 ```
 


### PR DESCRIPTION
User directive: *"onboarding an agent or developer should be repeatable and not dependent on machine — we should have steps to make things working and running easy."* Acceptance test: fresh checkout elsewhere + documented steps → working environment.

Two defects, both the same class — **the documented setup worked here and nowhere else.**

## 1. The stated Python version was this machine's, not the project's

README said **Python 3.13**. Every governed source pins **3.12**:

| Source | Pins |
|---|---|
| `pyproject.toml` | `requires-python = ">=3.12"` |
| `mypy.ini` | `python_version = 3.12` |
| `pyproject.toml` ruff | `target-version = "py312"` |
| all three CI lanes | `PYTHON_VERSION: "3.12"` |
| `Dockerfile` | `python:3.12-slim` |

The only 3.13 in sight is the interpreter in this checkout's virtualenv (3.13.3) — a personal environment documented as a requirement. A newcomer following the README would run every local check on an interpreter no gate uses.

Prerequisites are now a **table with a source column**, so each claim is falsifiable rather than remembered. `>=3.12` does permit newer interpreters; the README now says why 3.12 is the one that reproduces the gates.

## 2. Nothing documented creating a virtualenv — and the first step cannot succeed without one

`make install` runs `pip install` against whatever `python` resolves to. On a fresh machine that is the **system interpreter**, which distributions following **PEP 668** refuse outright. So the documented first step would fail on a clean Linux or macOS box.

**Why no gate caught it:** CI uses `actions/setup-python`, which supplies an isolated interpreter, so `make install` always succeeds there. The gate's environment differs from the target environment, and therefore cannot see this defect — the same mechanism as SQLite-green SQL being unreachable on PostgreSQL.

Added the venv step with both activation forms, and stated that dependencies install from `requirements-dev.lock.txt` under `--require-hashes` (1,125 hash-pinned entries), so the resulting environment is identical anywhere.

## Narrowed the tool list honestly
`uv` is a **dev dependency** installed by `make install`; `gh` is needed only for the main-gate coverage audit and the live branch-protection comparison, **never for `make check`**. Neither is a machine prerequisite, and listing them would send a newcomer installing tools they do not need. (Same correction shape as narrowing `gh` in the render pilot.)

## Verified
Every claim checked against its source file. The three port sentences pinned by `test_deployment_baseline_files` are **byte-identical and unwrapped**; that suite and `make lint` pass. Commands are shell-neutral with the PowerShell activation given inline rather than the block being labelled `powershell`.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)