### PR TITLE
docs: name the Windows interpreter form in the venv step

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,18 @@ From a fresh checkout, create and activate a virtual environment first — `make
 into whichever interpreter `python` resolves to, and installing into a system Python fails outright
 on distributions that follow PEP 668:
 
+Linux and macOS:
+
 ```bash
-python3.12 -m venv .venv          # Windows: py -3.12 -m venv .venv
-source .venv/bin/activate          # Windows PowerShell: .venv\Scripts\Activate.ps1
+python3.12 -m venv .venv
+source .venv/bin/activate
+```
+
+Windows PowerShell:
+
+```powershell
+py -3.12 -m venv .venv
+.venv\Scripts\Activate.ps1
 ```
 
 Then, from the repository root:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ into whichever interpreter `python` resolves to, and installing into a system Py
 on distributions that follow PEP 668:
 
 ```bash
-python3.12 -m venv .venv
+python3.12 -m venv .venv          # Windows: py -3.12 -m venv .venv
 source .venv/bin/activate          # Windows PowerShell: .venv\Scripts\Activate.ps1
 ```
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -29,9 +29,18 @@ From a fresh checkout, create and activate a virtual environment first — `make
 into whichever interpreter `python` resolves to, and installing into a system Python fails outright
 on distributions that follow PEP 668:
 
+Linux and macOS:
+
 ```bash
-python3.12 -m venv .venv          # Windows: py -3.12 -m venv .venv
-source .venv/bin/activate          # Windows PowerShell: .venv\Scripts\Activate.ps1
+python3.12 -m venv .venv
+source .venv/bin/activate
+```
+
+Windows PowerShell:
+
+```powershell
+py -3.12 -m venv .venv
+.venv\Scripts\Activate.ps1
 ```
 
 Then install dependencies from the repository root:

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -30,7 +30,7 @@ into whichever interpreter `python` resolves to, and installing into a system Py
 on distributions that follow PEP 668:
 
 ```bash
-python3.12 -m venv .venv
+python3.12 -m venv .venv          # Windows: py -3.12 -m venv .venv
 source .venv/bin/activate          # Windows PowerShell: .venv\Scripts\Activate.ps1
 ```
 


### PR DESCRIPTION
Follow-up to #364, from review of the identical change on `lotus-manage#670`.

The quick-start block **explicitly supports Windows** — it gives the PowerShell activation path on the very next line — but named `python3.12`, which standard Windows installations do not expose. They provide the `py` launcher. So the documented *first* command failed before the activation it was setting up could run.

Fixed in both `README.md` and `wiki/Getting-Started.md`, since the published wiki is where someone onboarding actually starts.

This is the portability lesson turned back on my own fix: I corrected a version claim and added a venv step, then wrote the venv command in a form that only works on the platforms I was not testing on. A prerequisite that cannot run is not more portable than the absolute path it replaced.

Verified: baseline-files pin suite and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)